### PR TITLE
[NetManager] Airqloud dashboard fixes

### DIFF
--- a/netmanager/src/redux/AirQloud/reducers.js
+++ b/netmanager/src/redux/AirQloud/reducers.js
@@ -6,7 +6,13 @@ import {
 
 const initialState = {
   airqlouds: {},
-  currentAirQloud: {},
+  currentAirQloud: {
+    _id: "61363c2c7e130a001e03949f",
+    name: "Empty",
+    long_name: "Empty",
+    sites: [],
+    siteOptions: [],
+  },
 };
 
 export default function (state = initialState, action) {

--- a/netmanager/src/redux/Dashboard/operations.js
+++ b/netmanager/src/redux/Dashboard/operations.js
@@ -62,14 +62,9 @@ export const loadUserDefaultGraphData = () => {
 
     return await getUserChartDefaultsApi(userID, airQloudID)
       .then(async (userDefaultsData) => {
-        let data = userDefaultsData;
-
-        if (isEmpty(data.defaults)) {
-          data = await getUserChartDefaultsApi(userID, userID);
-        }
         dispatch({
           type: LOAD_USER_DEFAULT_GRAPHS_SUCCESS,
-          payload: data.defaults || [],
+          payload: userDefaultsData.defaults || [],
         });
       })
       .catch((err) => {

--- a/netmanager/src/redux/Join/actions.js
+++ b/netmanager/src/redux/Join/actions.js
@@ -68,6 +68,7 @@ import {
   UPDATE_PWD_IN_URI,
   REGISTER_CANDIDATE_URI,
   DEFAULTS_URI } from "config/urls/authService";
+import { setDefaultAirQloud } from "../AirQloud/operations";
 
 
 /***************************errors ********************************* */
@@ -414,6 +415,7 @@ export const loginUser = userData => dispatch => {
         // Set current user
         dispatch(setCurrentUser(decoded));
         dispatch(updateOrganization({name: decoded.organization}))
+        dispatch(setDefaultAirQloud());
       } catch (e) {
         console.log(e);
       }

--- a/netmanager/src/views/containers/AirQloudDropDown.js
+++ b/netmanager/src/views/containers/AirQloudDropDown.js
@@ -3,7 +3,7 @@ import { useDispatch } from "react-redux";
 import { useAirQloudsData } from "utils/customHooks/AirQloudsHooks";
 import { useCurrentAirQloudData } from "redux/AirQloud/selectors";
 import { setCurrentAirQloudData } from "redux/AirQloud/operations";
-import {resetDefaultGraphData } from "redux/Dashboard/operations";
+import { resetDefaultGraphData } from "redux/Dashboard/operations";
 
 // styles
 import "assets/css/dropdown.css";

--- a/netmanager/src/views/containers/AirQloudDropDown.js
+++ b/netmanager/src/views/containers/AirQloudDropDown.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useRef, useState, useEffect } from "react";
 import { useDispatch } from "react-redux";
 import { useAirQloudsData } from "utils/customHooks/AirQloudsHooks";
 import { useCurrentAirQloudData } from "redux/AirQloud/selectors";
@@ -9,6 +9,8 @@ import { resetDefaultGraphData } from "redux/Dashboard/operations";
 import "assets/css/dropdown.css";
 
 const AirQloudDropDown = () => {
+  const ref = useRef();
+  const [show, setShow] = useState(false);
   const currentAirqQloud = useCurrentAirQloudData();
   const dispatch = useDispatch();
 
@@ -20,18 +22,35 @@ const AirQloudDropDown = () => {
     return 0;
   });
 
+  const toggleShow = () => setShow(!show);
+
   const handleAirQloudChange = (airqloud) => async () => {
+    toggleShow();
     await dispatch(setCurrentAirQloudData(airqloud));
     dispatch(resetDefaultGraphData());
   };
 
+  useEffect(() => {
+    const checkIfClickedOutside = (e) => {
+      // If the menu is open and the clicked target is not within the menu,
+      // then close the menu
+      if (show && ref.current && !ref.current.contains(e.target))
+        setShow(false);
+    };
+
+    document.addEventListener("mousedown", checkIfClickedOutside);
+
+    return () => {
+      // Cleanup the event listener
+      document.removeEventListener("mousedown", checkIfClickedOutside);
+    };
+  }, [show]);
+
   return (
-    <label className="dropdown">
+    <label className="dropdown" onClick={toggleShow} ref={ref}>
       <div className="dd-button">{currentAirqQloud.long_name}</div>
 
-      <input type="checkbox" className="dd-input" id="test" />
-
-      <ul className="dd-menu">
+      <ul className={`dd-menu ${(!show && "dd-input") || ""}`}>
         <li className="selected">
           {currentAirqQloud.long_name} AirQloud{" "}
           <span>

--- a/netmanager/src/views/pages/Dashboard/Dashboard.js
+++ b/netmanager/src/views/pages/Dashboard/Dashboard.js
@@ -21,6 +21,8 @@ import { isEmpty } from "underscore";
 import { useInitScrollTop } from "utils/customHooks";
 import ErrorBoundary from "views/ErrorBoundary/ErrorBoundary";
 import AirQloudDropDown from "../../containers/AirQloudDropDown";
+import { useCurrentAirQloudData } from "redux/AirQloud/selectors";
+import { flattenSiteOptions } from "utils/sites";
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -47,6 +49,7 @@ const Dashboard = () => {
   useInitScrollTop();
   const classes = useStyles();
 
+  const currentAirQloud = useCurrentAirQloudData();
   const dispatch = useDispatch();
   const userDefaultGraphs = useUserDefaultGraphsData();
   const recentEventsData = useEventsMapData();
@@ -74,21 +77,26 @@ const Dashboard = () => {
       VeryUnhealthy: 0,
       Hazardous: 0,
     };
+    const airqloudSites = flattenSiteOptions(currentAirQloud.siteOptions);
     recentEventsData.features &&
       recentEventsData.features.map((feature) => {
-        const pm2_5 =
-          feature.properties &&
-          feature.properties.pm2_5 &&
-          feature.properties.pm2_5.value;
-        Object.keys(PM_25_CATEGORY).map((key) => {
-          const valid = PM_25_CATEGORY[key];
-          if (pm2_5 > valid[0] && pm2_5 <= valid[1]) {
-            initialCount[key]++;
-          }
-        });
+        if (airqloudSites.includes(feature.properties.site_id)) {
+          const pm2_5 =
+            feature.properties &&
+            feature.properties.pm2_5 &&
+            (feature.properties.pm2_5.calibratedValue ||
+              feature.properties.pm2_5.value);
+
+          Object.keys(PM_25_CATEGORY).map((key) => {
+            const valid = PM_25_CATEGORY[key];
+            if (pm2_5 > valid[0] && pm2_5 <= valid[1]) {
+              initialCount[key]++;
+            }
+          });
+        }
       });
     setPm2_5SiteCount(initialCount);
-  }, [recentEventsData]);
+  }, [recentEventsData, currentAirQloud]);
 
   function appendLeadingZeroes(n) {
     if (n <= 9) {
@@ -121,7 +129,7 @@ const Dashboard = () => {
     <ErrorBoundary>
       <div className={classes.root}>
         <Grid container>
-          <Grid xs={12} sm={12} md={6} xl={6} style={{display: "flex"}}>
+          <Grid xs={12} sm={12} md={6} xl={6} style={{ display: "flex" }}>
             <AirQloudDropDown />
           </Grid>
         </Grid>


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)
- [x] Fix device count to match the current airqloud
- [x] Fix handling of default tenant airqloud
- [x] Hiding of Airqlouds dropdown

#### Is this change ready to hit production in its current state?
- [x] Yes
- [ ] No

#### Status of maturity (all need to be checked before merging):

- [x] I consider this code done
- [x] I've tested this locally
- [ ] This branch has been LGTM'ed by a reviewer

#### How should this be manually tested?
* Fetch and checkout to this branch locally
* Install requirements `npm install`
* Start netmanager application `npm run stage-mac` (macOS) or `npm run stage-pc` (windows Platform)
* Confirm the summary of changes listed above

#### What are the relevant tickets?
- [PLAT-863](https://airqoteam.atlassian.net/browse/PLAT-863)

