### PR TITLE
update alert timeout

### DIFF
--- a/netmanager/src/redux/MainAlert/operations.js
+++ b/netmanager/src/redux/MainAlert/operations.js
@@ -18,7 +18,7 @@ export const updateMainAlert = (newAlertData) => {
         type: HIDE_ALERT_SUCCESS,
         payload: { ...state, show: false, timeout: null },
       });
-    }, 3000);
+    }, newAlertData.severity === 'error'? 8000: 5000);
     dispatch({
       type: UPDATE_ALERT_SUCCESS,
       payload: { ...newAlertData, timeout },

--- a/netmanager/src/redux/MainAlert/operations.js
+++ b/netmanager/src/redux/MainAlert/operations.js
@@ -18,7 +18,7 @@ export const updateMainAlert = (newAlertData) => {
         type: HIDE_ALERT_SUCCESS,
         payload: { ...state, show: false, timeout: null },
       });
-    }, 20000);
+    }, 3000);
     dispatch({
       type: UPDATE_ALERT_SUCCESS,
       payload: { ...newAlertData, timeout },

--- a/netmanager/src/redux/MainAlert/operations.js
+++ b/netmanager/src/redux/MainAlert/operations.js
@@ -18,7 +18,7 @@ export const updateMainAlert = (newAlertData) => {
         type: HIDE_ALERT_SUCCESS,
         payload: { ...state, show: false, timeout: null },
       });
-    }, newAlertData.severity === 'error'? 8000: 5000);
+    }, newAlertData.severity === 'error'? 10000: 5000);
     dispatch({
       type: UPDATE_ALERT_SUCCESS,
       payload: { ...newAlertData, timeout },

--- a/netmanager/src/redux/MainAlert/operations.js
+++ b/netmanager/src/redux/MainAlert/operations.js
@@ -18,7 +18,7 @@ export const updateMainAlert = (newAlertData) => {
         type: HIDE_ALERT_SUCCESS,
         payload: { ...state, show: false, timeout: null },
       });
-    }, newAlertData.severity === 'error'? 10000: 5000);
+    }, newAlertData.severity === 'error'? 10000: 3000);
     dispatch({
       type: UPDATE_ALERT_SUCCESS,
       payload: { ...newAlertData, timeout },


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)
- Reduces disappearance time of platform alerts.
- Closes #420 

#### Is this change ready to hit production in its current state?
- [x] Yes
- [ ] No

#### Status of maturity (all need to be checked before merging):

- [x] I consider this code done
- [x] I've tested this locally
- [ ] This branch has been LGTM'ed by a reviewer

#### How should this be manually tested?
* Follow the instructions in the [README](https://github.com/airqo-platform/AirQo-frontend/blob/fx-disapperanceTime/netmanager/README.md) to run the application
* Carry out any action to trigger a success alert, the alert should last 5 seconds
* Carry out any action to trigger an error alert, the alert should last 10 seconds

#### What are the relevant tickets?
- [PLAT-1004](https://airqoteam.atlassian.net/browse/PLAT-1004)
- #420 

#### Screenshots (optional)