### PR TITLE
[NetManager] Use respective split deploy endpoints

### DIFF
--- a/netmanager/src/config/urls/deviceRegistry.js
+++ b/netmanager/src/config/urls/deviceRegistry.js
@@ -15,6 +15,8 @@ export const DEVICES_IN_LOCATION_URI = `${BASE_DEVICE_REGISTRY_URL}/devices/by/l
 
 export const DEPLOY_DEVICE_URI = `${BASE_DEVICE_REGISTRY_URL}/devices/ts/activity/deploy`;
 
+export const ADD_MAINTENANCE_LOGS_URI = `${BASE_DEVICE_REGISTRY_URL}/devices//ts/activity/maintain`;
+
 export const DELETE_DEVICE_URI = `${BASE_DEVICE_REGISTRY_URL}/devices/ts/delete`;
 
 export const ADD_COMPONENT_URI = `${BASE_DEVICE_REGISTRY_URL}/devices/add/components?device=`;

--- a/netmanager/src/config/urls/deviceRegistry.js
+++ b/netmanager/src/config/urls/deviceRegistry.js
@@ -35,4 +35,6 @@ export const DELETE_COMPONENT = `${BASE_DEVICE_REGISTRY_URL}/devices/delete/comp
 
 export const DELETE_DEVICE_PHOTO = `${BASE_DEVICE_REGISTRY_URL}/devices/photos`;
 
+export const RECALL_DEVICE_URI = `${BASE_DEVICE_REGISTRY_URL}/devices/ts/activity/recall`;
+
 export const EVENTS = `${BASE_DEVICE_REGISTRY_URL}/devices/events`;

--- a/netmanager/src/config/urls/deviceRegistry.js
+++ b/netmanager/src/config/urls/deviceRegistry.js
@@ -13,7 +13,7 @@ export const EDIT_DEVICE_URI = `${BASE_DEVICE_REGISTRY_URL}/devices/ts/update?de
 
 export const DEVICES_IN_LOCATION_URI = `${BASE_DEVICE_REGISTRY_URL}/devices/by/location?loc=`;
 
-export const DEPLOY_DEVICE_URI = `${BASE_DEVICE_REGISTRY_URL}/devices/ts/activity?type=`;
+export const DEPLOY_DEVICE_URI = `${BASE_DEVICE_REGISTRY_URL}/devices/ts/activity/deploy`;
 
 export const DELETE_DEVICE_URI = `${BASE_DEVICE_REGISTRY_URL}/devices/ts/delete`;
 

--- a/netmanager/src/views/apis/deviceRegistry.js
+++ b/netmanager/src/views/apis/deviceRegistry.js
@@ -1,6 +1,7 @@
 import axios from "axios";
 import {
   ALL_DEVICES_URI,
+    ADD_MAINTENANCE_LOGS_URI,
   ADD_COMPONENT_URI,
   GET_COMPONENTS_URI,
   DEPLOY_DEVICE_URI,
@@ -50,9 +51,9 @@ export const getDeviceMaintenanceLogsApi = async (deviceName) => {
     .then((response) => response.data);
 };
 
-export const addMaintenanceLogApi = async (logData) => {
+export const addMaintenanceLogApi = async (deviceName, logData) => {
   return await axios
-    .post(DEPLOY_DEVICE_URI + "maintain", logData)
+    .post(ADD_MAINTENANCE_LOGS_URI, logData, { params: { deviceName } })
     .then((response) => response.data);
 };
 

--- a/netmanager/src/views/apis/deviceRegistry.js
+++ b/netmanager/src/views/apis/deviceRegistry.js
@@ -12,6 +12,7 @@ import {
   DELETE_COMPONENT,
   DELETE_DEVICE_PHOTO,
   EVENTS,
+  RECALL_DEVICE_URI,
 } from "config/urls/deviceRegistry";
 import { DEVICE_MAINTENANCE_LOG_URI } from "config/urls/deviceMonitoring";
 import { DEVICE_RECENT_FEEDS } from "config/urls/dataManagement";
@@ -55,9 +56,9 @@ export const addMaintenanceLogApi = async (logData) => {
     .then((response) => response.data);
 };
 
-export const recallDeviceApi = async (recallData) => {
+export const recallDeviceApi = async (deviceName) => {
   return await axios
-    .post(DEPLOY_DEVICE_URI + "recall", recallData)
+    .post(RECALL_DEVICE_URI, {}, { params: { deviceName } })
     .then((response) => response.data);
 };
 

--- a/netmanager/src/views/apis/deviceRegistry.js
+++ b/netmanager/src/views/apis/deviceRegistry.js
@@ -62,9 +62,9 @@ export const recallDeviceApi = async (deviceName) => {
     .then((response) => response.data);
 };
 
-export const deployDeviceApi = async (deployData) => {
+export const deployDeviceApi = async (deviceName, deployData) => {
   return axios
-    .post(DEPLOY_DEVICE_URI + "deploy", deployData)
+    .post(DEPLOY_DEVICE_URI, deployData, { params: { deviceName } })
     .then((response) => response.data);
 };
 

--- a/netmanager/src/views/components/DataDisplay/DeviceView/DeviceDeployStatus.js
+++ b/netmanager/src/views/components/DataDisplay/DeviceView/DeviceDeployStatus.js
@@ -293,8 +293,8 @@ export default function DeviceDeployStatus({ deviceData }) {
     deviceData.mountType || ""
   );
   const [deploymentDate, setDeploymentDate] = useState(new Date());
-  const [primaryChecked, setPrimaryChecked] = useState(true);
-  const [collocationChecked, setCollocationChecked] = useState(false);
+  const [primaryChecked, setPrimaryChecked] = useState(deviceData.isPrimaryInLocation);
+  const [collocationChecked, setCollocationChecked] = useState(deviceData.isUsedForCollocation);
   const [recentFeed, setRecentFeed] = useState({});
   const [runReport, setRunReport] = useState({
     ranTest: false,
@@ -383,7 +383,7 @@ export default function DeviceDeployStatus({ deviceData }) {
       latitude: latitude.toString(),
       longitude: longitude.toString(),
       isPrimaryInLocation: primaryChecked,
-      isUserForCollocaton: collocationChecked,
+      isUsedForCollocation: collocationChecked,
     };
 
     setDeployLoading(true);
@@ -427,7 +427,7 @@ export default function DeviceDeployStatus({ deviceData }) {
       .catch((err) => {
         dispatch(
           updateMainAlert({
-            message: err.response.data.message,
+            message: err.response && err.response.data && err.response.data.message,
             show: true,
             severity: "error",
           })

--- a/netmanager/src/views/components/DataDisplay/DeviceView/DeviceDeployStatus.js
+++ b/netmanager/src/views/components/DataDisplay/DeviceView/DeviceDeployStatus.js
@@ -449,16 +449,9 @@ export default function DeviceDeployStatus({ deviceData }) {
   };
 
   const handleRecallSubmit = async () => {
-    const currentDate = new Date();
-    const recallData = {
-      deviceName: deviceData.name,
-      locationName: deviceData.locationID,
-      date: currentDate.toISOString(),
-    };
-
     setRecallOpen(!recallOpen);
 
-    await recallDeviceApi(recallData)
+    await recallDeviceApi(deviceData.name)
       .then((responseData) => {
         dispatch(
           updateMainAlert({

--- a/netmanager/src/views/components/DataDisplay/DeviceView/DeviceDeployStatus.js
+++ b/netmanager/src/views/components/DataDisplay/DeviceView/DeviceDeployStatus.js
@@ -433,7 +433,7 @@ export default function DeviceDeployStatus({ deviceData }) {
             severity: "success",
           })
         );
-        dispatch(updateDevice(deviceData.name, { isActive: true }));
+        dispatch(updateDevice(deviceData.name, responseData.updatedDevice));
       })
       .catch((err) => {
         dispatch(
@@ -459,7 +459,7 @@ export default function DeviceDeployStatus({ deviceData }) {
             severity: "success",
           })
         );
-        dispatch(updateDevice(deviceData.name, { isActive: false }));
+        dispatch(updateDevice(deviceData.name, responseData.updatedDevice));
       })
       .catch((err) => {
         dispatch(

--- a/netmanager/src/views/components/DataDisplay/DeviceView/DeviceDeployStatus.js
+++ b/netmanager/src/views/components/DataDisplay/DeviceView/DeviceDeployStatus.js
@@ -413,7 +413,6 @@ export default function DeviceDeployStatus({ deviceData }) {
       return;
     }
     const deployData = {
-      deviceName: deviceData.name,
       mountType: installationType,
       height: height,
       powerType: power,
@@ -425,7 +424,7 @@ export default function DeviceDeployStatus({ deviceData }) {
     };
 
     setDeployLoading(true);
-    await deployDeviceApi(deployData)
+    await deployDeviceApi(deviceData.name, deployData)
       .then((responseData) => {
         dispatch(
           updateMainAlert({

--- a/netmanager/src/views/components/DataDisplay/DeviceView/DeviceDeployStatus.js
+++ b/netmanager/src/views/components/DataDisplay/DeviceView/DeviceDeployStatus.js
@@ -39,6 +39,7 @@ import {
 import { updateMainAlert } from "redux/MainAlert/operations";
 import { getElapsedDurationMapper, getFirstNDurations } from "utils/dateTime";
 import { updateDevice } from "redux/DeviceRegistry/operations";
+import ConfirmDialog from "views/containers/ConfirmDialog";
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -51,7 +52,6 @@ const useStyles = makeStyles((theme) => ({
     color: grey[200],
   },
 }));
-
 
 const errorStyles = {
   color: "red",
@@ -172,51 +172,14 @@ const EmptyDeviceTest = ({ loading, onClick }) => {
 
 const RecallDevice = ({ deviceData, handleRecall, open, toggleOpen }) => {
   return (
-    <Dialog
+    <ConfirmDialog
       open={open}
-      onClose={toggleOpen}
-      aria-labelledby="form-dialog-title"
-      aria-describedby="form-dialog-description"
-      style={{ padding: "20px 10px" }}
-    >
-      <DialogTitle
-        id="form-dialog-title"
-        style={{
-          textTransform: "uppercase",
-          alignContent: "center",
-          fontSize: "1.1rem",
-        }}
-      >
-        Recall device
-      </DialogTitle>
-
-      <DialogContent>
-        Are you sure you want to recall device{" "}
-        <strong>{deviceData.name}</strong> from location{" "}
-        <strong>{deviceData.locationID}</strong>?
-      </DialogContent>
-
-      <DialogActions>
-        <Grid
-          container
-          alignItems="flex-end"
-          alignContent="flex-end"
-          justify="flex-end"
-        >
-          <Button variant="contained" onClick={toggleOpen}>
-            Cancel
-          </Button>
-          <Button
-            variant="contained"
-            color="primary"
-            onClick={handleRecall}
-            style={{ margin: "0 15px" }}
-          >
-            Recall device
-          </Button>
-        </Grid>
-      </DialogActions>
-    </Dialog>
+      close={toggleOpen}
+      message={`Are you sure you want to recall device ${deviceData.name}?`}
+      title={"Recall device"}
+      confirm={handleRecall}
+      confirmBtnMsg={"Recall"}
+    />
   );
 };
 

--- a/netmanager/src/views/components/DataDisplay/DeviceView/DeviceEdit.js
+++ b/netmanager/src/views/components/DataDisplay/DeviceView/DeviceEdit.js
@@ -1,6 +1,5 @@
 import React, { useState } from "react";
 import { useDispatch } from "react-redux";
-import PropTypes from "prop-types";
 import TextField from "@material-ui/core/TextField";
 import FormControl from "@material-ui/core/FormControl";
 import Paper from "@material-ui/core/Paper";
@@ -12,6 +11,7 @@ import LabelledSelect from "../../CustomSelects/LabelledSelect";
 import { isEmpty, isEqual } from "underscore";
 import { updateMainAlert } from "redux/MainAlert/operations";
 import { updateDeviceDetails } from "views/apis/deviceRegistry";
+import { updateDevice } from "redux/DeviceRegistry/operations";
 
 const transformLocationOptions = (locationsData) => {
   const transFormedOptions = [];
@@ -82,6 +82,7 @@ export default function DeviceEdit({ deviceData, locationsData }) {
     setEditLoading(true);
     await updateDeviceDetails(deviceData.name, editData)
       .then((responseData) => {
+        dispatch(updateDevice(deviceData.name, responseData.updatedDevice));
         dispatch(
           updateMainAlert({
             message: responseData.message,

--- a/netmanager/src/views/components/DataDisplay/DeviceView/DeviceEdit.js
+++ b/netmanager/src/views/components/DataDisplay/DeviceView/DeviceEdit.js
@@ -121,6 +121,17 @@ export default function DeviceEdit({ deviceData, locationsData }) {
         <Grid container spacing={1}>
           <Grid items xs={12} sm={6} style={gridItemStyle}>
             <TextField
+              id="name"
+              label="name"
+              value={editData.name}
+              onChange={handleTextFieldChange}
+              fullWidth
+              required
+              disabled
+            />
+          </Grid>
+          <Grid items xs={12} sm={6} style={gridItemStyle}>
+            <TextField
               id="owner"
               label="Owner"
               value={editData.owner}
@@ -292,6 +303,16 @@ export default function DeviceEdit({ deviceData, locationsData }) {
               id="mountType"
               label="Mount Type"
               value={editData.mountType}
+              onChange={handleTextFieldChange}
+              fullWidth
+            />
+          </Grid>
+
+          <Grid items xs={12} sm={6} style={gridItemStyle}>
+            <TextField
+              id="height"
+              label="height"
+              value={editData.height}
               onChange={handleTextFieldChange}
               fullWidth
             />

--- a/netmanager/src/views/components/DataDisplay/DeviceView/DeviceLogs.js
+++ b/netmanager/src/views/components/DataDisplay/DeviceView/DeviceLogs.js
@@ -259,8 +259,6 @@ const AddLogForm = ({ deviceName, deviceLocation, toggleShow }) => {
     const extracted_tags = [];
     tags && tags.map((tag) => extracted_tags.push(tag.value));
     const logData = {
-      deviceName,
-      locationName: deviceLocation,
       date: selectedDate.toISOString(),
       tags: extracted_tags,
       maintenanceType: (maintenanceType && maintenanceType.value) || "",
@@ -268,7 +266,7 @@ const AddLogForm = ({ deviceName, deviceLocation, toggleShow }) => {
     };
 
     setLoading(true);
-    await addMaintenanceLogApi(logData)
+    await addMaintenanceLogApi(deviceName, logData)
       .then(async (responseData) => {
         // dispatch(
         //   insertMaintenanceLog(


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)
- Change the deploy,  maintain and recall functionality to use the respective split endpoints. Check this [PR](https://github.com/airqo-platform/AirQo-api/pull/380) for endpoint details.
- Ensure the deployment data is persisted and shown on the device `edit `tab.
- The issues fixed by this PR - [246](https://github.com/airqo-platform/AirQo-frontend/issues/246), [247](https://github.com/airqo-platform/AirQo-frontend/issues/247)

#### Is this change ready to hit production in its current state?
- [x] Yes
- [ ] No

#### Status of maturity (all need to be checked before merging):

- [x] I consider this code done
- [x] I've tested this locally
- [ ] This branch has been LGTM'ed by a reviewer

#### How should this be manually tested?
* Incase this [PR](https://github.com/airqo-platform/AirQo-api/pull/380) is not yet merged and deployed, you need to set it up locally.  Then set the `REACT_APP_BASE_DEVICE_REGISTRY_URL` key in the NetManager `.env` to `http://localhost:3000/api/v1/`.
* Fetch this branch locally
* Install requirements using `npm install`
* Start Application using `npm run stage-mac` (MacOs) or `npm run stage-pc` (Windows PC)
* Verify that the deploy, recall,  and adding maintenance logs still work as expected.
* Verify that the issue stated above are fixed

#### What are the relevant tickets?
- [PLAT-558](https://airqoteam.atlassian.net/browse/PLAT-558)

#### Screenshots (optional)