### PR TITLE
[NetManager] Fix Graphs not showing not initial load

### DIFF
--- a/netmanager/src/redux/Dashboard/reducers/locationFilterReducer.js
+++ b/netmanager/src/redux/Dashboard/reducers/locationFilterReducer.js
@@ -1,6 +1,10 @@
-import { REFRESH_FILTER_LOCATION_DATA_SUCCESS, RESET_LOCATION_FILTER_SUCCESS } from "../actions";
+import {
+  REFRESH_FILTER_LOCATION_DATA_SUCCESS,
+  RESET_LOCATION_FILTER_SUCCESS,
+} from "../actions";
+import { LOGOUT_USER_SUCCESS } from "redux/Join/types";
 
-const initialState = []
+const initialState = [];
 
 export default function (state = initialState, action) {
   switch (action.type) {
@@ -8,6 +12,8 @@ export default function (state = initialState, action) {
       return initialState;
     case REFRESH_FILTER_LOCATION_DATA_SUCCESS:
       return action.payload;
+    case LOGOUT_USER_SUCCESS:
+      return initialState;
     default:
       return state;
   }

--- a/netmanager/src/redux/Dashboard/reducers/sitesReducer.js
+++ b/netmanager/src/redux/Dashboard/reducers/sitesReducer.js
@@ -1,4 +1,5 @@
 import { LOAD_DASHBOARD_SITES_SUCCESS } from "../actions";
+import { LOGOUT_USER_SUCCESS } from "redux/Join/types";
 
 const initialState = [];
 
@@ -6,6 +7,8 @@ export default function (state = initialState, action) {
   switch (action.type) {
     case LOAD_DASHBOARD_SITES_SUCCESS:
       return action.payload;
+    case LOGOUT_USER_SUCCESS:
+      return initialState;
     default:
       return state;
   }

--- a/netmanager/src/redux/Dashboard/reducers/userDefaultGraphsReducer.js
+++ b/netmanager/src/redux/Dashboard/reducers/userDefaultGraphsReducer.js
@@ -1,7 +1,9 @@
 import {
   LOAD_USER_DEFAULT_GRAPHS_SUCCESS,
-  RESET_USER_GRAPH_DEFAULTS_SUCCESS
+  RESET_USER_GRAPH_DEFAULTS_SUCCESS,
 } from "../actions";
+
+import { LOGOUT_USER_SUCCESS } from "redux/Join/types";
 
 const initialState = [];
 
@@ -11,6 +13,8 @@ export default function (state = initialState, action) {
       return initialState;
     case LOAD_USER_DEFAULT_GRAPHS_SUCCESS:
       return action.payload;
+    case LOGOUT_USER_SUCCESS:
+      return initialState;
 
     default:
       return state;

--- a/netmanager/src/redux/DeviceManagement/reducers/devicesStatus.js
+++ b/netmanager/src/redux/DeviceManagement/reducers/devicesStatus.js
@@ -1,4 +1,5 @@
 import { LOAD_DEVICES_STATUS_SUCCESS } from "../actions";
+import { LOGOUT_USER_SUCCESS } from "redux/Join/types";
 
 const initialState = {};
 
@@ -6,6 +7,8 @@ export default function (state = initialState, action) {
   switch (action.type) {
     case LOAD_DEVICES_STATUS_SUCCESS:
       return action.payload;
+    case LOGOUT_USER_SUCCESS:
+      return initialState;
     default:
       return state;
   }

--- a/netmanager/src/redux/DeviceManagement/reducers/devicesUptime.js
+++ b/netmanager/src/redux/DeviceManagement/reducers/devicesUptime.js
@@ -1,4 +1,5 @@
 import { LOAD_ALL_DEVICES_UPTIME_SUCCESS } from "../actions";
+import { LOGOUT_USER_SUCCESS } from "redux/Join/types";
 
 const initialState = {};
 
@@ -6,6 +7,8 @@ export default function (state = initialState, action) {
   switch (action.type) {
     case LOAD_ALL_DEVICES_UPTIME_SUCCESS:
       return { ...state, ...action.payload };
+    case LOGOUT_USER_SUCCESS:
+      return initialState;
     default:
       return state;
   }

--- a/netmanager/src/redux/DeviceManagement/reducers/networkUptime.js
+++ b/netmanager/src/redux/DeviceManagement/reducers/networkUptime.js
@@ -1,4 +1,5 @@
 import { LOAD_NETWORK_UPTIME_SUCCESS } from "../actions";
+import { LOGOUT_USER_SUCCESS } from "redux/Join/types";
 
 const initialState = [];
 
@@ -6,7 +7,9 @@ export default function (state = initialState, action) {
   switch (action.type) {
     case LOAD_NETWORK_UPTIME_SUCCESS:
       return action.payload;
+    case LOGOUT_USER_SUCCESS:
+      return initialState;
     default:
       return state;
   }
-};
+}

--- a/netmanager/src/redux/Join/reducers/authReducer.js
+++ b/netmanager/src/redux/Join/reducers/authReducer.js
@@ -2,14 +2,13 @@
 import {
     SET_CURRENT_USER,
     USER_LOADING,
-    UPDATE_PASSWORD_REQUEST,
-    UPDATE_PASSWORD_FAILED,
     UPDATE_PASSWORD_SUCCESS,
     REGISTRATION_SUCCESS,
     UPDATE_AUTHENTICATED_USER_SUCCESS,
     UPDATE_AUTHENTICATED_USER_REQUEST,
     UPDATE_AUTHENTICATED_USER_FAILED
 } from '../types';
+import { LOGOUT_USER_SUCCESS } from "redux/Join/types";
 
 const isEmpty = require('is-empty');
 
@@ -61,6 +60,8 @@ export default function(state = initialState, action) {
                 ...state,
                 updating: true
             };
+        case LOGOUT_USER_SUCCESS:
+            return initialState
         default:
             return state;
     }

--- a/netmanager/src/redux/Join/reducers/errorReducer.js
+++ b/netmanager/src/redux/Join/reducers/errorReducer.js
@@ -1,4 +1,6 @@
 import { CLEAR_ERRORS, GET_ERRORS, RESET_ERRORS_SUCCESS } from "../types";
+import { LOGOUT_USER_SUCCESS } from "redux/Join/types";
+
 const initialState = {
   errors: null,
 };
@@ -11,6 +13,9 @@ export default function (state = initialState, action) {
       return action.payload;
 
     case CLEAR_ERRORS:
+      return initialState;
+
+    case LOGOUT_USER_SUCCESS:
       return initialState;
 
     default:

--- a/netmanager/src/redux/Join/reducers/orgReducer.js
+++ b/netmanager/src/redux/Join/reducers/orgReducer.js
@@ -1,4 +1,5 @@
 import { UPDATE_ORGANIZATION_SUCCESS, RESET_ORGANIZATION_SUCCESS } from "../types";
+import { LOGOUT_USER_SUCCESS } from "redux/Join/types";
 
 const initialOrgState = { name: "" };
 
@@ -8,6 +9,8 @@ export default function (state = initialOrgState, action) {
       return initialOrgState;
     case UPDATE_ORGANIZATION_SUCCESS:
       return { ...state, ...action.payload };
+    case LOGOUT_USER_SUCCESS:
+      return initialOrgState
     default:
       return state;
   }

--- a/netmanager/src/redux/Join/reducers/userReducer.js
+++ b/netmanager/src/redux/Join/reducers/userReducer.js
@@ -38,6 +38,7 @@ import {
   UPDATE_PASSWORD_FAILED,
   RESET_USER_STATE_SUCCESS,
 } from '../types';
+import { LOGOUT_USER_SUCCESS } from "redux/Join/types";
 
 const initialState = {
   users: [],
@@ -594,6 +595,8 @@ export default function(state = initialState, action) {
         userToEdit: null,
         newUser: null
       };
+    case LOGOUT_USER_SUCCESS:
+      return initialState
 
     default:
       return state;

--- a/netmanager/src/redux/Maps/reducers.js
+++ b/netmanager/src/redux/Maps/reducers.js
@@ -1,4 +1,5 @@
 import { RENDER_MAP_DEFAULTS, RESET_MAP_DEFAULTS_SUCCESS } from "./types";
+import { LOGOUT_USER_SUCCESS } from "redux/Join/types";
 
 // create initial state
 
@@ -19,6 +20,8 @@ export default function (state = initialState, action) {
       return {
         ...state,
       };
+    case LOGOUT_USER_SUCCESS:
+      return initialState;
     default:
       return state;
   }

--- a/netmanager/src/views/pages/Dashboard/components/CustomisableChart/CustomisableChart.js
+++ b/netmanager/src/views/pages/Dashboard/components/CustomisableChart/CustomisableChart.js
@@ -470,7 +470,6 @@ const CustomisableChart = (props) => {
     dispatch(
       setUserDefaultGraphData({
         ...newFilter,
-        // locations: valueLabelToString(values.selectedOption),
         locations: optionToList(tempState.sites.selectedOption),
       })
     );

--- a/netmanager/src/views/pages/Dashboard/components/CustomisableChart/CustomisableChart.js
+++ b/netmanager/src/views/pages/Dashboard/components/CustomisableChart/CustomisableChart.js
@@ -252,8 +252,8 @@ const CustomisableChart = (props) => {
     setSiteOptions(options);
   }, [sites]);
 
-  const siteFilter = (values) => (site) => {
-    return values.includes(site.label);
+  const siteFilter = (selectedSites) => (site) => {
+    return selectedSites.includes(site.value);
   };
 
   const [values, setReactSelectValue] = useState({
@@ -470,7 +470,8 @@ const CustomisableChart = (props) => {
     dispatch(
       setUserDefaultGraphData({
         ...newFilter,
-        locations: valueLabelToString(values.selectedOption),
+        // locations: valueLabelToString(values.selectedOption),
+        locations: optionToList(tempState.sites.selectedOption),
       })
     );
     await fetchAndSetGraphData(newFilter);


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)
- Fix charts not showing on initial dashboard load by using site ids instead of labels when storing user defaults
- Finalise clearing redux state on user logout
- Carry out default graphs data cleaning

#### Is this change ready to hit production in its current state?
- [x] Yes
- [ ] No

#### Status of maturity (all need to be checked before merging):

- [x] I consider this code done
- [ ] I've tested this locally
- [ ] This branch has been LGTM'ed by a reviewer

#### How should this be manually tested?
* Fetch and checkout to this branch locally
* Install requirements `npm install`
* Start netmanager application `npm run stage-mac` (macOS) or `npm run stage-pc` (windows Platform)
* Confirm the summary of changes listed above

#### What are the relevant tickets?
- [N/A]()
