### PR TITLE
fix for displayig all labels on the bars for exceedance chart and mea…

### DIFF
--- a/netmanager/src/views/pages/Dashboard/Dashboard.js
+++ b/netmanager/src/views/pages/Dashboard/Dashboard.js
@@ -46,7 +46,7 @@ const useStyles = makeStyles((theme) => ({
     color: theme.palette.text.secondary,
   },
   chartContainer: {
-    height: 180,
+    height: 250,
     position: "relative",
   },
   mapContainer: {
@@ -221,7 +221,7 @@ const Dashboard = (props) => {
       ],
     },
     responsive: true,
-    maintainAspectRatio: false,
+    maintainAspectRatio: true,
     animation: false,
     legend: { display: false },
     cornerRadius: 0,

--- a/netmanager/src/views/pages/Dashboard/components/ExceedancesChart/ExceedancesChart.js
+++ b/netmanager/src/views/pages/Dashboard/components/ExceedancesChart/ExceedancesChart.js
@@ -499,7 +499,7 @@ const ExceedancesChart = props => {
             }],
           },
         
-          maintainAspectRatio: false,
+          maintainAspectRatio: true,
           responsive: true
           }}/>
         </div>


### PR DESCRIPTION
**What does this PR do?**
    - addresses the issue for displayig all labels on the bars for exceedance chart and mean for the past 28 days
  
**Which JIRA card(s)?**
    - [https://airqoteam.atlassian.net/browse/PLAT-89?atlOrigin=eyJpIjoiYTE2NTI2MTQ2MTdmNDlmZmIzMmQ5ZmM2Y2M2MTMzZWMiLCJwIjoiaiJ9](https://airqoteam.atlassian.net/browse/PLAT-89?atlOrigin=eyJpIjoiYTE2NTI2MTQ2MTdmNDlmZmIzMmQ5ZmM2Y2M2MTMzZWMiLCJwIjoiaiJ9)
**How do I test out this PR?**
-  git fetch branch  **fx-exceedances-netmanager**  
- change directory to airqo-frontend/analytics(analytics project)
- checkout the fx-exceedances-netmanager branch
- run npm install to get all the necessary dependencies. 
- After, run npm run local  
**Which changes should be /are ready for testing?**
 - Confirm that   all labels are displayed on the bar graphs for exceedances and graph for mean for the past 28 days 
![image](https://user-images.githubusercontent.com/8258229/93427006-b957b480-f8c5-11ea-81c0-d2851d418afc.png)

![image](https://user-images.githubusercontent.com/8258229/93466820-7d3c4800-f8f5-11ea-8758-69a5a5e77680.png)

