### PR TITLE
[NetManager] enable user and account settings update

### DIFF
--- a/netmanager/src/App.js
+++ b/netmanager/src/App.js
@@ -84,8 +84,15 @@ if (localStorage.jwtToken) {
   setAuthToken(token);
   // Decode token and get user info and exp
   const decoded = jwt_decode(token);
+  let currentUser = decoded
+
+  if (localStorage.currentUser) {
+    try {
+      currentUser = JSON.parse(localStorage.currentUser)
+    } catch(error){}
+  }
   // Set user and isAuthenticated
-  store.dispatch(setCurrentUser(decoded));
+  store.dispatch(setCurrentUser(currentUser));
   // Check for expired token
   const currentTime = Date.now() / 1000; // to get in milliseconds
   if (decoded.exp < currentTime) {

--- a/netmanager/src/redux/Join/actions.js
+++ b/netmanager/src/redux/Join/actions.js
@@ -230,6 +230,7 @@ export const editUser = userToEdit => (dispatch, getState) => {
       .then(response => {
           if (response) {
             dispatch(editUserSuccess(response.data, response.data.message));
+            dispatch(fetchUsers())
           } else {
             dispatch(editUserFailed(response.data.message));
           }

--- a/netmanager/src/redux/Join/actions.js
+++ b/netmanager/src/redux/Join/actions.js
@@ -506,30 +506,15 @@ export const confirmUserFailed = error => {
 };
 
 /**********************update the user password  ***********************************/
-export const updatePassword = userData => dispatch => {
+export const updatePassword = userData => (dispatch, getState) => {
+  const state = getState()
+  const id = state.auth.user._id
+  const tenant = state.organisation.name
   axios
-    .put(constants.UPDATE_PWD_IN_URI, userData)
-    .then(response => {
-      console.log(response.data);
-      if (response.data.success === true) {
-        dispatch({
-          type: UPDATE_PASSWORD_SUCCESS,
-          payload: response.data.result
-        });
-      } else {
-        dispatch({
-          type: UPDATE_PASSWORD_FAILED,
-          payload: response.data.err
-        });
-      }
-    })
-    .catch(error => {
-      console.log(error.data);
-      dispatch({
-        type: GET_ERRORS,
-        payload: error.response
-      });
-    });
+      .put(constants.UPDATE_PWD_IN_URI, userData, { params: { id, tenant } })
+      .then(response => response.data)
+      .then(data => dispatch({ type: UPDATE_PASSWORD_SUCCESS, payload: data.result}))
+      .catch(error => dispatch({type: GET_ERRORS, payload: error.response}));
 };
 
 /***************************update the user profile ******************** */

--- a/netmanager/src/redux/Join/actions.js
+++ b/netmanager/src/redux/Join/actions.js
@@ -642,26 +642,24 @@ export const fetchDefaultsFailed = error => {
 };
 
 /********************* update authenticated user ************************/
-export const updateAuthenticatedUser = newData => dispatch => {
+export const updateAuthenticatedUser = newData => (dispatch, getState) => {
   dispatch(updateAuthenticatedUserRequest());
-
-  return axios({
-    method: 'put',
-    url: constants.GET_USERS_URI + `${newData.id}`,
-    data: newData
-  })
-    .then(response => {
-      if (response) {
-        dispatch(
-          updateAuthenticatedUserSuccess(response.data, response.data.message)
-        );
-      } else {
-        dispatch(updateAuthenticatedUserFailed(response.data.message));
-      }
-    })
-    .catch(e => {
-      dispatch(updateAuthenticatedUserFailed(e));
-    });
+  const id = getState().auth.user._id
+  const tenant = getState().organisation.name
+  return axios
+      .put(constants.GET_USERS_URI, newData, { params: {id, tenant}})
+      .then(response => {
+        if (response) {
+          dispatch(
+            updateAuthenticatedUserSuccess(response.data, response.data.message)
+          );
+        } else {
+          dispatch(updateAuthenticatedUserFailed(response.data.message));
+        }
+      })
+      .catch(e => {
+        dispatch(updateAuthenticatedUserFailed(e));
+      });
 };
 
 export const updateAuthenticatedUserRequest = () => {

--- a/netmanager/src/redux/Join/actions.js
+++ b/netmanager/src/redux/Join/actions.js
@@ -362,6 +362,7 @@ export const loginUser = userData => dispatch => {
         setAuthToken(token);
         // Decode token to get user data
         const decoded = jwt_decode(token);
+        localStorage.setItem('currentUser', JSON.stringify(decoded))
         // Set current user
         dispatch(setCurrentUser(decoded));
         dispatch(updateOrganization({name: decoded.organization}))

--- a/netmanager/src/redux/Join/reducers/authReducer.js
+++ b/netmanager/src/redux/Join/reducers/authReducer.js
@@ -48,7 +48,7 @@ export default function(state = initialState, action) {
         case UPDATE_AUTHENTICATED_USER_SUCCESS:
             return {
                 ...state,
-                user: state.user,
+                user: action.payload,
                 updating: false
             };
         case UPDATE_AUTHENTICATED_USER_FAILED:

--- a/netmanager/src/views/apis/authService.js
+++ b/netmanager/src/views/apis/authService.js
@@ -8,3 +8,9 @@ export const updateUserPasswordApi = async (userId, tenant, userData) => {
     })
     .then((response) => response.data);
 };
+
+export const updateAuthenticatedUserApi = async (userId, tenant, userData) => {
+  return await axios
+    .put(constants.GET_USERS_URI, userData, { params: { tenant, id: userId } })
+    .then((response) => response.data);
+};

--- a/netmanager/src/views/apis/authService.js
+++ b/netmanager/src/views/apis/authService.js
@@ -1,0 +1,10 @@
+import axios from "axios";
+import constants from "../../config/constants";
+
+export const updateUserPasswordApi = async (userId, tenant, userData) => {
+  return await axios
+    .put(constants.UPDATE_PWD_IN_URI, userData, {
+      params: { tenant, id: userId },
+    })
+    .then((response) => response.data);
+};

--- a/netmanager/src/views/components/Loader/CircularLoader.js
+++ b/netmanager/src/views/components/Loader/CircularLoader.js
@@ -1,0 +1,48 @@
+import React from "react";
+import { makeStyles, createStyles } from "@material-ui/core/styles";
+import Fade from "@material-ui/core/Fade";
+import CircularProgress from "@material-ui/core/CircularProgress";
+import PropTypes from "prop-types";
+
+const useStyles = makeStyles((theme) =>
+  createStyles({
+    root: {
+      display: "flex",
+      flexDirection: "column",
+      alignItems: "center",
+    },
+    button: {
+      margin: theme.spacing(2),
+    },
+    placeholder: {
+      minHeight: 30,
+    },
+  })
+);
+
+export const CircularLoader = ({ loading, size }) => {
+  const classes = useStyles();
+
+  return (
+    <div className={classes.root}>
+      <div className={classes.placeholder}>
+        <Fade
+          in={loading}
+          style={{
+            transitionDelay: loading ? "500ms" : "0ms",
+          }}
+          unmountOnExit
+        >
+          <CircularProgress size={size || 30} />
+        </Fade>
+      </div>
+    </div>
+  );
+};
+
+CircularLoader.propTypes = {
+  loading: PropTypes.bool.isRequired,
+  size: PropTypes.number,
+};
+
+export default CircularLoader;

--- a/netmanager/src/views/layouts/Main/components/Topbar/Topbar.js
+++ b/netmanager/src/views/layouts/Main/components/Topbar/Topbar.js
@@ -18,6 +18,7 @@ import MenuIcon from "@material-ui/icons/Menu";
 import NotificationsIcon from "@material-ui/icons/NotificationsOutlined";
 import InputIcon from "@material-ui/icons/Input";
 import { logoutUser } from "redux/Join/actions";
+import { useOrgData } from "../../../../../redux/Join/selectors";
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -43,11 +44,12 @@ const Topbar = (props) => {
   const divProps = Object.assign({}, props);
   delete divProps.layout;
   const { className, onSidebarOpen, ...rest } = props;
-  const { user } = props.auth;
 
   const classes = useStyles();
 
   const [notifications] = useState([]);
+  const orgData = useOrgData();
+
   const kcca_logo_style = {
     height: "3.5em",
     width: "4em",
@@ -163,6 +165,16 @@ const Topbar = (props) => {
             src="/images/logos/mak_logo.jpg"
           />
         </RouterLink>
+        <div
+          style={{
+            textTransform: "uppercase",
+            marginLeft: "10px",
+            fontSize: 20,
+            fontWeight: "bold",
+          }}
+        >
+          {orgData.name}
+        </div>
         <p style={timer_style}>
           <span>{date.toLocaleString()}</span>
         </p>

--- a/netmanager/src/views/pages/Account/components/AccountDetails/AccountDetails.js
+++ b/netmanager/src/views/pages/Account/components/AccountDetails/AccountDetails.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import { useDispatch } from "react-redux";
 import { isEqual } from "underscore";
 import clsx from "clsx";
 import PropTypes from "prop-types";
@@ -17,6 +18,7 @@ import { useOrgData } from "../../../../../redux/Join/selectors";
 import { updateAuthenticatedUserApi } from "../../../../apis/authService";
 import Alert from "@material-ui/lab/Alert";
 import { CircularLoader } from "../../../../components/Loader/CircularLoader";
+import { updateAuthenticatedUserSuccess } from "../../../../../redux/Join/actions";
 
 const useStyles = makeStyles((theme) => ({
   container: {
@@ -42,6 +44,8 @@ const AccountDetails = (props) => {
   const { user } = mappedAuth;
 
   const classes = useStyles();
+
+  const dispatch = useDispatch();
 
   const initialState = {
     firstName: user.firstName,
@@ -93,6 +97,8 @@ const AccountDetails = (props) => {
     setLoading(true);
     await updateAuthenticatedUserApi(userId, tenant, form)
       .then((data) => {
+        localStorage.setItem("currentUser", JSON.stringify(data.user));
+        dispatch(updateAuthenticatedUserSuccess(data.user, data.message));
         setAlert({
           show: true,
           message: data.message,

--- a/netmanager/src/views/pages/Account/components/AccountDetails/AccountDetails.js
+++ b/netmanager/src/views/pages/Account/components/AccountDetails/AccountDetails.js
@@ -97,12 +97,20 @@ const AccountDetails = (props) => {
     setLoading(true);
     await updateAuthenticatedUserApi(userId, tenant, form)
       .then((data) => {
-        localStorage.setItem("currentUser", JSON.stringify(data.user));
-        dispatch(updateAuthenticatedUserSuccess(data.user, data.message));
+        if (data.success) {
+          localStorage.setItem("currentUser", JSON.stringify(data.user));
+          dispatch(updateAuthenticatedUserSuccess(data.user, data.message));
+          setAlert({
+            show: true,
+            message: data.message,
+            type: "success",
+          });
+          return;
+        }
         setAlert({
           show: true,
           message: data.message,
-          type: "success",
+          type: "error",
         });
       })
       .catch((err) => {

--- a/netmanager/src/views/pages/Account/components/AccountDetails/AccountDetails.js
+++ b/netmanager/src/views/pages/Account/components/AccountDetails/AccountDetails.js
@@ -1,190 +1,165 @@
-import React, { useState, useEffect } from 'react';
-import clsx from 'clsx';
-import PropTypes from 'prop-types';
-import { makeStyles } from '@material-ui/styles';
+import React, { useState, useEffect } from "react";
+import { isEqual } from "underscore";
+import clsx from "clsx";
+import PropTypes from "prop-types";
+import { makeStyles } from "@material-ui/styles";
 import {
-    Card,
-    CardHeader,
-    CardContent,
-    CardActions,
-    Divider,
-    Grid,
-    Button,
-    TextField
-} from '@material-ui/core';
+  Card,
+  CardHeader,
+  CardContent,
+  CardActions,
+  Divider,
+  Grid,
+  Button,
+  TextField,
+} from "@material-ui/core";
 
-const useStyles = makeStyles(theme => ({
-    container: {
-        display: 'flex',
-        flexWrap: 'wrap'
-    },
-    textField: {
-        marginLeft: theme.spacing.unit,
-        marginRight: theme.spacing.unit
-    },
-    dense: {
-        marginTop: 16
-    },
-    menu: {
-        width: 200
-    },
-    root: {}
+const useStyles = makeStyles((theme) => ({
+  container: {
+    display: "flex",
+    flexWrap: "wrap",
+  },
+  textField: {
+    marginLeft: theme.spacing.unit,
+    marginRight: theme.spacing.unit,
+  },
+  dense: {
+    marginTop: 16,
+  },
+  menu: {
+    width: 200,
+  },
+  root: {},
 }));
 
-const AccountDetails = props => {
-    const { className, mappeduserState, mappedAuth, ...rest } = props;
+const AccountDetails = (props) => {
+  const { className, mappeduserState, mappedAuth, ...rest } = props;
 
-    const { user } = mappedAuth;
-    console.log('the user is here: ');
-    console.dir(user);
+  const { user } = mappedAuth;
+  console.log("the user is here: ");
+  console.dir(user);
 
-    const classes = useStyles();
+  const classes = useStyles();
 
-    const initialState = {
-        firstName: user.firstName,
-        lastName: user.lastName,
-        email: user.email,
-        phoneNumber: ''
-    };
+  const initialState = {
+    firstName: user.firstName,
+    lastName: user.lastName,
+    email: user.email,
+    phoneNumber: "",
+  };
 
-    const [form, setState] = useState(initialState);
+  const [form, setState] = useState(initialState);
 
-    useEffect(() => {
-        var anchorElem = document.createElement('link');
-        anchorElem.setAttribute(
-            'href',
-            'https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css'
-        );
-        anchorElem.setAttribute('rel', 'stylesheet');
-        anchorElem.setAttribute('id', 'logincdn');
-    });
-
-    const handleChange = e => {
-        setState({
-            ...form,
-            [e.target.id]: e.target.value
-        });
-    };
-
-    const states = [{
-            value: 'Kyagwe',
-            label: 'Kyagwe'
-        },
-        {
-            value: 'Bukoto',
-            label: 'Bukoto'
-        },
-        {
-            value: 'Nansana',
-            label: 'Nansana'
-        }
-    ];
-
-    const clearState = () => {
-        setState({...initialState });
-    };
-
-    const onSubmit = e => {
-        e.preventDefault();
-        const userData = {
-            id: user._id,
-            firstName: form.firstName,
-            lastName: form.lastName,
-            email: form.email,
-            phoneNumber: form.phoneNumber
-        };
-        console.log('sending this guy here:');
-        console.log(userData);
-        props.mappedUpdateAuthenticatedUser(userData);
-        clearState();
-    };
-
-    return ( <
-        Card {...rest }
-        className = { clsx(classes.root, className) } >
-        <
-        form autoComplete = "off"
-        noValidate >
-        <
-        CardHeader subheader = "The information can be edited"
-        title = "Profile" / >
-        <
-        Divider / >
-        <
-        CardContent >
-        <
-        Grid container spacing = { 3 } >
-        <
-        Grid item md = { 6 }
-        xs = { 12 } >
-        <
-        TextField fullWidth helperText = "Please specify the first name"
-        label = "First name"
-        margin = "dense"
-        id = "firstName"
-        onChange = { handleChange }
-        required value = { form.firstName }
-        variant = "outlined" /
-        >
-        <
-        /Grid>{' '} <
-        Grid item md = { 6 }
-        xs = { 12 } >
-        <
-        TextField fullWidth label = "Last name"
-        margin = "dense"
-        id = "lastName"
-        onChange = { handleChange }
-        required value = { form.lastName }
-        variant = "outlined" /
-        >
-        <
-        /Grid>{' '} <
-        Grid item md = { 6 }
-        xs = { 12 } >
-        <
-        TextField fullWidth label = "Email Address"
-        margin = "dense"
-        id = "email"
-        onChange = { handleChange }
-        required value = { form.email }
-        variant = "outlined" /
-        >
-        <
-        /Grid>{' '} <
-        Grid item md = { 6 }
-        xs = { 12 } >
-        <
-        TextField fullWidth label = "Phone Number"
-        margin = "dense"
-        id = "phoneNumber"
-        onChange = { handleChange }
-        value = { form.phoneNumber }
-        variant = "outlined" /
-        >
-        <
-        /Grid>{' '} <
-        /Grid>{' '} <
-        /CardContent>{' '} <
-        Divider / >
-        <
-        CardActions >
-        <
-        Button color = "primary"
-        variant = "contained"
-        onClick = { onSubmit }
-        disabled >
-        Save details { ' ' } <
-        /Button>{' '} <
-        /CardActions>{' '} <
-        /form>{' '} <
-        /Card>
+  useEffect(() => {
+    var anchorElem = document.createElement("link");
+    anchorElem.setAttribute(
+      "href",
+      "https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css"
     );
+    anchorElem.setAttribute("rel", "stylesheet");
+    anchorElem.setAttribute("id", "logincdn");
+  });
+
+  const handleChange = (e) => {
+    setState({
+      ...form,
+      [e.target.id]: e.target.value,
+    });
+  };
+
+  const clearState = () => {
+    setState({ ...initialState });
+  };
+
+  const onSubmit = (e) => {
+    e.preventDefault();
+    const userData = {
+      id: user._id,
+      firstName: form.firstName,
+      lastName: form.lastName,
+      email: form.email,
+      phoneNumber: form.phoneNumber,
+    };
+    props.mappedUpdateAuthenticatedUser(userData);
+    clearState();
+  };
+
+  return (
+    <Card {...rest} className={clsx(classes.root, className)}>
+      <form autoComplete="off" noValidate>
+        <CardHeader subheader="The information can be edited" title="Profile" />
+        <Divider />
+        <CardContent>
+          <Grid container spacing={3}>
+            <Grid item md={6} xs={12}>
+              <TextField
+                fullWidth
+                helperText="Please specify the first name"
+                label="First name"
+                margin="dense"
+                id="firstName"
+                onChange={handleChange}
+                required
+                value={form.firstName}
+                variant="outlined"
+              />
+            </Grid>{" "}
+            <Grid item md={6} xs={12}>
+              <TextField
+                // fullWidth
+                label="Last name"
+                margin="dense"
+                id="lastName"
+                onChange={handleChange}
+                // required
+                value={form.lastName}
+                variant="outlined"
+              />
+            </Grid>{" "}
+            <Grid item md={6} xs={12}>
+              <TextField
+                fullWidth
+                label="Email Address"
+                margin="dense"
+                id="email"
+                onChange={handleChange}
+                required
+                value={form.email}
+                variant="outlined"
+              />
+            </Grid>{" "}
+            <Grid item md={6} xs={12}>
+              <TextField
+                fullWidth
+                label="Phone Number"
+                margin="dense"
+                id="phoneNumber"
+                onChange={handleChange}
+                value={form.phoneNumber}
+                variant="outlined"
+              />
+            </Grid>{" "}
+          </Grid>{" "}
+        </CardContent>{" "}
+        <Divider />
+        <CardActions>
+          <Button
+            color="primary"
+            variant="contained"
+            onClick={onSubmit}
+            disabled={isEqual(initialState, form)}
+          >
+            Save details{" "}
+          </Button>{" "}
+        </CardActions>{" "}
+      </form>{" "}
+    </Card>
+  );
 };
 
 AccountDetails.propTypes = {
-    className: PropTypes.string,
-    mappedAuth: PropTypes.object.isRequired
+  className: PropTypes.string,
+  mappedAuth: PropTypes.object.isRequired,
 };
 
 export default AccountDetails;

--- a/netmanager/src/views/pages/Account/components/AccountDetails/AccountDetails.js
+++ b/netmanager/src/views/pages/Account/components/AccountDetails/AccountDetails.js
@@ -33,11 +33,9 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 const AccountDetails = (props) => {
-  const { className, mappeduserState, mappedAuth, ...rest } = props;
+  const { className, mappedAuth, ...rest } = props;
 
   const { user } = mappedAuth;
-  console.log("the user is here: ");
-  console.dir(user);
 
   const classes = useStyles();
 
@@ -106,12 +104,12 @@ const AccountDetails = (props) => {
             </Grid>{" "}
             <Grid item md={6} xs={12}>
               <TextField
-                // fullWidth
+                fullWidth
                 label="Last name"
                 margin="dense"
                 id="lastName"
                 onChange={handleChange}
-                // required
+                required
                 value={form.lastName}
                 variant="outlined"
               />

--- a/netmanager/src/views/pages/Settings/components/Password/Password.js
+++ b/netmanager/src/views/pages/Settings/components/Password/Password.js
@@ -24,7 +24,8 @@ const useStyles = makeStyles(() => ({
 const Password = (props) => {
   const { className, mappedAuth, mappeduserState, ...rest } = props;
   const { user } = mappedAuth;
-  const userState = mappeduserState;
+
+  const orgData = useOrgData();
 
   const classes = useStyles();
 
@@ -75,13 +76,25 @@ const Password = (props) => {
     const userId = user._id;
     const tenant = orgData.name
     const userData = {
-      id: user._id,
-      password: newPassword.password,
-      password2: newPassword.password2,
+      ...newPassword,
+      old_pwd: newPassword.currentPassword,
     };
-    console.log("sending them through...");
-    console.log(userData);
-    props.mappedUpdatePassword(userData);
+
+    await updateUserPasswordApi(userId, tenant, userData)
+        .then(data => {
+          setAlert({
+            show: true,
+            message: "Password update success",
+            type: "success"
+          })
+        })
+        .catch(err => {
+          setAlert({
+            show: true,
+            message: err.response.data.message || err.response.data.password2,
+            type: "error"
+          })
+        })
     clearState();
   };
 
@@ -122,7 +135,13 @@ const Password = (props) => {
           helperText={errors.password2}
         />
       </CardContent>
+
       <Divider />
+
+      <CardContent style={alert.show ? {} : {display: "none"}}>
+          <Alert severity={alert.type} onClose={closeAlert}>{alert.message}</Alert>
+      </CardContent>
+
       <CardActions>
         <Button color="primary" variant="outlined" onClick={onSubmit} disabled={isEqual(initialState, newPassword)}>
           Update

--- a/netmanager/src/views/pages/Settings/components/Password/Password.js
+++ b/netmanager/src/views/pages/Settings/components/Password/Password.js
@@ -14,6 +14,7 @@ import {
   TextField,
 } from "@material-ui/core";
 import Alert from '@material-ui/lab/Alert';
+import { CircularLoader } from "../../../../components/Loader/CircularLoader";
 import { updateUserPasswordApi } from "../../../../apis/authService";
 import { useOrgData } from "../../../../../redux/Join/selectors";
 
@@ -44,6 +45,7 @@ const Password = (props) => {
   const [newPassword, setNewPassword] = useState(initialState);
   const [errors, setErrors] = useState(initialState)
   const [alert, setAlert] = useState(alertInitialState)
+  const [loading, setLoading] = useState(false);
 
 
   const clearState = () => {
@@ -79,7 +81,7 @@ const Password = (props) => {
       ...newPassword,
       old_pwd: newPassword.currentPassword,
     };
-
+    setLoading(true);
     await updateUserPasswordApi(userId, tenant, userData)
         .then(data => {
           setAlert({
@@ -95,6 +97,7 @@ const Password = (props) => {
             type: "error"
           })
         })
+    setLoading(false);
     clearState();
   };
 
@@ -146,6 +149,7 @@ const Password = (props) => {
         <Button color="primary" variant="outlined" onClick={onSubmit} disabled={isEqual(initialState, newPassword)}>
           Update
         </Button>
+        <CircularLoader loading={loading} />
       </CardActions>
     </Card>
   );

--- a/netmanager/src/views/pages/Settings/components/Password/Password.js
+++ b/netmanager/src/views/pages/Settings/components/Password/Password.js
@@ -3,6 +3,7 @@ import React, { useState } from "react";
 import PropTypes from "prop-types";
 import clsx from "clsx";
 import { makeStyles } from "@material-ui/styles";
+import { isEqual } from "underscore";
 import { updatePassword } from "redux/Join/actions";
 import {
   Card,
@@ -30,15 +31,15 @@ const Password = (props) => {
     password2: "",
   };
 
-  const [values, setValues] = useState(initialState);
+  const [newPassword, setNewPassword] = useState(initialState);
 
   const clearState = () => {
-    setValues({ ...initialState });
+    setNewPassword({ ...initialState });
   };
 
   const handleChange = (event) => {
-    setValues({
-      ...values,
+    setNewPassword({
+      ...newPassword,
       [event.target.id]: event.target.value,
     });
   };
@@ -47,8 +48,8 @@ const Password = (props) => {
     e.preventDefault();
     const userData = {
       id: user._id,
-      password: values.password,
-      password2: values.password2,
+      password: newPassword.password,
+      password2: newPassword.password2,
     };
     console.log("sending them through...");
     console.log(userData);
@@ -67,7 +68,7 @@ const Password = (props) => {
           id="password"
           onChange={handleChange}
           type="password"
-          value={values.password}
+          value={newPassword.password}
           variant="outlined"
         />
         <TextField
@@ -77,13 +78,13 @@ const Password = (props) => {
           onChange={handleChange}
           style={{ marginTop: "1rem" }}
           type="password"
-          value={values.password2}
+          value={newPassword.password2}
           variant="outlined"
         />
       </CardContent>
       <Divider />
       <CardActions>
-        <Button color="primary" variant="outlined" onClick={onSubmit} disabled>
+        <Button color="primary" variant="outlined" onClick={onSubmit} disabled={isEqual(initialState, newPassword)}>
           Update
         </Button>
       </CardActions>

--- a/netmanager/src/views/pages/Settings/components/Password/Password.js
+++ b/netmanager/src/views/pages/Settings/components/Password/Password.js
@@ -4,7 +4,6 @@ import PropTypes from "prop-types";
 import clsx from "clsx";
 import { makeStyles } from "@material-ui/styles";
 import { isEqual } from "underscore";
-import { updatePassword } from "redux/Join/actions";
 import {
   Card,
   CardHeader,
@@ -14,6 +13,9 @@ import {
   Button,
   TextField,
 } from "@material-ui/core";
+import Alert from '@material-ui/lab/Alert';
+import { updateUserPasswordApi } from "../../../../apis/authService";
+import { useOrgData } from "../../../../../redux/Join/selectors";
 
 const useStyles = makeStyles(() => ({
   root: {},
@@ -27,25 +29,51 @@ const Password = (props) => {
   const classes = useStyles();
 
   const initialState = {
+    currentPassword: "",
     password: "",
     password2: "",
   };
 
+  const alertInitialState = {
+    show: false,
+    message: "",
+    type: "success"
+  }
+
   const [newPassword, setNewPassword] = useState(initialState);
+  const [errors, setErrors] = useState(initialState)
+  const [alert, setAlert] = useState(alertInitialState)
+
 
   const clearState = () => {
     setNewPassword({ ...initialState });
   };
 
+  const closeAlert = () => {
+    setAlert(alertInitialState)
+  }
+
+  const setFieldError = (error) => {
+    setErrors({...errors, ...error})
+  }
+
   const handleChange = (event) => {
+    const id = event.target.id;
+    const value =event.target.value;
+    if (["password", "password2"].includes(id)) {
+      value !== newPassword.password ? setFieldError({ password2: "passwords don't match"}) :
+      setFieldError({ password2: ""})
+    }
     setNewPassword({
       ...newPassword,
       [event.target.id]: event.target.value,
     });
   };
 
-  const onSubmit = (e) => {
+  const onSubmit = async (e) => {
     e.preventDefault();
+    const userId = user._id;
+    const tenant = orgData.name
     const userData = {
       id: user._id,
       password: newPassword.password,
@@ -64,22 +92,34 @@ const Password = (props) => {
       <CardContent>
         <TextField
           fullWidth
-          label="Password"
+          label="Current Password"
+          id="currentPassword"
+          onChange={handleChange}
+          type="password"
+          value={newPassword.currentPassword}
+          variant="outlined"
+        />
+        <TextField
+          fullWidth
+          label="New Password"
           id="password"
           onChange={handleChange}
           type="password"
           value={newPassword.password}
           variant="outlined"
+          style={{ marginTop: "1rem" }}
         />
         <TextField
           fullWidth
-          label="Confirm password"
+          label="Confirm New Password"
           id="password2"
           onChange={handleChange}
           style={{ marginTop: "1rem" }}
           type="password"
           value={newPassword.password2}
           variant="outlined"
+          error={!!errors.password2}
+          helperText={errors.password2}
         />
       </CardContent>
       <Divider />


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)
- Enable authenticated user to update their information

#### Is this change ready to hit production in its current state?
- [ ] Yes
- [ ] No

#### Status of maturity (all need to be checked before merging):

- [ ] I consider this code done
- [ ] I've tested this locally
- [ ] This branch has been LGTM'ed by a reviewer

Good to have (up to reviewer's discretion):
- [ ] I've tested this on staging
- [ ] Unit test coverage of changes

#### How should this be manually tested?
* Pull and checkout to this [branch]() locally
* Install node requirements `npm install`
* Ensure the local auth-service with data-segregation is running. Check this [PR](https://github.com/airqo-platform/AirQo-api/pull/121) for more info
* You start the application in one of the two ways:
  1. `npm run dev-mac` (on mac) or `npm run dev-pc` (on windows platform)
  2. `npm run prod-mac` (on mac) or `npm run prod-pc` (on windows platform) and manually change the auth-service url configs to point to the locally running service. The benefit of this approach is you are able to load other data required by the app (such as analytics).
* On Accounts and Settings page, you should be able to edit user details and passwords respectively
#### What are the relevant tickets?
- [PLAT-119](https://airqoteam.atlassian.net/browse/PLAT-119)

#### Screenshots (optional)