### PR TITLE
[NetManager] add netmanager role

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+#### Summary of Changes (What does this PR do?)
+- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
+
+#### Is this change ready to hit production in its current state?
+- [ ] Yes
+- [ ] No
+
+#### Status of maturity (all need to be checked before merging):
+
+- [ ] I consider this code done
+- [ ] I've tested this locally
+- [ ] This branch has been LGTM'ed by a reviewer
+
+#### How should this be manually tested?
+* Please include the steps to be done inorder to setup and test this PR.
+
+#### What are the relevant tickets?
+- [ticket_id]()
+
+#### Screenshots (optional)

--- a/netmanager/src/views/layouts/Main/components/Sidebar/Sidebar.js
+++ b/netmanager/src/views/layouts/Main/components/Sidebar/Sidebar.js
@@ -50,14 +50,35 @@ const excludePages = (pages, excludedArr) => {
   });
 };
 
-const Sidebar = (props) => {
-  const { open, variant, onClose, className, ...rest } = props;
+const roleExcludePageMapper = {
+    collaborator: [
+        "Users",
+        "Candidates",
+        "Locate",
+        "Device Management",
+        "Location Registry",
+        "Device Registry",
+    ],
+    user : [
+        "Users",
+        "Candidates",
+        "Locate",
+        "Device Management",
+        "Location Registry",
+        "Device Registry",
+    ],
+    netmanager: [
+        "Users",
+        "Candidates",
+    ],
+    admin: [
+        "Candidates",
+    ],
+    super: [],
 
-  const classes = useStyles();
+  }
 
-  const orgData = useOrgData();
-
-  let pages = [
+const allMainPages = [
     {
       title: "Overview",
       href: "/overview",
@@ -96,7 +117,8 @@ const Sidebar = (props) => {
       icon: <EditLocationIcon />,
     },
   ];
-  const userManagementPages = [
+
+ const allUserManagementPages = [
     {
       title: "Users",
       href: "/admin/users",
@@ -119,36 +141,20 @@ const Sidebar = (props) => {
     },
   ];
 
+
+const Sidebar = (props) => {
+  const { open, variant, onClose, className, ...rest } = props;
+
+  const classes = useStyles();
+
+  const orgData = useOrgData();
+
   const { mappedAuth } = props;
   let { user } = mappedAuth;
-  let userPages = [];
+  const excludedPages = roleExcludePageMapper[user.privilege ] || roleExcludePageMapper.user;
+  let pages = excludePages(allMainPages, excludedPages);
+  const userPages = excludePages(allUserManagementPages, excludedPages);
 
-  try {
-    if (user.privilege === "super") {
-      userPages = userManagementPages;
-    } else if (user.privilege === "admin") {
-      userPages = excludePages(userManagementPages, ["Candidates"]);
-    } else {
-      userPages = excludePages(userManagementPages, [
-        "Users",
-        "Candidates",
-        "Locate",
-        "Device Management",
-        "Location Registry",
-        "Device Registry",
-      ]);
-      pages = excludePages(pages, [
-        "Users",
-        "Candidates",
-        "Locate",
-        "Device Management",
-        "Location Registry",
-        "Device Registry",
-      ]);
-    }
-  } catch (e) {
-    console.log(e);
-  }
 
   if (orgData.name.toLowerCase() === "airqo") {
     pages = excludePages(pages, ["Dashboard", "Export"]);

--- a/netmanager/src/views/layouts/Main/components/Sidebar/Sidebar.js
+++ b/netmanager/src/views/layouts/Main/components/Sidebar/Sidebar.js
@@ -151,7 +151,7 @@ const Sidebar = (props) => {
 
   const { mappedAuth } = props;
   let { user } = mappedAuth;
-  const excludedPages = roleExcludePageMapper[user.privilege ] || roleExcludePageMapper.user;
+  const excludedPages = roleExcludePageMapper[user.privilege] || roleExcludePageMapper.user;
   let pages = excludePages(allMainPages, excludedPages);
   const userPages = excludePages(allUserManagementPages, excludedPages);
 

--- a/netmanager/src/views/pages/UserList/components/UsersToolbar/UsersToolbar.js
+++ b/netmanager/src/views/pages/UserList/components/UsersToolbar/UsersToolbar.js
@@ -24,7 +24,7 @@ import { Alert, AlertTitle } from "@material-ui/lab";
 import { useMinimalSelectStyles } from "@mui-treasury/styles/select/minimal";
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
 import { SearchInput } from "views/components/SearchInput";
-import { useOrgData } from "../../../../../redux/Join/selectors";
+import { useOrgData } from "redux/Join/selectors";
 
 
 const useStyles = makeStyles((theme) => ({
@@ -70,20 +70,20 @@ const useStyles = makeStyles((theme) => ({
 
 const roles = [
   {
-    value: "none",
-    label: "none",
-  },
-  {
-    value: "admin",
-    label: "admin",
-  },
-  {
     value: "user",
     label: "user",
   },
   {
     value: "collaborator",
     label: "collaborator",
+  },
+  {
+    value: "netmanager",
+    label: "netmanager",
+  },
+  {
+    value: "admin",
+    label: "admin",
   },
 ];
 
@@ -107,7 +107,7 @@ const UsersToolbar = (props) => {
     email: "",
     password: "",
     password2: "",
-    privilege: "",
+    privilege: roles[0].value,
     errors: {},
   };
 


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)
- adds a new role netmanager to the platform
- add PR template (cherry picked from merge-url)

#### Is this change ready to hit production in its current state?
- [ ] Yes
- [ ] No

#### Status of maturity (all need to be checked before merging):

- [ ] I consider this code done
- [ ] I've tested this locally
- [ ] This branch has been LGTM'ed by a reviewer

#### How should this be manually tested?
* Pull and checkout to this [branch](https://github.com/airqo-platform/AirQo-frontend/tree/ch-merge-configs-PLAT-117) locally
* Install node requirements `npm install`
* Start the application `npm run stage-mac` (on mac) or `npm run stage-pc` (on windows platform)
* Create a new user with the role `netmanager` and login with this new user. You shouldn't be able to access `Users` and `Candidates` tabs.


#### What are the relevant tickets?
- [PLAT-293](https://airqoteam.atlassian.net/browse/PLAT-293)

#### Screenshots (optional)

![image](https://user-images.githubusercontent.com/39955305/98120459-07009e80-1ebf-11eb-8bc1-10385b148fd3.png)
