### PR TITLE
[NetManager] Use device details location details

### DIFF
--- a/netmanager/src/redux/MapData/operations.js
+++ b/netmanager/src/redux/MapData/operations.js
@@ -63,8 +63,8 @@ export const loadMapEventsData = (params) => async (dispatch) => {
           latitude: "Latitude",
         },
         (feature) => [
-          feature.location.longitude.value || feature.deviceDetails.longitude,
-          feature.location.latitude.value || feature.deviceDetails.latitude,
+          feature.deviceDetails.longitude || feature.location.longitude.value,
+          feature.deviceDetails.latitude || feature.location.latitude.value,
         ]
       );
 

--- a/netmanager/src/redux/MapData/operations.js
+++ b/netmanager/src/redux/MapData/operations.js
@@ -63,8 +63,8 @@ export const loadMapEventsData = (params) => async (dispatch) => {
           latitude: "Latitude",
         },
         (feature) => [
-          feature.location.longitude.value,
-          feature.location.latitude.value,
+          feature.location.longitude.value || feature.deviceDetails.longitude,
+          feature.location.latitude.value || feature.deviceDetails.latitude,
         ]
       );
 
@@ -73,8 +73,7 @@ export const loadMapEventsData = (params) => async (dispatch) => {
         payload,
       });
     })
-    .catch((err) => {
-        console.log("errors", err)
+    .catch(() => {
       dispatch({
         type: LOAD_MAP_EVENTS_FAILURE,
       });

--- a/netmanager/src/redux/MapData/operations.js
+++ b/netmanager/src/redux/MapData/operations.js
@@ -63,8 +63,14 @@ export const loadMapEventsData = (params) => async (dispatch) => {
           latitude: "Latitude",
         },
         (feature) => [
-          feature.deviceDetails.longitude || feature.location.longitude.value,
-          feature.deviceDetails.latitude || feature.location.latitude.value,
+          (feature.deviceDetails && feature.deviceDetails.longitude) ||
+            (feature.location &&
+              feature.location.longitude &&
+              feature.location.longitude.value),
+          (feature.deviceDetails && feature.deviceDetails.latitude) ||
+            (feature.location &&
+              feature.location.latitude &&
+              feature.location.latitude.value),
         ]
       );
 


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)
- Use device details location details to show nodes/sensors on map

#### Is this change ready to hit production in its current state?
- [x] Yes
- [ ] No

#### Status of maturity (all need to be checked before merging):

- [x] I consider this code done
- [x] I've tested this locally
- [ ] This branch has been LGTM'ed by a reviewer

#### How should this be manually tested?
* Fetch and checkout to this branch locally
* Install requirements `npm install`
* Start netmanager application `npm run stage-mac` (macOS) or `npm run stage-pc` (windows Platform)
* All nodes/sensors should be showing on map

#### What are the relevant tickets?
- [N/A]()

#### Screenshots (optional)