### PR TITLE
[NetManager] Enable data export

### DIFF
--- a/netmanager/src/views/apis/analytics.js
+++ b/netmanager/src/views/apis/analytics.js
@@ -1,5 +1,9 @@
 import axios from "axios";
-import { GET_DATA_MAP, GET_SITES } from "config/urls/analytics";
+import {
+  GET_DATA_MAP,
+  GET_SITES,
+  DOWNLOAD_CUSTOMISED_DATA_URI,
+} from "config/urls/analytics";
 
 export const getMonitoringSitesInfoApi = async (pm25Category) => {
   return await axios
@@ -9,4 +13,10 @@ export const getMonitoringSitesInfoApi = async (pm25Category) => {
 
 export const getSitesApi = async () => {
   return await axios.get(GET_SITES).then((response) => response.data);
+};
+
+export const downloadDataApi = async (downloadType, data) => {
+  return axios
+    .post(DOWNLOAD_CUSTOMISED_DATA_URI, data, { params: { downloadType } })
+    .then((response) => response.data);
 };

--- a/netmanager/src/views/layouts/common/Sidebar/Sidebar.js
+++ b/netmanager/src/views/layouts/common/Sidebar/Sidebar.js
@@ -153,7 +153,7 @@ const Sidebar = (props) => {
   const userPages = excludePages(allUserManagementPages, excludedPages);
 
   if (orgData.name.toLowerCase() === "airqo") {
-    pages = excludePages(pages, ["Export"]);
+    pages = excludePages(pages, []);
   } else {
     pages = excludePages(pages, ["Overview", "Device Management", "Locate"]);
   }

--- a/netmanager/src/views/pages/Download/Download.js
+++ b/netmanager/src/views/pages/Download/Download.js
@@ -13,18 +13,8 @@ import {
 import Select from "react-select";
 import PropTypes from "prop-types";
 import clsx from "clsx";
-import DateFnsUtils from "@date-io/date-fns";
 import TextField from "@material-ui/core/TextField";
-import {
-  MuiPickersUtilsProvider,
-  KeyboardTimePicker,
-  KeyboardDatePicker,
-} from "@material-ui/pickers";
-import axios from "axios";
-import { DOWNLOAD_DATA } from "config/urls/analytics";
-import { getMonitoringSitesLocationsApi } from "../../apis/location";
 import { isEmpty } from "underscore";
-import { formatDate } from "utils/dateTime";
 import { useDashboardSitesData } from "redux/Dashboard/selectors";
 import { loadSites } from "redux/Dashboard/operations";
 import { downloadDataApi } from "views/apis/analytics";

--- a/netmanager/src/views/pages/Download/Download.js
+++ b/netmanager/src/views/pages/Download/Download.js
@@ -112,7 +112,6 @@ const Download = (props) => {
       pollutants: getValues(pollutants),
       fileType: fileType.value,
     };
-    console.log("data", data);
 
     downloadDataApi("json", data)
       .then((response) => response.data)
@@ -143,7 +142,6 @@ const Download = (props) => {
         } else {
           const json2csvParser = new Parser();
           const csv = json2csvParser.parse(resData);
-          console.log(csv);
           let filename = `airquality-${frequency.value}-data.csv`;
           var link = document.createElement("a");
           link.setAttribute(

--- a/netmanager/src/views/pages/Download/Download.js
+++ b/netmanager/src/views/pages/Download/Download.js
@@ -23,6 +23,9 @@ import axios from "axios";
 import { DOWNLOAD_DATA } from "config/urls/analytics";
 import { getMonitoringSitesLocationsApi } from "../../apis/location";
 import { isEmpty } from "underscore";
+import { formatDate } from "utils/dateTime";
+import { useDashboardSitesData } from "redux/Dashboard/selectors";
+import { loadSites } from "redux/Dashboard/operations";
 
 const {
   Parser,
@@ -35,9 +38,31 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
+const createSiteOptions = (sites) => {
+  const options = [];
+  sites.map((site) =>
+    options.push({
+      value: site._id,
+      label: site.name || site.description || site.generated_name,
+    })
+  );
+  return options;
+};
+
 const Download = (props) => {
   const { className, staticContext, ...rest } = props;
   const classes = useStyles();
+
+  const sites = useDashboardSitesData();
+  const [siteOptions, setSiteOptions] = useState([]);
+
+  useEffect(() => {
+    if (isEmpty(sites)) loadSites();
+  }, []);
+
+  useEffect(() => {
+    setSiteOptions(createSiteOptions(sites));
+  }, [sites]);
 
   var startDate = new Date();
   startDate.setMonth(startDate.getMonth() - 1);
@@ -189,7 +214,11 @@ const Download = (props) => {
     <div className={classes.root}>
       <Grid container spacing={4}>
         <Grid item xs={12}>
-          <Card {...rest} className={clsx(classes.root, className)} style={{overflow: "visible"}}>
+          <Card
+            {...rest}
+            className={clsx(classes.root, className)}
+            style={{ overflow: "visible" }}
+          >
             <CardHeader
               subheader="Customize the data you want to download."
               title="Data Download"
@@ -207,8 +236,7 @@ const Download = (props) => {
                       variant="outlined"
                       InputLabelProps={{ shrink: true }}
                       type="date"
-                      // defaultValue={new Date().toLocaleDateString()}
-                      defaultValue={"2021-07-20"}
+                      defaultValue={formatDate(new Date().toISOString())}
                     />
                   </Grid>
 
@@ -220,8 +248,7 @@ const Download = (props) => {
                       variant="outlined"
                       InputLabelProps={{ shrink: true }}
                       type="date"
-                      // defaultValue={new Date().toLocaleDateString()}
-                      defaultValue={"2021-07-20"}
+                      defaultValue={formatDate(new Date().toISOString())}
                     />
                   </Grid>
 
@@ -232,7 +259,7 @@ const Download = (props) => {
                       name="location"
                       placeholder="Location(s)"
                       value={values.selectedOption}
-                      options={filterLocationsOptions}
+                      options={siteOptions}
                       onChange={handleMultiChange}
                       isMulti
                       variant="outlined"

--- a/netmanager/src/views/pages/Download/Download.js
+++ b/netmanager/src/views/pages/Download/Download.js
@@ -13,6 +13,7 @@ import Select from "react-select";
 import PropTypes from "prop-types";
 import clsx from "clsx";
 import DateFnsUtils from "@date-io/date-fns";
+import TextField from "@material-ui/core/TextField";
 import {
   MuiPickersUtilsProvider,
   KeyboardTimePicker,
@@ -83,9 +84,9 @@ const Download = (props) => {
   };
 
   const pollutantOptions = [
-    { value: "PM 2.5", label: "PM 2.5" },
-    { value: "PM 10", label: "PM 10" },
-    { value: "NO2", label: "NO2" },
+    { value: "pm2_5", label: "PM 2.5" },
+    { value: "pm10", label: "PM 10" },
+    { value: "no2", label: "NO2" },
   ];
 
   const [selectedPollutant, setSelectedPollutant] = useState([]);
@@ -105,16 +106,6 @@ const Download = (props) => {
     setSelectedType(selectedTypeOption);
   };
 
-  const degreeOfClean = [
-    { value: "Raw Data", label: "Raw Data" },
-    { value: "Clean Data", label: "Clean Data" },
-  ];
-
-  const [selectedClean, setSelectedClean] = useState();
-  const handleCleanessChange = (selecteddegreeOfClean) => {
-    setSelectedClean(selecteddegreeOfClean);
-  };
-
   const disableDownloadBtn = () => {
     return !(
       values &&
@@ -123,9 +114,7 @@ const Download = (props) => {
       selectedType &&
       selectedType.value &&
       selectedFrequency &&
-      selectedFrequency.value &&
-      selectedClean &&
-      selectedClean.value
+      selectedFrequency.value
     );
   };
 
@@ -139,8 +128,6 @@ const Download = (props) => {
       frequency: selectedFrequency.value,
       pollutants: selectedPollutant,
       fileType: selectedType.value,
-      degreeOfClean: selectedClean.value,
-      organisation_name: "KCCA",
     };
     console.log(JSON.stringify(params));
 
@@ -201,8 +188,8 @@ const Download = (props) => {
   return (
     <div className={classes.root}>
       <Grid container spacing={4}>
-        <Grid item md={8} xs={12}>
-          <Card {...rest} className={clsx(classes.root, className)}>
+        <Grid item xs={12}>
+          <Card {...rest} className={clsx(classes.root, className)} style={{overflow: "visible"}}>
             <CardHeader
               subheader="Customize the data you want to download."
               title="Data Download"
@@ -212,74 +199,30 @@ const Download = (props) => {
             <form onSubmit={handleSubmit}>
               <CardContent>
                 <Grid container spacing={2}>
-                  <Grid item md={12} xs={12}>
-                    <MuiPickersUtilsProvider utils={DateFnsUtils}>
-                      <Grid container spacing={1}>
-                        <Grid item lg={3} md={3} sm={6} xl={3} xs={12}>
-                          <KeyboardDatePicker
-                            disableToolbar
-                            variant="dialog"
-                            format="yyyy-MM-dd"
-                            margin="normal"
-                            id="date-picker-inline"
-                            label="Start Date"
-                            value={selectedDate}
-                            onChange={handleDateChange}
-                            KeyboardButtonProps={{
-                              "aria-label": "change date",
-                            }}
-                            required
-                            disableFuture
-                          />
-                        </Grid>
-                        <Grid item lg={3} md={3} sm={6} xl={3} xs={12}>
-                          <KeyboardTimePicker
-                            variant="dialog"
-                            margin="normal"
-                            id="time-picker"
-                            label="Start Time "
-                            value={selectedDate}
-                            onChange={handleDateChange}
-                            KeyboardButtonProps={{
-                              "aria-label": "change time",
-                            }}
-                            required
-                          />
-                        </Grid>
+                  <Grid item md={6} xs={12}>
+                    <TextField
+                      label="Start Date"
+                      className="reactSelect"
+                      fullWidth
+                      variant="outlined"
+                      InputLabelProps={{ shrink: true }}
+                      type="date"
+                      // defaultValue={new Date().toLocaleDateString()}
+                      defaultValue={"2021-07-20"}
+                    />
+                  </Grid>
 
-                        <Grid item lg={3} md={3} sm={6} xl={3} xs={12}>
-                          <KeyboardDatePicker
-                            disableToolbar
-                            variant="dialog"
-                            format="yyyy-MM-dd"
-                            margin="normal"
-                            id="date-picker-inline"
-                            label="End Date"
-                            value={selectedEndDate}
-                            onChange={handleEndDateChange}
-                            KeyboardButtonProps={{
-                              "aria-label": "change end date",
-                            }}
-                            required
-                            disableFuture
-                          />
-                        </Grid>
-                        <Grid item lg={3} md={3} sm={6} xl={3} xs={12}>
-                          <KeyboardTimePicker
-                            variant="dialog"
-                            margin="normal"
-                            id="time-picker"
-                            label="End Time "
-                            value={selectedEndDate}
-                            onChange={handleEndDateChange}
-                            KeyboardButtonProps={{
-                              "aria-label": "change end time",
-                            }}
-                            required
-                          />
-                        </Grid>
-                      </Grid>
-                    </MuiPickersUtilsProvider>
+                  <Grid item md={6} xs={12}>
+                    <TextField
+                      label="End Date"
+                      className="reactSelect"
+                      fullWidth
+                      variant="outlined"
+                      InputLabelProps={{ shrink: true }}
+                      type="date"
+                      // defaultValue={new Date().toLocaleDateString()}
+                      defaultValue={"2021-07-20"}
+                    />
                   </Grid>
 
                   <Grid item md={6} xs={12}>
@@ -333,22 +276,6 @@ const Download = (props) => {
                   <Grid item md={6} xs={12}>
                     <Select
                       fullWidth
-                      label="Degree of Cleaning"
-                      className="reactSelect"
-                      name="file-type"
-                      placeholder="Degree of Cleaning"
-                      value={selectedClean}
-                      options={degreeOfClean}
-                      onChange={handleCleanessChange}
-                      variant="outlined"
-                      margin="dense"
-                      required
-                    />
-                  </Grid>
-
-                  <Grid item md={6} xs={12}>
-                    <Select
-                      fullWidth
                       label="File Type"
                       className="reactSelect"
                       name="file-type"
@@ -377,16 +304,6 @@ const Download = (props) => {
                 </Button>
               </CardActions>
             </form>
-          </Card>
-        </Grid>
-        <Grid item md={4} xs={12}>
-          <Card {...rest} className={clsx(classes.root, className)}>
-            <CardHeader
-              subheader="Customize the data you want to download."
-              title="Data Download"
-            />
-            <Divider />
-            <CardContent>{/*<PollutantCategory />*/}</CardContent>
           </Card>
         </Grid>
       </Grid>

--- a/netmanager/src/views/pages/Download/Download.js
+++ b/netmanager/src/views/pages/Download/Download.js
@@ -22,7 +22,7 @@ import { roundToStartOfDay, roundToEndOfDay } from "utils/dateTime";
 
 const {
   Parser,
-  transforms: { unwind },
+  // transforms: { unwind },
 } = require("json2csv");
 
 const useStyles = makeStyles((theme) => ({
@@ -114,7 +114,7 @@ const Download = (props) => {
     };
     console.log("data", data);
 
-    downloadDataApi(fileType.value, data)
+    downloadDataApi("json", data)
       .then((response) => response.data)
       .then((resData) => {
         if (fileType.value === "json") {
@@ -141,20 +141,20 @@ const Download = (props) => {
             document.body.removeChild(a);
           }
         } else {
-          // const json2csvParser = new Parser();
-          // const csv = json2csvParser.parse(resData);
-          // console.log(csv);
-          // let filename = `airquality-${frequency.value}-data.csv`;
-          // var link = document.createElement("a");
-          // link.setAttribute(
-          //   "href",
-          //   "data:text/csv;charset=utf-8,%EF%BB%BF" + encodeURIComponent(csv)
-          // );
-          // link.setAttribute("download", filename);
-          // link.style.visibility = "hidden";
-          // document.body.appendChild(link);
-          // link.click();
-          // document.body.removeChild(link);
+          const json2csvParser = new Parser();
+          const csv = json2csvParser.parse(resData);
+          console.log(csv);
+          let filename = `airquality-${frequency.value}-data.csv`;
+          var link = document.createElement("a");
+          link.setAttribute(
+            "href",
+            "data:text/csv;charset=utf-8,%EF%BB%BF" + encodeURIComponent(csv)
+          );
+          link.setAttribute("download", filename);
+          link.style.visibility = "hidden";
+          document.body.appendChild(link);
+          link.click();
+          document.body.removeChild(link);
         }
       })
       .catch((err) => console.log(err && err.response && err.response.data));

--- a/netmanager/src/views/pages/Download/Download.js
+++ b/netmanager/src/views/pages/Download/Download.js
@@ -20,10 +20,7 @@ import { loadSites } from "redux/Dashboard/operations";
 import { downloadDataApi } from "views/apis/analytics";
 import { roundToStartOfDay, roundToEndOfDay } from "utils/dateTime";
 
-const {
-  Parser,
-  // transforms: { unwind },
-} = require("json2csv");
+const { Parser } = require("json2csv");
 
 const useStyles = makeStyles((theme) => ({
   root: {


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)
- Fix KCCA data export feature
- Enable Data export for AirQo

#### Is this change ready to hit production in its current state?
- [x] Yes
- [ ] No

#### Status of maturity (all need to be checked before merging):

- [x] I consider this code done
- [ ] I've tested this locally
- [ ] This branch has been LGTM'ed by a reviewer

#### How should this be manually tested?
* Set this backend [PR](https://github.com/airqo-platform/AirQo-api/pull/482)
* Fetch and checkout to this branch locally
* Set the `REACT_APP_BASE_ANALYTICS_URL` in frontend `.env`. sample value `http://localhost:5000/api/v1/` assuming nothing changed
* Install requirements `npm install`
* Start netmanager application `npm run stage-mac` (macOS) or `npm run stage-pc` (windows Platform)
* Confirm the summary of changes listed above

#### What are the relevant tickets?
- [PLAT-673](https://airqoteam.atlassian.net/browse/PLAT-673

#### Screenshots (optional)