### PR TITLE
Ft branding segregation

### DIFF
--- a/netmanager/package-lock.json
+++ b/netmanager/package-lock.json
@@ -5598,11 +5598,11 @@
       }
     },
     "cross-fetch": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.5.tgz",
-      "integrity": "sha512-FFLcLtraisj5eteosnX1gf01qYDCOc4fDy0+euOt8Kn9YBY2NtXL/pCoYPavw24NIQkQqm5ZOLsGD5Zzj0gyew==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.6.tgz",
+      "integrity": "sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==",
       "requires": {
-        "node-fetch": "2.6.0"
+        "node-fetch": "2.6.1"
       }
     },
     "cross-spawn": {
@@ -10829,14 +10829,14 @@
       }
     },
     "node-fetch": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "node-forge": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.0.tgz",
-      "integrity": "sha512-7ASaDa3pD+lJ3WvXFsxekJQelBKRpne+GOVbLbtHYdd7pFspyeuJHnWfLplGf3SwKGbfs/aYl5V/JCIaHVUKKQ=="
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
     },
     "node-int64": {
       "version": "0.4.0",
@@ -14182,11 +14182,11 @@
       "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo="
     },
     "selfsigned": {
-      "version": "1.10.7",
-      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.7.tgz",
-      "integrity": "sha512-8M3wBCzeWIJnQfl43IKwOmC4H/RAp50S8DF60znzjW5GVqTcSe2vWclt7hmYVPkKPlHWOu5EaWOMZ2Y6W8ZXTA==",
+      "version": "1.10.8",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.8.tgz",
+      "integrity": "sha512-2P4PtieJeEwVgTU9QEcwIRDQ/mXJLX8/+I3ur+Pg16nS8oNbrGxEso9NyYWy8NAmXiNl4dlAp5MwoNeCWzON4w==",
       "requires": {
-        "node-forge": "0.9.0"
+        "node-forge": "^0.10.0"
       }
     },
     "semver": {

--- a/netmanager/src/views/layouts/Main/components/Topbar/Topbar.js
+++ b/netmanager/src/views/layouts/Main/components/Topbar/Topbar.js
@@ -51,15 +51,9 @@ const Topbar = (props) => {
   const orgData = useOrgData();
 
   const logo_style = {
-    height: "3.5em",
-    width: "4em",
-    borderRadius: "15%",
-    paddingTop: ".2em",
-    marginRight: ".4em",
-  };
-  const airqo_logo_style = {
-    height: "3.5em",
+    height: "3.8em",
     width: "5em",
+    borderRadius: "15%",
     paddingTop: ".2em",
     marginRight: ".4em",
   };
@@ -149,7 +143,7 @@ const Topbar = (props) => {
         <RouterLink to="/">
           <img
             alt="airqo.net"
-            style={airqo_logo_style}
+            style={logo_style}
             src="https://res.cloudinary.com/drgm88r3l/image/upload/v1602488051/airqo_org_logos/airqo_logo.png"
           />
         </RouterLink>
@@ -174,7 +168,7 @@ const Topbar = (props) => {
         <RouterLink to="/">
           <img
             alt="airqo.net"
-            style={airqo_logo_style}
+            style={logo_style}
             src="https://res.cloudinary.com/drgm88r3l/image/upload/v1602488051/airqo_org_logos/airqo_logo.png"
           />
         </RouterLink>

--- a/netmanager/src/views/layouts/Main/components/Topbar/Topbar.js
+++ b/netmanager/src/views/layouts/Main/components/Topbar/Topbar.js
@@ -50,15 +50,8 @@ const Topbar = (props) => {
   const [notifications] = useState([]);
   const orgData = useOrgData();
 
-  const kcca_logo_style = {
+  const logo_style = {
     height: "3.5em",
-    width: "4em",
-    borderRadius: "15%",
-    paddingTop: ".2em",
-    marginRight: ".4em",
-  };
-  const mak_logo_style = {
-    height: "3.3em",
     width: "4em",
     borderRadius: "15%",
     paddingTop: ".2em",
@@ -144,27 +137,51 @@ const Topbar = (props) => {
   return (
     <AppBar {...rest} className={clsx(classes.root, className)}>
       <Toolbar>
-        <RouterLink to="/">
+        {orgData.name != 'airqo' && 
+          <>
+         <RouterLink to="/">
           <img
-            alt="Logo"
-            style={kcca_logo_style}
-            src="/images/logos/kcca-logo.jpg"
+            alt="mak.ac.ug"
+            style={logo_style}
+            src="https://res.cloudinary.com/drgm88r3l/image/upload/v1602488051/airqo_org_logos/mak_logo.png"
           />
         </RouterLink>
         <RouterLink to="/">
           <img
             alt="airqo.net"
             style={airqo_logo_style}
-            src="/images/logos/airqo_logo.png"
+            src="https://res.cloudinary.com/drgm88r3l/image/upload/v1602488051/airqo_org_logos/airqo_logo.png"
           />
         </RouterLink>
         <RouterLink to="/">
           <img
+              alt={orgData.name}
+              style={logo_style}
+              src={"https://res.cloudinary.com/drgm88r3l/image/upload/v1602488051/airqo_org_logos/" + orgData.name + "_logo.png"}
+          />
+          </RouterLink>
+          </>
+        }
+        {orgData.name == 'airqo' && 
+          <>
+          <RouterLink to="/">
+          <img
             alt="mak.ac.ug"
-            style={mak_logo_style}
-            src="/images/logos/mak_logo.jpg"
+            style={logo_style}
+            src="https://res.cloudinary.com/drgm88r3l/image/upload/v1602488051/airqo_org_logos/mak_logo.png"
+          />
+          </RouterLink>
+        <RouterLink to="/">
+          <img
+            alt="airqo.net"
+            style={airqo_logo_style}
+            src="https://res.cloudinary.com/drgm88r3l/image/upload/v1602488051/airqo_org_logos/airqo_logo.png"
           />
         </RouterLink>
+        
+          </>
+        }
+        
         <div
           style={{
             textTransform: "uppercase",

--- a/netmanager/src/views/layouts/Main/components/Topbar/Topbar.js
+++ b/netmanager/src/views/layouts/Main/components/Topbar/Topbar.js
@@ -50,6 +50,12 @@ const Topbar = (props) => {
   const [notifications] = useState([]);
   const orgData = useOrgData();
 
+  const logoContainerStyle = {
+    display: "flex",
+    // justifyContent: "space-around",
+    width: "330px",
+  }
+
   const logo_style = {
     height: "3.8em",
     width: "5em",
@@ -131,50 +137,52 @@ const Topbar = (props) => {
   return (
     <AppBar {...rest} className={clsx(classes.root, className)}>
       <Toolbar>
-        {orgData.name != 'airqo' && 
-          <>
-         <RouterLink to="/">
-          <img
-            alt="mak.ac.ug"
-            style={logo_style}
-            src="https://res.cloudinary.com/drgm88r3l/image/upload/v1602488051/airqo_org_logos/mak_logo.png"
-          />
-        </RouterLink>
-        <RouterLink to="/">
-          <img
-            alt="airqo.net"
-            style={logo_style}
-            src="https://res.cloudinary.com/drgm88r3l/image/upload/v1602488051/airqo_org_logos/airqo_logo.png"
-          />
-        </RouterLink>
-        <RouterLink to="/">
-          <img
-              alt={orgData.name}
+        <div style={logoContainerStyle}>
+          {orgData.name != 'airqo' &&
+            <>
+           <RouterLink to="/">
+            <img
+              alt="mak.ac.ug"
               style={logo_style}
-              src={"https://res.cloudinary.com/drgm88r3l/image/upload/v1602488051/airqo_org_logos/" + orgData.name + "_logo.png"}
-          />
+              src="https://res.cloudinary.com/drgm88r3l/image/upload/v1602488051/airqo_org_logos/mak_logo.png"
+            />
           </RouterLink>
-          </>
-        }
-        {orgData.name == 'airqo' && 
-          <>
           <RouterLink to="/">
-          <img
-            alt="mak.ac.ug"
-            style={logo_style}
-            src="https://res.cloudinary.com/drgm88r3l/image/upload/v1602488051/airqo_org_logos/mak_logo.png"
-          />
+            <img
+              alt="airqo.net"
+              style={logo_style}
+              src="https://res.cloudinary.com/drgm88r3l/image/upload/v1602488051/airqo_org_logos/airqo_logo.png"
+            />
           </RouterLink>
-        <RouterLink to="/">
-          <img
-            alt="airqo.net"
-            style={logo_style}
-            src="https://res.cloudinary.com/drgm88r3l/image/upload/v1602488051/airqo_org_logos/airqo_logo.png"
-          />
-        </RouterLink>
-        
-          </>
-        }
+          <RouterLink to="/">
+            <img
+                alt={orgData.name}
+                style={logo_style}
+                src={"https://res.cloudinary.com/drgm88r3l/image/upload/v1602488051/airqo_org_logos/" + orgData.name + "_logo.png"}
+            />
+            </RouterLink>
+            </>
+          }
+          {orgData.name == 'airqo' &&
+            <>
+            <RouterLink to="/">
+            <img
+              alt="mak.ac.ug"
+              style={logo_style}
+              src="https://res.cloudinary.com/drgm88r3l/image/upload/v1602488051/airqo_org_logos/mak_logo.png"
+            />
+            </RouterLink>
+          <RouterLink to="/">
+            <img
+              alt="airqo.net"
+              style={logo_style}
+              src="https://res.cloudinary.com/drgm88r3l/image/upload/v1602488051/airqo_org_logos/airqo_logo.png"
+            />
+          </RouterLink>
+
+            </>
+          }
+        </div>
         
         <div
           style={{


### PR DESCRIPTION
- **What does this PR do?**
Users able to see the logo of their organization 

- **How do I test it out?**
cd `AirQo-frontend/netmanager`
```
npm install 

For Windows:
npm run stage-pc

For Mac:
npm run stage-mac
```
Try to the logo as KCCA or AirQo to see how the logo displayed varies
- Which JIRA card is associated?


- **Any other considerations?**
NONE

![Screenshot 2020-10-13 at 06 12 18](https://user-images.githubusercontent.com/15224992/95851434-e2e7ec80-0d5a-11eb-9531-0216707c2ba1.png)
![Screenshot 2020-10-13 at 06 11 35](https://user-images.githubusercontent.com/15224992/95851438-e54a4680-0d5a-11eb-8768-7c7413854bd7.png)
