### PR TITLE
[GCE k8s deployment] updating Netmanager endpoints 

### DIFF
--- a/locate/src/config/constants.js
+++ b/locate/src/config/constants.js
@@ -1,35 +1,15 @@
-/*const constants = {
-  RUN_LOCATE_MODEL:
-    "https://locate-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/map/parishes",
-    //"http://localhost:4001/api/v1/map/parishes",
-  SAVE_LOCATE_MAP:
-    "https://locate-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/map/savelocatemap",
-  GET_LOCATE_MAP:
-    "https://locate-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/map/getlocatemap/",
-  UPDATE_LOCATE_MAP:
-    "https://locate-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/map/updatelocatemap/",
-  DELETE_LOCATE_MAP:
-    "https://locate-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/map/deletelocatemap/",
-  GET_DEVICE_STATUS_SUMMARY:
-    //"http://localhost:6000/api/v1/device/monitor/status",
-    "https://device-monitoring-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/device/monitor/status"
-};*/
-
 const prodConfig = {
-  VERIFY_TOKEN_URI: "https://airqo-250220.uc.r.appspot.com/api/v1/users/reset",
+  VERIFY_TOKEN_URI: "http://34.78.78.202:30000/api/v1/users/reset",
   UPDATE_PWD_URI:
-    "https://airqo-250220.uc.r.appspot.com/api/v1/users/updatePasswordViaEmail",
-  FORGOT_PWD_URI:
-    "https://airqo-250220.uc.r.appspot.com/api/v1/users/forgotPassword",
-  LOGIN_USER_URI:
-    "https://airqo-250220.uc.r.appspot.com/api/v1/users/loginUser",
-  REGISTER_USER_URI:
-    "https://airqo-250220.uc.r.appspot.com/api/v1/users/registerUser",
+    "http://34.78.78.202:30000/api/v1/users/updatePasswordViaEmail",
+  FORGOT_PWD_URI: "http://34.78.78.202:30000/api/v1/users/forgotPassword",
+  LOGIN_USER_URI: "http://34.78.78.202:30000/api/v1/users/loginUser",
+  REGISTER_USER_URI: "http://34.78.78.202:30000/api/v1/users/registerUser",
   REGISTER_CANDIDATE_URI:
-    "https://airqo-250220.uc.r.appspot.com/api/v1/users/registerCandidate",
-  REJECT_USER_URI: "https://airqo-250220.uc.r.appspot.com/api/v1/users/deny",
-  ACCEPT_USER_URI: "https://airqo-250220.uc.r.appspot.com/api/v1/users/accept",
-  GET_USERS_URI: "https://airqo-250220.uc.r.appspot.com/api/v1/users/",
+    "http://34.78.78.202:30000/api/v1/users/registerCandidate",
+  REJECT_USER_URI: "http://34.78.78.202:30000/api/v1/users/deny",
+  ACCEPT_USER_URI: "http://34.78.78.202:30000/api/v1/users/accept",
+  GET_USERS_URI: "http://34.78.78.202:30000/api/v1/users/",
   ALL_LOCATIONS_URI:
     "http://34.78.78.202:30005/api/v1/location_registry/locations",
   CREATE_ID_URI: "http://34.78.78.202:30005/api/v1/location_registry/create_id",
@@ -41,18 +21,11 @@ const prodConfig = {
     "http://34.78.78.202:30005/api/v1/location_registry/edit?loc_ref=",
   UPDATE_LOCATION_URI:
     "http://34.78.78.202:30005/api/v1/location_registry/update",
-  RUN_LOCATE_MODEL:
-    "https://locate-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/map/parishes",
-  SAVE_LOCATE_MAP:
-    "https://locate-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/map/savelocatemap",
-  GET_LOCATE_MAP:
-    "https://locate-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/map/getlocatemap/",
-  UPDATE_LOCATE_MAP:
-    "https://locate-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/map/updatelocatemap/",
-  DELETE_LOCATE_MAP:
-    "https://locate-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/map/deletelocatemap/",
-  // GET_DEVICE_STATUS_SUMMARY:
-  //   "https://device-monitoring-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/device/monitor/status",
+  RUN_LOCATE_MODEL: "http://34.78.78.202:30004/api/v1/map/parishes",
+  SAVE_LOCATE_MAP: "http://34.78.78.202:30004/api/v1/map/savelocatemap",
+  GET_LOCATE_MAP: "http://34.78.78.202:30004/api/v1/map/getlocatemap/",
+  UPDATE_LOCATE_MAP: "http://34.78.78.202:30004/api/v1/map/updatelocatemap/",
+  DELETE_LOCATE_MAP: "http://34.78.78.202:30004/api/v1/map/deletelocatemap/",
   GET_DEVICE_STATUS_SUMMARY:
     "http://34.78.78.202:30006/api/v1/device/monitor/status",
   GET_DEVICE_MAINTENANCE_LOG:
@@ -60,25 +33,22 @@ const prodConfig = {
   GET_DEVICE_POWER_TYPE:
     "http://34.78.78.202:30006/api/v1/device/monitor/power_type",
   GET_DEVICE_STATUS_FOR_PIECHART_DISPLAY:
-    "https://device-monitoring-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/device/monitor/status/latest",
+    "http://34.78.78.202:30006/api/v1/device/monitor/status/latest",
   GET_LATEST_OFFLINE_DEVICES:
-    "https://device-monitoring-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/monitor/devices/offline",
-  GET_NETWORK_UPTIME:
-    "https://device-monitoring-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/monitor/network/uptime",
+    "http://34.78.78.202:30006/api/v1/monitor/devices/offline",
+  GET_NETWORK_UPTIME: "http://34.78.78.202:30006/api/v1/monitor/network/uptime",
   ADD_MAINTENANCE_URI:
-    "https://data-manager-dot-airqo-250220.uc.r.appspot.com/api/v1/data/channels/maintenance/add",
-  REGISTER_DEVICE_URI:
-    "https://device-registry-dot-airqo-250220.uc.r.appspot.com/api/v1/devices/ts",
-  ALL_DEVICES_URI:
-    "https://device-registry-dot-airqo-250220.uc.r.appspot.com/api/v1/devices",
+    "http://34.78.78.202:30001/api/v1/data/channels/maintenance/add",
+  REGISTER_DEVICE_URI: "http://34.78.78.202:30002/api/v1/devices/ts",
+  ALL_DEVICES_URI: "http://34.78.78.202:30002/api/v1/devices",
   DEPLOY_DEVICE_URI:
-    "https://device-registry-dot-airqo-250220.uc.r.appspot.com/api/v1/devices/ts/deploy/device",
+    "http://34.78.78.202:30002/api/v1/devices/ts/deploy/device",
   DELETE_DEVICE_URI:
-    "https://device-registry-dot-airqo-250220.uc.r.appspot.com/api/v1/devices/ts/delete?device=",
+    "http://34.78.78.202:30002/api/v1/devices/ts/delete?device=",
   GET_NETWORK_BEST_PERFORMING_DEVICES:
-    "https://device-monitoring-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/monitor/network/devices/bestperforming",
+    "http://34.78.78.202:30006/api/v1/monitor/network/devices/bestperforming",
   GET_NETWORK_WORST_PERFORMING_DEVICES:
-    "https://device-monitoring-bknd-service-dot-airqo-250220.uc.r.appspot.com/api/v1/monitor/network/devices/worstperforming",
+    "http://34.78.78.202:30006/api/v1/monitor/network/devices/worstperforming",
 };
 
 const devConfig = {


### PR DESCRIPTION
- What does this PR do?
This PR updates the configs/constants for netmanager using the k8s cluster deployment urls. Targets all microservice URLs.

- What JIRA task is related to this PR?
No link available

- How do I test out this PR?
Run the following commands in order:
```
cd AirQo-frontend/locate
git checkout master
git pull
git checkout hotfix-netmanager-endpoints
npm install
npm run prod
```
Try to login using the Super Admin user and password - since that account already exists and voila!


