### PR TITLE
[NetManager] Fix device modals

### DIFF
--- a/netmanager/src/views/apis/deviceRegistry.js
+++ b/netmanager/src/views/apis/deviceRegistry.js
@@ -13,3 +13,9 @@ export const createDeviceComponentApi = async (deviceName, componentType, data) 
       .post(constants.ADD_COMPONENT_URI + deviceName, data, { params: { ctype }})
       .then((response) => response.data)
 }
+
+export const getFilteredDevicesApi = async (params) => {
+  return await axios
+    .get(constants.ALL_DEVICES_URI, { params })
+    .then((response) => response.data);
+};

--- a/netmanager/src/views/components/DataDisplay/DeviceView.js
+++ b/netmanager/src/views/components/DataDisplay/DeviceView.js
@@ -55,6 +55,7 @@ import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Checkbox from '@material-ui/core/Checkbox';
 import MenuItem from '@material-ui/core/MenuItem';
 import ListItemText from '@material-ui/core/ListItemText';
+import { getFilteredDevicesApi } from "../../apis/deviceRegistry";
 
 const useStyles = makeStyles(styles);
 
@@ -451,55 +452,17 @@ export default function DeviceView() {
   const [loaded, setLoaded] = useState(false);
   const [deviceData, setDeviceData] = useState([]);
   const [deviceName, setDeviceName] = useState('');
-  useEffect(() => {
-    let deviceID = params.channelId
-    axios.get(
-      constants.ALL_DEVICES_URI
-    )
-    .then(
-      res=>{
-        const ref = res.data;
-        for (var i=0; i<ref.length; i++){
-          if (ref[i].channelID==deviceID){
-            //console.log('ref[i].name');
-            //console.log(ref[i].name);
-            setDeviceData(ref[i]);
-            setDeviceName(ref[i].name);
-            console.log('getting maintenance logs')
-            console.log(logs(ref[i].name));
-            console.log(getComponents(ref[i].name));
-            setLoaded(true);
-          }
-        }
-    }).catch(
-      console.log
-    )
-  }, []);
 
   const [componentData, setComponentData] = useState([]);
-  //const [deviceName, setDeviceName] = useState('');
+
   useEffect(() => {
-    let deviceID = params.channelId
-    axios.get(
-      constants.ALL_DEVICES_URI
-    )
-    .then(
-      res=>{
-        const ref = res.data;
-        for (var i=0; i<ref.length; i++){
-          if (ref[i].channelID==deviceID){
-            console.log('ref[i].name');
-            console.log(ref[i].name);
-            setDeviceData(ref[i]);
-            setDeviceName(ref[i].name);
-            console.log('getting maintenance logs')
-            console.log(logs(ref[i].name));
-            setLoaded(true);
-          }
-        }
-    }).catch(
-      console.log
-    )
+    getFilteredDevicesApi({ chid: params.channelId })
+        .then(responseData => {
+          setDeviceData(responseData.device);
+          setDeviceName(responseData.device.name);
+          setLoaded(true);
+        })
+        .catch(console.log)
   }, []);
 
   //Edit dialog parameters
@@ -855,6 +818,12 @@ export default function DeviceView() {
                  </TableRow>
                  <TableRow>
                    <TableCell><b>Phone Number: </b>{"0"+deviceData.phoneNumber}</TableCell>
+                 </TableRow>
+                 <TableRow>
+                   <TableCell><b>Read Key: </b>{deviceData.readKey}</TableCell>
+                 </TableRow>
+                 <TableRow>
+                   <TableCell><b>Write Key: </b>{deviceData.writeKey}</TableCell>
                  </TableRow>
                </TableBody>
             </Table>

--- a/netmanager/src/views/components/DataDisplay/Devices.js
+++ b/netmanager/src/views/components/DataDisplay/Devices.js
@@ -1082,18 +1082,18 @@ const DevicesTable = (props) => {
           </DialogTitle>
 
           <DialogContent>
-            <div style={{ width: 300 }}>
+            <form className={classes.modelWidth} >
+            <div>
               <TextField
                 id="deviceName"
                 label="Device Name"
                 value={deviceName}
-                fullWidth={true}
-              />{" "}
-              <br />
+                fullWidth
+                disabled
+              />
               <FormControl
                 required
-                className={classes.formControl}
-                fullWidth={true}
+                fullWidth
               >
                 <InputLabel htmlFor="demo-dialog-native">
                   Type of Maintenance
@@ -1102,6 +1102,10 @@ const DevicesTable = (props) => {
                   native
                   value={maintenanceType}
                   onChange={handleMaintenanceTypeChange}
+                  inputProps={{
+                    native: true,
+                    style: {height: "40px", marginTop: "10px"},
+                  }}
                   input={<Input id="demo-dialog-native" />}
                 >
                   <option aria-label="None" value="" />
@@ -1112,8 +1116,8 @@ const DevicesTable = (props) => {
               <br />
               <FormControl
                 required
-                className={classes.formControl}
-                fullWidth={true}
+                className
+                fullWidth
               >
                 <InputLabel htmlFor="demo-dialog-native">
                   Description of Activities
@@ -1122,7 +1126,7 @@ const DevicesTable = (props) => {
                   multiple
                   value={maintenanceDescription}
                   onChange={handleMaintenanceDescriptionChange}
-                  input={<Input />}
+                  input={<Input style={{height: "50px", marginTop: "10px"}}/>}
                   renderValue={(selected) => selected.join(", ")}
                   MenuProps={MenuProps}
                 >
@@ -1156,31 +1160,29 @@ const DevicesTable = (props) => {
                 />
               </MuiPickersUtilsProvider>
             </div>
+            </form>
           </DialogContent>
 
           <DialogActions>
             <Grid
               container
-              alignItems="center"
-              alignContent="center"
-              justify="center"
+              alignItems="flex-end"
+              alignContent="flex-end"
+              justify="flex-end"
             >
+              <Button
+                variant="contained"
+                onClick={handleMaintenanceClose}
+              >
+                Cancel
+              </Button>
               <Button
                 variant="contained"
                 color="primary"
                 onClick={handleMaintenanceSubmit}
+                style={{ margin: "0 15px" }}
               >
-                {" "}
                 Update
-              </Button>
-              &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-              <Button
-                variant="contained"
-                color="primary"
-                onClick={handleMaintenanceClose}
-              >
-                {" "}
-                Cancel
               </Button>
             </Grid>
           </DialogActions>

--- a/netmanager/src/views/components/DataDisplay/Devices.js
+++ b/netmanager/src/views/components/DataDisplay/Devices.js
@@ -1204,7 +1204,7 @@ const DevicesTable = (props) => {
           </DialogTitle>
 
           <DialogContent>
-            <Grid container spacing={1}>
+            <Grid container spacing={1} className={classes.modelWidth}>
               <Grid container item xs={12} spacing={3}>
                 <Grid item xs={6}>
                   <TextField
@@ -1212,7 +1212,7 @@ const DevicesTable = (props) => {
                     label="Device Name"
                     value={deviceName}
                     required
-                    fullWidth={true}
+                    fullWidth
                   />
                 </Grid>
                 <Grid item xs={6}>
@@ -1221,7 +1221,7 @@ const DevicesTable = (props) => {
                     label="height"
                     value={height}
                     onChange={handleHeightChange}
-                    fullWidth={true}
+                    fullWidth
                   />
                 </Grid>
               </Grid>
@@ -1229,8 +1229,7 @@ const DevicesTable = (props) => {
                 <Grid item xs={6}>
                   <FormControl
                     required
-                    className={classes.formControl}
-                    fullWidth={true}
+                    fullWidth
                   >
                     <InputLabel htmlFor="demo-dialog-native">
                       Location ID
@@ -1240,6 +1239,10 @@ const DevicesTable = (props) => {
                       required
                       value={locationID}
                       onChange={handleLocationIDChange}
+                      inputProps={{
+                        native: true,
+                        style: {height: "40px", marginTop: "10px"},
+                      }}
                       input={<Input id="demo-dialog-native" />}
                     >
                       <option aria-label="None" value="" />
@@ -1262,7 +1265,7 @@ const DevicesTable = (props) => {
                 </Grid>
 
                 <Grid item xs={6}>
-                  <FormControl className={classes.formControl} fullWidth={true}>
+                  <FormControl fullWidth>
                     <InputLabel htmlFor="demo-dialog-native">
                       Power Type
                     </InputLabel>
@@ -1270,6 +1273,10 @@ const DevicesTable = (props) => {
                       native
                       value={power}
                       onChange={handlePowerChange}
+                      inputProps={{
+                        native: true,
+                        style: {height: "40px", marginTop: "10px"},
+                      }}
                       input={<Input id="demo-dialog-native" />}
                     >
                       <option aria-label="None" value="" />
@@ -1320,6 +1327,7 @@ const DevicesTable = (props) => {
                       />
                     }
                     label="I wish to make this my primary device in this location"
+                    style={{ margin: "10px 0 0 5px" }}
                   />
                   <FormControlLabel
                     control={
@@ -1331,6 +1339,7 @@ const DevicesTable = (props) => {
                       />
                     }
                     label="This deployment is a formal collocation"
+                    style={{ marginLeft: "5px" }}
                   />
                 </Grid>{" "}
               </div>
@@ -1340,26 +1349,23 @@ const DevicesTable = (props) => {
           <DialogActions>
             <Grid
               container
-              alignItems="center"
-              alignContent="center"
-              justify="center"
+              alignItems="flex-end"
+              alignContent="flex-end"
+              justify="flex-end"
             >
+              <Button
+                variant="contained"
+                onClick={handleDeployClose}
+              >
+                Cancel
+              </Button>
               <Button
                 variant="contained"
                 color="primary"
                 onClick={handleDeploySubmit}
+                style={{ margin: "0 15px" }}
               >
-                {" "}
                 Deploy
-              </Button>
-              &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-              <Button
-                variant="contained"
-                color="primary"
-                onClick={handleDeployClose}
-              >
-                {" "}
-                Cancel
               </Button>
             </Grid>
           </DialogActions>

--- a/netmanager/src/views/components/DataDisplay/Devices.js
+++ b/netmanager/src/views/components/DataDisplay/Devices.js
@@ -1386,33 +1386,30 @@ const DevicesTable = (props) => {
           </DialogTitle>
 
           <DialogContent>
-            Are you sure you want to recall device {deviceName} from location{" "}
-            {locationID}?
+            Are you sure you want to recall device <strong>{deviceName}</strong> from location{" "}
+            <strong>{locationID}</strong>?
           </DialogContent>
 
           <DialogActions>
             <Grid
               container
-              alignItems="center"
-              alignContent="center"
-              justify="center"
+              alignItems="flex-end"
+              alignContent="flex-end"
+              justify="flex-end"
             >
+              <Button
+                variant="contained"
+                onClick={handleRecallClose}
+              >
+                NO
+              </Button>
               <Button
                 variant="contained"
                 color="primary"
                 onClick={handleRecallSubmit}
+                style={{ margin: "0 15px" }}
               >
-                {" "}
                 YES
-              </Button>
-              &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-              <Button
-                variant="contained"
-                color="primary"
-                onClick={handleRecallClose}
-              >
-                {" "}
-                NO
               </Button>
             </Grid>
           </DialogActions>

--- a/netmanager/src/views/components/DataDisplay/Devices.js
+++ b/netmanager/src/views/components/DataDisplay/Devices.js
@@ -74,10 +74,12 @@ const useStyles = makeStyles((theme) => ({
   table: {
     fontFamily: "Open Sans",
   },
+  modelWidth: {
+    minWidth: 450,
+  },
   formControl: {
-    minWidth: 200,
-    height: 50,
-    margin: "15 0"
+    height: 40,
+    margin: "15px 0"
   },
   input: {
     color: "black",
@@ -101,7 +103,10 @@ const useStyles = makeStyles((theme) => ({
   button: {
     margin: "10px",
     width: "60px"
-  }
+  },
+  textFieldMargin: {
+    margin: "15 0"
+  },
 }));
 
 const DevicesTable = (props) => {
@@ -1416,62 +1421,57 @@ const DevicesTable = (props) => {
           <DialogTitle id="form-dialog-title">Add a device</DialogTitle>
 
           <DialogContent>
-            <form className={classes.formControl}>
+            <form className={classes.modelWidth}>
               <TextField
                 required
+                className={classes.textFieldMargin}
                 id="deviceName"
                 value={registerName}
                 onChange={handleRegisterNameChange}
                 label="Device Name"
-                fullWidth={true}
+                fullWidth
               />
-              <br />
               <TextField
                 id="standard-basic"
+                className={classes.textFieldMargin}
                 label="Description"
                 value={description}
                 onChange={handleDescriptionChange}
-                fullWidth={true}
+                fullWidth
                 required
               />
-              <br />
               <TextField
                 id="standard-basic"
                 label="Manufacturer"
                 value={manufacturer}
                 onChange={handleManufacturerChange}
-                fullWidth={true}
+                fullWidth
               />
-              <br />
               <TextField
                 id="standard-basic"
                 label="Product Name"
                 value={productName}
                 onChange={handleProductNameChange}
-                fullWidth={true}
+                fullWidth
               />
-              <br />
               <TextField
                 id="standard-basic"
                 label="Latitude"
                 value={latitude}
                 onChange={handleLatitudeChange}
-                fullWidth={true}
+                fullWidth
                 required
               />
-              <br />
               <TextField
                 id="standard-basic"
                 label="Longitude"
                 value={longitude}
                 onChange={handleLongitudeChange}
-                fullWidth={true}
+                fullWidth
                 required
               />
-              <br />
-              <FormControl required fullWidth={true}>
+              <FormControl required fullWidth>
                 <InputLabel htmlFor="demo-dialog-native">
-                  {" "}
                   Data Access
                 </InputLabel>
                 <Select
@@ -1479,7 +1479,10 @@ const DevicesTable = (props) => {
                   native
                   value={visibility}
                   onChange={handleVisibilityChange}
-                  input={<Input id="demo-dialog-native" />}
+                  inputProps={{
+                    native: true,
+                    style: {height: "40px", marginTop: "10px", border: "1px solid red"},
+                  }}
                 >
                   <option aria-label="None" value="" />
                   <option value="true">True</option>
@@ -1492,19 +1495,20 @@ const DevicesTable = (props) => {
                 label="Owner"
                 value={owner}
                 onChange={handleOwnerChange}
-                fullWidth={true}
+                fullWidth
               />
-              <br />
-              <FormControl fullWidth={true}>
+              <FormControl fullWidth>
                 <InputLabel htmlFor="demo-dialog-native">
-                  {" "}
                   Internet Service Provider
                 </InputLabel>
                 <Select
                   native
                   value={ISP}
                   onChange={handleISPChange}
-                  input={<Input id="demo-dialog-native" />}
+                  inputProps={{
+                    native: true,
+                    style: {height: "40px", marginTop: "10px", border: "1px solid red"},
+                  }}
                 >
                   <option aria-label="None" value="" />
                   <option value="MTN">MTN</option>
@@ -1517,39 +1521,35 @@ const DevicesTable = (props) => {
                 label="Phone Number"
                 value={phone}
                 onChange={handlePhoneChange}
-                fullWidth={true}
+                fullWidth
               />
-              <br />
             </form>
           </DialogContent>
 
           <DialogActions>
             <Grid
               container
-              alignItems="center"
-              alignContent="center"
-              justify="center"
+              alignItems="flex-end"
+              alignContent="flex-end"
+              justify="flex-end"
             >
+              <Button
+                variant="contained"
+                type="button"
+                onClick={handleRegisterClose}
+              >
+                Cancel
+              </Button>
               <Button
                 variant="contained"
                 color="primary"
                 type="submit"
                 onClick={handleRegisterSubmit}
+                style={{margin: "0 15px"}}
               >
-                {" "}
                 Register
               </Button>
-              &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-              <Button
-                variant="contained"
-                color="primary"
-                type="button"
-                onClick={handleRegisterClose}
-              >
-                {" "}
-                Cancel
-              </Button>
-            </Grid>{" "}
+            </Grid>
             <br />
           </DialogActions>
         </Dialog>
@@ -1740,7 +1740,7 @@ const DevicesTable = (props) => {
               </div>
 
               <div className={classes.fieldMargin}>
-                <FormControl required fullWidth={true} className={classes.formControl}>
+                <FormControl required fullWidth={true} className={`${classes.modelWidth} ${classes.formControl}`}>
                 <InputLabel shrink htmlFor="demo-dialog-native-1">
                   Component Type
                 </InputLabel>

--- a/netmanager/src/views/components/DataDisplay/Devices.js
+++ b/netmanager/src/views/components/DataDisplay/Devices.js
@@ -1481,7 +1481,7 @@ const DevicesTable = (props) => {
                   onChange={handleVisibilityChange}
                   inputProps={{
                     native: true,
-                    style: {height: "40px", marginTop: "10px", border: "1px solid red"},
+                    style: {height: "40px", marginTop: "10px"},
                   }}
                 >
                   <option aria-label="None" value="" />
@@ -1507,7 +1507,7 @@ const DevicesTable = (props) => {
                   onChange={handleISPChange}
                   inputProps={{
                     native: true,
-                    style: {height: "40px", marginTop: "10px", border: "1px solid red"},
+                    style: {height: "40px", marginTop: "10px"},
                   }}
                 >
                   <option aria-label="None" value="" />
@@ -1565,66 +1565,60 @@ const DevicesTable = (props) => {
           <DialogTitle id="form-dialog-title">Edit a device</DialogTitle>
 
           <DialogContent>
-            <form className={classes.formControl}>
+            <form className={classes.modelWidth}>
               <TextField
                 required
                 id="standard-basic"
                 label="Device Name"
                 value={registerName}
-                fullWidth={true}
+                fullWidth
+                disabled
                 onChange={handleRegisterNameChange}
                 InputProps={{
                   readOnly: true,
                 }}
-              />{" "}
-              <br />
+              />
               <TextField
                 id="standard-basic"
                 label="Description"
                 value={description}
                 onChange={handleDescriptionChange}
-                fullWidth={true}
+                fullWidth
                 required
               />
-              <br />
               <TextField
                 id="standard-basic"
                 label="Manufacturer"
                 value={manufacturer}
                 onChange={handleManufacturerChange}
-                fullWidth={true}
+                fullWidth
               />
-              <br />
               <TextField
                 id="standard-basic"
                 label="Product Name"
                 value={productName}
                 onChange={handleProductNameChange}
-                fullWidth={true}
+                fullWidth
               />
-              <br />
               <TextField
                 id="standard-basic"
                 label="Latitude"
                 value={latitude}
                 onChange={handleLatitudeChange}
-                fullWidth={true}
+                fullWidth
                 required
               />
-              <br />
               <TextField
                 id="standard-basic"
                 label="Longitude"
                 value={longitude}
                 onChange={handleLongitudeChange}
-                fullWidth={true}
+                fullWidth
                 required
               />
-              <br />
               <FormControl
                 required
-                className={classes.formControl}
-                fullWidth={true}
+                fullWidth
               >
                 <InputLabel htmlFor="demo-dialog-native">
                   Data Access
@@ -1633,6 +1627,10 @@ const DevicesTable = (props) => {
                   native
                   value={visibility}
                   onChange={handleVisibilityChange}
+                  inputProps={{
+                    native: true,
+                    style: {height: "40px", marginTop: "10px", border: "1px solid red"},
+                  }}
                   input={<Input id="demo-dialog-native" />}
                 >
                   <option aria-label="None" value="" />
@@ -1645,19 +1643,21 @@ const DevicesTable = (props) => {
                 label="Owner"
                 value={owner}
                 onChange={handleOwnerChange}
-                fullWidth={true}
+                fullWidth
                 required
               />
-              <br />
-              <FormControl className={classes.formControl} fullWidth={true}>
+              <FormControl fullWidth>
                 <InputLabel htmlFor="demo-dialog-native">
-                  {" "}
                   Internet Service Provider
                 </InputLabel>
                 <Select
                   native
                   value={ISP}
                   onChange={handleISPChange}
+                  inputProps={{
+                    native: true,
+                    style: {height: "40px", marginTop: "10px"},
+                  }}
                   input={<Input id="demo-dialog-native" />}
                 >
                   <option aria-label="None" value="" />
@@ -1671,39 +1671,35 @@ const DevicesTable = (props) => {
                 label="Phone Number"
                 value={phone}
                 onChange={handlePhoneChange}
-                fullWidth={true}
+                fullWidth
               />
-              <br />
             </form>
           </DialogContent>
 
           <DialogActions>
             <Grid
               container
-              alignItems="center"
-              alignContent="center"
-              justify="center"
+              alignItems="flex-end"
+              alignContent="flex-end"
+              justify="flex-end"
             >
+              <Button
+                variant="contained"
+                type="button"
+                onClick={handleEditClose}
+              >
+                Cancel
+              </Button>
               <Button
                 variant="contained"
                 type="submit"
                 color="primary"
                 onClick={handleEditSubmit}
+                style={{ margin: "0 15px" }}
               >
-                {" "}
                 Update
               </Button>
-              &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-              <Button
-                variant="contained"
-                color="primary"
-                type="button"
-                onClick={handleEditClose}
-              >
-                {" "}
-                Cancel
-              </Button>
-            </Grid>{" "}
+            </Grid>
             <br />
           </DialogActions>
         </Dialog>


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)
- Fixes all popup models on device page

#### Is this change ready to hit production in its current state?
- [x] Yes
- [ ] No

#### Status of maturity (all need to be checked before merging):

- [x] I consider this code done
- [x] I've tested this locally
- [ ] This branch has been LGTM'ed by a reviewer

#### How should this be manually tested?
* Pull and checkout to this [branch](https://github.com/airqo-platform/AirQo-frontend/tree/ch-merge-configs-PLAT-117) locally
* Install node requirements `npm install`
* Start the application `npm run stage-mac` (on mac) or `npm run stage-pc` (on windows platform)
* Goto device registry and click on add device, the modal that pops up must be well formatted
* Repeat the action above for all device actions (edit a device, deploy a device recall... etc)

#### What are the relevant tickets?
- [PLAT-244](https://airqoteam.atlassian.net/browse/PLAT-244)
- [PLAT-243](https://airqoteam.atlassian.net/browse/PLAT-243)

#### Screenshots (optional)

