### PR TITLE
fix device-monitoring urls

### DIFF
--- a/netmanager/src/config/constants.js
+++ b/netmanager/src/config/constants.js
@@ -32,15 +32,15 @@ const prodConfig = {
   UPDATE_LOCATE_MAP: "http://34.78.78.202:30004/api/v1/map/updatelocatemap/",
   DELETE_LOCATE_MAP: "http://34.78.78.202:30004/api/v1/map/deletelocatemap/",
   GET_DEVICE_STATUS_SUMMARY:
-    "http://34.78.78.202:30006/api/v1/device/monitor/status",
+    "http://34.78.78.202:30006/api/v1/monitor/device/status",
   GET_MAINTENANCE_LOGS:
-    "http://34.78.78.202:30006/api/v1/device/monitor/maintenance_logs",
+    "http://34.78.78.202:30006/api/v1/monitor/device/maintenance_logs",
   GET_DEVICE_MAINTENANCE_LOG:
-    "http://34.78.78.202:30006/api/v1/device/monitor/maintenance_logs/",
+    "http://34.78.78.202:30006/api/v1/monitor/device/maintenance_logs/",
   GET_DEVICE_POWER_TYPE:
-    "http://34.78.78.202:30006/api/v1/device/monitor/power_type",
+    "http://34.78.78.202:30006/api/v1/monitor/device/power_type",
   GET_DEVICE_STATUS_FOR_PIECHART_DISPLAY:
-    "http://34.78.78.202:30006/api/v1/device/monitor/status/latest",
+    "http://34.78.78.202:30006/api/v1/monitor/device/status/latest",
   GET_LATEST_OFFLINE_DEVICES:
     "http://34.78.78.202:30006/api/v1/monitor/devices/offline",
   GET_NETWORK_UPTIME: "http://34.78.78.202:30006/api/v1/monitor/network/uptime",
@@ -50,7 +50,7 @@ const prodConfig = {
   GET_DEVICE_SENSOR_CORRELATION:
     "http://34.78.78.202:30006/api/v1/monitor/device/sensors/correlation",
   DEVICE_MAINTENANCE_LOG_URI:
-    "http://34.78.78.202:30006/api/v1/device/monitor/maintenance_logs/",
+    "http://34.78.78.202:30006/api/v1/monitor/device/maintenance_logs/",
   ADD_MAINTENANCE_URI:
     "http://34.78.78.202:30001/api/v1/data/channels/maintenance/add",
   DEVICE_RECENT_FEEDS: "http://34.78.78.202:30001/api/v1/data/feeds/transform/recent",
@@ -158,15 +158,15 @@ const devConfig = {
   UPDATE_LOCATE_MAP: "http://localhost:4000/api/v1/map/updatelocatemap/",
   DELETE_LOCATE_MAP: "http://localhost:4000/api/v1/map/deletelocatemap/",
   GET_DEVICE_STATUS_SUMMARY:
-    "http://localhost:4001/api/v1/device/monitor/status",
+    "http://localhost:4001/api/v1/monitor/device/status",
   GET_MAINTENANCE_LOGS:
-    "http://localhost:4001/api/v1/device/monitor/maintenance_logs",
+    "http://localhost:4001/api/v1/monitor/device/maintenance_logs",
   GET_DEVICE_MAINTENANCE_LOG:
-    "http://localhost:4001/api/v1/device/monitor/maintenance_logs/",
+    "http://localhost:4001/api/v1/monitor/device/maintenance_logs/",
   GET_DEVICE_POWER_TYPE:
-    "http://localhost:4001/api/v1/device/monitor/power_type",
+    "http://localhost:4001/api/v1/monitor/device/power_type",
   GET_DEVICE_STATUS_FOR_PIECHART_DISPLAY:
-    "http://localhost:4001/api/v1/device/monitor/status/latest",
+    "http://localhost:4001/api/v1/monitor/device/status/latest",
   GET_LATEST_OFFLINE_DEVICES:
     "http://localhost:4001/api/v1/monitor/devices/offline",
   GET_NETWORK_UPTIME: "http://localhost:4001/api/v1/monitor/network/uptime",
@@ -200,7 +200,7 @@ const devConfig = {
     "http://localhost:3000/api/v1/devices/by/location?loc=",
   DEPLOY_DEVICE_URI: "http://localhost:3000/api/v1/devices/ts/activity?type=",
   DEVICE_MAINTENANCE_LOG_URI:
-    "http://localhost:4001/api/v1/device/monitor/maintenance_logs/",
+    "http://localhost:4001/api/v1/monitor/device/maintenance_logs/",
   //DELETE_DEVICE_URI: "http://127.0.0.1:3000/api/api/v1/devices/ts/delete?device="
   GET_ONLINE_OFFLINE_MAINTENANCE_STATUS:
     "http://127.0.0.1:4001/api/v1/monitor/devices/online_offline",
@@ -248,15 +248,15 @@ const stageConfig = {
   UPDATE_LOCATE_MAP: "http://34.78.78.202:31004/api/v1/map/updatelocatemap/",
   DELETE_LOCATE_MAP: "http://34.78.78.202:31004/api/v1/map/deletelocatemap/",
   GET_DEVICE_STATUS_SUMMARY:
-    "http://34.78.78.202:31006/api/v1/device/monitor/status",
+    "http://34.78.78.202:31006/api/v1/monitor/device/status",
   GET_MAINTENANCE_LOGS:
-    "http://34.78.78.202:31006/api/v1/device/monitor/maintenance_logs",
+    "http://34.78.78.202:31006/api/v1/monitor/device/maintenance_logs",
   GET_DEVICE_MAINTENANCE_LOG:
-    "http://34.78.78.202:31006/api/v1/device/monitor/maintenance_logs/",
+    "http://34.78.78.202:31006/api/v1/monitor/device/maintenance_logs/",
   GET_DEVICE_POWER_TYPE:
-    "http://34.78.78.202:31006/api/v1/device/monitor/power_type",
+    "http://34.78.78.202:31006/api/v1/monitor/device/power_type",
   GET_DEVICE_STATUS_FOR_PIECHART_DISPLAY:
-    "http://34.78.78.202:31006/api/v1/device/monitor/status/latest",
+    "http://34.78.78.202:31006/api/v1/monitor/device/status/latest",
   GET_LATEST_OFFLINE_DEVICES:
     "http://34.78.78.202:31006/api/v1/monitor/devices/offline",
   GET_NETWORK_UPTIME: "http://34.78.78.202:31006/api/v1/monitor/network/uptime",
@@ -266,7 +266,7 @@ const stageConfig = {
   GET_DEVICE_SENSOR_CORRELATION:
     "http://34.78.78.202:31006/api/v1/monitor/device/sensors/correlation",
   DEVICE_MAINTENANCE_LOG_URI:
-    "http://34.78.78.202:31006/api/v1/device/monitor/maintenance_logs/",
+    "http://34.78.78.202:31006/api/v1/monitor/device/maintenance_logs/",
   ADD_MAINTENANCE_URI:
     "http://34.78.78.202:31001/api/v1/data/channels/maintenance/add",
   DEVICE_RECENT_FEEDS: "http://34.78.78.202:31001/api/v1/data/feeds/transform/recent",

--- a/netmanager/src/views/components/DataDisplay/DeviceView/DeviceOverview.js
+++ b/netmanager/src/views/components/DataDisplay/DeviceView/DeviceOverview.js
@@ -3,8 +3,6 @@ import { useDispatch } from "react-redux";
 import { makeStyles } from "@material-ui/core/styles";
 import AccessTime from "@material-ui/icons/AccessTime";
 // core components
-import GridItem from "../../Grid/GridItem.js";
-import GridContainer from "../../Grid/GridContainer.js";
 import Card from "../../Card/Card.js";
 import { Map, TileLayer, Marker, Popup } from "react-leaflet";
 import {
@@ -12,7 +10,6 @@ import {
   Table,
   TableBody,
   TableCell,
-  TableHead,
   TableRow,
   Paper,
 } from "@material-ui/core";
@@ -505,7 +502,7 @@ export default function DeviceOverview({ deviceData }) {
                 alignContent="left"
               >
                 <TableBody>
-                  {deviceMaintenanceLogs.slice(0, 8).map((log, index) => (
+                  {deviceMaintenanceLogs.map((log, index) => (
                     <TableRow key={index}>
                       <TableCell>{formatDate(new Date(log.date))}</TableCell>
                       <TableCell>
@@ -574,7 +571,7 @@ export default function DeviceOverview({ deviceData }) {
                 alignContent="left"
               >
                 <TableBody style={{ alignContent: "left", alignItems: "left" }}>
-                  {deviceComponents.slice(0, 7).map((component, index) => (
+                  {deviceComponents.map((component, index) => (
                     <TableRow key={index} style={{ align: "left" }}>
                       <TableCell>{component.description}</TableCell>
                       <TableCell>


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)
- Fixes device-monitoring urls to match that of the updated micro-service

#### Is this change ready to hit production in its current state?
- [ ] Yes
- [ ] No

#### Status of maturity (all need to be checked before merging):

- [ ] I consider this code done
- [ ] I've tested this locally
- [ ] This branch has been LGTM'ed by a reviewer

#### How should this be manually tested?
* Install requirements `npm install`
* Start the application `npm run stage-mac` (macOS) or `npm run stage-pc` (Windows platform)
* Ensure that `device management` and `device overview` loads successfully

#### What are the relevant tickets?
- [N/A]()

#### Screenshots (optional)