### PR TITLE
[NetManager]: capitalise device powerType

### DIFF
--- a/netmanager/public/index.html
+++ b/netmanager/public/index.html
@@ -6,15 +6,15 @@
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
-    <meta name="description" content="Web site created using create-react-app" />
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+    <meta name="description" content="AirQo is Africa's leading air quality monitoring, research and analytics network. We use low cost technologies and AI to close the gaps in air quality data across the continent. Work with us to find data-driven solutions to your air quality challenges" />
+    <link rel="apple-touch-icon" href="%PUBLIC_URL%/favicon-96x96.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
-    <link rel="apple-touch-icon" sizes="76x76" href="%PUBLIC_URL%/apple-icon.png" />
+    <link rel="apple-touch-icon" sizes="76x76" href="%PUBLIC_URL%/favicon-96x96.png" />
     <link rel="stylesheet" href="//cdn.jsdelivr.net/chartist.js/latest/chartist.min.css" />
 
     <script src="//cdn.jsdelivr.net/chartist.js/latest/chartist.min.js"></script>

--- a/netmanager/src/utils/string.js
+++ b/netmanager/src/utils/string.js
@@ -1,0 +1,4 @@
+export const capitalize = (s) => {
+  if (typeof s !== "string") return "";
+  return s.charAt(0).toUpperCase() + s.slice(1);
+};

--- a/netmanager/src/views/components/DataDisplay/DeviceView/DeviceEdit.js
+++ b/netmanager/src/views/components/DataDisplay/DeviceView/DeviceEdit.js
@@ -12,6 +12,7 @@ import { isEmpty, isEqual } from "underscore";
 import { updateMainAlert } from "redux/MainAlert/operations";
 import { updateDeviceDetails } from "views/apis/deviceRegistry";
 import { updateDevice } from "redux/DeviceRegistry/operations";
+import { capitalize } from "utils/string";
 
 const transformLocationOptions = (locationsData) => {
   const transFormedOptions = [];
@@ -283,7 +284,7 @@ export default function DeviceEdit({ deviceData, locationsData }) {
               <InputLabel htmlFor="demo-dialog-native">Power Type</InputLabel>
               <Select
                 native
-                value={editData.powerType}
+                value={capitalize(editData.powerType)}
                 onChange={handleSelectFieldChange("powerType")}
                 inputProps={{
                   native: true,


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)
- Some device powerTypes are not displayed in the frontend because the values are not capitalised, hence missed by the dropdown option on device powerType (In the edit section of device view section).
- The example device is `aq_83` (on staging)
- Update app meta data.

#### Is this change ready to hit production in its current state?
- [x] Yes
- [ ] No

#### Status of maturity (all need to be checked before merging):

- [x] I consider this code done
- [x] I've tested this locally
- [ ] This branch has been LGTM'ed by a reviewer

#### How should this be manually tested?
* Fetch and checkout to this branch locally
* Install requirements `npm install`
* Start netmanager application `npm run stage-mac` (macOS) or `npm run stage-pc` (windows Platform)
* Cross check that device `aq_83`'s powerType is showing (in the edit section of device view). Can verify that it's not showing on staging.

#### What are the relevant tickets?
- [N/A]()

#### Screenshots (optional)