### PR TITLE
fix netmanager top cards issues

### DIFF
--- a/locate/src/views/components/DataDisplay/DeviceManagement.js
+++ b/locate/src/views/components/DataDisplay/DeviceManagement.js
@@ -272,7 +272,8 @@ export default function DeviceManagement() {
     axios.get(constants.GET_DEVICE_STATUS_SUMMARY).then(({ data }) => {
       //console.log(data[0].loc_power_suppy);
       let no_devices = 0;
-      [data].map((item) => { //Priscilla added array to data- Daniel needs to cross check why api is not returning array
+      data.map((item) => {
+        //Priscilla added array to data- Daniel needs to cross check why api is not returning array
         no_devices++;
       });
       setStatusSummary(data);
@@ -309,7 +310,8 @@ export default function DeviceManagement() {
       let due_maintenance = 0;
       let overdue_maintenance = 0;
 
-      [data].map((item) => { //Priscilla added array to data- Daniel needs to cross check why api is not returning array
+      data.map((item) => {
+        //Priscilla added array to data- Daniel needs to cross check why api is not returning array
         let nextMaintenance = item.nextMaintenance;
         // next maintenance === "" assume overdue for maintenance
         if (nextMaintenance == "") {


### PR DESCRIPTION
**What does this PR do?**
This PR basically removes the array added to `data` in the frontend GET request using `axios`. 
**What JIRA task is related to this PR?**
N/A
**How do I test out this PR?**
Git clone this repo, cd to `locate`, run `npm run local` and observe the numbers showing up in the cards without any error. Also, see screenshot attached to compare with your results. Remember to run the [backend service](https://github.com/airqo-platform/AirQo-api/pull/127) simultaneously 


![Screenshot 2020-08-04 at 13 11 38](https://user-images.githubusercontent.com/15224992/89283343-ae1e3180-d655-11ea-9f83-dd57035b8ee0.png)