### PR TITLE
Add GCS as an option for storing static files

### DIFF
--- a/website/.gitignore
+++ b/website/.gitignore
@@ -139,3 +139,4 @@ dmypy.json
 cython_debug/
 .idea/
 node_modules/
+ google_application_credentials.json

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -137,3 +137,5 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+.idea/
+node_modules/

--- a/website/backend/settings.py
+++ b/website/backend/settings.py
@@ -27,7 +27,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = config('SECRET_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = config('DEBUG', 'True') == 'True'
+DEBUG = config('DEBUG', False)
 
 ALLOWED_HOSTS = []
 
@@ -143,12 +143,8 @@ STATIC_ROOT = os.path.join(BASE_DIR, 'static')
 STATICFILES_DIRS = []
 
 if not DEBUG:
-    GS_CREDENTIALS = service_account.Credentials.from_service_account_file(
-        os.path.join(BASE_DIR, 'google_application_credentials.json')
-    )
-
     DEFAULT_FILE_STORAGE = 'storages.backends.gcloud.GoogleCloudStorage'
-    GS_BUCKET_NAME = 'airqo-website'
+    GS_BUCKET_NAME = config('GS_BUCKET_NAME')
     STATICFILES_STORAGE = 'storages.backends.gcloud.GoogleCloudStorage'
 
 STATIC_URL = STATIC_HOST + 'static/'

--- a/website/requirements.txt
+++ b/website/requirements.txt
@@ -6,3 +6,4 @@ drf-yasg
 invoke
 python-decouple
 psycopg2-binary
+django-storages[google]


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)
- Adds GCS as an option for storing static files while running in production and staging

#### Is this change ready to hit production in its current state?
- [ ] Yes
- [ ] No

#### Status of maturity (all need to be checked before merging):

- [x] I consider this code done
- [x] I've tested this locally
- [ ] This branch has been LGTM'ed by a reviewer

#### How should this be manually tested?

- Create a virtual environment and install the packages and dependencies

```bash
pip install -r requirements.txt
npm install 
```

- Set environment variables
```
WEB_STATIC_HOST=https://storage.googleapis.com/airqo-website/
DEBUG=False
GS_BUCKET_NAME=airqo-website
```

- Add [google_application_credentials.json](https://drive.google.com/file/d/1SpgL2MauriC2vVWiy1NG9i27gja4a4gJ/view?usp=sharing) to the base directory
- Collect static files
```python
python manage.py collectstatic --no-input
```
wait for files to upload. You should get an putput similar to `179 static files copied, 10 unmodified.`

Run the app
```
inv run-web
```

#### What are the relevant tickets?
- [WEB-73](https://airqoteam.atlassian.net/browse/WEB-73)

#### Screenshots (optional)
<img width="1035" alt="Screenshot 2022-02-23 at 15 59 06" src="https://user-images.githubusercontent.com/37845280/155326082-a2831c6c-df67-421f-be2c-b087ad18b2d1.png">
