### PR TITLE
[NetManager] Mobile Responsiveness part 3

### DIFF
--- a/netmanager/src/views/pages/ForgotPassword/ForgotPassword.js
+++ b/netmanager/src/views/pages/ForgotPassword/ForgotPassword.js
@@ -87,7 +87,6 @@ class ForgotPassword extends Component {
           })
         })
         .catch(err => {
-          debugger
           this.setAlert({
             show: true,
             message: err.response.data.message,

--- a/netmanager/src/views/pages/ForgotPassword/ForgotPassword.js
+++ b/netmanager/src/views/pages/ForgotPassword/ForgotPassword.js
@@ -9,6 +9,7 @@ import { forgotPasswordResetApi } from "../../apis/authService";
 import Alert from "@material-ui/lab/Alert";
 import { CardContent } from "@material-ui/core";
 import ArrowBackIcon from '@material-ui/icons/ArrowBack';
+import Grid from "@material-ui/core/Grid";
 
 const title = {
   pageTitle: "Forgot Password Screen",
@@ -100,82 +101,99 @@ class ForgotPassword extends Component {
     const { errors } = this.state;
 
     return (
-      <div className="container">
-        <div style={{ marginTop: "4rem" }} className="row">
-          <div className="col s8 offset-s2">
-            <div >
-              <Link
-                  to="/"
-                  style={{
-                    display: "flex",
-                    alignItems: "center",
-                    textTransform: "uppercase",
-                    color: "#2979FF"}}>
-                <ArrowBackIcon /><span>Back to home</span>
-              </Link>
+      <div className="container"
+         style={{
+          maxWidth: "1000px",
+          marginTop: "4rem",
+          backgroundColor: "#fff",
+        }}>
+        <Grid container>
+          <Grid
+            item
+            xs={12}
+            sm={4}
+            style={{
+              padding: "1em",
+              backgroundColor: "#3067e2",
+              height: "100% !important",
+              minHeight: "100px",
+            }}
+          />
+          <Grid item xs={12} sm={8}>
+            <div className="row">
+              <div>
+                <div>
+                  <h4>
+                    <b>Forgot Password</b>
+                  </h4>
+                  <p className="grey-text text-darken-1">
+                    Don't have an account?{" "}
+                    <Link to="/request-access">Request Access</Link>
+                  </p>
+                </div>
+                <form noValidate onSubmit={this.onSubmit}>
+                  <CardContent style={this.state.alert.show ? {} : { display: "none" }}>
+                    <Alert severity={this.state.alert.type} onClose={this.onAlertClose}>
+                      {this.state.alert.message}
+                    </Alert>
+                  </CardContent>
+                  <div className="input-field col s12">
+                    <input
+                      onChange={this.onChange}
+                      value={this.state.organisation}
+                      error={errors.organisation}
+                      id="organisation"
+                      type="text"
+                      className={classnames("", {
+                        invalid: errors.organisation,
+                      })}
+                    />
+                    <label htmlFor="organisation">Organisation</label>
+                    <span className="red-text">
+                      {errors.email}
+                      {errors.emailnotfound}
+                    </span>
+                  </div>
+                  <div className="input-field col s12">
+                    <input
+                      onChange={this.onChange}
+                      value={this.state.email}
+                      error={errors.email}
+                      id="email"
+                      type="email"
+                      className={classnames("", {
+                        invalid: errors.email || errors.emailnotfound,
+                      })}
+                    />
+                    <label htmlFor="email">Email</label>
+                    <span className="red-text">
+                      {errors.email}
+                      {errors.emailnotfound}
+                    </span>
+                  </div>
+                  <div className="col s12" style={{ paddingLeft: "11.250px" }}>
+                    <button
+                      style={{
+                        width: "150px",
+                        borderRadius: "3px",
+                        letterSpacing: "1.5px",
+                        marginTop: "1rem",
+                      }}
+                      type="submit"
+                      className="btn btn-large waves-effect waves-light hoverable blue accent-3"
+                    >
+                      Submit
+                    </button>
+                  </div>
+                </form>
+                <div className="col s12" style={{ paddingTop: "20px" }}>
+                  <Link to="/login"> Login?</Link>
+                </div>
+              </div>
             </div>
-            <div className="col s12" style={{ paddingLeft: "11.250px" }}>
-              <h4>
-                <b>Forgot Password</b>
-              </h4>
-            </div>
-            <form noValidate onSubmit={this.onSubmit}>
-              <CardContent style={this.state.alert.show ? {} : { display: "none" }}>
-                <Alert severity={this.state.alert.type} onClose={this.onAlertClose}>
-                  {this.state.alert.message}
-                </Alert>
-              </CardContent>
-              <div className="input-field col s12">
-                <input
-                  onChange={this.onChange}
-                  value={this.state.organisation}
-                  error={errors.organisation}
-                  id="organisation"
-                  type="text"
-                  className={classnames("", {
-                    invalid: errors.organisation,
-                  })}
-                />
-                <label htmlFor="organisation">Organisation</label>
-                <span className="red-text">
-                  {errors.email}
-                  {errors.emailnotfound}
-                </span>
-              </div>
-              <div className="input-field col s12">
-                <input
-                  onChange={this.onChange}
-                  value={this.state.email}
-                  error={errors.email}
-                  id="email"
-                  type="email"
-                  className={classnames("", {
-                    invalid: errors.email || errors.emailnotfound,
-                  })}
-                />
-                <label htmlFor="email">Email</label>
-                <span className="red-text">
-                  {errors.email}
-                  {errors.emailnotfound}
-                </span>
-              </div>
-              <div className="col s12" style={{ paddingLeft: "11.250px" }}>
-                <button
-                  style={{
-                    width: "150px",
-                    borderRadius: "3px",
-                    letterSpacing: "1.5px",
-                    marginTop: "1rem",
-                  }}
-                  type="submit"
-                  className="btn btn-large waves-effect waves-light hoverable blue accent-3"
-                >
-                  Submit
-                </button>
-              </div>
-            </form>
-          </div>
-        </div>
+          </Grid>
+        </Grid>
+
       </div>
     );
   }

--- a/netmanager/src/views/pages/ResetPassword/ResetPassword.js
+++ b/netmanager/src/views/pages/ResetPassword/ResetPassword.js
@@ -10,6 +10,7 @@ import { Link, useLocation, BrowserRouter as Router } from "react-router-dom";
 
 import classnames from "classnames";
 import constants from "../../../config/constants";
+import Grid from "@material-ui/core/Grid";
 
 const validPasswordRegex = RegExp(/(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{6,}/);
 
@@ -112,9 +113,29 @@ export default function ResetPassword() {
   };
 
   return (
-    <div className="container">
+    <div
+        className="container"
+        style={{
+          maxWidth: "1000px",
+          marginTop: "4rem",
+          backgroundColor: "#fff",
+        }}
+    >
+      <Grid container>
+        <Grid
+            item
+            xs={12}
+            sm={4}
+            style={{
+              padding: "1em",
+              backgroundColor: "#3067e2",
+              height: "100% !important",
+              minHeight: "100px",
+            }}
+          />
+        <Grid item xs={12} sm={8}>
       <div className="row">
-        <div className="col s8 offset-s2">
+        <div>
           {!updated && (
               <>
                 <div className="col s12" style={{ paddingLeft: "11.250px" }}>
@@ -232,6 +253,9 @@ export default function ResetPassword() {
           )}
         </div>
       </div>
+        </Grid>
+      </Grid>
+
     </div>
   );
 }

--- a/netmanager/src/views/pages/SignUp/Login.js
+++ b/netmanager/src/views/pages/SignUp/Login.js
@@ -5,10 +5,11 @@ import { connect } from "react-redux";
 import { CardContent } from "@material-ui/core";
 import Alert from "@material-ui/lab/Alert";
 import { clearErrors, loginUser } from "../../../redux/Join/actions";
+import Grid from "@material-ui/core/Grid";
 import classnames from "classnames";
 import { isEmpty, omit } from "underscore";
 import { isFormFullyFilled } from "./utils";
-import usrsStateConnector from "views/stateConnectors/usersStateConnector";
+import usersStateConnector from "views/stateConnectors/usersStateConnector";
 
 class Login extends Component {
   constructor(props) {
@@ -103,121 +104,127 @@ class Login extends Component {
   render() {
     const { errors } = this.state;
     return (
-      <div className="container">
-        <div
-          className="row"
-          style={{
-            marginTop: "4rem",
-            height: "auto",
-            backgroundColor: "#3067e2",
-          }}
-        >
-          <div
-            className="col s4"
+      <div
+        className="container"
+        style={{
+          marginTop: "4rem",
+          height: "auto",
+          backgroundColor: "#fff",
+          maxWidth: "1000px",
+        }}
+      >
+        <Grid container>
+          <Grid
+            item
+            xs={12}
+            sm={4}
             style={{
               padding: "1em",
+              backgroundColor: "#3067e2",
+              height: "100% !important",
+              minHeight: "100px",
             }}
           />
-          <div
-            className="col s8"
-            style={{ backgroundColor: "#fff", padding: "1em" }}
-          >
-            <div className="col s12" style={{ paddingLeft: "11.250px" }}>
-              <h4>
-                <b>Login</b>
-              </h4>
-              <p className="grey-text text-darken-1">
-                Don't have an account?{" "}
-                <Link to="/request-access">Request Access</Link>
-              </p>
-            </div>
-            <form noValidate onSubmit={this.onSubmit}>
-              <CardContent
-                style={
-                  isEmpty(this.props.errors.data) ? { display: "none" } : {}
-                }
-              >
-                <Alert
-                  severity="error"
-                  onClose={() => {
-                    this.props.clearErrors();
-                  }}
+          <Grid item xs={12} sm={8}>
+            <div style={{ margin: "10px" }}>
+              <div>
+                <h4>
+                  <b>Login</b>
+                </h4>
+                <p className="grey-text text-darken-1">
+                  Don't have an account?{" "}
+                  <Link to="/request-access">Request Access</Link>
+                </p>
+              </div>
+              <form noValidate onSubmit={this.onSubmit}>
+                <CardContent
+                  style={
+                    isEmpty(this.props.errors.data) ? { display: "none" } : {}
+                  }
                 >
-                  {this.props.errors.data && this.props.errors.data.message}
-                </Alert>
-              </CardContent>
-              <div className="input-field col s12">
-                <input
-                  onChange={this.onChange}
-                  value={this.state.organization}
-                  error={errors.organization}
-                  id="organization"
-                  type="text"
-                  className={classnames("", {
-                    invalid: errors.organization || errors.credentialsnotfound,
-                  })}
-                />
-                <label htmlFor="organization">Organization</label>
-                <span className="red-text">
-                  {errors.organization}
-                  {errors.credentialsnotfound}
-                </span>
+                  <Alert
+                    severity="error"
+                    onClose={() => {
+                      this.props.clearErrors();
+                    }}
+                  >
+                    {this.props.errors.data && this.props.errors.data.message}
+                  </Alert>
+                </CardContent>
+                <div className="input-field col s12">
+                  <input
+                    onChange={this.onChange}
+                    value={this.state.organization}
+                    error={errors.organization}
+                    id="organization"
+                    type="text"
+                    className={classnames("", {
+                      invalid:
+                        errors.organization || errors.credentialsnotfound,
+                    })}
+                  />
+                  <label htmlFor="organization">Organization</label>
+                  <span className="red-text">
+                    {errors.organization}
+                    {errors.credentialsnotfound}
+                  </span>
+                </div>
+                <div className="input-field col s12">
+                  <input
+                    onChange={this.onChange}
+                    value={this.state.userName}
+                    error={errors.userName}
+                    id="userName"
+                    type="text"
+                    className={classnames("", {
+                      invalid: errors.userName || errors.credentialsnotfound,
+                    })}
+                  />
+                  <label htmlFor="userName">Username</label>
+                  <span className="red-text">
+                    {errors.userName}
+                    {errors.credentialsnotfound}
+                  </span>
+                </div>
+                <div className="input-field col s12">
+                  <input
+                    onChange={this.onChange}
+                    value={this.state.password}
+                    error={errors.password}
+                    id="password"
+                    type="password"
+                    className={classnames("", {
+                      invalid: errors.password || errors.passwordincorrect,
+                    })}
+                  />
+                  <label htmlFor="password">Password</label>
+                  <span className="red-text">
+                    {errors.password}
+                    {errors.passwordincorrect}
+                  </span>
+                </div>
+                <div className="col s12" style={{ paddingLeft: "11.250px" }}>
+                  <button
+                    style={{
+                      width: "150px",
+                      borderRadius: "3px",
+                      letterSpacing: "1.5px",
+                      marginTop: "1rem",
+                    }}
+                    type="submit"
+                    className="btn btn-large waves-effect waves-light hoverable blue accent-3"
+                  >
+                    Login
+                  </button>
+                </div>
+              </form>
+              {/*<div></div>*/}
+              <div className="col s12" style={{ paddingTop: "20px" }}>
+                <Link to="/forgot"> Forgotten Password?</Link>
               </div>
-              <div className="input-field col s12">
-                <input
-                  onChange={this.onChange}
-                  value={this.state.userName}
-                  error={errors.userName}
-                  id="userName"
-                  type="text"
-                  className={classnames("", {
-                    invalid: errors.userName || errors.credentialsnotfound,
-                  })}
-                />
-                <label htmlFor="userName">Username</label>
-                <span className="red-text">
-                  {errors.userName}
-                  {errors.credentialsnotfound}
-                </span>
-              </div>
-              <div className="input-field col s12">
-                <input
-                  onChange={this.onChange}
-                  value={this.state.password}
-                  error={errors.password}
-                  id="password"
-                  type="password"
-                  className={classnames("", {
-                    invalid: errors.password || errors.passwordincorrect,
-                  })}
-                />
-                <label htmlFor="password">Password</label>
-                <span className="red-text">
-                  {errors.password}
-                  {errors.passwordincorrect}
-                </span>
-              </div>
-              <div className="col s12" style={{ paddingLeft: "11.250px" }}>
-                <button
-                  style={{
-                    width: "150px",
-                    borderRadius: "3px",
-                    letterSpacing: "1.5px",
-                    marginTop: "1rem",
-                  }}
-                  type="submit"
-                  className="btn btn-large waves-effect waves-light hoverable blue accent-3"
-                >
-                  Login
-                </button>
-              </div>
-            </form>
-            <div></div>
-            <div className="col s12" style={{ paddingTop: "20px" }}>
-              <Link to="/forgot"> Forgotten Password?</Link>
             </div>
-          </div>
-        </div>
+          </Grid>
+        </Grid>
       </div>
     );
   }
@@ -233,6 +240,6 @@ const mapStateToProps = (state) => ({
   auth: state.auth,
   errors: state.errors,
 });
-export default usrsStateConnector(
+export default usersStateConnector(
   connect(mapStateToProps, { clearErrors, loginUser })(Login)
 );

--- a/netmanager/src/views/pages/SignUp/Register.js
+++ b/netmanager/src/views/pages/SignUp/Register.js
@@ -312,6 +312,7 @@ class Register extends Component {
                     variant="outlined"
                     error={!!errors.description}
                     helperText={errors.description}
+                    InputLabelProps={{style: {fontSize: "0.8rem"}}}
                 />
               </div>
 

--- a/netmanager/src/views/pages/SignUp/Register.js
+++ b/netmanager/src/views/pages/SignUp/Register.js
@@ -180,10 +180,16 @@ class Register extends Component {
     const { errors } = this.state;
     const { classes } = this.props;
     return (
-      <div className="container">
-        <div style={{marginTop: "4rem"}} className="row">
+      <div
+          className="container"
+          style={{
+            maxWidth: "600px",
+            marginTop: "4rem",
+            backgroundColor: "#fff",
+          }}>
+        <div className="row">
           <div
-            className="col s8 offset-s2"
+            className=" offset-s2"
             style={{
               backgroundColor: "#3067e2",
               height: "15vh",
@@ -191,7 +197,7 @@ class Register extends Component {
             }}
           />
           <div
-            className="col s8 offset-s2"
+            className="offset-s2"
             style={{ backgroundColor: "#fff", padding: "1em" }}
           >
             <div className="col s12" style={{ paddingLeft: "11.250px" }}>
@@ -298,8 +304,8 @@ class Register extends Component {
                     label="Outline in detailed nature your interest in AirQuality"
                     fullWidth
                     multiline
-                    rows="2"
-                    rowsMax="5"
+                    rows="5"
+                    rowsMax="10"
                     value={this.state.description}
                     onChange={this.onChange}
                     margin="normal"
@@ -316,7 +322,7 @@ class Register extends Component {
                       width: "150px",
                       borderRadius: "3px",
                       letterSpacing: "1.5px",
-                      marginTop: "1rem",
+                      margin: "1rem",
                     }}
                     type="submit"
                     className="btn btn-large waves-effect waves-light hoverable blue accent-3"


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)
- Mobile responsiveness for login, forgot-password, request-access, reset-password pages

#### Is this change ready to hit production in its current state?
- [x] Yes
- [ ] No

#### Status of maturity (all need to be checked before merging):

- [x] I consider this code done
- [ ] I've tested this locally
- [ ] This branch has been LGTM'ed by a reviewer

#### How should this be manually tested?
* Fetch this branch locally
* Install requirements using `npm install`
* Start Application using `npm run stage-mac` (MacOs) or `npm run stage-pc` (Windows PC)
* Navigate to the pages stated above, they should be responsive.

#### What are the relevant tickets?
- [PLAT-501](https://airqoteam.atlassian.net/browse/PLAT-501)

#### Screenshots (optional)