### PR TITLE
Changing the title of the Analytics dashboard

### DIFF
--- a/netmanager/src/views/pages/Dashboard/Dashboard.js
+++ b/netmanager/src/views/pages/Dashboard/Dashboard.js
@@ -383,7 +383,9 @@ const Dashboard = (props) => {
 
   return (
     <div className={classes.root}>
-      <h4>Number of nodes at each AQI risk level</h4>
+      <h4>Welcome to the AirQo ANALYTICS dashboard</h4>
+      <br />
+      <h6>Number of nodes at each AQI risk level</h6>
       <br />
       <Grid container spacing={4}>
         <Grid item lg={2} sm={6} xl={2} xs={12}>
@@ -530,12 +532,10 @@ const Dashboard = (props) => {
 
         <Grid item lg={6} md={6} sm={12} xl={6} xs={12}>
           <Grid item lg={12} sm={12} xl={12} xs={12}>
-          <div className={classes.mapContainer}>
-              <Map/>
+            <div className={classes.mapContainer}>
+              <Map />
             </div>
           </Grid>
-
-          
         </Grid>
 
         <Grid item lg={6} md={6} sm={12} xl={6} xs={12}>


### PR DESCRIPTION
- What does this PR do?

This PR changes the title of the Analytics dashboard.

![image](https://user-images.githubusercontent.com/1590213/93204457-cdcd6d00-f75e-11ea-9bd2-0c5f89e0f3ad.png)


- How do I test out this PR?

cd AirQo-frontend/netmanager
npm install

> for MAC

npm run stage-mac

> for Windows

npm run stage-pc

- Any other considerations?

node version: v12.18.1