### PR TITLE
Loading added to exceedances and averages charts

### DIFF
--- a/netmanager/src/views/pages/Dashboard/components/AveragesChart.js
+++ b/netmanager/src/views/pages/Dashboard/components/AveragesChart.js
@@ -406,7 +406,13 @@ const AveragesChart = ({ classes }) => {
         <CardContent>
           <div className={classes.chartContainer}>
             {loading ? (
-              <div>
+              <div 
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                height: "30vh"
+              }}>
                 loading...
               </div>
             ):(

--- a/netmanager/src/views/pages/Dashboard/components/AveragesChart.js
+++ b/netmanager/src/views/pages/Dashboard/components/AveragesChart.js
@@ -61,6 +61,8 @@ const AveragesChart = ({ classes }) => {
     `Mean Daily ${pollutant.label} Over the Past 28 Days`
   );
 
+  const [loading, setLoading] = useState(false);
+
   const handlePollutantChange = (pollutant) => {
     setTempPollutant(pollutant);
   };
@@ -314,6 +316,7 @@ const AveragesChart = ({ classes }) => {
   };
 
   const fetchAndSetAverages = (pollutant) => {
+    setLoading(true);
     axios
       .post(DAILY_MEAN_AVERAGES_URI, {
         startDate: roundToStartOfDay(startDate).toISOString(),
@@ -337,9 +340,14 @@ const AveragesChart = ({ classes }) => {
           return 0;
         });
         const [labels, average_values, background_colors] = unzip(zippedArr);
-        setAverages({ labels, average_values, background_colors });
+        setAverages({ labels, average_values, background_colors })
+;
+        setLoading(false);
       })
-      .catch((e) => console.log(e));
+      .catch((e) => {
+        setLoading(false);
+        console.log(e);
+      });
   };
 
   const handleSubmit = async (e) => {
@@ -397,7 +405,13 @@ const AveragesChart = ({ classes }) => {
         <Divider />
         <CardContent>
           <div className={classes.chartContainer}>
+            {loading ? (
+              <div>
+                loading...
+              </div>
+            ):(
             <Bar data={locationsGraphData} options={options_main} />
+            )}
           </div>
         </CardContent>
       </Card>

--- a/netmanager/src/views/pages/Dashboard/components/ExceedancesChart/ExceedancesChart.js
+++ b/netmanager/src/views/pages/Dashboard/components/ExceedancesChart/ExceedancesChart.js
@@ -389,7 +389,12 @@ const ExceedancesChart = (props) => {
         <Grid item lg={12} sm={12} xl={12} xs={12}>
           <div className={chartContainer}>
             {loading ? (
-              <div>
+              <div style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                height: "30vh"
+              }}>
                 loading...
               </div>
             ):(

--- a/netmanager/src/views/pages/Dashboard/components/ExceedancesChart/ExceedancesChart.js
+++ b/netmanager/src/views/pages/Dashboard/components/ExceedancesChart/ExceedancesChart.js
@@ -82,6 +82,8 @@ const ExceedancesChart = (props) => {
     `${pollutant.label} Exceedances Over the Past 28 Days Based on ${standard.label}`
   );
 
+  const [loading, setLoading] = useState(false);
+
   const handleStandardChange = (standard) => {
     setTempStandard(standard);
   };
@@ -141,6 +143,7 @@ const ExceedancesChart = (props) => {
   };
 
   const fetchAndSetExceedanceData = async (filter) => {
+    setLoading(true);
     filter = {
       ...filter,
       startDate: roundToStartOfDay(filter.startDate).toISOString(),
@@ -191,6 +194,7 @@ const ExceedancesChart = (props) => {
             myVeryUnhealthyValues.push(element.exceedance.VeryUnhealthy);
             myHazardousValues.push(element.exceedance.Hazardous);
           });
+          setLoading(false);
           setLocations(myLocations);
           setDataset([
             {
@@ -242,9 +246,13 @@ const ExceedancesChart = (props) => {
               borderWidth: 1,
             },
           ]);
+          setLoading(false);
         }
       })
-      .catch(console.log);
+      .catch(err => {
+        console.log(err);
+        setLoading(false);
+      });
   };
 
   const rootCustomChartContainerId = "rootCustomChartContainerId" + idSuffix;
@@ -380,6 +388,11 @@ const ExceedancesChart = (props) => {
       <CardContent>
         <Grid item lg={12} sm={12} xl={12} xs={12}>
           <div className={chartContainer}>
+            {loading ? (
+              <div>
+                loading...
+              </div>
+            ):(
             <Bar
               data={{
                 labels: locations,
@@ -458,7 +471,7 @@ const ExceedancesChart = (props) => {
                   responsive: true,
                 }
               }
-            />
+            />)}
           </div>
         </Grid>
 


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)
- On customising a chart(the exceedance chart and average chart), loading is enabled while data to be fed into the chart is retrieved in the background

#### Is this change ready to hit production in its current state?
- [x] Yes
- [ ] No

#### Status of maturity (all need to be checked before merging):

- [x] I consider this code done
- [x] I've tested this locally
- [x] This branch has been LGTM'ed by a reviewer

#### How should this be manually tested?
* Do a git gull of this branch, run the code, try customising the exceedances or average charts

#### What are the relevant tickets?
- [ticket_id]()