### PR TITLE
[NetManager] Hide airqo data

### DIFF
--- a/netmanager/src/views/components/DataDisplay/Devices.js
+++ b/netmanager/src/views/components/DataDisplay/Devices.js
@@ -28,6 +28,7 @@ import CreatableSelect from 'react-select/creatable';
 import MenuItem from '@material-ui/core/MenuItem';
 import ListItemText from '@material-ui/core/ListItemText';
 import Autocomplete from '@material-ui/lab/Autocomplete';
+import { useOrgData } from "redux/Join/selectors";
 
 const useStyles = makeStyles(theme => ({
   root: {},
@@ -83,6 +84,7 @@ const MenuProps = {
     },
   },
 };
+const orgData = useOrgData();
   const { className, users, ...rest } = props;
   const classes = useStyles();
   const [data, setData] = useState([]);   
@@ -528,7 +530,9 @@ const MenuProps = {
         const ref = res.data;
         console.log('Devices loading')
         console.log(ref);
-        setData(ref);
+        if(orgData.name.toLowerCase() === "airqo") {
+                  setData(ref);
+        }
 
     }).catch(
       console.log

--- a/netmanager/src/views/components/LocationList/LocationsTable.js
+++ b/netmanager/src/views/components/LocationList/LocationsTable.js
@@ -29,6 +29,7 @@ import constants from '../../../config/constants.js';
 
 import MaterialTable, { MTablePagination, Paper} from 'material-table';
 import { configs } from 'eslint-plugin-prettier';
+import { useOrgData } from "redux/Join/selectors";
 
 
 const useStyles = makeStyles(theme => ({
@@ -62,6 +63,8 @@ const LocationsTable = props => {
   const { className, users, ...rest } = props;
 
   const classes = useStyles();
+
+  const orgData = useOrgData();
 
   const [data, setData] = useState([]);   
 
@@ -103,7 +106,9 @@ const LocationsTable = props => {
         setIsLoading(false);
         const ref = res.data;
         console.log(ref);
-        setData(ref);
+        if (orgData.name.toLowerCase() === "airqo") {
+          setData(ref);
+        }
 
     }).catch(
       console.log

--- a/netmanager/src/views/layouts/Main/components/Sidebar/Sidebar.js
+++ b/netmanager/src/views/layouts/Main/components/Sidebar/Sidebar.js
@@ -153,7 +153,7 @@ const Sidebar = (props) => {
   if (orgData.name.toLowerCase() === "airqo") {
     pages = excludePages(pages, ["Dashboard", "Export"]);
   } else {
-    pages = excludePages(pages, ["Device Management"]);
+    pages = excludePages(pages, ["Device Management", "Locate"]);
   }
 
   return (

--- a/netmanager/src/views/layouts/Main/components/Sidebar/Sidebar.js
+++ b/netmanager/src/views/layouts/Main/components/Sidebar/Sidebar.js
@@ -17,6 +17,7 @@ import EditLocationIcon from "@material-ui/icons/EditLocation";
 import AspectRatioIcon from "@material-ui/icons/AspectRatio";
 import SupervisedUserCircleIcon from "@material-ui/icons/SupervisedUserCircle";
 import CloudDownloadIcon from "@material-ui/icons/CloudDownload";
+import { useOrgData } from "redux/Join/selectors";
 
 import { Profile, SidebarNav } from "./components";
 
@@ -53,6 +54,8 @@ const Sidebar = (props) => {
   const { open, variant, onClose, className, ...rest } = props;
 
   const classes = useStyles();
+
+  const orgData = useOrgData();
 
   let pages = [
     {
@@ -145,6 +148,12 @@ const Sidebar = (props) => {
     }
   } catch (e) {
     console.log(e);
+  }
+
+  if (orgData.name.toLowerCase() === "airqo") {
+    pages = excludePages(pages, ["Dashboard", "Export"]);
+  } else {
+    pages = excludePages(pages, ["Device Management"]);
   }
 
   return (

--- a/netmanager/src/views/pages/Dashboard/Dashboard.js
+++ b/netmanager/src/views/pages/Dashboard/Dashboard.js
@@ -14,28 +14,23 @@ import { Line, Bar } from "react-chartjs-2";
 import clsx from "clsx";
 import PropTypes from "prop-types";
 import {
-  Pm25Levels,
   Map,
   CustomisableChart,
   PollutantCategory,
   ExceedancesChart,
-  TotalProfit,
 } from "./components";
 import { useEffect, useState } from "react";
 import "chartjs-plugin-annotation";
 import palette from "theme/palette";
-import ArrowDropDownIcon from "@material-ui/icons/ArrowDropDown";
-import ArrowRightIcon from "@material-ui/icons/ArrowRight";
-//import Legend from './components/Map/Legend'
 import axios from "axios";
 import constants from "config/constants";
 import { MoreHoriz } from "@material-ui/icons";
 import Menu from "@material-ui/core/Menu";
 import MenuItem from "@material-ui/core/MenuItem";
-import MoreVertIcon from "@material-ui/icons/MoreVert";
 import domtoimage from "dom-to-image";
 import JsPDF from "jspdf";
-import { useUserDefaultGraphsData } from "../../../redux/Dashboard/selectors";
+import { useUserDefaultGraphsData } from "redux/Dashboard/selectors";
+import { useOrgData } from "redux/Join/selectors";
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -73,9 +68,9 @@ const Dashboard = (props) => {
     mappedErrors,
     ...rest
   } = props;
-  // const { user, isAuthenticated } = mappedAuth;
 
   const userDefaultGraphs = useUserDefaultGraphsData();
+  const orgData = useOrgData();
 
   function appendLeadingZeroes(n) {
     if (n <= 9) {
@@ -93,28 +88,16 @@ const Dashboard = (props) => {
       todaysDate.getFullYear()
   );
 
-  const [backgroundColors, setBackgroundColors] = useState([]);
-
   const [
     pm25CategoriesLocationCount,
     setPm25CategoriesLocationCount,
   ] = useState([]);
 
-  // useEffect(() => {
-  //   try{
-  //       props.fetchDefaults(user._id);
-  //   }
-  //   catch(e){
-  //   console.log(e);
-  //   }
-  //     }, []);
-
-  //   useEffect(() => {
-  // return ()=>{
-  //   props.fetchDefaults(user._id);
-  // }
-
-  //   }, []);
+  useEffect(() => {
+    if (orgData.name.toLowerCase() === "airqo") {
+      props.history.push("/overview");
+    }
+  }, []);
 
   //load JIRA Helpdek widget
   // console.log(user._id);
@@ -387,7 +370,12 @@ const Dashboard = (props) => {
   return (
     <div className={classes.root}>
       <header
-        style={{ display: "inline-flex", flexWrap: "wrap", width: "674px", padding: "0 0 30px 0" }}
+        style={{
+          display: "inline-flex",
+          flexWrap: "wrap",
+          width: "674px",
+          padding: "0 0 30px 0",
+        }}
       >
         <h4>Welcome to the AirQo ANALYTICS dashboard</h4>
         <br />

--- a/netmanager/src/views/pages/Dashboard/Dashboard.js
+++ b/netmanager/src/views/pages/Dashboard/Dashboard.js
@@ -97,7 +97,7 @@ const Dashboard = (props) => {
     if (orgData.name.toLowerCase() === "airqo") {
       props.history.push("/overview");
     }
-  }, []);
+  });
 
   //load JIRA Helpdek widget
   // console.log(user._id);


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)
- Hide sidebar tabs and dashboard depending the org logged in as.

#### Is this change ready to hit production in its current state?
- [ ] Yes
- [ ] No

#### Status of maturity (all need to be checked before merging):

- [ ] I consider this code done
- [ ] I've tested this locally
- [ ] This branch has been LGTM'ed by a reviewer

Good to have (up to reviewer's discretion):
- [ ] I've tested this on staging
- [ ] Unit test coverage of changes

#### How should this be manually tested?
* Pull and checkout to this [branch]() locally
* Install node requirements `npm install`
* You start the application using `npm run dev-mac` (on mac) or `npm run dev-pc` (on windows platform)
* Logging in  using `airqo` org, you should not be able to access the `dashboard` and `export` tabs on the sidebar.
* Logging in  using `kcca` org, you should not be able to access the `device management` on the sidebar.

#### What are the relevant tickets?

#### Screenshots (optional)