### PR TITLE
[NetManager] Alignment dashboard feedback

### DIFF
--- a/netmanager/src/views/layouts/Main/components/Topbar/Topbar.js
+++ b/netmanager/src/views/layouts/Main/components/Topbar/Topbar.js
@@ -74,6 +74,15 @@ const Topbar = (props) => {
     props.logoutUser();
   };
 
+  const timer_style = {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    width: "100%",
+    fontSize: 20,
+    fontWeight: "bold",
+  };
+
   /***
    * Handling the menue details.
    */
@@ -154,8 +163,8 @@ const Topbar = (props) => {
             src="/images/logos/mak_logo.jpg"
           />
         </RouterLink>
-        <p style={{ fontSize: 20, marginLeft: "50%", fontWeight: "bold" }}>
-          {date.toLocaleString()}
+        <p style={timer_style}>
+          <span>{date.toLocaleString()}</span>
         </p>
         <div className={classes.flexGrow} />
         <Hidden mdDown>

--- a/netmanager/src/views/pages/Dashboard/Dashboard.js
+++ b/netmanager/src/views/pages/Dashboard/Dashboard.js
@@ -387,7 +387,7 @@ const Dashboard = (props) => {
   return (
     <div className={classes.root}>
       <header
-        style={{ display: "inline-flex", flexWrap: "wrap", width: "674px" }}
+        style={{ display: "inline-flex", flexWrap: "wrap", width: "674px", padding: "0 0 30px 0" }}
       >
         <h4>Welcome to the AirQo ANALYTICS dashboard</h4>
         <br />

--- a/netmanager/src/views/pages/Dashboard/Dashboard.js
+++ b/netmanager/src/views/pages/Dashboard/Dashboard.js
@@ -386,10 +386,14 @@ const Dashboard = (props) => {
 
   return (
     <div className={classes.root}>
-      <h4>Welcome to the AirQo ANALYTICS dashboard</h4>
-      <br />
-      <h6>Number of nodes at each AQI risk level</h6>
-      <br />
+      <header
+        style={{ display: "inline-flex", flexWrap: "wrap", width: "674px" }}
+      >
+        <h4>Welcome to the AirQo ANALYTICS dashboard</h4>
+        <br />
+        <h6>Number of nodes at each AQI risk level</h6>
+        <br />
+      </header>
       <Grid container spacing={4}>
         <Grid item lg={2} sm={6} xl={2} xs={12}>
           <PollutantCategory

--- a/netmanager/src/views/pages/Dashboard/components/Map/Map.js
+++ b/netmanager/src/views/pages/Dashboard/components/Map/Map.js
@@ -241,8 +241,8 @@ const Map = (props) => {
                 <span>
                   Last Refreshed: {getDateString(contact.LastHour)} (EAT)
                 </span>
-                <Divider />
-                <Link to={`/location/${contact.Parish}`}>More Details</Link>
+                {/*<Divider />*/}
+                {/*<Link to={`/location/${contact.Parish}`}>More Details</Link>*/}
               </Popup>
             </Marker>
           ))}


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)
- Recenter the clock at the top of the page.
- Left align “Number of nodes at each AQI risk level” title.
- Disable link from map that leads to location registry page

#### Is this change ready to hit production in its current state?
- [x] Yes
- [ ] No

#### Status of maturity (all need to be checked before merging):

- [x] I consider this code done
- [x] I've tested this locally
- [ ] This branch has been LGTM'ed by a reviewer

Good to have (up to reviewer's discretion):
- [ ] I've tested this on staging
- [ ] Unit test coverage of changes

#### How should this be manually tested?
* Pull and checkout to this [branch]() locally
* Install node requirements `npm install`
* Start the application `npm run prod-mac` (on mac) or `npm run prod-pc` (on windows platform)
* Ensure that the topbar clock is centered, the `Number of nodes at each AQI risk level` title is left aligned and
the link from map to location does not appear on clicking a mark on the dashboard map.


#### What are the relevant tickets?
- [PLAT-144/ recenter ticket](https://airqoteam.atlassian.net/browse/PLAT-144)
- [PLAT-145/Align AQI title](https://airqoteam.atlassian.net/browse/PLAT-145)
- [PLAT-143/disable map-location link](https://airqoteam.atlassian.net/browse/PLAT-143)

#### Screenshots (optional)