### PR TITLE
[NetManager] Split Management Tab

### DIFF
--- a/netmanager/package-lock.json
+++ b/netmanager/package-lock.json
@@ -10995,6 +10995,11 @@
         }
       }
     },
+    "material-ui-nested-menu-item": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/material-ui-nested-menu-item/-/material-ui-nested-menu-item-1.0.2.tgz",
+      "integrity": "sha512-LZb8xI0FrAI/A3P2vT3CB9bmSoOFWOK0dikTc1t9VvEpp1a8hZkbVUz7VhETnoLUYu3NXCkgulmXcl3zitqI9A=="
+    },
     "md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",

--- a/netmanager/package.json
+++ b/netmanager/package.json
@@ -51,6 +51,7 @@
         "leaflet-spin": "^1.1.2",
         "mapbox-gl": "^2.5.1",
         "material-table": "^1.57.2",
+        "material-ui-nested-menu-item": "^1.0.2",
         "moment": "^2.29.1",
         "moment-timezone": "^0.5.31",
         "node-sass": "^4.14.1",

--- a/netmanager/src/AppRoutes.js
+++ b/netmanager/src/AppRoutes.js
@@ -16,7 +16,8 @@ import { LargeCircularLoader } from "views/components/Loader/CircularLoader";
 const Account = lazy(() => import("./views/pages/Account"));
 const AnalyticsDashboard = lazy(() => import("./views/pages/Dashboard"));
 const DeviceView = lazy(() => import("./views/components/DataDisplay/DeviceView"));
-const Manager = lazy(() => import("./views/components/DataDisplay/DeviceManagement"));
+const ManagerMap = lazy(() => import("./views/components/DataDisplay/DeviceManagement/ManagementMap"));
+const ManagerStats = lazy(() => import("./views/components/DataDisplay/DeviceManagement/ManagementStats"));
 const Map = lazy(() => import("./views/components/Map"));
 const OverlayMap = lazy(() => import("./views/pages/Map"));
 const ForgotPassword = lazy(() => import("./views/pages/ForgotPassword"));
@@ -103,8 +104,14 @@ const AppRoutes = () => {
           />
           <PrivateRoute
             exact
-            path="/manager"
-            component={Manager}
+            path="/manager/map"
+            component={ManagerMap}
+            layout={MainLayout}
+          />
+          <PrivateRoute
+            exact
+            path="/manager/stats"
+            component={ManagerStats}
             layout={MainLayout}
           />
           <PrivateRoute

--- a/netmanager/src/assets/css/manager-map.css
+++ b/netmanager/src/assets/css/manager-map.css
@@ -1,8 +1,7 @@
 .manager-map-container {
-    margin-top: 10px;
-    height: calc(100vh - 64px - 10px);
-    height: -moz-calc(100vh - 64px - 10px);
-    height: -webkit-calc(100vh - 64px - 10px);
+    height: calc(100vh - 64px);
+    height: -moz-calc(100vh - 64px);
+    height: -webkit-calc(100vh - 64px);
     position: relative;
 }
 

--- a/netmanager/src/assets/scss/device-management.sass
+++ b/netmanager/src/assets/scss/device-management.sass
@@ -3,11 +3,16 @@
   margin: 0 auto
   position: relative
 
+.map-container-wrapper
+  width: 100%
+  margin: 0
+  position: relative
+
 
 .card-container
   width: 15%
   min-width: 150px
-  padding: 1px
+  padding: 5px
 
   &:hover
     cursor: pointer
@@ -115,7 +120,7 @@
 
 .map-container
   width: 100%
-  margin: 20px 0
+  margin: 0px
   position: relative
   height: calc(100vh - 300px)
 

--- a/netmanager/src/utils/dateTime.js
+++ b/netmanager/src/utils/dateTime.js
@@ -13,9 +13,7 @@ export const formatDateString = (
 
 export const getElapsedDurationMapper = (dateTimeStr) => {
   let delta =
-    Math.abs(
-      new Date() - new Date(moment.utc(dateTimeStr).tz(moment.tz.guess()))
-    ) / 1000;
+    Math.abs(moment.utc(new Date()) - moment.utc(new Date(dateTimeStr))) / 1000;
   let seconds = delta;
   let result = {};
   let structure = {

--- a/netmanager/src/views/components/DataDisplay/DeviceManagement/ManagementMap.js
+++ b/netmanager/src/views/components/DataDisplay/DeviceManagement/ManagementMap.js
@@ -1,0 +1,313 @@
+import React, { useState, useEffect } from "react";
+import { useLocation } from "react-router-dom";
+import { useDispatch } from "react-redux";
+import DevicesIcon from "@material-ui/icons/Devices";
+import ReportProblem from "@material-ui/icons/ReportProblem";
+import BatteryFullIcon from "@material-ui/icons/BatteryFull";
+import RestoreIcon from "@material-ui/icons/Restore";
+import WbSunnyIcon from "@material-ui/icons/WbSunny";
+import PowerIcon from "@material-ui/icons/Power";
+import Hidden from "@material-ui/core/Hidden";
+import Tooltip from "@material-ui/core/Tooltip";
+import Card from "views/components/Card/Card";
+import moment from "moment";
+import { isEmpty, mapObject, omit, values } from "underscore";
+import {
+  useDevicesStatusData,
+  useNetworkUptimeData,
+  useManagementFilteredDevicesData,
+  useActiveFiltersData,
+} from "redux/DeviceManagement/selectors";
+import {
+  loadDevicesStatusData,
+  loadNetworkUptimeData,
+  updateFilteredDevicesData,
+  updateActiveFilters,
+} from "redux/DeviceManagement/operations";
+import { updateDeviceBackUrl } from "redux/Urls/operations";
+import { loadDevicesData } from "redux/DeviceRegistry/operations";
+import { useDevicesData } from "redux/DeviceRegistry/selectors";
+import { roundToStartOfDay, roundToEndOfDay } from "utils/dateTime";
+
+import { useInitScrollTop } from "utils/customHooks";
+import MapBoxMap from "../Map/MapBoxMap";
+
+import ErrorBoundary from "views/ErrorBoundary/ErrorBoundary";
+
+// css style
+import "chartjs-plugin-annotation";
+import "assets/scss/device-management.sass";
+import "assets/css/device-view.css"; // there are some shared styles here too :)
+
+const DEVICE_FILTER_FIELDS = {
+  all: {},
+  due: { key: "maintenance_status", value: "due" },
+  overDue: { key: "maintenance_status", value: "overdue" },
+  solar: { key: "powerType", value: "solar" },
+  alternator: { key: "powerType", value: "alternator" },
+  mains: { key: "powerType", value: "mains" },
+};
+
+const OverviewCardMini = ({ label, icon, value, filterActive, onClick }) => {
+  return (
+    <Tooltip title={label}>
+      <div className={"card-container-mini"} onClick={onClick}>
+        <Card
+          style={
+            filterActive
+              ? { margin: 0, borderRadius: 0 }
+              : { margin: 0, background: "#f2f2f2", borderRadius: 0 }
+          }
+        >
+          <div className={"card-title-wrapper-mini"}>
+            <span
+              className={"card-title-icon-mini"}
+              style={filterActive ? {} : { background: "#6d94ea" }}
+            >
+              {icon}
+            </span>
+            <h3
+              className={"card-title-mini"}
+              style={filterActive ? {} : { color: "#999" }}
+            >
+              {value}
+            </h3>
+          </div>
+        </Card>
+      </div>
+    </Tooltip>
+  );
+};
+
+const OverviewCard = ({ label, icon, value, filterActive, onClick }) => {
+  return (
+    <div className={"card-container"} onClick={onClick}>
+      <Card
+        style={
+          filterActive ? { margin: 0 } : { margin: 0, background: "#f2f2f2" }
+        }
+      >
+        <div className={"card-title-wrapper"}>
+          <span
+            className={"card-title-icon"}
+            style={filterActive ? {} : { background: "#6d94ea" }}
+          >
+            {icon}
+          </span>
+          <h3
+            className={"card-title"}
+            style={filterActive ? {} : { color: "#999" }}
+          >
+            {value}
+          </h3>
+          <div className={"card-divider"} />
+          <p className={"card-category"}>{label}</p>
+        </div>
+      </Card>
+    </div>
+  );
+};
+
+export default function ManagementMap() {
+  useInitScrollTop();
+  const location = useLocation();
+  const devicesStatusData = useDevicesStatusData();
+  const networkUptimeData = useNetworkUptimeData();
+  const activeFilters = useActiveFiltersData();
+  const allDevices = useDevicesData();
+  const dispatch = useDispatch();
+  const [devices, setDevices] = useState([]);
+  const filteredDevices = useManagementFilteredDevicesData();
+  const deviceFilters = activeFilters.main;
+
+  const updateDevices = (devices, newValues) => {
+    const newDevices = [];
+    (devices || []).map((device) => {
+      newDevices.push({ ...device, ...newValues });
+    });
+    return newDevices;
+  };
+
+  const filterDevices = (devices, key) => {
+    const filter = DEVICE_FILTER_FIELDS[key];
+    if (key === "all") {
+      return !deviceFilters[key] ? devices : [];
+    }
+    if (!deviceFilters[key]) {
+      const prevFiltered = filteredDevices.filter(
+        (device) => device[filter.key] !== filter.value
+      );
+      const filtered = devices.filter(
+        (device) => device[filter.key] === filter.value
+      );
+
+      return [...prevFiltered, ...filtered];
+    }
+
+    return filteredDevices.filter(
+      (device) => device[filter.key] !== filter.value
+    );
+  };
+
+  const toggleDeviceFilter = (key) => {
+    if (key === "all") {
+      if (!deviceFilters[key]) {
+        return mapObject(deviceFilters, () => true);
+      }
+      return mapObject(deviceFilters, () => false);
+    }
+    const all = values(
+      omit({ ...deviceFilters, [key]: !deviceFilters[key] }, "all")
+    ).every((value) => value === true);
+
+    return { ...deviceFilters, all, [key]: !deviceFilters[key] };
+  };
+
+  const handleDeviceFilterClick = (key) => () => {
+    dispatch(updateFilteredDevicesData(filterDevices(devices, key)));
+    dispatch(updateActiveFilters({ main: toggleDeviceFilter(key) }));
+  };
+
+  const cardsData = [
+    {
+      label: "Devices on the network",
+      value: devicesStatusData.total_active_device_count,
+      icon: <DevicesIcon />,
+      filterActive: deviceFilters.all,
+      onClick: handleDeviceFilterClick("all"),
+    },
+    {
+      label: "Due for maintenance",
+      value: devicesStatusData.count_due_maintenance,
+      icon: <RestoreIcon />,
+      filterActive: deviceFilters.due,
+      onClick: handleDeviceFilterClick("due"),
+    },
+    {
+      label: "Overdue for maintenance",
+      value: devicesStatusData.count_overdue_maintenance,
+      icon: <ReportProblem />,
+      filterActive: deviceFilters.overDue,
+      onClick: handleDeviceFilterClick("overDue"),
+    },
+    {
+      label: "Solar powered",
+      value: devicesStatusData.count_of_solar_devices,
+      icon: <WbSunnyIcon />,
+      filterActive: deviceFilters.solar,
+      onClick: handleDeviceFilterClick("solar"),
+    },
+    {
+      label: "Alternator",
+      value: devicesStatusData.count_of_alternator_devices,
+      icon: <BatteryFullIcon />,
+      filterActive: deviceFilters.alternator,
+      onClick: handleDeviceFilterClick("alternator"),
+    },
+    {
+      label: "Mains Powered",
+      value: devicesStatusData.count_of_mains,
+      icon: <PowerIcon />,
+      filterActive: deviceFilters.mains,
+      onClick: handleDeviceFilterClick("mains"),
+    },
+  ];
+
+  useEffect(() => {
+    if (isEmpty(devicesStatusData)) {
+      dispatch(
+        loadDevicesStatusData({
+          startDate: roundToStartOfDay(new Date().toISOString()).toISOString(),
+          endDate: roundToEndOfDay(new Date().toISOString()).toISOString(),
+          limit: 1,
+        })
+      );
+    }
+    if (isEmpty(networkUptimeData)) {
+      dispatch(
+        loadNetworkUptimeData({
+          startDate: roundToStartOfDay(
+            moment(new Date()).subtract(28, "days").toISOString()
+          ).toISOString(),
+          endDate: roundToEndOfDay(new Date().toISOString()).toISOString(),
+        })
+      );
+    }
+
+    if (isEmpty(allDevices)) dispatch(loadDevicesData());
+
+    dispatch(updateDeviceBackUrl(location.pathname));
+  }, []);
+
+  useEffect(() => {
+    let lineLabel = [];
+    let lineData = [];
+    if (isEmpty(networkUptimeData)) {
+      return;
+    }
+    networkUptimeData.sort(
+      (a, b) => new Date(a.created_at) - new Date(b.created_at)
+    );
+
+    networkUptimeData.map((val) => {
+      lineLabel.push(val.created_at);
+      lineData.push(parseFloat(val.uptime).toFixed(2));
+    });
+  }, [networkUptimeData]);
+
+  useEffect(() => {
+    const devices = [
+      ...updateDevices(devicesStatusData.offline_devices, { isOnline: false }),
+      ...updateDevices(devicesStatusData.online_devices, { isOnline: true }),
+    ];
+    setDevices(devices);
+  }, [devicesStatusData]);
+
+  return (
+    <ErrorBoundary>
+      <div className={"map-container-wrapper"}>
+        <div
+          style={{
+            display: "flex",
+            flexWrap: "wrap",
+            alignItems: "center",
+            justifyContent: "space-between",
+            position: "absolute",
+            width: "100%",
+            zIndex: 20,
+          }}
+        >
+          <Hidden mdDown>
+            {cardsData.map((data, key) => {
+              return (
+                <OverviewCard
+                  label={data.label}
+                  value={data.value}
+                  icon={data.icon}
+                  filterActive={data.filterActive}
+                  onClick={data.onClick}
+                  key={key}
+                />
+              );
+            })}
+          </Hidden>
+          <Hidden lgUp>
+            {cardsData.map((data, key) => {
+              return (
+                <OverviewCardMini
+                  label={data.label}
+                  value={data.value}
+                  icon={data.icon}
+                  filterActive={data.filterActive}
+                  onClick={data.onClick}
+                  key={key}
+                />
+              );
+            })}
+          </Hidden>
+        </div>
+        <MapBoxMap />
+      </div>
+    </ErrorBoundary>
+  );
+}

--- a/netmanager/src/views/components/DataDisplay/DeviceManagement/ManagementStats.js
+++ b/netmanager/src/views/components/DataDisplay/DeviceManagement/ManagementStats.js
@@ -1,28 +1,15 @@
 import React, { useState, useEffect } from "react";
 import { useHistory, useLocation } from "react-router-dom";
 import { useDispatch } from "react-redux";
-import DevicesIcon from "@material-ui/icons/Devices";
-import ReportProblem from "@material-ui/icons/ReportProblem";
-import BatteryFullIcon from "@material-ui/icons/BatteryFull";
-import RestoreIcon from "@material-ui/icons/Restore";
-import WbSunnyIcon from "@material-ui/icons/WbSunny";
-import PowerIcon from "@material-ui/icons/Power";
-import Hidden from "@material-ui/core/Hidden";
-import Tooltip from "@material-ui/core/Tooltip";
-import Card from "../Card/Card.js";
 import moment from "moment";
-import { isEmpty, mapObject, omit, values } from "underscore";
+import { isEmpty } from "underscore";
 import {
   useDevicesStatusData,
   useNetworkUptimeData,
-  useManagementFilteredDevicesData,
-  useActiveFiltersData,
 } from "redux/DeviceManagement/selectors";
 import {
   loadDevicesStatusData,
   loadNetworkUptimeData,
-  updateFilteredDevicesData,
-  updateActiveFilters,
 } from "redux/DeviceManagement/operations";
 import { createBarChartData, ApexTimeSeriesData } from "utils/charts";
 import { updateDeviceBackUrl } from "redux/Urls/operations";
@@ -41,7 +28,6 @@ import {
   useDeviceUptimeLeaderboard,
   useInitScrollTop,
 } from "utils/customHooks";
-import MapBoxMap from "./Map/MapBoxMap";
 import ErrorBoundary from "views/ErrorBoundary/ErrorBoundary";
 
 // css style
@@ -49,143 +35,22 @@ import "chartjs-plugin-annotation";
 import "assets/scss/device-management.sass";
 import "assets/css/device-view.css"; // there are some shared styles here too :)
 
-const DEVICE_FILTER_FIELDS = {
-  all: {},
-  due: { key: "maintenance_status", value: "due" },
-  overDue: { key: "maintenance_status", value: "overdue" },
-  solar: { key: "powerType", value: "solar" },
-  alternator: { key: "powerType", value: "alternator" },
-  mains: { key: "powerType", value: "mains" },
-};
-
-const OverviewCardMini = ({ label, icon, value, filterActive, onClick }) => {
-  return (
-    <Tooltip title={label}>
-      <div className={"card-container-mini"} onClick={onClick}>
-        <Card
-          style={
-            filterActive
-              ? { margin: 0, borderRadius: 0 }
-              : { margin: 0, background: "#f2f2f2", borderRadius: 0 }
-          }
-        >
-          <div className={"card-title-wrapper-mini"}>
-            <span
-              className={"card-title-icon-mini"}
-              style={filterActive ? {} : { background: "#6d94ea" }}
-            >
-              {icon}
-            </span>
-            <h3
-              className={"card-title-mini"}
-              style={filterActive ? {} : { color: "#999" }}
-            >
-              {value}
-            </h3>
-          </div>
-        </Card>
-      </div>
-    </Tooltip>
-  );
-};
-
-const OverviewCard = ({ label, icon, value, filterActive, onClick }) => {
-  return (
-    <div className={"card-container"} onClick={onClick}>
-      <Card
-        style={
-          filterActive ? { margin: 0 } : { margin: 0, background: "#f2f2f2" }
-        }
-      >
-        <div className={"card-title-wrapper"}>
-          <span
-            className={"card-title-icon"}
-            style={filterActive ? {} : { background: "#6d94ea" }}
-          >
-            {icon}
-          </span>
-          <h3
-            className={"card-title"}
-            style={filterActive ? {} : { color: "#999" }}
-          >
-            {value}
-          </h3>
-          <div className={"card-divider"} />
-          <p className={"card-category"}>{label}</p>
-        </div>
-      </Card>
-    </div>
-  );
-};
-
-export default function DeviceManagement() {
+export default function ManagementStat() {
   useInitScrollTop();
   const history = useHistory();
   const location = useLocation();
   const devicesStatusData = useDevicesStatusData();
   const networkUptimeData = useNetworkUptimeData();
-  const activeFilters = useActiveFiltersData();
   const leaderboardData = useDeviceUptimeLeaderboard();
   const allDevices = useDevicesData();
   const dispatch = useDispatch();
   const [devicesUptime, setDevicesUptime] = useState([]);
   const [devicesUptimeDescending, setDevicesUptimeDescending] = useState(true);
-  const [devices, setDevices] = useState([]);
-  const filteredDevices = useManagementFilteredDevicesData();
-  const deviceFilters = activeFilters.main;
   const [pieChartStatusValues, setPieChartStatusValues] = useState([]);
   const [networkUptimeDataset, setNetworkUptimeDataset] = useState({
     bar: { label: [], data: [] },
     line: { label: [], data: [] },
   });
-
-  const updateDevices = (devices, newValues) => {
-    const newDevices = [];
-    (devices || []).map((device) => {
-      newDevices.push({ ...device, ...newValues });
-    });
-    return newDevices;
-  };
-
-  const filterDevices = (devices, key) => {
-    const filter = DEVICE_FILTER_FIELDS[key];
-    if (key === "all") {
-      return !deviceFilters[key] ? devices : [];
-    }
-    if (!deviceFilters[key]) {
-      const prevFiltered = filteredDevices.filter(
-        (device) => device[filter.key] !== filter.value
-      );
-      const filtered = devices.filter(
-        (device) => device[filter.key] === filter.value
-      );
-
-      return [...prevFiltered, ...filtered];
-    }
-
-    return filteredDevices.filter(
-      (device) => device[filter.key] !== filter.value
-    );
-  };
-
-  const toggleDeviceFilter = (key) => {
-    if (key === "all") {
-      if (!deviceFilters[key]) {
-        return mapObject(deviceFilters, () => true);
-      }
-      return mapObject(deviceFilters, () => false);
-    }
-    const all = values(
-      omit({ ...deviceFilters, [key]: !deviceFilters[key] }, "all")
-    ).every((value) => value === true);
-
-    return { ...deviceFilters, all, [key]: !deviceFilters[key] };
-  };
-
-  const handleDeviceFilterClick = (key) => () => {
-    dispatch(updateFilteredDevicesData(filterDevices(devices, key)));
-    dispatch(updateActiveFilters({ main: toggleDeviceFilter(key) }));
-  };
 
   const sortLeaderBoardData = (leaderboardData) => {
     const sortByName = (device1, device2) => {
@@ -226,51 +91,6 @@ export default function DeviceManagement() {
     setDevicesUptime(devicesUptime.reverse());
     setDevicesUptimeDescending(!devicesUptimeDescending);
   };
-
-  const cardsData = [
-    {
-      label: "Devices on the network",
-      value: devicesStatusData.total_active_device_count,
-      icon: <DevicesIcon />,
-      filterActive: deviceFilters.all,
-      onClick: handleDeviceFilterClick("all"),
-    },
-    {
-      label: "Due for maintenance",
-      value: devicesStatusData.count_due_maintenance,
-      icon: <RestoreIcon />,
-      filterActive: deviceFilters.due,
-      onClick: handleDeviceFilterClick("due"),
-    },
-    {
-      label: "Overdue for maintenance",
-      value: devicesStatusData.count_overdue_maintenance,
-      icon: <ReportProblem />,
-      filterActive: deviceFilters.overDue,
-      onClick: handleDeviceFilterClick("overDue"),
-    },
-    {
-      label: "Solar powered",
-      value: devicesStatusData.count_of_solar_devices,
-      icon: <WbSunnyIcon />,
-      filterActive: deviceFilters.solar,
-      onClick: handleDeviceFilterClick("solar"),
-    },
-    {
-      label: "Alternator",
-      value: devicesStatusData.count_of_alternator_devices,
-      icon: <BatteryFullIcon />,
-      filterActive: deviceFilters.alternator,
-      onClick: handleDeviceFilterClick("alternator"),
-    },
-    {
-      label: "Mains Powered",
-      value: devicesStatusData.count_of_mains,
-      icon: <PowerIcon />,
-      filterActive: deviceFilters.mains,
-      onClick: handleDeviceFilterClick("mains"),
-    },
-  ];
 
   useEffect(() => {
     if (isEmpty(devicesStatusData)) {
@@ -325,11 +145,6 @@ export default function DeviceManagement() {
   }, [networkUptimeData]);
 
   useEffect(() => {
-    const devices = [
-      ...updateDevices(devicesStatusData.offline_devices, { isOnline: false }),
-      ...updateDevices(devicesStatusData.online_devices, { isOnline: true }),
-    ];
-    setDevices(devices);
     setPieChartStatusValues([
       devicesStatusData.count_of_offline_devices,
       devicesStatusData.count_of_online_devices,
@@ -354,48 +169,6 @@ export default function DeviceManagement() {
   return (
     <ErrorBoundary>
       <div className={"container-wrapper"}>
-        <div
-          style={{
-            display: "flex",
-            flexWrap: "wrap",
-            alignItems: "center",
-            justifyContent: "space-between",
-            position: "absolute",
-            width: "100%",
-            zIndex: 20,
-          }}
-        >
-          <Hidden mdDown>
-            {cardsData.map((data, key) => {
-              return (
-                <OverviewCard
-                  label={data.label}
-                  value={data.value}
-                  icon={data.icon}
-                  filterActive={data.filterActive}
-                  onClick={data.onClick}
-                  key={key}
-                />
-              );
-            })}
-          </Hidden>
-          <Hidden lgUp>
-            {cardsData.map((data, key) => {
-              return (
-                <OverviewCardMini
-                  label={data.label}
-                  value={data.value}
-                  icon={data.icon}
-                  filterActive={data.filterActive}
-                  onClick={data.onClick}
-                  key={key}
-                />
-              );
-            })}
-          </Hidden>
-        </div>
-        <MapBoxMap />
-
         <div
           style={{
             display: "flex",

--- a/netmanager/src/views/layouts/common/Sidebar/Sidebar.js
+++ b/netmanager/src/views/layouts/common/Sidebar/Sidebar.js
@@ -53,7 +53,7 @@ const roleExcludePageMapper = {
     "Users",
     "Candidates",
     "Locate",
-    "Device Management",
+    "Network Monitoring",
     "Location Registry",
     "Device Registry",
     "Site Registry",
@@ -62,7 +62,7 @@ const roleExcludePageMapper = {
     "Users",
     "Candidates",
     "Locate",
-    "Device Management",
+    "Network Monitoring",
     "Location Registry",
     "Device Registry",
     "Site Registry",
@@ -100,14 +100,14 @@ const allMainPages = [
     icon: <LocateIcon />,
   },
   {
-    title: "Device Management",
+    title: "Network Monitoring",
     href: "/manager",
     icon: <ManageIcon />,
     collapse: true,
     nested: true,
     nestItems: [
-      { title: "Device Map", href: "/manager/map" },
-      { title: "Device Stats", href: "/manager/stats" },
+      { title: "Network Map", href: "/manager/map" },
+      { title: "Network Statistics", href: "/manager/stats" },
     ],
   },
   {
@@ -162,7 +162,7 @@ const Sidebar = (props) => {
   if (orgData.name.toLowerCase() === "airqo") {
     pages = excludePages(pages, []);
   } else {
-    pages = excludePages(pages, ["Overview", "Device Management", "Locate"]);
+    pages = excludePages(pages, ["Overview", "Network Monitoring", "Locate"]);
   }
 
   return (

--- a/netmanager/src/views/layouts/common/Sidebar/Sidebar.js
+++ b/netmanager/src/views/layouts/common/Sidebar/Sidebar.js
@@ -104,6 +104,11 @@ const allMainPages = [
     href: "/manager",
     icon: <ManageIcon />,
     collapse: true,
+    nested: true,
+    nestItems: [
+      { title: "Device Map", href: "/manager/map" },
+      { title: "Device Stats", href: "/manager/stats" },
+    ],
   },
   {
     title: "Device Registry",

--- a/netmanager/src/views/layouts/common/Sidebar/components/SidebarNav/SidebarNav.js
+++ b/netmanager/src/views/layouts/common/Sidebar/components/SidebarNav/SidebarNav.js
@@ -2,7 +2,7 @@
 /* eslint-disable react/display-name */
 import React, { forwardRef, useState } from "react";
 import { useDispatch } from "react-redux";
-import { NavLink as RouterLink } from "react-router-dom";
+import { NavLink as RouterLink, useLocation } from "react-router-dom";
 import clsx from "clsx";
 import PropTypes from "prop-types";
 import { makeStyles } from "@material-ui/styles";
@@ -34,6 +34,18 @@ const useStyles = makeStyles((theme) => ({
     letterSpacing: 0,
     width: "100%",
     fontWeight: theme.typography.fontWeightMedium,
+  },
+  buttonActive: {
+    color: theme.palette.primary.main,
+    padding: "10px 8px",
+    justifyContent: "flex-start",
+    textTransform: "none",
+    letterSpacing: 0,
+    width: "100%",
+    fontWeight: theme.typography.fontWeightMedium,
+    "& $icon": {
+      color: theme.palette.primary.main,
+    },
   },
   nestButton: {
     color: colors.blueGrey[800],
@@ -106,6 +118,7 @@ export const SidebarWidgets = ({ className, ...rest }) => {
 const SidebarNav = (props) => {
   const classes = useStyles();
   const { pages, className, ...rest } = props;
+  const location = useLocation();
 
   return (
     <List {...rest} className={clsx(classes.root, className)}>
@@ -115,8 +128,11 @@ const SidebarNav = (props) => {
             <NestedMenuItem
               label={
                 <Button
-                  activeClassName={classes.active}
-                  className={classes.button}
+                  className={
+                    (location.pathname.includes(page.href) &&
+                      classes.buttonActive) ||
+                    classes.button
+                  }
                 >
                   <div className={classes.icon}>{page.icon}</div>
                   {page.title}

--- a/netmanager/src/views/layouts/common/Sidebar/components/SidebarNav/SidebarNav.js
+++ b/netmanager/src/views/layouts/common/Sidebar/components/SidebarNav/SidebarNav.js
@@ -6,7 +6,8 @@ import { NavLink as RouterLink } from "react-router-dom";
 import clsx from "clsx";
 import PropTypes from "prop-types";
 import { makeStyles } from "@material-ui/styles";
-import { List, ListItem, Button, colors } from "@material-ui/core";
+import { List, ListItem, Button, MenuItem, colors } from "@material-ui/core";
+import NestedMenuItem from "material-ui-nested-menu-item";
 import Switch from "views/components/Switch";
 import { useUserPreferenceData } from "redux/UserPreference/selectors";
 import { updateUserPreferenceData } from "redux/UserPreference/operators";
@@ -33,6 +34,15 @@ const useStyles = makeStyles((theme) => ({
     letterSpacing: 0,
     width: "100%",
     fontWeight: theme.typography.fontWeightMedium,
+  },
+  nestButton: {
+    color: colors.blueGrey[800],
+    padding: "0px",
+    justifyContent: "flex-start",
+    textTransform: "none",
+    letterSpacing: 0,
+    width: "100%",
+    fontWeight: theme.typography.fontWeightRegular,
   },
   buttonPushed: {
     color: colors.blueGrey[800],
@@ -99,19 +109,52 @@ const SidebarNav = (props) => {
 
   return (
     <List {...rest} className={clsx(classes.root, className)}>
-      {pages.map((page) => (
-        <ListItem className={classes.item} disableGutters key={page.title}>
-          <Button
-            activeClassName={classes.active}
-            className={classes.button}
-            component={CustomRouterLink}
-            to={page.href}
-          >
-            <div className={classes.icon}>{page.icon}</div>
-            {page.title}
-          </Button>
-        </ListItem>
-      ))}
+      {pages.map((page) => {
+        if (page.nested) {
+          return (
+            <NestedMenuItem
+              label={
+                <Button
+                  activeClassName={classes.active}
+                  className={classes.button}
+                >
+                  <div className={classes.icon}>{page.icon}</div>
+                  {page.title}
+                </Button>
+              }
+              parentMenuOpen={true}
+              style={{ padding: "0px" }}
+            >
+              {page.nestItems.map((nestPage, key) => (
+                <MenuItem>
+                  <Button
+                    activeClassName={classes.active}
+                    className={classes.nestButton}
+                    component={CustomRouterLink}
+                    to={nestPage.href}
+                    key={key}
+                  >
+                    {nestPage.title}
+                  </Button>
+                </MenuItem>
+              ))}
+            </NestedMenuItem>
+          );
+        }
+        return (
+          <ListItem className={classes.item} disableGutters key={page.title}>
+            <Button
+              activeClassName={classes.active}
+              className={classes.button}
+              component={CustomRouterLink}
+              to={page.href}
+            >
+              <div className={classes.icon}>{page.icon}</div>
+              {page.title}
+            </Button>
+          </ListItem>
+        );
+      })}
     </List>
   );
 };


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)
- Explicitly state the utc timezones while computing `last refreshed` value
- Split `Device Management` tab into separate `map` and `stats` nested tabs

#### Is this change ready to hit production in its current state?
- [x] Yes
- [ ] No

#### Status of maturity (all need to be checked before merging):

- [x] I consider this code done
- [ ] I've tested this locally
- [ ] This branch has been LGTM'ed by a reviewer

#### How should this be manually tested?
* Fetch and checkout to this branch locally
* Install requirements `npm install`
* Start netmanager staging application `npm run stage`
* Confirm the summary of changes listed above

#### What are the relevant tickets?
- [N/A]()
