### PR TITLE
Tidy up chart title & Refactor Endpoints URIs

### DIFF
--- a/analytics/package.json
+++ b/analytics/package.json
@@ -9,7 +9,7 @@
     "scripts": {
         "start": "serve -s build",
         "prestart": "npm install -g serve",
-        "local": "NODE_ENV=development PORT=5000 react-scripts start",
+        "local": "react-scripts start",
         "stage": "NODE_ENV=stage PORT=5000 react-scripts start",
         "build": "react-scripts build",
         "test": "react-scripts test",

--- a/analytics/src/config/constants.js
+++ b/analytics/src/config/constants.js
@@ -15,7 +15,9 @@ const devConfig = {
   DEFAULTS_URI: 'http://localhost:3000/api/v1/users/defaults',
   GENERATE_CUSTOMISABLE_CHARTS_URI: 'http://127.0.0.1:5000/api/v1/dashboard/customisedchart',
   GET_CUSTOMISABLE_CHART_INITIAL_DATA_URI: 'http://127.0.0.1:5000/api/v1/dashboard/customisedchart/random',
-  GET_MONITORING_SITES_LOCATIONS_URI: 'http://127.0.0.1:5000/api/v1/dashboard/monitoringsites/locations?organisation_name=KCCA'
+  GET_MONITORING_SITES_LOCATIONS_URI: 'http://127.0.0.1:5000/api/v1/dashboard/monitoringsites/locations?organisation_name=KCCA',
+  GET_PM25_CATEGORY_COUNT_URI:'http://127.0.0.1:5000/api/v1/dashboard/locations/pm25categorycount?organisation_name=KCCA',
+  GET_HISTORICAL_DAILY_MEAN_AVERAGES_FOR_LAST_28_DAYS_URI:'http://127.0.0.1:5000/api/v1/dashboard/historical/daily/devices'
 };
 const testConfig = {
   VERIFY_TOKEN_URI: 'http://localhost:3000/api/v1/users/reset/you',
@@ -56,7 +58,8 @@ const stageConfig = {
   DEFAULTS_URI: 'https://airqo-250220.uc.r.appspot.com/api/v1/users/defaults',
   GENERATE_CUSTOMISABLE_CHARTS_URI: 'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/dashboard/customisedchart',
   GET_CUSTOMISABLE_CHART_INITIAL_DATA_URI: 'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/dashboard/customisedchart/random',
-  GET_MONITORING_SITES_LOCATIONS_URI: 'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/dashboard/monitoringsites/locations?organisation_name=KCCA'
+  GET_MONITORING_SITES_LOCATIONS_URI: 'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/dashboard/monitoringsites/locations?organisation_name=KCCA',
+  GET_PM25_CATEGORY_COUNT_URI:'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/dashboard/locations/pm25categorycount?organisation_name=KCCA'
 };
 const prodConfig = {
   VERIFY_TOKEN_URI:
@@ -81,7 +84,9 @@ const prodConfig = {
   DEFAULTS_URI: 'https://airqo-250220.uc.r.appspot.com/api/v1/users/defaults',
   GENERATE_CUSTOMISABLE_CHARTS_URI: 'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/dashboard/customisedchart',
   GET_CUSTOMISABLE_CHART_INITIAL_DATA_URI: 'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/dashboard/customisedchart/random',
-  GET_MONITORING_SITES_LOCATIONS_URI: 'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/dashboard/monitoringsites/locations?organisation_name=KCCA'
+  GET_MONITORING_SITES_LOCATIONS_URI: 'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/dashboard/monitoringsites/locations?organisation_name=KCCA',
+  GET_PM25_CATEGORY_COUNT_URI:'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/dashboard/locations/pm25categorycount?organisation_name=KCCA'
+
 };
 const defaultConfig = {
   PORT: process.env.PORT || 5000,

--- a/analytics/src/config/constants.js
+++ b/analytics/src/config/constants.js
@@ -14,6 +14,8 @@ const devConfig = {
   GET_CANDIDATES_URI: 'http://localhost:3000/api/v1/users/candidates/fetch',
   DEFAULTS_URI: 'http://localhost:3000/api/v1/users/defaults',
   GENERATE_CUSTOMISABLE_CHARTS_URI: 'http://127.0.0.1:5000/api/v1/dashboard/customisedchart',
+  GET_CUSTOMISABLE_CHART_INITIAL_DATA_URI: 'http://127.0.0.1:5000/api/v1/dashboard/customisedchart/random',
+  GET_MONITORING_SITES_LOCATIONS_URI: 'http://127.0.0.1:5000/api/v1/dashboard/monitoringsites/locations?organisation_name=KCCA'
 };
 const testConfig = {
   VERIFY_TOKEN_URI: 'http://localhost:3000/api/v1/users/reset/you',
@@ -53,6 +55,8 @@ const stageConfig = {
     'https://airqo-250220.uc.r.appspot.com/api/v1/users/candidates/fetch',
   DEFAULTS_URI: 'https://airqo-250220.uc.r.appspot.com/api/v1/users/defaults',
   GENERATE_CUSTOMISABLE_CHARTS_URI: 'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/dashboard/customisedchart',
+  GET_CUSTOMISABLE_CHART_INITIAL_DATA_URI: 'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/dashboard/customisedchart/random',
+  GET_MONITORING_SITES_LOCATIONS_URI: 'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/dashboard/monitoringsites/locations?organisation_name=KCCA'
 };
 const prodConfig = {
   VERIFY_TOKEN_URI:
@@ -76,6 +80,8 @@ const prodConfig = {
     'https://airqo-250220.uc.r.appspot.com/api/v1/users/candidates/fetch',
   DEFAULTS_URI: 'https://airqo-250220.uc.r.appspot.com/api/v1/users/defaults',
   GENERATE_CUSTOMISABLE_CHARTS_URI: 'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/dashboard/customisedchart',
+  GET_CUSTOMISABLE_CHART_INITIAL_DATA_URI: 'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/dashboard/customisedchart/random',
+  GET_MONITORING_SITES_LOCATIONS_URI: 'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/dashboard/monitoringsites/locations?organisation_name=KCCA'
 };
 const defaultConfig = {
   PORT: process.env.PORT || 5000,

--- a/analytics/src/config/constants.js
+++ b/analytics/src/config/constants.js
@@ -19,7 +19,14 @@ const devConfig = {
   GET_PM25_CATEGORY_COUNT_URI:'http://127.0.0.1:5000/api/v1/dashboard/locations/pm25categorycount?organisation_name=KCCA',
   GET_HISTORICAL_DAILY_MEAN_AVERAGES_FOR_LAST_28_DAYS_URI:'http://127.0.0.1:5000/api/v1/dashboard/historical/daily/devices',
   GENERATE_DEVICE_GRAPH_URI:'http://127.0.0.1:5000/api/v1/device/graph',
-  DOWNLOAD_CUSTOMISED_DATA_URI: 'http://127.0.0.1:5000/api/v1/data/download'
+  DOWNLOAD_CUSTOMISED_DATA_URI: 'http://127.0.0.1:5000/api/v1/data/download',
+  GET_DEFAULT_REPORT_TEMPLATE_URI:'http://127.0.0.1:5000/api/v1/report/get_default_report_template',
+  SAVE_MONTHLY_REPORT_URI:'http://127.0.0.1:5000/api/v1/report/save_monthly_report',
+  GET_MONTHLY_REPORT_URI:'http://127.0.0.1:5000/api/v1/report/get_monthly_report/',
+  DELETE_MONTHLY_REPORT_URI:'http://127.0.0.1:5000/api/v1/report/delete_monthly_report/',
+  UPDATE_MONTHLY_REPORT_URI:'http://127.0.0.1:5000/api/v1/report/update_monthly_report/',
+  EXCEEDANCES_URI:'http://127.0.0.1:5000/api/v1/dashboard/exceedances',
+  GET_MONITORING_SITES_URI:'http://127.0.0.1:5000/api/v1/dashboard/monitoringsites?organisation_name=KCCA'
 };
 const testConfig = {
   VERIFY_TOKEN_URI: 'http://localhost:3000/api/v1/users/reset/you',
@@ -64,7 +71,14 @@ const stageConfig = {
   GET_PM25_CATEGORY_COUNT_URI:'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/dashboard/locations/pm25categorycount?organisation_name=KCCA',
   GET_HISTORICAL_DAILY_MEAN_AVERAGES_FOR_LAST_28_DAYS_URI:'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/dashboard/historical/daily/devices',
   GENERATE_DEVICE_GRAPH_URI:'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/device/graph',
-  DOWNLOAD_CUSTOMISED_DATA_URI: 'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/data/download'
+  DOWNLOAD_CUSTOMISED_DATA_URI: 'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/data/download',
+  GET_DEFAULT_REPORT_TEMPLATE_URI:'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/report/get_default_report_template',
+  SAVE_MONTHLY_REPORT_URI:'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/report/save_monthly_report',
+  GET_MONTHLY_REPORT_URI:'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/report/get_monthly_report/',
+  DELETE_MONTHLY_REPORT_URI:'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/report/delete_monthly_report/',
+  UPDATE_MONTHLY_REPORT_URI:'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/report/update_monthly_report/',
+  EXCEEDANCES_URI:'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/dashboard/exceedances',
+  GET_MONITORING_SITES_URI:'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/dashboard/monitoringsites?organisation_name=KCCA'
 };
 const prodConfig = {
   VERIFY_TOKEN_URI:
@@ -93,7 +107,14 @@ const prodConfig = {
   GET_PM25_CATEGORY_COUNT_URI:'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/dashboard/locations/pm25categorycount?organisation_name=KCCA',
   GET_HISTORICAL_DAILY_MEAN_AVERAGES_FOR_LAST_28_DAYS_URI:'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/dashboard/historical/daily/devices',
   GENERATE_DEVICE_GRAPH_URI:'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/device/graph',
-  DOWNLOAD_CUSTOMISED_DATA_URI: 'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/data/download'
+  DOWNLOAD_CUSTOMISED_DATA_URI: 'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/data/download',
+  GET_DEFAULT_REPORT_TEMPLATE_URI:'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/report/get_default_report_template',
+  SAVE_MONTHLY_REPORT_URI:'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/report/save_monthly_report',
+  GET_MONTHLY_REPORT_URI:'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/report/get_monthly_report/',
+  DELETE_MONTHLY_REPORT_URI:'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/report/delete_monthly_report/',
+  UPDATE_MONTHLY_REPORT_URI:'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/report/update_monthly_report/',
+  EXCEEDANCES_URI:'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/dashboard/exceedances',
+  GET_MONITORING_SITES_URI:'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/dashboard/monitoringsites?organisation_name=KCCA'
 };
 const defaultConfig = {
   PORT: process.env.PORT || 5000,

--- a/analytics/src/config/constants.js
+++ b/analytics/src/config/constants.js
@@ -12,7 +12,8 @@ const devConfig = {
   ACCEPT_USER_URI: 'http://localhost:3000/api/v1/users/accept',
   GET_USERS_URI: 'http://localhost:3000/api/v1/users/',
   GET_CANDIDATES_URI: 'http://localhost:3000/api/v1/users/candidates/fetch',
-  DEFAULTS_URI: 'http://localhost:3000/api/v1/users/defaults'
+  DEFAULTS_URI: 'http://localhost:3000/api/v1/users/defaults',
+  GENERATE_CUSTOMISABLE_CHARTS_URI: 'http://127.0.0.1:5000/api/v1/dashboard/customisedchart',
 };
 const testConfig = {
   VERIFY_TOKEN_URI: 'http://localhost:3000/api/v1/users/reset/you',
@@ -50,7 +51,8 @@ const stageConfig = {
   GET_USERS_URI: 'https://airqo-250220.uc.r.appspot.com/api/v1/users/',
   GET_CANDIDATES_URI:
     'https://airqo-250220.uc.r.appspot.com/api/v1/users/candidates/fetch',
-  DEFAULTS_URI: 'https://airqo-250220.uc.r.appspot.com/api/v1/users/defaults'
+  DEFAULTS_URI: 'https://airqo-250220.uc.r.appspot.com/api/v1/users/defaults',
+  GENERATE_CUSTOMISABLE_CHARTS_URI: 'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/dashboard/customisedchart',
 };
 const prodConfig = {
   VERIFY_TOKEN_URI:
@@ -72,7 +74,8 @@ const prodConfig = {
   GET_USERS_URI: 'https://airqo-250220.uc.r.appspot.com/api/v1/users/',
   GET_CANDIDATES_URI:
     'https://airqo-250220.uc.r.appspot.com/api/v1/users/candidates/fetch',
-  DEFAULTS_URI: 'https://airqo-250220.uc.r.appspot.com/api/v1/users/defaults'
+  DEFAULTS_URI: 'https://airqo-250220.uc.r.appspot.com/api/v1/users/defaults',
+  GENERATE_CUSTOMISABLE_CHARTS_URI: 'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/dashboard/customisedchart',
 };
 const defaultConfig = {
   PORT: process.env.PORT || 5000,

--- a/analytics/src/config/constants.js
+++ b/analytics/src/config/constants.js
@@ -17,7 +17,9 @@ const devConfig = {
   GET_CUSTOMISABLE_CHART_INITIAL_DATA_URI: 'http://127.0.0.1:5000/api/v1/dashboard/customisedchart/random',
   GET_MONITORING_SITES_LOCATIONS_URI: 'http://127.0.0.1:5000/api/v1/dashboard/monitoringsites/locations?organisation_name=KCCA',
   GET_PM25_CATEGORY_COUNT_URI:'http://127.0.0.1:5000/api/v1/dashboard/locations/pm25categorycount?organisation_name=KCCA',
-  GET_HISTORICAL_DAILY_MEAN_AVERAGES_FOR_LAST_28_DAYS_URI:'http://127.0.0.1:5000/api/v1/dashboard/historical/daily/devices'
+  GET_HISTORICAL_DAILY_MEAN_AVERAGES_FOR_LAST_28_DAYS_URI:'http://127.0.0.1:5000/api/v1/dashboard/historical/daily/devices',
+  GENERATE_DEVICE_GRAPH_URI:'http://127.0.0.1:5000/api/v1/device/graph',
+  DOWNLOAD_CUSTOMISED_DATA_URI: 'http://127.0.0.1:5000/api/v1/data/download'
 };
 const testConfig = {
   VERIFY_TOKEN_URI: 'http://localhost:3000/api/v1/users/reset/you',
@@ -59,7 +61,10 @@ const stageConfig = {
   GENERATE_CUSTOMISABLE_CHARTS_URI: 'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/dashboard/customisedchart',
   GET_CUSTOMISABLE_CHART_INITIAL_DATA_URI: 'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/dashboard/customisedchart/random',
   GET_MONITORING_SITES_LOCATIONS_URI: 'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/dashboard/monitoringsites/locations?organisation_name=KCCA',
-  GET_PM25_CATEGORY_COUNT_URI:'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/dashboard/locations/pm25categorycount?organisation_name=KCCA'
+  GET_PM25_CATEGORY_COUNT_URI:'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/dashboard/locations/pm25categorycount?organisation_name=KCCA',
+  GET_HISTORICAL_DAILY_MEAN_AVERAGES_FOR_LAST_28_DAYS_URI:'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/dashboard/historical/daily/devices',
+  GENERATE_DEVICE_GRAPH_URI:'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/device/graph',
+  DOWNLOAD_CUSTOMISED_DATA_URI: 'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/data/download'
 };
 const prodConfig = {
   VERIFY_TOKEN_URI:
@@ -85,8 +90,10 @@ const prodConfig = {
   GENERATE_CUSTOMISABLE_CHARTS_URI: 'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/dashboard/customisedchart',
   GET_CUSTOMISABLE_CHART_INITIAL_DATA_URI: 'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/dashboard/customisedchart/random',
   GET_MONITORING_SITES_LOCATIONS_URI: 'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/dashboard/monitoringsites/locations?organisation_name=KCCA',
-  GET_PM25_CATEGORY_COUNT_URI:'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/dashboard/locations/pm25categorycount?organisation_name=KCCA'
-
+  GET_PM25_CATEGORY_COUNT_URI:'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/dashboard/locations/pm25categorycount?organisation_name=KCCA',
+  GET_HISTORICAL_DAILY_MEAN_AVERAGES_FOR_LAST_28_DAYS_URI:'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/dashboard/historical/daily/devices',
+  GENERATE_DEVICE_GRAPH_URI:'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/device/graph',
+  DOWNLOAD_CUSTOMISED_DATA_URI: 'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/data/download'
 };
 const defaultConfig = {
   PORT: process.env.PORT || 5000,

--- a/analytics/src/views/Dashboard/Dashboard.js
+++ b/analytics/src/views/Dashboard/Dashboard.js
@@ -27,6 +27,7 @@ import ArrowDropDownIcon from '@material-ui/icons/ArrowDropDown';
 import ArrowRightIcon from '@material-ui/icons/ArrowRight';
 //import Legend from './components/Map/Legend'
 import axios from 'axios';
+import constants from '../../config/constants'
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -142,15 +143,11 @@ const Dashboard = props => {
 
   useEffect(() => {
     axios
-      .get(
-        'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/dashboard/locations/pm25categorycount?organisation_name=KCCA'
-      )
-      //axios.get('http://127.0.0.1:5000/api/v1/dashboard/locations/pm25categorycount?organisation_name=KCCA')
+      .get(constants.GET_PM25_CATEGORY_COUNT_URI)
       .then(res => res.data)
       .then(data => {
         setPm25CategoriesLocationCount(data);
-        console.log(data);
-        //console.log(data.pm25_categories)
+        console.log(data);        
       })
       .catch(e => {
         console.log(e);
@@ -160,10 +157,7 @@ const Dashboard = props => {
   const [locations, setLocations] = useState([]);
 
   useEffect(() => {
-    fetch(
-      'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/dashboard/historical/daily/devices'
-    )
-      //fetch('http://127.0.0.1:5000/api/v1/dashboard/historical/daily/devices')
+    fetch(constants.GET_HISTORICAL_DAILY_MEAN_AVERAGES_FOR_LAST_28_DAYS_URI)      
       .then(res => res.json())
       .then(locationsData => {
         setLocations(locationsData.results);

--- a/analytics/src/views/Dashboard/components/CustomisableChart/CustomisableChart.js
+++ b/analytics/src/views/Dashboard/components/CustomisableChart/CustomisableChart.js
@@ -140,8 +140,7 @@ const CustomisableChart = props => {
   const [filterLocations,setFilterLocations] = useState([]);
   
   useEffect(() => {
-    fetch('https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/dashboard/monitoringsites/locations?organisation_name=KCCA')
-    //fetch('http://127.0.0.1:5000/api/v1/dashboard/monitoringsites/locations?organisation_name=KCCA')
+    fetch(constants.GET_MONITORING_SITES_LOCATIONS_URI)    
       .then(res => res.json())
       .then((filterLocationsData) => {
         setFilterLocations(filterLocationsData.airquality_monitoring_sites)
@@ -220,8 +219,7 @@ const CustomisableChart = props => {
 
   useEffect(() => {
     
-    axios.get('https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/dashboard/customisedchart/random')
-    //axios.get('http://127.0.0.1:5000/api/v1/dashboard/customisedchart/random')
+    axios.get(constants.GET_CUSTOMISABLE_CHART_INITIAL_DATA_URI)   
       .then(res => res.data)
       .then((customisedChartData) => {
         setCustomisedGraphData(customisedChartData)

--- a/analytics/src/views/Dashboard/components/CustomisableChart/CustomisableChart.js
+++ b/analytics/src/views/Dashboard/components/CustomisableChart/CustomisableChart.js
@@ -20,6 +20,7 @@ import Typography from '@material-ui/core/Typography';
 import {MoreHoriz, Close} from '@material-ui/icons';
 import MuiDialogTitle from '@material-ui/core/DialogTitle';
 import validate from 'validate.js';
+import constants from '../../../../config/constants'
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -246,9 +247,7 @@ const CustomisableChart = props => {
     }
     //console.log(JSON.stringify(filter));
 
-    axios.post(
-      'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/dashboard/customisedchart',      
-      //'http://127.0.0.1:5000/api/v1/dashboard/customisedchart', 
+    axios.post(constants.GENERATE_CUSTOMISABLE_CHARTS_URI, 
       JSON.stringify(filter),
       { headers: { 'Content-Type': 'application/json' } }
     ).then(res => res.data)

--- a/analytics/src/views/Dashboard/components/CustomisableChart/CustomisableChart.js
+++ b/analytics/src/views/Dashboard/components/CustomisableChart/CustomisableChart.js
@@ -33,6 +33,12 @@ const useStyles = makeStyles(theme => ({
     width: 56
   },
 
+  subheader:{
+    color: '#263238' ,
+    fontSize: 16,    
+    fontWeight: 500
+}
+
     
 }));
 
@@ -46,7 +52,8 @@ const styles = (theme) => ({
     right: theme.spacing(1),
     top: theme.spacing(1),
     color: theme.palette.grey[500],
-  },
+  }
+ 
 });
 
 const DialogTitle = withStyles(styles)((props) => {
@@ -125,6 +132,8 @@ const CustomisableChart = props => {
   };
 
   const [customChartTitle, setCustomChartTitle] = useState('Custom Chart Title');
+  const [customChartTitleSecondSection, setCustomChartTitleSecondSection] = useState('Custom Chart Title');
+
   
 
   const handleDateChange = (date) => {
@@ -224,6 +233,7 @@ const CustomisableChart = props => {
       .then((customisedChartData) => {
         setCustomisedGraphData(customisedChartData)
         setCustomChartTitle(customisedChartData.custom_chart_title)
+        setCustomChartTitleSecondSection(customisedChartData.custom_chart_title_second_section)
       })
       .catch(console.log)
   },[]);
@@ -243,16 +253,15 @@ const CustomisableChart = props => {
       pollutant: selectedPollutant.value,
       organisation_name: 'KCCA'     
     }
-    //console.log(JSON.stringify(filter));
-
+   
     axios.post(constants.GENERATE_CUSTOMISABLE_CHARTS_URI, 
       JSON.stringify(filter),
       { headers: { 'Content-Type': 'application/json' } }
     ).then(res => res.data)
       .then((customisedChartData) => {
-        setCustomisedGraphData(customisedChartData)    
-        console.log(customisedChartData)
-
+        setCustomisedGraphData(customisedChartData) 
+        
+        setCustomChartTitleSecondSection(customisedChartData.custom_chart_title_second_section)
         setCustomChartTitle(customisedChartData.custom_chart_title)
         setCustomisedGraphLabel(customisedChartData.results?customisedChartData.results[0].chart_label:'')
         console.log(customisedChartData.results[0].chart_label)
@@ -395,9 +404,14 @@ const CustomisableChart = props => {
           </IconButton>
         }      
         
-        title= {customChartTitle}
+        title= {customChartTitle} 
+        subheader={customChartTitleSecondSection}
         style={{ textAlign: 'center' }}
+        classes={{subheader: classes.subheader }}
+       
       />
+        
+
       <Divider />
       <CardContent>
                 

--- a/analytics/src/views/Dashboard/components/ExceedancesChart/ExceedancesChart.js
+++ b/analytics/src/views/Dashboard/components/ExceedancesChart/ExceedancesChart.js
@@ -10,7 +10,8 @@ import axios from 'axios';
 //import LoadingSpinner from '../../../Graphs/loadingSpinner';
 import Select from 'react-select';
 import palette from 'theme/palette';
-
+import constants from 'config/constants'
+import { constant } from 'underscore';
 const useStyles = makeStyles(theme => ({
   root: {
     height: '100%'
@@ -75,8 +76,7 @@ const ExceedancesChart = props => {
     //setLoading(true);
 
     axios.post(
-      'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/dashboard/exceedances',
-      //'http://127.0.0.1:5000//api/v1/dashboard/exceedances', 
+      constants.EXCEEDANCES_URI, 
       JSON.stringify(effectFilter),
       { headers: { 'Content-Type': 'application/json' } }
     )
@@ -219,8 +219,7 @@ const ExceedancesChart = props => {
       console.log(filter_string);
   
       axios.post(
-        'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/dashboard/exceedances',
-        //'http://127.0.0.1:5000//api/v1/dashboard/exceedances', 
+        constants.EXCEEDANCES_URI,
         filter_string,
         { headers: { 'Content-Type': 'application/json' } }
       )

--- a/analytics/src/views/Dashboard/components/Map/Map.js
+++ b/analytics/src/views/Dashboard/components/Map/Map.js
@@ -10,6 +10,7 @@ import FullscreenControl from 'react-leaflet-fullscreen';
 import 'react-leaflet-fullscreen/dist/styles.css';
 import L from 'leaflet';
 // import Legend from "./Legend";
+import constants from 'config/constants'
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -49,8 +50,7 @@ const Map = props => {
   const [contacts,setContacts ] = useState([]);
 
   useEffect(() => {
-   fetch('https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/dashboard/monitoringsites?organisation_name=KCCA')
-    //fetch('http://127.0.0.1:5000/api/v1/dashboard/monitoringsites?organisation_name=KCCA')
+   fetch(constants.GET_MONITORING_SITES_URI)    
       .then(res => res.json())
       .then((contactData) => {
         setContacts(contactData.airquality_monitoring_sites)

--- a/analytics/src/views/Download/Download.js
+++ b/analytics/src/views/Download/Download.js
@@ -45,8 +45,7 @@ const Download = (props) => {
   const [filterLocations,setFilterLocations] = useState([]);
 
   useEffect(() => {
-    fetch(constants.GET_MONITORING_SITES_LOCATIONS_URI)
-    //fetch('http://127.0.0.1:5000/api/v1/dashboard/monitoringsites/locations?organisation_name=KCCA')
+    fetch(constants.GET_MONITORING_SITES_LOCATIONS_URI)    
       .then(res => res.json())
       .then((filterLocationsData) => {
         setFilterLocations(filterLocationsData.airquality_monitoring_sites)
@@ -124,9 +123,8 @@ const Download = (props) => {
     console.log(JSON.stringify(params));
   
    
-    axios.post(
-      'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/data/download',
-      //'http://localhost:5000/api/v1/data/download', 
+    axios.post(constants.DOWNLOAD_CUSTOMISED_DATA_URI
+      , 
       JSON.stringify(params),
       { headers: { 'Content-Type': 'application/json' } }
     ).then(res => res.data)

--- a/analytics/src/views/Download/Download.js
+++ b/analytics/src/views/Download/Download.js
@@ -7,10 +7,10 @@ import clsx from 'clsx';
 import DateFnsUtils from '@date-io/date-fns';
 import {MuiPickersUtilsProvider, KeyboardTimePicker, KeyboardDatePicker} from '@material-ui/pickers';
 import axios from 'axios';
-//import {PollutantCategory} from '../Dashboard/components'
 //import CsvDownloader from 'react-csv-downloader';
 import jsonexport from 'jsonexport'
 //import {CSVDownload} from 'react-csv';
+import constants from 'config/constants'
 const { Parser, transforms: { unwind } } = require('json2csv');
 const useStyles = makeStyles(theme => ({
   root: {
@@ -45,7 +45,7 @@ const Download = (props) => {
   const [filterLocations,setFilterLocations] = useState([]);
 
   useEffect(() => {
-    fetch('https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/dashboard/monitoringsites/locations?organisation_name=KCCA')
+    fetch(constants.GET_MONITORING_SITES_LOCATIONS_URI)
     //fetch('http://127.0.0.1:5000/api/v1/dashboard/monitoringsites/locations?organisation_name=KCCA')
       .then(res => res.json())
       .then((filterLocationsData) => {

--- a/analytics/src/views/Graphs/Graphs.js
+++ b/analytics/src/views/Graphs/Graphs.js
@@ -17,6 +17,7 @@ import LoadingSpinner from './loadingSpinner';
 import 'chartjs-plugin-annotation';
 import html2canvas from 'html2canvas';
 import { Done } from '@material-ui/icons';
+import constants from 'config/constants'
 //import * as jsPDF from 'jspdf';
 //import domtoimage from 'dom-to-image';
 
@@ -86,8 +87,7 @@ const Graphs = props => {
 
     axios
       .post(
-        'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/device/graph',
-        //'http://127.0.0.1:5000/api/v1/device/graph',
+        constants.GENERATE_DEVICE_GRAPH_URI,
         JSON.stringify(effectFilter),
         { headers: { 'Content-Type': 'application/json' } }
       )
@@ -147,9 +147,9 @@ const Graphs = props => {
 
   useEffect(() => {
     fetch(
-      'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/dashboard/monitoringsites/locations?organisation_name=KCCA'
+      constants.GET_MONITORING_SITES_LOCATIONS_URI
     )
-      //fetch('http://127.0.0.1:5000/api/v1/dashboard/monitoringsites/locations?organisation_name=KCCA')
+      
       .then(res => res.json())
       .then(filterLocationsData => {
         setFilterLocations(filterLocationsData.airquality_monitoring_sites);
@@ -384,8 +384,7 @@ const Graphs = props => {
 
     axios
       .post(
-        'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/device/graph',
-        //'http://127.0.0.1:5000/api/v1/device/graph',
+        constants.GENERATE_DEVICE_GRAPH_URI,        
         JSON.stringify(filter),
         { headers: { 'Content-Type': 'application/json' } }
       )

--- a/analytics/src/views/Locations/LocationList.js
+++ b/analytics/src/views/Locations/LocationList.js
@@ -5,7 +5,7 @@ import ChevronRightIcon from '@material-ui/icons/ChevronRight';
 import ChevronLeftIcon from '@material-ui/icons/ChevronLeft';
 
 import { LocationsToolbar, LocationCard } from './components';
-//import mockData from './data';
+import constants from '../../config/constants'
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -29,8 +29,7 @@ const LocationList = () => {
   const [locations,setLocations ] = useState([]);
 
   useEffect(() => {
-    fetch('https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/dashboard/monitoringsites?organisation_name=KCCA')
-    //fetch('http://127.0.0.1:5000/api/v1/dashboard/monitoringsites?organisation_name=KCCA')
+    fetch(constants.GET_MONITORING_SITES_LOCATIONS_URI)
       .then(res => res.json())
       .then((locationData) => {
         setLocations(locationData.airquality_monitoring_sites)

--- a/analytics/src/views/ReportTemplate/Main.js
+++ b/analytics/src/views/ReportTemplate/Main.js
@@ -25,6 +25,7 @@ import { Editor } from 'react-draft-wysiwyg';
 import 'react-draft-wysiwyg/dist/react-draft-wysiwyg.css';
 import '../../assets/scss/report.css';
 import axios from 'axios';
+import constants from 'config/constants';
 
 class Main extends Component {
   constructor(props) {
@@ -63,12 +64,8 @@ class Main extends Component {
   };
 
   componentDidMount() {
-    // local: http://127.0.0.1:4000
     axios
-      .get(
-        'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/report/get_default_report_template'
-      )
-      //.get("http://127.0.0.1:5000/api/v1/report/get_default_report_template")
+      .get(constants.GET_DEFAULT_REPORT_TEMPLATE_URI)     
       .then(res => {
         let result = res.data[0];
         this.setState({
@@ -116,8 +113,7 @@ class Main extends Component {
     // make api call to save report
     axios
       .post(
-        'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/report/save_monthly_report',
-        //"http://127.0.0.1:5000/api/v1/report/save_monthly_report",
+        constants.SAVE_MONTHLY_REPORT_URI,        
         {
           user_id: this.state.user_id,
           report_name: this.state.report_name,
@@ -159,8 +155,7 @@ class Main extends Component {
   handlePrevSavedOpen = () => {
     axios
       .get(
-        'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/report/get_monthly_report/' +
-          //"http://127.0.0.1:5000/api/v1/report/get_monthly_report/" +
+        constants.GET_MONTHLY_REPORT_URI+          
           this.state.user_id
       )
       .then(res => {
@@ -196,7 +191,7 @@ class Main extends Component {
     // make api call to save report
     axios
       .delete(
-        'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/report/delete_monthly_report/' +
+        constants.DELETE_MONTHLY_REPORT_URI+
           report_name
       )
       .then(res => {
@@ -222,7 +217,7 @@ class Main extends Component {
   onUpdateDraft = () => {
     axios
       .post(
-        'https://analytcs-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/report/update_monthly_report/' +
+         constants.UPDATE_MONTHLY_REPORT_URI+
           this.state.report_name,
         {
           report_body: convertToRaw(this.state.editorState.getCurrentContent())

--- a/analytics/src/views/Reports/graph.js
+++ b/analytics/src/views/Reports/graph.js
@@ -8,7 +8,7 @@ import Select from 'react-select';
 import DateFnsUtils from '@date-io/date-fns';
 import {MuiPickersUtilsProvider, KeyboardTimePicker, KeyboardDatePicker} from '@material-ui/pickers';
 import axios from 'axios';
-
+import constants from 'config/constants'
 const useStyles = makeStyles(theme => ({
   root: {
     padding: theme.spacing(3)
@@ -69,7 +69,7 @@ const Graphs = props => {
   const [filterLocations,setFilterLocations] = useState([]);
 
   useEffect(() => {
-    fetch('http://127.0.0.1:5000/api/v1/dashboard/monitoringsites/locations?organisation_name=KCCA')
+    fetch(constants.GET_MONITORING_SITES_LOCATIONS_URI)
       .then(res => res.json())
       .then((filterLocationsData) => {
         setFilterLocations(filterLocationsData.airquality_monitoring_sites)
@@ -81,8 +81,7 @@ const Graphs = props => {
 
   const [values, setReactSelectValue] = useState({ selectedOption: [] });
 
-  const handleMultiChange = selectedOption => {
-    //setValue('reactSelect', selectedOption);
+  const handleMultiChange = selectedOption => {    
     setReactSelectValue({ selectedOption });
   }
 
@@ -137,7 +136,7 @@ const Graphs = props => {
     console.log(JSON.stringify(filter));
 
     axios.post(
-      'http://127.0.0.1:5000/api/v1/device/graph', 
+      constants.GENERATE_DEVICE_GRAPH_URI, 
       JSON.stringify(filter),
       { headers: { 'Content-Type': 'application/json' } }
     )


### PR DESCRIPTION
**What does this PR do?**
    - Tidies up title on customisable charts 
    - Refactors out analytics endpoint URIs to same location for the various environments (config/constants.js)
**Which JIRA card(s)?**
    - [https://airqoteam.atlassian.net/jira/software/projects/NLYTCS/boards/29?assignee=5d922cc14258550c23a16713&selectedIssue=NLYTCS-102](https://airqoteam.atlassian.net/jira/software/projects/NLYTCS/boards/29?assignee=5d922cc14258550c23a16713&selectedIssue=NLYTCS-102)
**How do I test out this PR?**
-  git fetch branch  **ft-tidy-up-chart-title**  
- run npm install to get all the necessary dependencies. 
- After, run npm run local /or npm run prod to view the changes. 
- Remember to have the backend service running as well (https://github.com/airqo-platform/AirQo-api/pull/103). 

**Which changes should be /are ready for testing?**
 - Check out the titles of the customisable graphs
 ![image](https://user-images.githubusercontent.com/8258229/87437801-6dec0600-c5f7-11ea-8dc2-7e78a9f21a30.png)
 - Observe the file changes to view the refactored endpoints URIs

