### PR TITLE
[NetManager]  add 5th kcca default graph

### DIFF
--- a/netmanager/src/redux/Dashboard/constants.js
+++ b/netmanager/src/redux/Dashboard/constants.js
@@ -33,4 +33,11 @@ export const KCCAInitialUserDefaultGraphsState = [
     chartTitle: "Mean Daily PM 2.5 for Nakawa division",
     locations: ["Nakawa", "Kiswa", "Luzira", "Naguru I", "Kyanja"],
   },
+  {
+    pollutant: "PM 2.5",
+    frequency: "daily",
+    chartType: "line",
+    chartTitle: "Mean Daily PM 2.5 for Central division",
+    locations: ["Civic Centre", "Nakasero II", "Kisenyi II", "Kamwokya II"],
+  },
 ];

--- a/netmanager/src/views/pages/Dashboard/components/CustomisableChart/CustomisableChart.js
+++ b/netmanager/src/views/pages/Dashboard/components/CustomisableChart/CustomisableChart.js
@@ -37,6 +37,7 @@ import Menu from "@material-ui/core/Menu";
 import MenuItem from "@material-ui/core/MenuItem";
 import domtoimage from "dom-to-image";
 import JsPDF from "jspdf";
+import { isEmpty } from "underscore";
 import { useFilterLocationData } from "../../../../../redux/Dashboard/selectors";
 import {
   refreshFilterLocationData,
@@ -359,12 +360,12 @@ const CustomisableChart = (props) => {
   }*/
 
   const customisedGraphData = {
-    chart_type: customGraphData.results
-      ? customGraphData.results[0].chart_type
-      : null,
-    labels: customGraphData.results
-      ? customGraphData.results[0].chart_data.labels
-      : null,
+    chart_type: isEmpty(customGraphData.results)
+      ? null
+      : customGraphData.results[0].chart_type,
+    labels: isEmpty(customGraphData.results)
+      ? null
+      : customGraphData.results[0].chart_data.labels,
     datasets: customGraphData.datasets,
   };
 

--- a/netmanager/src/views/pages/Dashboard/components/CustomisableChart/CustomisableChart.js
+++ b/netmanager/src/views/pages/Dashboard/components/CustomisableChart/CustomisableChart.js
@@ -499,12 +499,20 @@ const CustomisableChart = (props) => {
     }
   };
 
-  const exportToJpeg = (chart) =>
+  const exportToJpeg = (chart) => {
+    setAnchorEl(null);
     exportToImage(chart, "jpeg", domtoimage.toJpeg);
+  };
 
-  const exportToPng = (chart) => exportToImage(chart, "png", domtoimage.toPng);
+  const exportToPng = (chart) => {
+    setAnchorEl(null);
+
+    exportToImage(chart, "png", domtoimage.toPng);
+  };
 
   const exportToPdf = async (chart) => {
+    setAnchorEl(null);
+
     const width = chart.offsetWidth;
     const height = chart.offsetHeight;
     try {
@@ -525,6 +533,7 @@ const CustomisableChart = (props) => {
   };
 
   const print = async (chart) => {
+    setAnchorEl(null);
     try {
       const dataUrl = await domtoimage.toJpeg(chart, { filter });
       let html = "<html><head><title></title></head>";


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)
- Add KCCA 5th graph for Central division
- Enable closing of chart menu when clicked
- Fix error caused when an empty dataset for a given location is returned

#### Is this change ready to hit production in its current state?
- [x] Yes
- [ ] No

#### Status of maturity (all need to be checked before merging):

- [x] I consider this code done
- [x] I've tested this locally
- [ ] This branch has been LGTM'ed by a reviewer

Good to have (up to reviewer's discretion):
- [ ] I've tested this on staging
- [ ] Unit test coverage of changes

#### How should this be manually tested?
* Pull and checkout to this [branch]() locally
* Install node requirements `npm install`
* Start the application `npm run prod-mac` (on mac) or `npm run prod-pc` (on windows platform)
* Ensure that there are five graphs for the five division in Kampala. Ensure the chart menu is closed when any of the menu options is clicked. Finally, ensure that when and empty dataset for a given location (e.g Mutundwe) is returned, the app does not crush.


#### What are the relevant tickets?
- [PLAT-153/ 5th graph](https://airqoteam.atlassian.net/browse/PLAT-153)
- [PLAT-151/menu closing](https://airqoteam.atlassian.net/browse/PLAT-151)
- [PLAT-149/empty dataset(Mutundwe)](https://airqoteam.atlassian.net/browse/PLAT-149)

#### Screenshots (optional)