### PR TITLE
adding documentation link to the top bar

### DIFF
--- a/netmanager/src/views/layouts/Main/components/Topbar/Topbar.js
+++ b/netmanager/src/views/layouts/Main/components/Topbar/Topbar.js
@@ -17,6 +17,7 @@ import {
 import MenuIcon from "@material-ui/icons/Menu";
 import NotificationsIcon from "@material-ui/icons/NotificationsOutlined";
 import InputIcon from "@material-ui/icons/Input";
+import EditLocationIcon from "@material-ui/icons/EditLocation";
 import { logoutUser } from "redux/Join/actions";
 import { useOrgData } from "../../../../../redux/Join/selectors";
 
@@ -180,6 +181,16 @@ const Topbar = (props) => {
         </p>
         <div className={classes.flexGrow} />
         <Hidden mdDown>
+        <a style={{
+            textTransform: "uppercase",
+            marginLeft: "10px",
+            fontSize: 16,
+            fontWeight: "bold",
+            color:'#fff' ,
+          }} href="https://docs.airqo.net/airqo-handbook/-MHlrqORW-vI38ybYLVC/" target='_blank'>
+          Documentation
+        </a>
+       
           <IconButton color="inherit">
             <Badge
               badgeContent={notifications.length}

--- a/netmanager/src/views/layouts/Main/components/Topbar/Topbar.js
+++ b/netmanager/src/views/layouts/Main/components/Topbar/Topbar.js
@@ -182,16 +182,16 @@ const Topbar = (props) => {
         </p>
         <div className={classes.flexGrow} />
         <Hidden mdDown>
-        <a style={{
-            textTransform: "uppercase",
-            marginLeft: "10px",
-            fontSize: 16,
-            fontWeight: "bold",
-            color:'#fff' ,
-          }} href="https://docs.airqo.net/airqo-handbook/-MHlrqORW-vI38ybYLVC/" target='_blank'>
-          
-          <HelpIcon/>
-        </a>
+
+          <IconButton color="inherit" href="https://docs.airqo.net/airqo-handbook/-MHlrqORW-vI38ybYLVC/" target="_blank">
+            <Badge
+              badgeContent={notifications.length}
+              color="primary"
+              variant="dot"
+            >
+              <HelpIcon />
+            </Badge>
+          </IconButton>
        
           <IconButton color="inherit">
             <Badge

--- a/netmanager/src/views/layouts/Main/components/Topbar/Topbar.js
+++ b/netmanager/src/views/layouts/Main/components/Topbar/Topbar.js
@@ -17,7 +17,8 @@ import {
 import MenuIcon from "@material-ui/icons/Menu";
 import NotificationsIcon from "@material-ui/icons/NotificationsOutlined";
 import InputIcon from "@material-ui/icons/Input";
-import EditLocationIcon from "@material-ui/icons/EditLocation";
+import FindInPageIcon from '@material-ui/icons/FindInPage';
+import HelpIcon from '@material-ui/icons/Help';
 import { logoutUser } from "redux/Join/actions";
 import { useOrgData } from "../../../../../redux/Join/selectors";
 
@@ -188,7 +189,8 @@ const Topbar = (props) => {
             fontWeight: "bold",
             color:'#fff' ,
           }} href="https://docs.airqo.net/airqo-handbook/-MHlrqORW-vI38ybYLVC/" target='_blank'>
-          Documentation
+          
+          <HelpIcon/>
         </a>
        
           <IconButton color="inherit">


### PR DESCRIPTION
**What does this PR do?**
    - addresses the issue of accessing platform documention from top bar
      
**Which JIRA card(s)?**
    - [https://airqoteam.atlassian.net/jira/software/projects/PLAT/boards/41?assignee=5d922cc14258550c23a16713&selectedIssue=PLAT-198](https://airqoteam.atlassian.net/jira/software/projects/PLAT/boards/41?assignee=5d922cc14258550c23a16713&selectedIssue=PLAT-198)
**How do I test out this PR?**
-  git fetch branch  **fx-documentation**  
- change directory to airqo-frontend/netmanager
- checkout the fx-documentation branch
- After, run npm run dev-mac or dev-pc  
**Which changes should be /are ready for testing?**
 - Confirm that you can access documentation from top bar 


