### PR TITLE
fix for displayig all labels on the bars for exceedance chart and mean for the past 28 days

### DIFF
--- a/analytics/src/views/Dashboard/Dashboard.js
+++ b/analytics/src/views/Dashboard/Dashboard.js
@@ -45,7 +45,7 @@ const useStyles = makeStyles((theme) => ({
     color: theme.palette.text.secondary,
   },
   chartContainer: {
-    height: 180,
+    height: 250,
     position: "relative",
   },
   actions: {
@@ -213,7 +213,7 @@ const Dashboard = (props) => {
       ],
     },
     responsive: true,
-    maintainAspectRatio: false,
+    //maintainAspectRatio: false,
     animation: false,
     legend: { display: false },
     cornerRadius: 0,

--- a/analytics/src/views/Dashboard/components/ExceedancesChart/ExceedancesChart.js
+++ b/analytics/src/views/Dashboard/components/ExceedancesChart/ExceedancesChart.js
@@ -499,7 +499,7 @@ const ExceedancesChart = props => {
             }],
           },
         
-          maintainAspectRatio: false,
+          maintainAspectRatio: true,
           responsive: true
           }}/>
         </div>


### PR DESCRIPTION

**What does this PR do?**
    - addresses the issue for displayig all labels on the bars for exceedance chart and mean for the past 28 days
  
**Which JIRA card(s)?**
    - [https://airqoteam.atlassian.net/browse/PLAT-89?atlOrigin=eyJpIjoiYTE2NTI2MTQ2MTdmNDlmZmIzMmQ5ZmM2Y2M2MTMzZWMiLCJwIjoiaiJ9](https://airqoteam.atlassian.net/browse/PLAT-89?atlOrigin=eyJpIjoiYTE2NTI2MTQ2MTdmNDlmZmIzMmQ5ZmM2Y2M2MTMzZWMiLCJwIjoiaiJ9)
**How do I test out this PR?**
-  git fetch branch  **fx-exceedances**  
- change directory to airqo-frontend/analytics(analytics project)
- checkout the fx-exceedances branch
- run npm install to get all the necessary dependencies. 
- After, run npm run local  
**Which changes should be /are ready for testing?**
 - Confirm that   all labels are displayed on the bar graphs for exceedances and graph for mean for the past 28 days 
![image](https://user-images.githubusercontent.com/8258229/93427006-b957b480-f8c5-11ea-81c0-d2851d418afc.png)


