### PR TITLE
[NetManger] Hotfix - mapbox v2 transpiling

### DIFF
--- a/netmanager/package-lock.json
+++ b/netmanager/package-lock.json
@@ -2577,24 +2577,18 @@
       }
     },
     "@mapbox/geojson-rewind": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/geojson-rewind/-/geojson-rewind-0.5.0.tgz",
-      "integrity": "sha512-73l/qJQgj/T/zO1JXVfuVvvKDgikD/7D/rHAD28S9BG1OTstgmftrmqfCx4U+zQAmtsB6HcDA3a7ymdnJZAQgg==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-rewind/-/geojson-rewind-0.5.1.tgz",
+      "integrity": "sha512-eL7fMmfTBKjrb+VFHXCGv9Ot0zc3C0U+CwXo1IrP+EPwDczLoXv34Tgq3y+2mPSFNVUXgU42ILWJTC7145KPTA==",
       "requires": {
-        "concat-stream": "~2.0.0",
+        "get-stream": "^6.0.1",
         "minimist": "^1.2.5"
       },
       "dependencies": {
-        "concat-stream": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
-          "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
-          "requires": {
-            "buffer-from": "^1.0.0",
-            "inherits": "^2.0.3",
-            "readable-stream": "^3.0.2",
-            "typedarray": "^0.0.6"
-          }
+        "get-stream": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+          "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="
         }
       }
     },
@@ -2609,9 +2603,9 @@
       "integrity": "sha1-zlblOfg1UrWNENZy6k1vya3HsjQ="
     },
     "@mapbox/mapbox-gl-supported": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-1.5.0.tgz",
-      "integrity": "sha512-/PT1P6DNf7vjEEiPkVIRJkvibbqWtqnyGaBz3nfRdcxclNSnSdaLU5tfAgcD7I8Yt5i+L19s406YLl1koLnLbg=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-2.0.0.tgz",
+      "integrity": "sha512-zu4udqYiBrKMQKwpKJ4hhPON7tz0QR/JZ3iGpHnNWFmH3Sv/ysxlICATUtGCFpsyJf2v1WpFhlzaZ3GhhKmPMA=="
     },
     "@mapbox/point-geometry": {
       "version": "0.1.0",
@@ -2619,9 +2613,9 @@
       "integrity": "sha1-ioP5M1x4YO/6Lu7KJUMyqgru2PI="
     },
     "@mapbox/tiny-sdf": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-1.1.1.tgz",
-      "integrity": "sha512-Ihn1nZcGIswJ5XGbgFAvVumOgWpvIjBX9jiRlIl46uQG9vJOF51ViBYHF95rEZupuyQbEmhLaDPLQlU7fUTsBg=="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.0.4.tgz",
+      "integrity": "sha512-CBtL2rhZiYmdIryksp0zh4Mmx54iClYfNb0mpYeHrZnq4z84lVjre7LBWGPEjWspEn6AiF0lxC1HaZDye89m3g=="
     },
     "@mapbox/unitbezier": {
       "version": "0.0.0",
@@ -2757,6 +2751,11 @@
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
+        },
+        "gl-matrix": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.3.0.tgz",
+          "integrity": "sha512-COb7LDz+SXaHtl/h4LeaFcNdJdAQSDeVqjiIihSXNrkWObZLhDI4hIkZC11Aeqp7bcE72clzB0BnDXr2SmslRA=="
         }
       }
     },
@@ -5006,9 +5005,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001120",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001120.tgz",
-      "integrity": "sha512-JBP68okZs1X8D7MQTY602jxMYBmXEKOFkzTBaNSkubooMPFOAv2TXWaKle7qgHpjLDhUzA/TMT0qsNleVyXGUQ=="
+      "version": "1.0.30001270",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001270.tgz",
+      "integrity": "sha512-TcIC7AyNWXhcOmv2KftOl1ShFAaHQYcB/EPL/hEyMrcS7ZX0/DvV1aoy6BzV0+16wTpoAyTMGDNAJfSqS/rz7A=="
     },
     "canvg": {
       "version": "1.5.3",
@@ -6677,9 +6676,9 @@
       }
     },
     "earcut": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.2.tgz",
-      "integrity": "sha512-eZoZPPJcUHnfRZ0PjLvx2qBordSiO8ofC3vt+qACLM95u+4DovnbYNpQtJh0DNsWj8RnxrQytD4WA8gj5cRIaQ=="
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.3.tgz",
+      "integrity": "sha512-iRDI1QeCQIhMCZk48DRDMVgQSSBDmbzzNhnxIo+pwx3swkfjMh6vh0nWLq1NdvGHLKH6wIrAM3vQWeTj6qeoug=="
     },
     "ecc-jsbn": {
       "version": "0.1.2",
@@ -8398,9 +8397,9 @@
       }
     },
     "gl-matrix": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.3.0.tgz",
-      "integrity": "sha512-COb7LDz+SXaHtl/h4LeaFcNdJdAQSDeVqjiIihSXNrkWObZLhDI4hIkZC11Aeqp7bcE72clzB0BnDXr2SmslRA=="
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.3.tgz",
+      "integrity": "sha512-wcCp8vu8FT22BnvKVPjXa/ICBWRq/zjFfdofZy1WSpQZpphblv12/bOQLBC1rMM7SGOFS9ltVmKOHil5+Ml7gA=="
     },
     "glob": {
       "version": "7.1.6",
@@ -10746,23 +10745,23 @@
       }
     },
     "mapbox-gl": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.12.0.tgz",
-      "integrity": "sha512-B3URR4qY9R/Bx+DKqP8qmGCai8IOZYMSZF7ZSvcCZaYTaOYhQQi8ErTEDZtFMOR0ZPj7HFWOkkhl5SqvDfpJpA==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-2.5.1.tgz",
+      "integrity": "sha512-mUYOe8z+00fWEtBDAtiNeVDH2wsoEQlOK0UskbIPKnG1XRTDYzzofh8f/1BHe1Q3OLxce2TQ+Ou3uo1yAlePaA==",
       "requires": {
         "@mapbox/geojson-rewind": "^0.5.0",
         "@mapbox/geojson-types": "^1.0.2",
         "@mapbox/jsonlint-lines-primitives": "^2.0.2",
-        "@mapbox/mapbox-gl-supported": "^1.5.0",
+        "@mapbox/mapbox-gl-supported": "^2.0.0",
         "@mapbox/point-geometry": "^0.1.0",
-        "@mapbox/tiny-sdf": "^1.1.1",
+        "@mapbox/tiny-sdf": "^2.0.2",
         "@mapbox/unitbezier": "^0.0.0",
         "@mapbox/vector-tile": "^1.3.1",
         "@mapbox/whoots-js": "^3.1.0",
         "csscolorparser": "~1.0.3",
         "earcut": "^2.2.2",
         "geojson-vt": "^3.2.1",
-        "gl-matrix": "^3.2.1",
+        "gl-matrix": "^3.3.0",
         "grid-index": "^1.1.0",
         "minimist": "^1.2.5",
         "murmurhash-js": "^1.0.0",
@@ -10770,7 +10769,7 @@
         "potpack": "^1.0.1",
         "quickselect": "^2.0.0",
         "rw": "^1.3.3",
-        "supercluster": "^7.1.0",
+        "supercluster": "^7.1.3",
         "tinyqueue": "^2.0.3",
         "vt-pbf": "^3.1.1"
       }
@@ -13360,9 +13359,9 @@
       }
     },
     "protocol-buffers-schema": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.4.0.tgz",
-      "integrity": "sha512-G/2kcamPF2S49W5yaMGdIpkG6+5wZF0fzBteLKgEHjbNzqjZQ85aAs1iJGto31EJaSTkNvHs5IXuHSaTLWBAiA=="
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
+      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw=="
     },
     "proxy-addr": {
       "version": "2.0.6",
@@ -13976,56 +13975,6 @@
         "prop-types": "^15.7.2",
         "resize-observer-polyfill": "^1.5.1",
         "viewport-mercator-project": "^7.0.4"
-      },
-      "dependencies": {
-        "@mapbox/mapbox-gl-supported": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-2.0.0.tgz",
-          "integrity": "sha512-zu4udqYiBrKMQKwpKJ4hhPON7tz0QR/JZ3iGpHnNWFmH3Sv/ysxlICATUtGCFpsyJf2v1WpFhlzaZ3GhhKmPMA=="
-        },
-        "@mapbox/tiny-sdf": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.0.4.tgz",
-          "integrity": "sha512-CBtL2rhZiYmdIryksp0zh4Mmx54iClYfNb0mpYeHrZnq4z84lVjre7LBWGPEjWspEn6AiF0lxC1HaZDye89m3g=="
-        },
-        "mapbox-gl": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-2.5.1.tgz",
-          "integrity": "sha512-mUYOe8z+00fWEtBDAtiNeVDH2wsoEQlOK0UskbIPKnG1XRTDYzzofh8f/1BHe1Q3OLxce2TQ+Ou3uo1yAlePaA==",
-          "requires": {
-            "@mapbox/geojson-rewind": "^0.5.0",
-            "@mapbox/geojson-types": "^1.0.2",
-            "@mapbox/jsonlint-lines-primitives": "^2.0.2",
-            "@mapbox/mapbox-gl-supported": "^2.0.0",
-            "@mapbox/point-geometry": "^0.1.0",
-            "@mapbox/tiny-sdf": "^2.0.2",
-            "@mapbox/unitbezier": "^0.0.0",
-            "@mapbox/vector-tile": "^1.3.1",
-            "@mapbox/whoots-js": "^3.1.0",
-            "csscolorparser": "~1.0.3",
-            "earcut": "^2.2.2",
-            "geojson-vt": "^3.2.1",
-            "gl-matrix": "^3.3.0",
-            "grid-index": "^1.1.0",
-            "minimist": "^1.2.5",
-            "murmurhash-js": "^1.0.0",
-            "pbf": "^3.2.1",
-            "potpack": "^1.0.1",
-            "quickselect": "^2.0.0",
-            "rw": "^1.3.3",
-            "supercluster": "^7.1.3",
-            "tinyqueue": "^2.0.3",
-            "vt-pbf": "^3.1.1"
-          }
-        },
-        "supercluster": {
-          "version": "7.1.4",
-          "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-7.1.4.tgz",
-          "integrity": "sha512-GhKkRM1jMR6WUwGPw05fs66pOFWhf59lXq+Q3J3SxPvhNcmgOtLRV6aVQPMRsmXdpaeFJGivt+t7QXUPL3ff4g==",
-          "requires": {
-            "kdbush": "^3.0.0"
-          }
-        }
       }
     },
     "react-perfect-scrollbar": {
@@ -16331,9 +16280,9 @@
       }
     },
     "supercluster": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-7.1.0.tgz",
-      "integrity": "sha512-LDasImUAFMhTqhK+cUXfy9C2KTUqJ3gucLjmNLNFmKWOnDUBxLFLH9oKuXOTCLveecmxh8fbk8kgh6Q0gsfe2w==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-7.1.4.tgz",
+      "integrity": "sha512-GhKkRM1jMR6WUwGPw05fs66pOFWhf59lXq+Q3J3SxPvhNcmgOtLRV6aVQPMRsmXdpaeFJGivt+t7QXUPL3ff4g==",
       "requires": {
         "kdbush": "^3.0.0"
       }
@@ -17160,13 +17109,13 @@
       "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ=="
     },
     "vt-pbf": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/vt-pbf/-/vt-pbf-3.1.1.tgz",
-      "integrity": "sha512-pHjWdrIoxurpmTcbfBWXaPwSmtPAHS105253P1qyEfSTV2HJddqjM+kIHquaT/L6lVJIk9ltTGc0IxR/G47hYA==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/vt-pbf/-/vt-pbf-3.1.3.tgz",
+      "integrity": "sha512-2LzDFzt0mZKZ9IpVF2r69G9bXaP2Q2sArJCmcCgvfTdCCZzSyz4aCLoQyUilu37Ll56tCblIZrXFIjNUpGIlmA==",
       "requires": {
         "@mapbox/point-geometry": "0.1.0",
         "@mapbox/vector-tile": "^1.3.1",
-        "pbf": "^3.0.5"
+        "pbf": "^3.2.1"
       }
     },
     "w3c-hr-time": {
@@ -17964,6 +17913,53 @@
       "integrity": "sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==",
       "requires": {
         "errno": "~0.1.7"
+      }
+    },
+    "worker-loader": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/worker-loader/-/worker-loader-3.0.8.tgz",
+      "integrity": "sha512-XQyQkIFeRVC7f7uRhFdNMe/iJOdO6zxAaR3EWbDp45v3mDhrTi+++oswKNxShUNjPC/1xUp5DB29YKLhFo129g==",
+      "requires": {
+        "loader-utils": "^2.0.0",
+        "schema-utils": "^3.0.0"
+      },
+      "dependencies": {
+        "@types/json-schema": {
+          "version": "7.0.9",
+          "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
+          "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ=="
+        },
+        "ajv": {
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "loader-utils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^2.1.2"
+          }
+        },
+        "schema-utils": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
+          "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+          "requires": {
+            "@types/json-schema": "^7.0.8",
+            "ajv": "^6.12.5",
+            "ajv-keywords": "^3.5.2"
+          }
+        }
       }
     },
     "worker-rpc": {

--- a/netmanager/package.json
+++ b/netmanager/package.json
@@ -35,7 +35,7 @@
         "leaflet-draw": "^1.0.4",
         "leaflet-makimarkers": "^3.1.0",
         "leaflet-spin": "^1.1.2",
-        "mapbox-gl": "^1.12.0",
+        "mapbox-gl": "^2.5.1",
         "material-table": "^1.57.2",
         "moment": "^2.29.1",
         "moment-timezone": "^0.5.31",
@@ -76,6 +76,7 @@
         "styled-components": "^5.1.0",
         "underscore": "^1.11.0",
         "validate.js": "^0.13.1",
+        "worker-loader": "^3.0.8",
         "yarn": "^1.22.4"
     },
     "scripts": {
@@ -102,7 +103,9 @@
         "production": [
             ">0.2%",
             "not dead",
-            "not op_mini all"
+            "not op_mini all",
+            "not chrome < 51",
+            "not safari < 10"
         ],
         "development": [
             "last 1 chrome version",

--- a/netmanager/src/views/components/DataDisplay/Map/MapBoxMap.js
+++ b/netmanager/src/views/components/DataDisplay/Map/MapBoxMap.js
@@ -3,7 +3,18 @@ import ReactMapGL, { Marker, Popup } from "react-map-gl";
 import { useHistory } from "react-router-dom";
 import { MapKey } from "./MapKey";
 
+// import mapboxgl from 'mapbox-gl';
+
 import "assets/css/manager-map.css";
+
+
+import 'mapbox-gl/dist/mapbox-gl.css';
+import mapboxgl from 'mapbox-gl';
+
+// eslint-disable-next-line import/no-webpack-loader-syntax
+mapboxgl.workerClass = require('worker-loader!mapbox-gl/dist/mapbox-gl-csp-worker').default;
+
+
 
 const onlineClassGenerator = (online) =>
   (online && "manager-online") || "manager-offline";

--- a/netmanager/src/views/pages/Map/OverlayMap.js
+++ b/netmanager/src/views/pages/Map/OverlayMap.js
@@ -1,6 +1,5 @@
 import React, { useRef, useEffect, useState } from "react";
 import { useDispatch } from "react-redux";
-import mapboxgl from "mapbox-gl";
 import { isEmpty } from "underscore";
 import { heatMapPaint } from "./paints";
 import { getFirstDuration } from "utils/dateTime";
@@ -19,6 +18,12 @@ import { useInitScrollTop } from "utils/customHooks";
 
 // css
 import "assets/css/overlay-map.css";
+
+import 'mapbox-gl/dist/mapbox-gl.css';
+import mapboxgl from 'mapbox-gl';
+
+// eslint-disable-next-line import/no-webpack-loader-syntax
+mapboxgl.workerClass = require('worker-loader!mapbox-gl/dist/mapbox-gl-csp-worker').default;
 
 const markerDetailsPM2_5 = {
   0.0: ["marker-good", "Good"],


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)
- Mapbox load  error occuring because of ES6-ES5 incompatible transpiling. Read more [here](https://docs.mapbox.com/mapbox-gl-js/guides/install/#transpiling)

#### Is this change ready to hit production in its current state?
- [x] Yes
- [ ] No

#### Status of maturity (all need to be checked before merging):

- [x] I consider this code done
- [ ] I've tested this locally
- [ ] This branch has been LGTM'ed by a reviewer

#### How should this be manually tested?
* Fetch and checkout to this branch locally
* Install requirements `npm install`
* Build the app `npm run build`
* Serve the build folder `serve -s build`
* load the app in browser and confirm the `device-management` map loads successfully

#### What are the relevant tickets?
- N/A
