### PR TITLE
[NetManager] UI issues fixes

### DIFF
--- a/netmanager/src/assets/css/copyable.css
+++ b/netmanager/src/assets/css/copyable.css
@@ -1,0 +1,8 @@
+.copyable-icon {
+    fill: #58606a;
+    cursor: pointer;
+}
+
+.copyable-icon:hover {
+    fill: #0366d6;
+}

--- a/netmanager/src/assets/img/CopyIcon.js
+++ b/netmanager/src/assets/img/CopyIcon.js
@@ -1,0 +1,44 @@
+import React from "react";
+
+import "assets/css/copyable.css";
+
+export const CopySuccessIcon = ({ className, onClick }) => {
+  return (
+    <svg
+      className={className || ""}
+      viewBox="0 0 16 16"
+      version="1.1"
+      width="16"
+      height="16"
+      aria-hidden="true"
+      onClick={onClick}
+      fill="green"
+    >
+      <path
+        fillRule="evenodd"
+        d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"
+      />
+    </svg>
+  );
+};
+
+const CopyIcon = ({ className, onClick }) => {
+  return (
+    <svg
+      className={className || "copyable-icon"}
+      viewBox="0 0 16 16"
+      version="1.1"
+      width="16"
+      height="16"
+      aria-hidden="true"
+      onClick={onClick}
+    >
+      <path
+        fillRule="evenodd"
+        d="M5.75 1a.75.75 0 00-.75.75v3c0 .414.336.75.75.75h4.5a.75.75 0 00.75-.75v-3a.75.75 0 00-.75-.75h-4.5zm.75 3V2.5h3V4h-3zm-2.874-.467a.75.75 0 00-.752-1.298A1.75 1.75 0 002 3.75v9.5c0 .966.784 1.75 1.75 1.75h8.5A1.75 1.75 0 0014 13.25v-9.5a1.75 1.75 0 00-.874-1.515.75.75 0 10-.752 1.298.25.25 0 01.126.217v9.5a.25.25 0 01-.25.25h-8.5a.25.25 0 01-.25-.25v-9.5a.25.25 0 01.126-.217z"
+      />
+    </svg>
+  );
+};
+
+export default CopyIcon;

--- a/netmanager/src/views/components/Copy/Copyable.js
+++ b/netmanager/src/views/components/Copy/Copyable.js
@@ -1,0 +1,42 @@
+import React, { useState, useRef } from "react";
+import CopyIcon, { CopySuccessIcon } from "assets/img/CopyIcon";
+
+const Copyable = ({ value, className }) => {
+  const copyRef = useRef();
+  const [copied, setCopied] = useState(false);
+
+  const onClick = () => {
+    // let comp = document.getElementById(componentID);
+    let comp = copyRef.current;
+    let textArea = document.createElement("textarea");
+    textArea.value = comp.textContent;
+    document.body.appendChild(textArea);
+    /* Select the text field */
+    textArea.select();
+    textArea.setSelectionRange(0, 99999); /* For mobile devices */
+
+    /* Copy the text inside the text field */
+    document.execCommand("copy");
+    textArea.remove();
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1000);
+  };
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+      }}
+    >
+      <span ref={copyRef}>{value}</span>
+      {copied ? (
+        <CopySuccessIcon />
+      ) : (
+        <CopyIcon onClick={onClick} className={className} />
+      )}
+    </div>
+  );
+};
+
+export default Copyable;

--- a/netmanager/src/views/components/DataDisplay/DeviceView/DeviceOverview.js
+++ b/netmanager/src/views/components/DataDisplay/DeviceView/DeviceOverview.js
@@ -40,6 +40,7 @@ import {
 } from "utils/charts";
 import { BarChartIcon, LineChartIcon } from "assets/img";
 import { pearsonCorrelation } from "utils/statistics";
+import Copyable from "views/components/Copy/Copyable";
 
 const useStyles = makeStyles(styles);
 
@@ -187,12 +188,7 @@ export default function DeviceOverview({ deviceData }) {
             style={{ alignContent: "left", alignItems: "left" }}
           >
             <TableContainer component={Paper}>
-              <Table
-                stickyHeader
-                aria-label="sticky table"
-                style={{ cursor: "pointer" }}
-                onClick={() => goTo("edit")}
-              >
+              <Table stickyHeader aria-label="sticky table">
                 <TableBody>
                   <TableRow>
                     <TableCell>
@@ -261,7 +257,9 @@ export default function DeviceOverview({ deviceData }) {
                       <b>Read Key</b>
                     </TableCell>
                     <TableCell>
-                      {deviceData.readKey || BLANK_PLACE_HOLDER}
+                      <Copyable
+                        value={deviceData.readKey || BLANK_PLACE_HOLDER}
+                      />
                     </TableCell>
                   </TableRow>
                   <TableRow>
@@ -269,7 +267,9 @@ export default function DeviceOverview({ deviceData }) {
                       <b>Write Key</b>
                     </TableCell>
                     <TableCell>
-                      {deviceData.writeKey || BLANK_PLACE_HOLDER}
+                      <Copyable
+                        value={deviceData.writeKey || BLANK_PLACE_HOLDER}
+                      />
                     </TableCell>
                   </TableRow>
                 </TableBody>

--- a/netmanager/src/views/pages/Download/Download.js
+++ b/netmanager/src/views/pages/Download/Download.js
@@ -122,6 +122,20 @@ const Download = (props) => {
   //console.log(values.selectedOption);
   //console.log(selectedPollutant);
 
+  const disableDownloadBtn = () => {
+    return !(
+      values &&
+      values.selectedOption &&
+      selectedPollutant &&
+      selectedType &&
+      selectedType.value &&
+      selectedFrequency &&
+      selectedFrequency.value &&
+      selectedClean &&
+      selectedClean.value
+    );
+  };
+
   let handleSubmit = (e) => {
     e.preventDefault();
 
@@ -362,7 +376,12 @@ const Download = (props) => {
 
               <Divider />
               <CardActions>
-                <Button color="primary" variant="outlined" type="submit">
+                <Button
+                  color="primary"
+                  variant="outlined"
+                  type="submit"
+                  disabled={disableDownloadBtn()}
+                >
                   {" "}
                   Download Data
                 </Button>


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)
- Enable copying of device keys
- Disable download button for partially filled data down form

#### Is this change ready to hit production in its current state?
- [x] Yes
- [ ] No

#### Status of maturity (all need to be checked before merging):

- [x] I consider this code done
- [x] I've tested this locally
- [ ] This branch has been LGTM'ed by a reviewer

#### How should this be manually tested?
* Fetch and checkout to this branch locally
* Install requirements `npm install`
* Start the application `npm run stage-mac` (MacOS) or `npm run stage-pc` (Windows)
* You be able to copy device keys (read and write) from the device overview page
* On data export page, the download button should only be active when the form is fully filled.

#### What are the relevant tickets?
- [PLAT-478](https://airqoteam.atlassian.net/browse/PLAT-478)

#### Screenshots (optional)