### PR TITLE
Commented out css bug from switch.css

### DIFF
--- a/netmanager/src/assets/css/switch.css
+++ b/netmanager/src/assets/css/switch.css
@@ -156,7 +156,7 @@
 }
 
 /* Dark mode */
-@media screen and (prefers-color-scheme: dark) {
+/* @media screen and (prefers-color-scheme: dark) {
   form {
     background-color: #101010;
   }
@@ -188,7 +188,7 @@
   .toggles [type="checkbox"][disabled] + label::after {
     border-color: #555;
   }
-}
+} */
 
 /* RTL */
 /* https://twitter.com/dror3go/status/1102946375396982784 */


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)
This PR includes a bug fix for the dark mode form element appearance. Previously, if the platform was run on a browser in dark mode then the form elements would change their backgrounds to #010101. 
That was a bug from a css file that was changing only form attributes according to the browser theme. 

#### Is this change ready to hit production in its current state?
- [x] Yes
- [ ] No

#### Status of maturity (all need to be checked before merging):

- [ ] I consider this code done
- [x] I've tested this locally
- [ ] This branch has been LGTM'ed by a reviewer

#### How should this be manually tested?
The branch should be pulled and run with a browser in dark mode. One will be able to see that the platform form elements remain with their light backgrounds.
