### PR TITLE
added component section on device view page

### DIFF
--- a/netmanager/src/views/components/DataDisplay/DeviceView.js
+++ b/netmanager/src/views/components/DataDisplay/DeviceView.js
@@ -939,6 +939,56 @@ export default function DeviceView() {
         </GridItem>
       </GridContainer>
 
+      <GridContainer>
+      <GridItem xs={12} sm={12} md={4}>
+          <Card>
+            <CardHeader color="info">
+              <h4 className={classes.cardTitle}>Device Components</h4>
+            </CardHeader>
+            <CardBody>
+            <div alignContent = "left" style = {{alignContent:"left", alignItems:"left"}}>
+            <TableContainer component={Paper} className = {classes.table}>  
+             <Table stickyHeader  aria-label="sticky table" alignItems="left" alignContent="left">
+               <TableHead>
+                 <TableRow style={{ align: 'left' }} >  
+                  <TableCell>Description</TableCell>                  
+                  <TableCell>Quantities</TableCell>
+                  <TableCell>Actions</TableCell>
+                </TableRow>
+                 
+              </TableHead>  
+               <TableBody style = {{alignContent:"left", alignItems:"left"}} >  
+               {componentsData.map( (component) => (
+                 <TableRow style={{ align: 'left' }} >  
+                  <TableCell>{component.description}</TableCell>                  
+                  <TableCell>{jsonArrayToString(component.measurement)}</TableCell>
+                  <TableCell>
+                  
+                  <Tooltip title="Edit">
+                    <Link onClick= {handleEditComponentClick(deviceName, component.name, component.description, jsonArrayToString(component.measurement).split(", "))} style = {{"color":"black"}}>
+                    <EditOutlined> </EditOutlined> 
+                    </Link>
+                    </Tooltip>
+                  <Tooltip title="Delete">
+                    <Link onClick= {handleDeleteComponentClick(component.name)} style = {{"color":"black"}}>
+                    <DeleteOutlined> </DeleteOutlined> 
+                    </Link>
+                  </Tooltip>
+                  
+                  </TableCell>
+                </TableRow>))
+                }
+               </TableBody>
+            </Table>
+          </TableContainer>
+                
+              </div>
+             
+            </CardBody>
+          </Card>
+      </GridItem> 
+      </GridContainer>
+
       {responseOpen?
     (
       <Dialog


### PR DESCRIPTION
**What does this PR do?**
    -  restores component section on device view page
      
**Which JIRA card(s)?**
    n/a
**How do I test out this PR?**
-  git fetch branch  **ft-detail-page-component-section**  
- change directory to airqo-frontend/netmanager 
- run npm install to get all the necessary dependencies. 
- After, run npm run local  
**Which changes should be /are ready for testing?**
 - Confirm that device components table displays on the device details page (demo with device aq_04
NB: Ensure to run the backend services for device registry and device monitoring using this latest master
![image](https://user-images.githubusercontent.com/8258229/90768041-d1eca300-e2f6-11ea-9334-2cc344cf89f9.png)
![image](https://user-images.githubusercontent.com/8258229/90768107-e761cd00-e2f6-11ea-898c-6f02a5f22ecb.png)
