### PR TITLE
[NetManager] Fix node memory issue

### DIFF
--- a/netmanager/package.json
+++ b/netmanager/package.json
@@ -80,7 +80,7 @@
         "prod-pc": "set REACT_APP_ENV=production&&react-scripts start",
         "build": "react-scripts --max_old_space_size=4096 build",
         "SMD-build-mac": "GENERATE_SOURCEMAP=false react-scripts build",
-        "SMD-build-pc": "set GENERATE_SOURCEMAP=false && react-scripts build",
+        "SMD-build-pc": "set GENERATE_SOURCEMAP=false&&react-scripts build",
         "test": "react-scripts test",
         "eject": "react-scripts eject",
         "create-env": "printenv > .env"

--- a/netmanager/package.json
+++ b/netmanager/package.json
@@ -78,7 +78,9 @@
         "dev-pc": "set REACT_APP_ENV=development&&react-scripts start",
         "stage-pc": "set REACT_APP_ENV=staging&&react-scripts start",
         "prod-pc": "set REACT_APP_ENV=production&&react-scripts start",
-        "build": "react-scripts build",
+        "build": "react-scripts --max_old_space_size=4096 build",
+        "SMD-build-mac": "GENERATE_SOURCEMAP=false react-scripts build",
+        "SMD-build-pc": "set GENERATE_SOURCEMAP=false && react-scripts build",
         "test": "react-scripts test",
         "eject": "react-scripts eject",
         "create-env": "printenv > .env"


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)
Fixes this [issue](https://github.com/airqo-platform/AirQo-frontend/issues/133) by;
- Increasing node memory limit
- Adding options to build without generating source maps.

#### Is this change ready to hit production in its current state?
- [x] Yes
- [ ] No

#### Status of maturity (all need to be checked before merging):

- [x] I consider this code done
- [x] I've tested this locally
- [ ] This branch has been LGTM'ed by a reviewer

#### How should this be manually tested?
* Pull and checkout to this [branch]() locally
* Install node requirements `npm install`
* Build the app with source maps `npm run build`
* Build the app without source maps `npm run SMD-build-mac` (on Mac OS) or `npm run SMD-build-pc` (on windows paltform)
* Both build must be successful.

#### What are the relevant tickets?
- [PLAT-227](https://airqoteam.atlassian.net/browse/PLAT-227)

#### Screenshots (optional)

> Please add run command for Windows too.

