### PR TITLE
[NetManager]: add confidence interval to heatmap

### DIFF
--- a/netmanager/src/views/pages/Map/OverlayMap.js
+++ b/netmanager/src/views/pages/Map/OverlayMap.js
@@ -196,9 +196,7 @@ const MapSettings = ({
             <Checkbox checked={showHeatmap} color="default" /> Heatmap
           </MenuItem>
           <Divider />
-          <MenuItem
-            onClick={() => onCalibratedChange(!showCalibratedValues)}
-          >
+          <MenuItem onClick={() => onCalibratedChange(!showCalibratedValues)}>
             <Checkbox checked={showCalibratedValues} color="default" />{" "}
             Calibrated values
           </MenuItem>
@@ -315,14 +313,29 @@ export const OverlayMap = ({
           return;
         }
 
-        const reducer = (accumulator, feature) =>
-          accumulator + parseFloat(feature.properties.predicted_value);
+        const reducerFactory = (key) => (accumulator, feature) =>
+          accumulator + parseFloat(feature.properties[key]);
         let average_predicted_value =
-          features.reduce(reducer, 0) / features.length;
+          features.reduce(reducerFactory("predicted_value"), 0) /
+          features.length;
+
+        let average_confidence_int =
+          features.reduce(reducerFactory("interval"), 0) / features.length;
 
         popup
           .setLngLat(e.lngLat)
-          .setText(`${average_predicted_value.toFixed(2)}`)
+          .setHTML(
+            `<table>
+                <tr>
+                    <td><b>Predicted value</b></td>
+                    <td>${average_predicted_value.toFixed(2)}</td>
+                </tr>
+                <tr>
+                    <td><b>Confidence interval</b></td>
+                    <td>&#177; ${average_confidence_int.toFixed(2)}</td>
+                </tr>
+            </table>`
+          )
           .addTo(map);
       });
     });


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)
- Add confidence interval to heatmap

#### Is this change ready to hit production in its current state?
- [x] Yes
- [ ] No

#### Status of maturity (all need to be checked before merging):

- [x] I consider this code done
- [ ] I've tested this locally
- [ ] This branch has been LGTM'ed by a reviewer

#### How should this be manually tested?
* If this [PR](https://github.com/airqo-platform/AirQo-api/pull/386) is not yet merged and deployed. Set it locally and the appropriate `REACT_APP_BASE_PREDICT_URL` value in the `.env` of netmanager.
* Fetch and checkout to this branch locally
* Install requirements `npm install`
* Start netmanager application `npm run stage-mac` (macOS) or `npm run stage-pc` (windows Platform)
* Go to the heatmap and hover on it, should both the `predicted value` and its corresponding confidence interval.

#### What are the relevant tickets?
- [PLAT-622](https://airqoteam.atlassian.net/browse/PLAT-622)

#### Screenshots (optional)