### PR TITLE
introduce multitenancy for reset password page

### DIFF
--- a/netmanager/src/views/pages/ResetPassword/ResetPassword.js
+++ b/netmanager/src/views/pages/ResetPassword/ResetPassword.js
@@ -36,46 +36,54 @@ class ResetPassword extends Component {
   //extract token and DATE from URL params and
   //passes it back to server's reset route for verification
   async componentDidMount() {
-    var anchorElem = document.createElement('link');
-    anchorElem.setAttribute('href', 'https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css');
-    anchorElem.setAttribute('rel','stylesheet') ;
-    anchorElem.setAttribute('id','logincdn') ;
+    var anchorElem = document.createElement("link");
+    anchorElem.setAttribute(
+      "href",
+      "https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css"
+    );
+    anchorElem.setAttribute("rel", "stylesheet");
+    anchorElem.setAttribute("id", "logincdn");
 
     //document.body.appendChild(anchorElem);
-    document.getElementsByTagName('head')[0].appendChild(anchorElem);
- 
-    const {
-      match: {
-        params: { token },
-      },
-    } = this.props;
+    document.getElementsByTagName("head")[0].appendChild(anchorElem);
 
-      await axios.get(constants.VERIFY_TOKEN_URI, {
+    const {
+      // match: {
+      //   params: {token}
+      // },
+      location: { search },
+    } = this.props;
+    const { tenant, token } = search;
+    console.log("the tenant: ", tenant);
+    console.log("the token: ", token);
+    await axios
+      .get(constants.VERIFY_TOKEN_URI, {
         params: {
           resetPasswordToken: token,
+          tenant: tenant,
         },
-      }).then(response=>{
-        console.log("this is my response: ")
-   console.log(response);
-   if (response.data.message === "password reset link a-ok") {
-    this.setState({
-      userName: response.data.userName,
-      updated: false,
-      isLoading: false,
-      error: false,
-    });
-  }
-  else {
-    this.setState({
-      updated: false,
-      isLoading: false,
-      error: true,
-    });
-  }
-      }).catch(error=>{
-        console.log(error.data);
       })
-
+      .then((response) => {
+        console.log("this is my response: ");
+        console.log(response);
+        if (response.data.message === "password reset link a-ok") {
+          this.setState({
+            userName: response.data.userName,
+            updated: false,
+            isLoading: false,
+            error: false,
+          });
+        } else {
+          this.setState({
+            updated: false,
+            isLoading: false,
+            error: true,
+          });
+        }
+      })
+      .catch((error) => {
+        console.log(error.data);
+      });
   }
 
   onChange = (e) => {
@@ -86,7 +94,7 @@ class ResetPassword extends Component {
 
   //if the user is authenticated and allowed to reset their password.
   //update password while logged into the app, as well
-  onSubmit =  (e) => {
+  onSubmit = (e) => {
     e.preventDefault();
     const { userName, password } = this.state;
     const {
@@ -96,34 +104,40 @@ class ResetPassword extends Component {
     } = this.props;
 
     return axios
-    .put(constants.UPDATE_PWD_URI,{
-          userName,
-          password,
-          resetPasswordToken: token
-        } )
-    .then(response => {
+      .put(constants.UPDATE_PWD_URI, {
+        userName,
+        password,
+        resetPasswordToken: token,
+      })
+      .then((response) => {
         if (response.data.message === "password updated") {
           this.setState({
-                      updated: true,
-                      error: false,
-                       });
+            updated: true,
+            error: false,
+          });
         } else {
           this.setState({
-                              updated: false,
-                              error: true,
-                        });
+            updated: false,
+            error: true,
+          });
         }
-    })
-    .catch(e => {
-      console.log(e.data)
-    });
-
-
+      })
+      .catch((e) => {
+        console.log(e.data);
+      });
   };
 
   render() {
     // const { errors } = this.state;
-    const { userName, password, password2, error, isLoading, updated, errors } = this.state;
+    const {
+      userName,
+      password,
+      password2,
+      error,
+      isLoading,
+      updated,
+      errors,
+    } = this.state;
 
     if (error) {
       return (
@@ -148,91 +162,82 @@ class ResetPassword extends Component {
           </div>
         </div>
       );
-    }
-
-    else if (isLoading) {
+    } else if (isLoading) {
+      return <div>Loading User Data...</div>;
+    } else if (!isLoading && !error) {
       return (
-    
-          <div>Loading User Data...</div>
-       
-      );
-    }
-
-    else if (!isLoading && !error) {
-
-    return (
-      <div className="container">
-        <div className="row">
-          <div className="col s8 offset-s2">
-            <div className="col s12" style={{ paddingLeft: "11.250px" }}>
-              <h4>
-                <b>Reset Password</b>
-              </h4>
-            </div>
-            <form noValidate onSubmit={this.onSubmit}>
-              <div className="input-field col s12">
-                <input
-                  onChange={this.onChange}
-                  value={password}
-                  error={errors.password}
-                  id="password"
-                  type="password"
-                  className={classnames("", {
-                    invalid: errors.password,
-                  })}
-                />
-                <label htmlFor="password">Password</label>
-                <span className="red-text">{errors.password}</span>
-              </div>
-              <div className="input-field col s12">
-                <input
-                  onChange={this.onChange}
-                  value={password2}
-                  error={errors.password2}
-                  id="password2"
-                  type="password"
-                  className={classnames("", {
-                    invalid: errors.password2,
-                  })}
-                />
-                <label htmlFor="password2">Confirm Password</label>
-                <span className="red-text">{errors.password2}</span>
-              </div>
+        <div className="container">
+          <div className="row">
+            <div className="col s8 offset-s2">
               <div className="col s12" style={{ paddingLeft: "11.250px" }}>
-                <button
-                  style={{
-                    width: "150px",
-                    borderRadius: "3px",
-                    letterSpacing: "1.5px",
-                    marginTop: "1rem",
-                  }}
-                  type="submit"
-                  className="btn btn-large waves-effect waves-light hoverable blue accent-3"
-                >
-                  Reset
-                </button>
+                <h4>
+                  <b>Reset Password</b>
+                </h4>
               </div>
-            </form>
-            {updated && (
-              <div>
-                <Link to="/" className="btn-flat waves-effect">
-                  <i className="material-icons left">keyboard_backspace</i> Back
-                  to home
-                </Link>
-                <p>
-                  Your password has been successfully reset, please try logging
-                  in again.
-                </p>
-                <p className="grey-text text-darken-1">
-                  Already have an account? <Link to="/login">Log in</Link>
-                </p>
-              </div>
-            )}
+              <form noValidate onSubmit={this.onSubmit}>
+                <div className="input-field col s12">
+                  <input
+                    onChange={this.onChange}
+                    value={password}
+                    error={errors.password}
+                    id="password"
+                    type="password"
+                    className={classnames("", {
+                      invalid: errors.password,
+                    })}
+                  />
+                  <label htmlFor="password">Password</label>
+                  <span className="red-text">{errors.password}</span>
+                </div>
+                <div className="input-field col s12">
+                  <input
+                    onChange={this.onChange}
+                    value={password2}
+                    error={errors.password2}
+                    id="password2"
+                    type="password"
+                    className={classnames("", {
+                      invalid: errors.password2,
+                    })}
+                  />
+                  <label htmlFor="password2">Confirm Password</label>
+                  <span className="red-text">{errors.password2}</span>
+                </div>
+                <div className="col s12" style={{ paddingLeft: "11.250px" }}>
+                  <button
+                    style={{
+                      width: "150px",
+                      borderRadius: "3px",
+                      letterSpacing: "1.5px",
+                      marginTop: "1rem",
+                    }}
+                    type="submit"
+                    className="btn btn-large waves-effect waves-light hoverable blue accent-3"
+                  >
+                    Reset
+                  </button>
+                </div>
+              </form>
+              {updated && (
+                <div>
+                  <Link to="/" className="btn-flat waves-effect">
+                    <i className="material-icons left">keyboard_backspace</i>{" "}
+                    Back to home
+                  </Link>
+                  <p>
+                    Your password has been successfully reset, please try
+                    logging in again.
+                  </p>
+                  <p className="grey-text text-darken-1">
+                    Already have an account? <Link to="/login">Log in</Link>
+                  </p>
+                </div>
+              )}
+            </div>
           </div>
         </div>
-      </div>
-    );
-  }
+      );
+    }
   }
 }
 


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)
Introduces multi-tenancy to the react route for resetting the password

#### Is this change ready to hit production in its current state?
- [ ] Yes
- [ ] No

#### Status of maturity (all need to be checked before merging):

- [ ] I consider this code done
- [ ] I've tested this locally
- [ ] This branch has been LGTM'ed by a reviewer

#### How should this be manually tested?
```
cd AirQo-frontend/netmanager
npm install
```
`npm run dev-mac` for Linux and `npm run dev-pc` for Windows

-  Go to the password forgot page and send a reset link
- Afterwards, click on the sent link to proceed with the reset process.

#### What are the relevant tickets?
N/A

#### Screenshots (optional)