### PR TITLE
[NetManager] Heatmap shape/boundary (possibly Kawempe)

### DIFF
--- a/netmanager/src/config/constants.js
+++ b/netmanager/src/config/constants.js
@@ -1,0 +1,2 @@
+export const MAX_CONFIDENCE_INTERVAL =
+  process.env.REACT_APP_MAX_CONFIDENCE_INTERVAL || 30;

--- a/netmanager/src/redux/MapData/operations.js
+++ b/netmanager/src/redux/MapData/operations.js
@@ -21,8 +21,6 @@ export const loadPM25HeatMapData = () => async (dispatch) => {
           longitude: "longitude",
           latitude: "latitude",
         },
-        undefined,
-        true
       );
       dispatch({
         type: LOAD_PM25_HEATMAP_DATA_SUCCESS,
@@ -73,7 +71,6 @@ export const loadMapEventsData = (params) => async (dispatch) => {
           feature.location.longitude.value,
           feature.location.latitude.value,
         ],
-        true
       );
 
       dispatch({

--- a/netmanager/src/redux/MapData/operations.js
+++ b/netmanager/src/redux/MapData/operations.js
@@ -45,9 +45,7 @@ export const loadPM25SensorData = () => async (dispatch) => {
         {
           longitude: "Longitude",
           latitude: "Latitude",
-        },
-        undefined,
-        true
+        }
       );
       dispatch({
         type: LOAD_PM25_SENSOR_DATA_SUCCESS,

--- a/netmanager/src/redux/MapData/operations.js
+++ b/netmanager/src/redux/MapData/operations.js
@@ -1,4 +1,5 @@
 // for representing chained operations using redux-thunk
+import { MAX_CONFIDENCE_INTERVAL } from "config/constants";
 import {
   LOAD_PM25_HEATMAP_DATA_SUCCESS,
   LOAD_PM25_HEATMAP_DATA_FAILURE,
@@ -21,6 +22,8 @@ export const loadPM25HeatMapData = () => async (dispatch) => {
           longitude: "longitude",
           latitude: "latitude",
         },
+        undefined,
+        (feature) => feature.interval <= MAX_CONFIDENCE_INTERVAL
       );
       dispatch({
         type: LOAD_PM25_HEATMAP_DATA_SUCCESS,
@@ -70,7 +73,7 @@ export const loadMapEventsData = (params) => async (dispatch) => {
         (feature) => [
           feature.location.longitude.value,
           feature.location.latitude.value,
-        ],
+        ]
       );
 
       dispatch({

--- a/netmanager/src/redux/MapData/operations.js
+++ b/netmanager/src/redux/MapData/operations.js
@@ -15,10 +15,15 @@ import { getEventsApi } from "views/apis/deviceRegistry";
 export const loadPM25HeatMapData = () => async (dispatch) => {
   return await heatmapPredictApi()
     .then((responseData) => {
-      const payload = transformDataToGeoJson(responseData.data || [], {
-        longitude: "longitude",
-        latitude: "latitude",
-      });
+      const payload = transformDataToGeoJson(
+        responseData.data || [],
+        {
+          longitude: "longitude",
+          latitude: "latitude",
+        },
+        undefined,
+        true
+      );
       dispatch({
         type: LOAD_PM25_HEATMAP_DATA_SUCCESS,
         payload,
@@ -39,7 +44,9 @@ export const loadPM25SensorData = () => async (dispatch) => {
         {
           longitude: "Longitude",
           latitude: "Latitude",
-        }
+        },
+        undefined,
+        true
       );
       dispatch({
         type: LOAD_PM25_SENSOR_DATA_SUCCESS,
@@ -65,7 +72,8 @@ export const loadMapEventsData = (params) => async (dispatch) => {
         (feature) => [
           feature.location.longitude.value,
           feature.location.latitude.value,
-        ]
+        ],
+        true
       );
 
       dispatch({
@@ -74,7 +82,7 @@ export const loadMapEventsData = (params) => async (dispatch) => {
       });
     })
     .catch((err) => {
-        console.log("errors", err)
+      console.log("errors", err);
       dispatch({
         type: LOAD_MAP_EVENTS_FAILURE,
       });

--- a/netmanager/src/views/pages/Map/utils.js
+++ b/netmanager/src/views/pages/Map/utils.js
@@ -7,21 +7,23 @@
 export const transformDataToGeoJson = (
   data,
   { longitude, latitude, ...rest },
-  coordinateGetter
+  coordinateGetter,
+  filterCondition
 ) => {
   let features = [];
   data.map((feature) => {
-    features.push({
-      type: "Feature",
-      properties: { ...rest, ...feature },
-      geometry: {
-        type: "Point",
-        coordinates: (coordinateGetter && coordinateGetter(feature)) || [
-          feature[longitude],
-          feature[latitude],
-        ],
-      },
-    });
+    filterCondition &&
+      features.push({
+        type: "Feature",
+        properties: { ...rest, ...feature },
+        geometry: {
+          type: "Point",
+          coordinates: (coordinateGetter && coordinateGetter(feature)) || [
+            feature[longitude],
+            feature[latitude],
+          ],
+        },
+      });
   });
 
   return {

--- a/netmanager/src/views/pages/Map/utils.js
+++ b/netmanager/src/views/pages/Map/utils.js
@@ -3,16 +3,17 @@
  *  @param {Object[]} data - data to be transformed
  *  @param {Object} coordinates - Object indicating coordinate keys within the data
  *  @param {function} [coordinateGetter] - function that extracts and returns the coordinates [longitude, latitude] from a feature
+ *  @param {function} [filter] - function for filtering feature. Return true to all values
  */
 export const transformDataToGeoJson = (
   data,
   { longitude, latitude, ...rest },
   coordinateGetter,
-  filterCondition
+  filter = () => true
 ) => {
   let features = [];
   data.map((feature) => {
-    filterCondition &&
+    filter(feature) &&
       features.push({
         type: "Feature",
         properties: { ...rest, ...feature },


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)
- only show heatmap points with a given confidence interval (default is 30)

#### Is this change ready to hit production in its current state?
- [x] Yes
- [ ] No

#### Status of maturity (all need to be checked before merging):

- [ ] I consider this code done
- [ ] I've tested this locally
- [ ] This branch has been LGTM'ed by a reviewer

#### How should this be manually tested?
* Fetch and checkout to this branch locally
* Install requirements `npm install`
* Start netmanager application `npm run stage-mac` (macOS) or `npm run stage-pc` (windows Platform)
* Ensure the heatmap shape changes (not the square previously show). All values should have a confidence interval less than 30.

#### What are the relevant tickets?
- [PLAT-658](https://airqoteam.atlassian.net/browse/PLAT-658)

#### Screenshots (optional)
![image](https://user-images.githubusercontent.com/39955305/124653967-9e7f1c80-dea6-11eb-8b1e-87d25d641ca1.png)
