### PR TITLE
[NetManager] exclude site registry for normal users

### DIFF
--- a/netmanager/src/views/layouts/common/Sidebar/Sidebar.js
+++ b/netmanager/src/views/layouts/common/Sidebar/Sidebar.js
@@ -56,6 +56,7 @@ const roleExcludePageMapper = {
     "Device Management",
     "Location Registry",
     "Device Registry",
+    "Site Registry",
   ],
   user: [
     "Users",
@@ -64,6 +65,7 @@ const roleExcludePageMapper = {
     "Device Management",
     "Location Registry",
     "Device Registry",
+    "Site Registry",
   ],
   netmanager: ["Users", "Candidates"],
   admin: ["Candidates"],


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)
- Hides `Site Registry` from normal users

#### Is this change ready to hit production in its current state?
- [x] Yes
- [ ] No

#### Status of maturity (all need to be checked before merging):

- [x] I consider this code done
- [ ] I've tested this locally
- [ ] This branch has been LGTM'ed by a reviewer

#### How should this be manually tested?
* Fetch and checkout to this branch locally
* Install requirements `npm install`
* Start netmanager application `npm run stage-mac` (macOS) or `npm run stage-pc` (windows Platform)
* Login as a non-admin users (normal user or collaborator). You should not be able to access `Site Registry` tab.

#### What are the relevant tickets?
- [PLAT-711](https://airqoteam.atlassian.net/browse/PLAT-711)
