### PR TITLE
[NetManager] Hot fix reduce fields

### DIFF
--- a/netmanager/src/views/components/DataDisplay/DeviceView/DeviceEdit.js
+++ b/netmanager/src/views/components/DataDisplay/DeviceView/DeviceEdit.js
@@ -4,7 +4,7 @@ import TextField from "@material-ui/core/TextField";
 import Paper from "@material-ui/core/Paper";
 import { Button, Grid } from "@material-ui/core";
 import OutlinedSelect from "../../CustomSelects/OutlinedSelect";
-import { isEmpty, isEqual } from "underscore";
+import { isEmpty, isEqual, omit } from "underscore";
 import { updateMainAlert } from "redux/MainAlert/operations";
 import { updateDeviceDetails } from "views/apis/deviceRegistry";
 import { loadDevicesData } from "redux/DeviceRegistry/operations";
@@ -20,12 +20,22 @@ const gridItemStyle = {
   padding: "5px",
 };
 
+const EDIT_OMITTED_KEYS = [
+  "owner",
+  "device_manufacturer",
+  "product_name",
+  "site",
+  "powerType",
+  "mountType",
+  "height",
+  "deployment_date",
+  "nextMaintenance",
+];
+
 const EditDeviceForm = ({ deviceData, siteOptions }) => {
   const dispatch = useDispatch();
   const [editData, setEditData] = useState({
-    locationName: "",
-    siteName: "",
-    ...deviceData,
+    ...omit(deviceData, EDIT_OMITTED_KEYS),
   });
 
   const [errors, setErrors] = useState({});
@@ -71,6 +81,7 @@ const EditDeviceForm = ({ deviceData, siteOptions }) => {
         );
       })
       .catch((err) => {
+        console.log("errors", err.response.data);
         const newErrors =
           (err.response && err.response.data && err.response.data.errors) || {};
         setErrors(newErrors);
@@ -101,7 +112,7 @@ const EditDeviceForm = ({ deviceData, siteOptions }) => {
       <Paper
         style={{
           margin: "0 auto",
-          minHeight: "400px",
+          minHeight: "200px",
           padding: "20px 20px",
           maxWidth: "1500px",
         }}
@@ -126,54 +137,12 @@ const EditDeviceForm = ({ deviceData, siteOptions }) => {
               autoFocus
               margin="dense"
               variant="outlined"
-              id="owner"
-              label="Owner"
-              value={editData.owner}
-              onChange={handleTextFieldChange}
-              error={!!errors.owner}
-              helperText={errors.owner}
-              fullWidth
-            />
-          </Grid>
-          <Grid items xs={12} sm={4} style={gridItemStyle}>
-            <TextField
-              autoFocus
-              margin="dense"
-              variant="outlined"
               id="description"
               label="Description"
               value={editData.description}
               onChange={handleTextFieldChange}
               error={!!errors.description}
               helperText={errors.description}
-              fullWidth
-            />
-          </Grid>
-          <Grid items xs={12} sm={4} style={gridItemStyle}>
-            <TextField
-              autoFocus
-              margin="dense"
-              variant="outlined"
-              id="device_manufacturer"
-              label="Manufacturer"
-              value={editData.device_manufacturer}
-              onChange={handleTextFieldChange}
-              error={!!errors.device_manufacturer}
-              helperText={errors.device_manufacturer}
-              fullWidth
-            />
-          </Grid>
-          <Grid items xs={12} sm={4} style={gridItemStyle}>
-            <TextField
-              autoFocus
-              margin="dense"
-              variant="outlined"
-              id="product_name"
-              label="Product Name"
-              value={editData.product_name}
-              onChange={handleTextFieldChange}
-              error={!!errors.product_name}
-              helperText={errors.product_name}
               fullWidth
             />
           </Grid>
@@ -261,106 +230,106 @@ const EditDeviceForm = ({ deviceData, siteOptions }) => {
               <option value="Africell">Africell</option>
             </TextField>
           </Grid>
-          <Grid
-            items
-            xs={12}
-            sm={4}
-            style={{ display: "flex", alignItems: "center" }}
-          >
-            <OutlinedSelect
-              label={"Site"}
-              defaultValue={site}
-              onChange={(selectedValue) => {
-                setEditData({ ...editData, site: selectedValue });
-                setSite(selectedValue);
-              }}
-              options={siteOptions}
-              fullWidth
-            />
-          </Grid>
+          {/*<Grid*/}
+          {/*  items*/}
+          {/*  xs={12}*/}
+          {/*  sm={4}*/}
+          {/*  style={{ display: "flex", alignItems: "center" }}*/}
+          {/*>*/}
+          {/*  <OutlinedSelect*/}
+          {/*    label={"Site"}*/}
+          {/*    defaultValue={site}*/}
+          {/*    onChange={(selectedValue) => {*/}
+          {/*      setEditData({ ...editData, site: selectedValue });*/}
+          {/*      setSite(selectedValue);*/}
+          {/*    }}*/}
+          {/*    options={siteOptions}*/}
+          {/*    fullWidth*/}
+          {/*  />*/}
+          {/*</Grid>*/}
 
-          <Grid items xs={12} sm={4} style={gridItemStyle}>
-            <TextField
-              select
-              fullWidth
-              label="Power Type"
-              style={{ margin: "10px 0" }}
-              value={capitalize(editData.powerType)}
-              onChange={handleSelectFieldChange("powerType")}
-              SelectProps={{
-                native: true,
-                style: { width: "100%", height: "50px" },
-              }}
-              error={!!errors.powerType}
-              helperText={errors.powerType}
-              variant="outlined"
-            >
-              <option aria-label="None" value="" />
-              <option value="Mains">Mains</option>
-              <option value="Solar">Solar</option>
-              <option value="Battery">Battery</option>
-            </TextField>
-          </Grid>
+          {/*<Grid items xs={12} sm={4} style={gridItemStyle}>*/}
+          {/*  <TextField*/}
+          {/*    select*/}
+          {/*    fullWidth*/}
+          {/*    label="Power Type"*/}
+          {/*    style={{ margin: "10px 0" }}*/}
+          {/*    value={capitalize(editData.powerType)}*/}
+          {/*    onChange={handleSelectFieldChange("powerType")}*/}
+          {/*    SelectProps={{*/}
+          {/*      native: true,*/}
+          {/*      style: { width: "100%", height: "50px" },*/}
+          {/*    }}*/}
+          {/*    error={!!errors.powerType}*/}
+          {/*    helperText={errors.powerType}*/}
+          {/*    variant="outlined"*/}
+          {/*  >*/}
+          {/*    <option aria-label="None" value="" />*/}
+          {/*    <option value="Mains">Mains</option>*/}
+          {/*    <option value="Solar">Solar</option>*/}
+          {/*    <option value="Battery">Battery</option>*/}
+          {/*  </TextField>*/}
+          {/*</Grid>*/}
 
-          <Grid items xs={12} sm={4} style={gridItemStyle}>
-            <TextField
-              autoFocus
-              select
-              margin="dense"
-              variant="outlined"
-              id="mountType"
-              label="Mount Type"
-              value={capitalize(editData.mountType)}
-              onChange={handleSelectFieldChange("mountType")}
-              SelectProps={{
-                native: true,
-                style: { width: "100%", height: "50px" },
-              }}
-              error={!!errors.mountType}
-              helperText={errors.mountType}
-              fullWidth
-            >
-              <option value="" />
-              <option value="Faceboard">Faceboard</option>
-              <option value="Pole">Pole</option>
-              <option value="Rooftop">Rooftop</option>
-              <option value="Suspended">Suspended</option>
-              <option value="Wall">Wall</option>
-            </TextField>
-          </Grid>
+          {/*<Grid items xs={12} sm={4} style={gridItemStyle}>*/}
+          {/*  <TextField*/}
+          {/*    autoFocus*/}
+          {/*    select*/}
+          {/*    margin="dense"*/}
+          {/*    variant="outlined"*/}
+          {/*    id="mountType"*/}
+          {/*    label="Mount Type"*/}
+          {/*    value={capitalize(editData.mountType)}*/}
+          {/*    onChange={handleSelectFieldChange("mountType")}*/}
+          {/*    SelectProps={{*/}
+          {/*      native: true,*/}
+          {/*      style: { width: "100%", height: "50px" },*/}
+          {/*    }}*/}
+          {/*    error={!!errors.mountType}*/}
+          {/*    helperText={errors.mountType}*/}
+          {/*    fullWidth*/}
+          {/*  >*/}
+          {/*    <option value="" />*/}
+          {/*    <option value="Faceboard">Faceboard</option>*/}
+          {/*    <option value="Pole">Pole</option>*/}
+          {/*    <option value="Rooftop">Rooftop</option>*/}
+          {/*    <option value="Suspended">Suspended</option>*/}
+          {/*    <option value="Wall">Wall</option>*/}
+          {/*  </TextField>*/}
+          {/*</Grid>*/}
 
-          <Grid items xs={12} sm={4} style={gridItemStyle}>
-            <TextField
-              autoFocus
-              margin="dense"
-              variant="outlined"
-              id="height"
-              label="height"
-              type="number"
-              value={editData.height}
-              onChange={handleTextFieldChange}
-              error={!!errors.height}
-              helperText={errors.height}
-              fullWidth
-            />
-          </Grid>
+          {/*<Grid items xs={12} sm={4} style={gridItemStyle}>*/}
+          {/*  <TextField*/}
+          {/*    autoFocus*/}
+          {/*    margin="dense"*/}
+          {/*    variant="outlined"*/}
+          {/*    id="height"*/}
+          {/*    label="height"*/}
+          {/*    type="number"*/}
+          {/*    value={editData.height}*/}
+          {/*    onChange={handleTextFieldChange}*/}
+          {/*    error={!!errors.height}*/}
+          {/*    helperText={errors.height}*/}
+          {/*    fullWidth*/}
+          {/*  />*/}
+          {/*</Grid>*/}
 
-          <Grid items xs={12} sm={4} style={gridItemStyle}>
-            <TextField
-              autoFocus
-              margin="dense"
-              variant="outlined"
-              id="deployment_date"
-              label="Deployment Date"
-              type="date"
-              InputLabelProps={{ shrink: true }}
-              defaultValue={getDateString(editData.deployment_date)}
-              onChange={handleTextFieldChange}
-              error={!!errors.deployment_date}
-              helperText={errors.deployment_date}
-              fullWidth
-            />
-          </Grid>
+          {/*<Grid items xs={12} sm={4} style={gridItemStyle}>*/}
+          {/*  <TextField*/}
+          {/*    autoFocus*/}
+          {/*    margin="dense"*/}
+          {/*    variant="outlined"*/}
+          {/*    id="deployment_date"*/}
+          {/*    label="Deployment Date"*/}
+          {/*    type="date"*/}
+          {/*    InputLabelProps={{ shrink: true }}*/}
+          {/*    defaultValue={getDateString(editData.deployment_date)}*/}
+          {/*    onChange={handleTextFieldChange}*/}
+          {/*    error={!!errors.deployment_date}*/}
+          {/*    helperText={errors.deployment_date}*/}
+          {/*    fullWidth*/}
+          {/*  />*/}
+          {/*</Grid>*/}
 
           <Grid
             container

--- a/netmanager/src/views/components/DataDisplay/DeviceView/DeviceEdit.js
+++ b/netmanager/src/views/components/DataDisplay/DeviceView/DeviceEdit.js
@@ -69,6 +69,10 @@ const EditDeviceForm = ({ deviceData, siteOptions }) => {
         editData.deployment_date
       ).toISOString();
 
+    if (isEmpty(editData.latitude)) delete editData.latitude;
+
+    if (isEmpty(editData.longitude)) delete editData.longitude;
+
     await updateDeviceDetails(deviceData._id, editData)
       .then((responseData) => {
         dispatch(loadDevicesData());

--- a/netmanager/src/views/components/DataDisplay/DeviceView/DeviceLogs.js
+++ b/netmanager/src/views/components/DataDisplay/DeviceView/DeviceLogs.js
@@ -81,10 +81,6 @@ const EditLog = ({ deviceName, deviceLocation, toggleShow, log }) => {
     createTagOption("Air quality sensor(s) works/replacement"),
   ];
 
-  const maintenanceTypeOptions = [
-    { value: "preventive", label: "Preventive" },
-    { value: "Corrective", label: "Corrective" },
-  ];
 
   const handleSubmit = async (evt) => {
     evt.preventDefault();
@@ -95,7 +91,6 @@ const EditLog = ({ deviceName, deviceLocation, toggleShow, log }) => {
       locationName: deviceLocation,
       date: selectedDate.toISOString(),
       tags: extracted_tags,
-      maintenanceType: (maintenanceType && maintenanceType.value) || "",
       description: description,
     };
 
@@ -158,17 +153,6 @@ const EditLog = ({ deviceName, deviceLocation, toggleShow, log }) => {
             value={deviceName}
             fullWidth
             disabled
-          />
-        </div>
-        <div style={{ margin: "5px 0" }}>
-          <CreatableLabelledSelect
-            label={"Type of Maintenance"}
-            options={maintenanceTypeOptions}
-            isClearable
-            value={maintenanceType}
-            onChange={(newValue: any, actionMeta: any) =>
-              setMaintenanceType(newValue)
-            }
           />
         </div>
         <div style={{ margin: "10px 0" }}>

--- a/netmanager/src/views/components/DataDisplay/DeviceView/DeviceLogs.js
+++ b/netmanager/src/views/components/DataDisplay/DeviceView/DeviceLogs.js
@@ -442,12 +442,12 @@ export default function DeviceLogs({ deviceName, deviceLocation }) {
       },
     },
     {
-      title: "Next Maintenance",
-      field: "nextMaintenance",
+      title: "Created On",
+      field: "createdAt",
       cellStyle: { width: 100, maxWidth: 100 },
       render: (rowData) => (
         <div className={"table-truncate"}>
-          {humanReadableDate(rowData.nextMaintenance)}
+          {humanReadableDate(rowData.createdAt)}
         </div>
       ),
     },

--- a/netmanager/src/views/components/DataDisplay/DeviceView/DeviceLogs.js
+++ b/netmanager/src/views/components/DataDisplay/DeviceView/DeviceLogs.js
@@ -238,7 +238,6 @@ const EditLog = ({ deviceName, deviceLocation, toggleShow, log }) => {
 const AddLogForm = ({ deviceName, deviceLocation, toggleShow }) => {
   const dispatch = useDispatch();
   const [loading, setLoading] = useState(false);
-  const [maintenanceType, setMaintenanceType] = useState(null);
   const [description, setDescription] = useState("");
   const [tags, setTags] = useState([]);
   const [selectedDate, setSelectedDate] = useState(new Date());
@@ -262,11 +261,6 @@ const AddLogForm = ({ deviceName, deviceLocation, toggleShow }) => {
     createTagOption("Air quality sensor(s) works/replacement"),
   ];
 
-  const maintenanceTypeOptions = [
-    { value: "preventive", label: "Preventive" },
-    { value: "corrective", label: "Corrective" },
-  ];
-
   const handleSubmit = async (evt) => {
     evt.preventDefault();
     const extracted_tags = [];
@@ -274,7 +268,6 @@ const AddLogForm = ({ deviceName, deviceLocation, toggleShow }) => {
     const logData = {
       date: selectedDate.toISOString(),
       tags: extracted_tags,
-      maintenanceType: (maintenanceType && maintenanceType.value) || "",
       description: description,
     };
 
@@ -349,17 +342,6 @@ const AddLogForm = ({ deviceName, deviceLocation, toggleShow }) => {
             value={deviceName}
             fullWidth
             disabled
-          />
-        </div>
-        <div style={{ margin: "5px 0" }}>
-          <CreatableLabelledSelect
-            label={"Type of Maintenance"}
-            options={maintenanceTypeOptions}
-            isClearable
-            value={maintenanceType}
-            onChange={(newValue: any, actionMeta: any) =>
-              setMaintenanceType(newValue)
-            }
           />
         </div>
         <div style={{ margin: "10px 0" }}>
@@ -439,7 +421,6 @@ export default function DeviceLogs({ deviceName, deviceLocation }) {
   const maintenanceLogs = useDeviceLogsData(deviceName);
 
   const logsColumns = [
-    { title: "Maintenance type", field: "maintenanceType" },
     {
       title: "Description",
       field: "description",

--- a/netmanager/src/views/components/DataDisplay/Devices.js
+++ b/netmanager/src/views/components/DataDisplay/Devices.js
@@ -205,26 +205,14 @@ const CreateDevice = ({ open, setOpen }) => {
   const dispatch = useDispatch();
   const newDeviceInitState = {
     long_name: "",
-    description: "",
-    visibility: false,
     generation_version: "",
     generation_count: "",
-    device_manufacturer: "",
-    product_name: "",
-    ISP: "",
-    phoneNumber: "",
   };
 
   const initialErrors = {
     long_name: "",
-    description: "",
-    visibility: "",
     generation_version: "",
     generation_count: "",
-    device_manufacturer: "",
-    product_name: "",
-    ISP: "",
-    phoneNumber: "",
   };
 
   const [newDevice, setNewDevice] = useState(newDeviceInitState);
@@ -313,40 +301,6 @@ const CreateDevice = ({ open, setOpen }) => {
           <TextField
             autoFocus
             margin="dense"
-            label="Description"
-            variant="outlined"
-            value={newDevice.description}
-            onChange={handleDeviceDataChange("description")}
-            error={!!errors.description}
-            helperText={errors.description}
-            fullWidth
-            required
-          />
-          <TextField
-            select
-            fullWidth
-            label="Data Access"
-            style={{ margin: "10px 0" }}
-            value={newDevice.visibility}
-            onChange={handleDeviceDataChange("visibility")}
-            error={!!errors.visibility}
-            helperText={errors.visibility}
-            SelectProps={{
-              native: true,
-              style: { width: "100%", height: "50px" },
-              MenuProps: {
-                className: classes.menu,
-              },
-            }}
-            variant="outlined"
-            required
-          >
-            <option value={false}>Private</option>
-            <option value={true}>Public</option>
-          </TextField>
-          <TextField
-            autoFocus
-            margin="dense"
             label="Generation Version"
             variant="outlined"
             type="number"
@@ -369,62 +323,6 @@ const CreateDevice = ({ open, setOpen }) => {
             onChange={handleDeviceDataChange("generation_count")}
             fullWidth
             required
-          />
-          <TextField
-            autoFocus
-            margin="dense"
-            label="Manufacturer"
-            variant="outlined"
-            value={newDevice.device_manufacturer}
-            onChange={handleDeviceDataChange("device_manufacturer")}
-            error={!!errors.device_manufacturer}
-            helperText={errors.device_manufacturer}
-            fullWidth
-          />
-          <TextField
-            autoFocus
-            margin="dense"
-            label="Product Name"
-            variant="outlined"
-            value={newDevice.product_name}
-            onChange={handleDeviceDataChange("product_name")}
-            error={!!errors.product_name}
-            helperText={errors.product_name}
-            fullWidth
-          />
-          <TextField
-            select
-            fullWidth
-            label="Internet Service Provider"
-            style={{ margin: "10px 0" }}
-            value={newDevice.ISP}
-            onChange={handleDeviceDataChange("ISP")}
-            error={!!errors.ISP}
-            helperText={errors.ISP}
-            SelectProps={{
-              native: true,
-              style: { width: "100%", height: "50px" },
-              MenuProps: {
-                className: classes.menu,
-              },
-            }}
-            variant="outlined"
-          >
-            <option value="" />
-            <option value="MTN">MTN</option>
-            <option value="Airtel">Airtel</option>
-            <option value="Africell">Africell</option>
-          </TextField>
-          <TextField
-            autoFocus
-            margin="dense"
-            label="Phone Number"
-            variant="outlined"
-            value={newDevice.phoneNumber}
-            onChange={handleDeviceDataChange("phoneNumber")}
-            error={!!errors.phoneNumber}
-            helperText={errors.phoneNumber}
-            fullWidth
           />
         </form>
       </DialogContent>
@@ -570,10 +468,7 @@ const DevicesTable = (props) => {
         }}
       />
 
-      <CreateDevice
-        open={registerOpen}
-        setOpen={setRegisterOpen}
-      />
+      <CreateDevice open={registerOpen} setOpen={setRegisterOpen} />
       <ConfirmDialog
         open={delDevice.open}
         title={"Delete a device?"}


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)
- Device Add fields are reduced to three.
- Device edit fields only contain fields not shared with deployment
- Removed `maintenanceType` field from maintenance logs
- Maintenance log table now shows the `createdAt` field instead of `nextMaintenance `date

#### Is this change ready to hit production in its current state?
- [x] Yes
- [ ] No

#### Status of maturity (all need to be checked before merging):

- [x] I consider this code done
- [x] I've tested this locally
- [ ] This branch has been LGTM'ed by a reviewer

#### How should this be manually tested?
* Set this backend [Backend Validation](https://github.com/airqo-platform/AirQo-api/pull/511)
* Fetch and checkout to this branch locally
* Set the `REACT_APP_BASE_DEVICE_REGISTRY_URL` in frontend `.env`. sample value `http://localhost:3000/api/v1/` assuming nothing changed
* Install requirements `npm install`
* Start netmanager application `npm run stage-mac` (macOS) or `npm run stage-pc` (windows Platform)
* Confirm the summary of changes listed above

#### What are the relevant tickets?
- [N/A]()
