### PR TITLE
[NetManager] Add time period/range on custom charts

### DIFF
--- a/netmanager/src/views/components/CustomSelects/LabelledSelect.js
+++ b/netmanager/src/views/components/CustomSelects/LabelledSelect.js
@@ -1,0 +1,63 @@
+import React from "react";
+import Select, { components } from "react-select";
+import PropTypes from "prop-types";
+
+const customSelectStyles = {
+  menu: (provided, state) => ({
+    ...provided,
+    zIndex: 20,
+  }),
+};
+
+const Label = ({ label, isFloating }) => {
+  const top = isFloating ? `5px` : `35%`;
+  const fontSize = isFloating ? `0.65rem` : `1rem`;
+
+  const labelStyle = {
+    left: "10px",
+    top: top,
+    pointerEvents: "none",
+    position: "absolute",
+    transition: "0.2s ease all",
+    MozTransition: "0.2s ease all",
+    WebkitTransition: "0.2s ease all",
+    fontSize: fontSize,
+    zIndex: 10,
+  };
+  return <label style={labelStyle}>{label}</label>;
+};
+
+Label.propTypes = {
+  label: PropTypes.string.isRequired,
+  isFloating: PropTypes.bool.isRequired,
+};
+
+const Control = (props) => {
+  return (
+    <div style={{ position: "relative" }}>
+      <Label
+        label={props.selectProps.label}
+        isFloating={props.isFocused || props.hasValue}
+      />
+      <components.Control {...props} />
+    </div>
+  );
+};
+
+const LabelledSelect = ({ label, components, ...props }) => {
+  return (
+    <Select
+      styles={customSelectStyles}
+      label={label}
+      components={{ ...components, Control }}
+      {...props}
+    />
+  );
+};
+
+LabelledSelect.propTypes = {
+  label: PropTypes.string.isRequired,
+  components: PropTypes.object,
+};
+
+export default LabelledSelect;

--- a/netmanager/src/views/pages/Dashboard/components/CustomisableChart/CustomisableChart.js
+++ b/netmanager/src/views/pages/Dashboard/components/CustomisableChart/CustomisableChart.js
@@ -42,6 +42,7 @@ import {
   refreshFilterLocationData,
   setUserDefaultGraphData,
 } from "../../../../../redux/Dashboard/operations";
+import { omit } from "underscore";
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -122,6 +123,60 @@ const CustomisableChart = (props) => {
     errors: {},
   });
 
+  const periodOptions = [
+    {
+      value: "Last 30 days",
+      label: "Last 30 days",
+      unitValue: 30,
+      unit: "day",
+      endDate: null,
+    },
+    {
+      value: "Last 90 days",
+      label: "Last 90 days",
+      unitValue: 90,
+      unit: "day",
+      endDate: null,
+    },
+    {
+      value: "Custom range",
+      label: "Custom range",
+      unitValue: 30,
+      unit: "day",
+      endDate: null,
+    },
+  ];
+
+  const [selectedPeriod, setSelectedPeriod] = useState(periodOptions[0]);
+  const [disableDatePickers, setDisableDatePickers] = useState(true)
+
+  const generateStartAndEndDates = (period) => {
+    let endDate = period.endDate ? new Date(period.endDate) : new Date();
+    let startDate = new Date(
+      endDate.getFullYear(),
+      endDate.getMonth(),
+      endDate.getDate() - period.unitValue
+    );
+
+    return [startDate, endDate];
+  };
+
+  const handlePeriodChange = (selectedPeriodOption) => {
+    if (isCustomPeriod(selectedPeriodOption)) {
+      setDisableDatePickers(false);
+      return;
+    }
+    const [startDate, endDate] = generateStartAndEndDates(selectedPeriodOption);
+    setSelectedStartDate(startDate);
+    setSelectedEndDate(endDate);
+    setSelectedPeriod(selectedPeriodOption);
+    setDisableDatePickers(true);
+  };
+
+  const isCustomPeriod = (period) => {
+    return period.label.toLowerCase() === "Custom range".toLowerCase();
+  };
+
   var startDate = new Date();
   startDate.setMonth(startDate.getMonth() - 1);
   startDate.setHours(0, 0, 0, 0);
@@ -201,18 +256,6 @@ const CustomisableChart = (props) => {
     { value: "daily", label: "Daily" },
     { value: "monthly", label: "Monthly" },
   ];
-
-  const periodOptions = [
-    { value: "Last 30 days", label: "Last 30 days" },
-    { value: "Last 90 days", label: "Last 90 days" },
-    { value: "Custom range", label: "Custom range" },
-  ];
-
-  const [selectedPeriod, setSelectedPeriod] = useState(periodOptions[0]);
-
-  const handlePeriodChange = (selectedPriodOption) => {
-    setSelectedPeriod(selectedPriodOption);
-  };
 
   const [selectedFrequency, setSelectedFrequency] = useState(
     toValueLabelObject(defaultFilter.frequency)
@@ -703,6 +746,7 @@ const CustomisableChart = (props) => {
                         <Grid container spacing={1}>
                           <Grid item lg={6} md={6} sm={6} xl={6} xs={12}>
                             <KeyboardDatePicker
+                                disabled={disableDatePickers}
                               disableToolbar
                               variant="dialog"
                               format="yyyy-MM-dd"

--- a/netmanager/src/views/pages/Dashboard/components/CustomisableChart/CustomisableChart.js
+++ b/netmanager/src/views/pages/Dashboard/components/CustomisableChart/CustomisableChart.js
@@ -341,6 +341,19 @@ const CustomisableChart = (props) => {
   let handleSubmit = async (e) => {
     e.preventDefault();
 
+    let period = omit(
+      { ...selectedPeriod, endDate: selectedEndDate },
+      "startDate"
+    );
+
+    if (!isCustomPeriod(period)) {
+      period = { ...period, endDate: null };
+    }
+
+    console.log("period", period);
+    console.log("period stringified");
+    console.log(JSON.stringify(period));
+
     let newFilter = {
       ...defaultFilter,
       locations: values.selectedOption,

--- a/netmanager/src/views/pages/Dashboard/components/CustomisableChart/CustomisableChart.js
+++ b/netmanager/src/views/pages/Dashboard/components/CustomisableChart/CustomisableChart.js
@@ -1,13 +1,11 @@
 import React from "react";
 import { useDispatch } from "react-redux";
-import clsx from "clsx";
 import PropTypes from "prop-types";
 import { makeStyles, withStyles } from "@material-ui/styles";
 import {
   Card,
   CardContent,
   CardHeader,
-  CardActions,
   Divider,
   Grid,
   Button,
@@ -38,6 +36,7 @@ import MenuItem from "@material-ui/core/MenuItem";
 import domtoimage from "dom-to-image";
 import JsPDF from "jspdf";
 import { isEmpty } from "underscore";
+import LabelledSelect from "../../../../components/CustomSelects/LabelledSelect";
 import { useFilterLocationData } from "../../../../../redux/Dashboard/selectors";
 import {
   refreshFilterLocationData,
@@ -110,25 +109,6 @@ const DialogTitle = withStyles(styles)((props) => {
     </MuiDialogTitle>
   );
 });
-
-const schema = {
-  location: {
-    presence: { allowEmpty: false, message: "is required" },
-  },
-  chartType: {
-    presence: { allowEmpty: false, message: "is required" },
-  },
-  chartFrequency: {
-    presence: { allowEmpty: false, message: "is required" },
-  },
-  pollutant: {
-    presence: { allowEmpty: false, message: "is required" },
-  },
-  policy: {
-    presence: { allowEmpty: false, message: "is required" },
-    checked: true,
-  },
-};
 
 const CustomisableChart = (props) => {
   const { className, idSuffix, defaultFilter, ...rest } = props;
@@ -222,6 +202,18 @@ const CustomisableChart = (props) => {
     { value: "monthly", label: "Monthly" },
   ];
 
+  const periodOptions = [
+    { value: "Last 30 days", label: "Last 30 days" },
+    { value: "Last 90 days", label: "Last 90 days" },
+    { value: "Custom range", label: "Custom range" },
+  ];
+
+  const [selectedPeriod, setSelectedPeriod] = useState(periodOptions[0]);
+
+  const handlePeriodChange = (selectedPriodOption) => {
+    setSelectedPeriod(selectedPriodOption);
+  };
+
   const [selectedFrequency, setSelectedFrequency] = useState(
     toValueLabelObject(defaultFilter.frequency)
   );
@@ -264,9 +256,6 @@ const CustomisableChart = (props) => {
   });
 
   const [customGraphData, setCustomisedGraphData] = useState([]);
-
-  const hasError = (field) =>
-    formState.touched[field] && formState.errors[field] ? true : false;
 
   const fetchAndSetGraphData = async (filter) => {
     return await axios
@@ -647,8 +636,8 @@ const CustomisableChart = (props) => {
                       />
                     </Grid>
 
-                    <Grid item md={4} xs={12}>
-                      <Select
+                    <Grid item md={6} xs={12}>
+                      <LabelledSelect
                         fullWidth
                         label="Chart Type"
                         className="reactSelect"
@@ -660,17 +649,11 @@ const CustomisableChart = (props) => {
                         variant="outlined"
                         margin="dense"
                         required
-                        error={hasError("chartType")}
-                        helperText={
-                          hasError("chartType")
-                            ? formState.errors.chartType[0]
-                            : null
-                        }
                       />
                     </Grid>
 
-                    <Grid item md={4} xs={12}>
-                      <Select
+                    <Grid item md={6} xs={12}>
+                      <LabelledSelect
                         fullWidth
                         label="Frequency"
                         className=""
@@ -684,8 +667,8 @@ const CustomisableChart = (props) => {
                         required
                       />
                     </Grid>
-                    <Grid item md={4} xs={12}>
-                      <Select
+                    <Grid item md={6} xs={12}>
+                      <LabelledSelect
                         fullWidth
                         label="Pollutant"
                         className=""
@@ -694,6 +677,21 @@ const CustomisableChart = (props) => {
                         value={selectedPollutant}
                         options={pollutantOptions}
                         onChange={handlePollutantChange}
+                        variant="outlined"
+                        margin="dense"
+                        required
+                      />
+                    </Grid>
+
+                    <Grid item md={6} xs={12}>
+                      <LabelledSelect
+                        fullWidth
+                        label="Time range"
+                        name="Time range"
+                        placeholder="Time range"
+                        value={selectedPeriod}
+                        options={periodOptions}
+                        onChange={handlePeriodChange}
                         variant="outlined"
                         margin="dense"
                         required

--- a/netmanager/src/views/pages/Dashboard/components/CustomisableChart/CustomisableChart.js
+++ b/netmanager/src/views/pages/Dashboard/components/CustomisableChart/CustomisableChart.js
@@ -148,7 +148,7 @@ const CustomisableChart = (props) => {
   ];
 
   const [selectedPeriod, setSelectedPeriod] = useState(periodOptions[0]);
-  const [disableDatePickers, setDisableDatePickers] = useState(true)
+  const [disableDatePickers, setDisableDatePickers] = useState(true);
 
   const generateStartAndEndDates = (period) => {
     let endDate = period.endDate ? new Date(period.endDate) : new Date();
@@ -182,6 +182,16 @@ const CustomisableChart = (props) => {
   startDate.setHours(0, 0, 0, 0);
 
   const [selectedDate, setSelectedStartDate] = useState(startDate);
+  const [selectedEndDate, setSelectedEndDate] = useState(new Date());
+
+  const handleEndDateChange = (date) => {
+    setSelectedEndDate(date);
+  };
+
+  const handleDateChange = (date) => {
+    setSelectedStartDate(date);
+  };
+
   const [open, setOpen] = useState(false);
 
   const handleClickOpen = () => {
@@ -199,16 +209,6 @@ const CustomisableChart = (props) => {
     customChartTitleSecondSection,
     setCustomChartTitleSecondSection,
   ] = useState("Custom Chart Title");
-
-  const handleDateChange = (date) => {
-    setSelectedStartDate(date);
-  };
-
-  const [selectedEndDate, setSelectedEndDate] = useState(new Date());
-
-  const handleEndDateChange = (date) => {
-    setSelectedEndDate(date);
-  };
 
   const filterLocationsOptions = useFilterLocationData();
 
@@ -746,7 +746,7 @@ const CustomisableChart = (props) => {
                         <Grid container spacing={1}>
                           <Grid item lg={6} md={6} sm={6} xl={6} xs={12}>
                             <KeyboardDatePicker
-                                disabled={disableDatePickers}
+                              disabled={disableDatePickers}
                               disableToolbar
                               variant="dialog"
                               format="yyyy-MM-dd"
@@ -764,6 +764,7 @@ const CustomisableChart = (props) => {
                           </Grid>
                           <Grid item lg={6} md={6} sm={6} xl={6} xs={12}>
                             <KeyboardTimePicker
+                              disabled={disableDatePickers}
                               variant="dialog"
                               margin="normal"
                               id="time-picker"
@@ -779,6 +780,7 @@ const CustomisableChart = (props) => {
 
                           <Grid item lg={6} md={6} sm={6} xl={6} xs={12}>
                             <KeyboardDatePicker
+                              disabled={disableDatePickers}
                               disableToolbar
                               variant="dialog"
                               format="yyyy-MM-dd"
@@ -796,6 +798,7 @@ const CustomisableChart = (props) => {
                           </Grid>
                           <Grid item lg={6} md={6} sm={6} xl={6} xs={12}>
                             <KeyboardTimePicker
+                              disabled={disableDatePickers}
                               variant="dialog"
                               margin="normal"
                               id="time-picker"

--- a/netmanager/src/views/pages/Dashboard/components/CustomisableChart/CustomisableChart.js
+++ b/netmanager/src/views/pages/Dashboard/components/CustomisableChart/CustomisableChart.js
@@ -80,6 +80,10 @@ const toValueLabelArray = (arr) => {
   return newArr;
 };
 
+const formatDate = (date) => {
+  return date.toISOString().split("T")[0];
+};
+
 const styles = (theme) => ({
   root: {
     margin: 0,
@@ -318,12 +322,19 @@ const CustomisableChart = (props) => {
       )
       .then((res) => res.data)
       .then((customisedChartData) => {
+        let modifiedChartTitle = customisedChartData.custom_chart_title;
+        let splitChartTitleArray = customisedChartData.custom_chart_title.split(
+          " Between "
+        );
+        if (!isEmpty(splitChartTitleArray)) {
+          modifiedChartTitle = splitChartTitleArray[0];
+        }
         setCustomisedGraphData(customisedChartData);
 
         setCustomChartTitleSecondSection(
-          customisedChartData.custom_chart_title_second_section
+          `Between ${formatDate(selectedDate)} and ${formatDate(selectedEndDate)}`
         );
-        setCustomChartTitle(customisedChartData.custom_chart_title);
+        setCustomChartTitle(modifiedChartTitle);
         setCustomisedGraphLabel(
           customisedChartData.results
             ? customisedChartData.results[0].chart_label

--- a/netmanager/src/views/pages/Dashboard/components/CustomisableChart/CustomisableChart.js
+++ b/netmanager/src/views/pages/Dashboard/components/CustomisableChart/CustomisableChart.js
@@ -147,7 +147,18 @@ const CustomisableChart = (props) => {
     },
   ];
 
-  const [selectedPeriod, setSelectedPeriod] = useState(periodOptions[0]);
+  const initialPeriod = () => {
+    let period = periodOptions[0];
+    if (defaultFilter.period !== undefined) {
+      try {
+        period = JSON.parse(defaultFilter.period);
+        // eslint-disable-next-line no-empty
+      } catch (err) {}
+    }
+    return period;
+  };
+
+  const [selectedPeriod, setSelectedPeriod] = useState(initialPeriod());
   const [disableDatePickers, setDisableDatePickers] = useState(true);
 
   const generateStartAndEndDates = (period) => {
@@ -177,12 +188,10 @@ const CustomisableChart = (props) => {
     return period.label.toLowerCase() === "Custom range".toLowerCase();
   };
 
-  var startDate = new Date();
-  startDate.setMonth(startDate.getMonth() - 1);
-  startDate.setHours(0, 0, 0, 0);
+  let [startDate, endDate] = generateStartAndEndDates(initialPeriod());
 
   const [selectedDate, setSelectedStartDate] = useState(startDate);
-  const [selectedEndDate, setSelectedEndDate] = useState(new Date());
+  const [selectedEndDate, setSelectedEndDate] = useState(endDate);
 
   const handleEndDateChange = (date) => {
     setSelectedEndDate(date);
@@ -350,12 +359,9 @@ const CustomisableChart = (props) => {
       period = { ...period, endDate: null };
     }
 
-    console.log("period", period);
-    console.log("period stringified");
-    console.log(JSON.stringify(period));
-
     let newFilter = {
       ...defaultFilter,
+      period: JSON.stringify(period),
       locations: values.selectedOption,
       startDate: selectedDate,
       endDate: selectedEndDate,
@@ -386,6 +392,7 @@ const CustomisableChart = (props) => {
   }, [formState.values]);
 
   useEffect(() => {
+    handlePeriodChange(selectedPeriod);
     fetchAndSetGraphData(graphFilter);
   }, []);
 


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)
- Add time period/range on custom charts

#### Is this change ready to hit production in its current state?
- [ ] Yes
- [ ] No

#### Status of maturity (all need to be checked before merging):

- [ ] I consider this code done
- [ ] I've tested this locally
- [ ] This branch has been LGTM'ed by a reviewer

Good to have (up to reviewer's discretion):
- [ ] I've tested this on staging
- [ ] Unit test coverage of changes

#### How should this be manually tested?
* Pull and checkout to this [branch]() locally
* Install node requirements `npm install`
* Ensure the local auth-service with data-segregation is running. Check this [PR](https://github.com/airqo-platform/AirQo-api/pull/121) for more info
* You start the application in one of the two ways:
  1. `npm run dev-mac` (on mac) or `npm run dev-pc` (on windows platform)
  2. `npm run prod-mac` (on mac) or `npm run prod-pc` (on windows platform) and manually change the auth-service url configs to point to the locally running service. The benefit of this approach is you are able to load other data required by the app (such as analytics).
* On the dashboard, trying to customise any chart should show a new field for setting time ranges. The date pickers should be disabled for any range other than `Custom range`.

#### What are the relevant tickets?
* [Time Period defaults](https://airqoteam.atlassian.net/browse/PLAT-152)
* [chart title](https://airqoteam.atlassian.net/browse/PLAT-148)

#### Screenshots (optional)
<img width="848" alt="Screenshot 2020-10-01 at 13 16 44" src="https://user-images.githubusercontent.com/39955305/94797434-c78af200-03e8-11eb-8379-38965f976449.png">

