### PR TITLE
[NetManager] manually parse status data

### DIFF
--- a/netmanager/src/redux/DeviceManagement/operations.js
+++ b/netmanager/src/redux/DeviceManagement/operations.js
@@ -16,9 +16,17 @@ import {
 export const loadDevicesStatusData = () => async (dispatch) => {
   return await getDevicesStatusApi()
     .then((responseData) => {
+      let data;
+      try {
+        data = responseData.data.data[0];
+      } catch (err) {
+        data = JSON.parse(responseData.data.replace(/\bNaN\b/g, "null"))
+          .data[0];
+      }
+
       dispatch({
         type: LOAD_DEVICES_STATUS_SUCCESS,
-        payload: responseData.data[0],
+        payload: data,
       });
     })
     .catch((err) => {

--- a/netmanager/src/views/apis/deviceMonitoring.js
+++ b/netmanager/src/views/apis/deviceMonitoring.js
@@ -28,7 +28,7 @@ export const getDeviceSensorCorrelationApi = async (params) => {
 export const getDevicesStatusApi = async () => {
   return await axios
     .get(constants.ALL_DEVICES_STATUS)
-    .then((response) => response.data);
+    .then((response) => response);
 };
 
 export const getNetworkUptimeApi = async (params) => {


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)
- Manually deserialise axios response for device update incase the auto-deserialisation fails.

#### Is this change ready to hit production in its current state?
- [ ] Yes
- [ ] No

#### Status of maturity (all need to be checked before merging):

- [ ] I consider this code done
- [ ] I've tested this locally
- [ ] This branch has been LGTM'ed by a reviewer

#### How should this be manually tested?
* Checkout this branch locally
* run npm install
* Start the app `npm run stage-mac (macOs)` or `npm run stage-pc (PC)`
* Device management page should load data

#### What are the relevant tickets?
- [N/A]()

#### Screenshots (optional)