### PR TITLE
[NetManager] Hot-fix Loading of dashboard user defaults

### DIFF
--- a/netmanager/src/redux/Dashboard/constants.js
+++ b/netmanager/src/redux/Dashboard/constants.js
@@ -1,0 +1,36 @@
+export const KCCAInitialUserDefaultGraphsState = [
+  {
+    pollutant: "PM 2.5",
+    frequency: "daily",
+    chartType: "line",
+    chartTitle: "Mean Daily PM 2.5 for Kawempe division",
+    locations: [
+      "Bwaise II",
+      "Kyebando",
+      "Komamboga",
+      "Kazo Angola",
+      "Wandegeya",
+    ],
+  },
+  {
+    pollutant: "PM 2.5",
+    frequency: "daily",
+    chartType: "line",
+    chartTitle: "Mean Daily PM 2.5 for Lubaga division",
+    locations: ["Namirembe", "Kawala", "Lubya", "Nakulabye", "Mutundwe"],
+  },
+  {
+    pollutant: "PM 2.5",
+    frequency: "daily",
+    chartType: "line",
+    chartTitle: "Mean Daily PM 2.5 for Makindye division",
+    locations: ["Kibuye I", "Nsambya Central", "Kisugu", "Ggaba"],
+  },
+  {
+    pollutant: "PM 2.5",
+    frequency: "daily",
+    chartType: "line",
+    chartTitle: "Mean Daily PM 2.5 for Nakawa division",
+    locations: ["Nakawa", "Kiswa", "Luzira", "Naguru I", "Kyanja"],
+  },
+];

--- a/netmanager/src/redux/Dashboard/operations.js
+++ b/netmanager/src/redux/Dashboard/operations.js
@@ -8,6 +8,8 @@ import {
   SET_USER_DEFAULTS_GRAPHS_SUCCESS,
   SET_USER_DEFAULTS_GRAPHS_ERROR,
 } from "./actions";
+import { KCCAInitialUserDefaultGraphsState } from "./constants";
+import { filterDefaults } from "./utils";
 import constants from "../../config/constants";
 
 export const refreshFilterLocationData = () => {
@@ -39,7 +41,7 @@ export const loadUserDefaultGraphData = () => {
         const { defaults } = userDefaultsData;
         dispatch({
           type: LOAD_USER_DEFAULT_GRAPHS_SUCCESS,
-          payload: defaults,
+          payload: filterDefaults(defaults, KCCAInitialUserDefaultGraphsState),
         });
       })
       .catch((err) => {

--- a/netmanager/src/redux/Dashboard/reducers/userDefaultGraphsReducer.js
+++ b/netmanager/src/redux/Dashboard/reducers/userDefaultGraphsReducer.js
@@ -1,64 +1,10 @@
 import { LOAD_USER_DEFAULT_GRAPHS_SUCCESS } from "../actions";
 
-const initialUserDefaultGraphsState = [
-  {
-    pollutant: "PM 2.5",
-    frequency: "daily",
-    chartType: "line",
-    chartTitle: "Mean Daily PM 2.5 for Kawempe division",
-    locations: [
-      "Bwaise II",
-      "Kyebando",
-      "Komamboga",
-      "Kazo Angola",
-      "Wandegeya",
-    ],
-  },
-  {
-    pollutant: "PM 2.5",
-    frequency: "daily",
-    chartType: "line",
-    chartTitle: "Mean Daily PM 2.5 for Lubaga division",
-    locations: ["Namirembe", "Kawala", "Lubya", "Nakulabye", "Mutundwe"],
-  },
-  {
-    pollutant: "PM 2.5",
-    frequency: "daily",
-    chartType: "line",
-    chartTitle: "Mean Daily PM 2.5 for Makindye division",
-    locations: ["Kibuye I", "Nsambya Central", "Kisugu", "Ggaba"],
-  },
-  {
-    pollutant: "PM 2.5",
-    frequency: "daily",
-    chartType: "line",
-    chartTitle: "Mean Daily PM 2.5 for Nakawa division",
-    locations: ["Nakawa", "Kiswa", "Luzira", "Naguru I", "Kyanja"],
-  },
-];
-
-const filterState = (newValues, state) => {
-  if (newValues.length >= 4) {
-    return newValues;
-  }
-  const newState = state.filter((element) => {
-    const index = 0;
-
-    while (index < newValues.length) {
-      if (element.chartTitle === newValues[0].chartTitle) {
-        return false;
-      }
-    }
-    return true;
-  });
-
-  return [...newValues, ...newState];
-};
-
-export default function (state = initialUserDefaultGraphsState, action) {
+export default function (state = [], action) {
   switch (action.type) {
     case LOAD_USER_DEFAULT_GRAPHS_SUCCESS:
-      return filterState(action.payload, state);
+      return action.payload;
+
     default:
       return state;
   }

--- a/netmanager/src/redux/Dashboard/utils.js
+++ b/netmanager/src/redux/Dashboard/utils.js
@@ -1,0 +1,24 @@
+import { isEmpty } from "underscore";
+
+export const filterDefaults = (newValues, defaults) => {
+  if (isEmpty(newValues)) {
+    return defaults;
+  }
+
+  if (newValues.length >= defaults.length) {
+    return newValues;
+  }
+  const newDefaults = defaults.filter((element) => {
+    let index = 0;
+
+    while (index < newValues.length) {
+      if (element.chartTitle === newValues[index].chartTitle) {
+        return false;
+      }
+      index++;
+    }
+    return true;
+  });
+
+  return [...newValues, ...newDefaults];
+};


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)
- fix loading of dashboard user defaults
#### Is this change ready to hit production in its current state?
- [x] Yes
- [ ] No

#### Status of maturity (all need to be checked before merging):

- [x] I consider this code done
- [x] I've tested this locally
- [ ] This branch has been LGTM'ed by a reviewer

Good to have (up to reviewer's discretion):
- [ ] I've tested this on staging
- [ ] Unit test coverage of changes

#### How should this be manually tested?
* Pull and checkout to this [branch]() locally
* Install node requirements `npm install`
* Start the application `npm run prod-mac` (on mac) or `npm run prod-pc` (on windows platform)
* You should able to load the dashboards and set custom graphs without the paging freezing
#### What are the relevant tickets?
- [None]()

#### Screenshots (optional)