### PR TITLE
Added Loader to Registry page and maintenace logs page, average and exceedances charts

### DIFF
--- a/netmanager/src/views/components/DataDisplay/DeviceView/DeviceLogs.js
+++ b/netmanager/src/views/components/DataDisplay/DeviceView/DeviceLogs.js
@@ -568,6 +568,7 @@ export default function DeviceLogs({ deviceName, deviceLocation }) {
       <div>
         {show.logTable && (
           <MaintenanceLogsTable
+            isLoading={maintenanceLogs.length === 0}
             title={<TableTitle deviceName={deviceName} />}
             columns={logsColumns}
             data={maintenanceLogs}

--- a/netmanager/src/views/components/DataDisplay/DeviceView/DeviceLogs.js
+++ b/netmanager/src/views/components/DataDisplay/DeviceView/DeviceLogs.js
@@ -568,7 +568,7 @@ export default function DeviceLogs({ deviceName, deviceLocation }) {
       <div>
         {show.logTable && (
           <MaintenanceLogsTable
-            isLoading={maintenanceLogs.length === 0}
+            isLoading={isEmpty(maintenanceLogs)}
             title={<TableTitle deviceName={deviceName} />}
             columns={logsColumns}
             data={maintenanceLogs}

--- a/netmanager/src/views/components/DataDisplay/Devices.js
+++ b/netmanager/src/views/components/DataDisplay/Devices.js
@@ -450,6 +450,7 @@ const DevicesTable = (props) => {
           userPreferencePaginationKey={"devices"}
           columns={deviceColumns}
           data={deviceList}
+          isLoading={deviceList.length === 0}
           onRowClick={(event, rowData) => {
             event.preventDefault();
             return history.push(`/device/${rowData.name}/overview`);

--- a/netmanager/src/views/components/DataDisplay/Devices.js
+++ b/netmanager/src/views/components/DataDisplay/Devices.js
@@ -450,7 +450,7 @@ const DevicesTable = (props) => {
           userPreferencePaginationKey={"devices"}
           columns={deviceColumns}
           data={deviceList}
-          isLoading={deviceList.length === 0}
+          isLoading={isEmpty(devices)}
           onRowClick={(event, rowData) => {
             event.preventDefault();
             return history.push(`/device/${rowData.name}/overview`);

--- a/netmanager/src/views/pages/Dashboard/components/AveragesChart.js
+++ b/netmanager/src/views/pages/Dashboard/components/AveragesChart.js
@@ -61,6 +61,8 @@ const AveragesChart = ({ classes }) => {
     `Mean Daily ${pollutant.label} Over the Past 28 Days`
   );
 
+  const [loading, setLoading] = useState(false);
+
   const handlePollutantChange = (pollutant) => {
     setTempPollutant(pollutant);
   };
@@ -314,6 +316,7 @@ const AveragesChart = ({ classes }) => {
   };
 
   const fetchAndSetAverages = (pollutant) => {
+    setLoading(true);
     axios
       .post(DAILY_MEAN_AVERAGES_URI, {
         startDate: roundToStartOfDay(startDate).toISOString(),
@@ -338,8 +341,11 @@ const AveragesChart = ({ classes }) => {
         });
         const [labels, average_values, background_colors] = unzip(zippedArr);
         setAverages({ labels, average_values, background_colors });
+        setLoading(false);
       })
-      .catch((e) => console.log(e));
+      .catch((e) => {
+        setLoading(false);
+        console.log(e)});
   };
 
   const handleSubmit = async (e) => {
@@ -397,7 +403,19 @@ const AveragesChart = ({ classes }) => {
         <Divider />
         <CardContent>
           <div className={classes.chartContainer}>
+            {loading ? (
+              <div 
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                height: "30vh"
+              }}>
+                loading...
+              </div>
+            ):(
             <Bar data={locationsGraphData} options={options_main} />
+            )}
           </div>
         </CardContent>
       </Card>

--- a/netmanager/src/views/pages/Dashboard/components/ExceedancesChart/ExceedancesChart.js
+++ b/netmanager/src/views/pages/Dashboard/components/ExceedancesChart/ExceedancesChart.js
@@ -82,6 +82,8 @@ const ExceedancesChart = (props) => {
     `${pollutant.label} Exceedances Over the Past 28 Days Based on ${standard.label}`
   );
 
+  const [loading, setLoading] = useState(false);
+
   const handleStandardChange = (standard) => {
     setTempStandard(standard);
   };
@@ -141,6 +143,7 @@ const ExceedancesChart = (props) => {
   };
 
   const fetchAndSetExceedanceData = async (filter) => {
+    setLoading(true);
     filter = {
       ...filter,
       startDate: roundToStartOfDay(filter.startDate).toISOString(),
@@ -191,6 +194,7 @@ const ExceedancesChart = (props) => {
             myVeryUnhealthyValues.push(element.exceedance.VeryUnhealthy);
             myHazardousValues.push(element.exceedance.Hazardous);
           });
+          setLoading(false);
           setLocations(myLocations);
           setDataset([
             {
@@ -242,9 +246,13 @@ const ExceedancesChart = (props) => {
               borderWidth: 1,
             },
           ]);
+          setLoading(false);
         }
       })
-      .catch(console.log);
+      .catch(err => {
+        console.log(err);
+        setLoading(false);
+      });
   };
 
   const rootCustomChartContainerId = "rootCustomChartContainerId" + idSuffix;
@@ -380,6 +388,17 @@ const ExceedancesChart = (props) => {
       <CardContent>
         <Grid item lg={12} sm={12} xl={12} xs={12}>
           <div className={chartContainer}>
+          {loading ? (
+            <div 
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              height: "30vh"
+            }}>
+              loading...
+            </div>
+          ):(
             <Bar
               data={{
                 labels: locations,
@@ -459,6 +478,7 @@ const ExceedancesChart = (props) => {
                 }
               }
             />
+          )}
           </div>
         </Grid>
 


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)
- Added progress bars to maintenance logs and device registry tables to show while data is being fetched

#### Is this change ready to hit production in its current state?
- [x] Yes
- [ ] No

#### Status of maturity (all need to be checked before merging):

- [x] I consider this code done
- [x] I've tested this locally
- [ ] This branch has been LGTM'ed by a reviewer

#### How should this be manually tested?
* Do a git pull of this branch and run `npm run stage`. Go to the device registry page(loader will appear). Also go select a device and a loader will appear for maintenace logs table

#### What are the relevant tickets?
- [ticket_id]()