### PR TITLE
Candidate request submission and reject dates

### DIFF
--- a/netmanager/src/utils/dateTime.js
+++ b/netmanager/src/utils/dateTime.js
@@ -68,15 +68,17 @@ export const humanReadableDate = (dateString, options) => {
 };
 
 export const formatDate = (date) => {
-  let d = new Date(date),
-    month = "" + (d.getMonth() + 1),
-    day = "" + d.getDate(),
-    year = d.getFullYear();
+    if(!date) return '-';
 
-  if (month.length < 2) month = "0" + month;
-  if (day.length < 2) day = "0" + day;
+    date = new Date(date)
+    let day = date.getDate();
+    let month = date.getMonth()+1;
+    const year = date.getFullYear();
 
-  return [year, month, day].join("-");
+    if (day < 10) day = `0${day}`
+    if (month < 10) month = `0${month}`
+
+  return [year, month, day].join('-');
 };
 
 export const roundToEndOfDay = (dateISOString) => {

--- a/netmanager/src/views/pages/CandidateList/components/CandidatesTable/CandidatesTable.js
+++ b/netmanager/src/views/pages/CandidateList/components/CandidatesTable/CandidatesTable.js
@@ -216,33 +216,23 @@ const CandidatesTable = (props) => {
               {
                 title: "Rejected",
                 field: "updatedAt",
-                render: (candidate) => <span>
-                    {candidate.status === 'rejected'? formatDateString(candidate.updatedAt, 'DD-MM-YYYY HH:mm:ss') : '-' }
-                    </span>
-              },
-              {
-                title: "Status",
-                field: "status",
-                  render: (candidate) => (<div>
-                      <span
-                          style={
-                              candidate.status === 'pending' ? {
-                                  padding: "5px",
-                                  border: "1px solid #e3e3e3",
-                                  background: "#e3e3e3",
-                                  fontWeight: "bold",
-                                  borderRadius: "5px"
-                              } : {
-                                  padding: "5px",
-                                  border: "1px solid #d70c00",
-                                  background: "#d70c00",
-                                  color: "white",
-                                  fontWeight: "bold",
-                                  borderRadius: "5px"
-                              }}>
-                          {candidate.status}
-                      </span>
-                  </div>)
+                render: (candidate) => {
+                    const pending = candidate.status === 'pending';
+                    return (
+                        <span 
+                            style={
+                                pending ? {
+                                    padding: "5px",
+                                    border: "1px solid #e3e3e3",
+                                    background: "#e3e3e3",
+                                    fontWeight: "bold",
+                                    borderRadius: "5px"
+                                } : null}
+                        >
+                            {pending ? 'pending' : formatDateString(candidate.updatedAt, 'DD-MM-YYYY HH:mm:ss')}
+                        </span>
+                    )
+                }
               },
               {
                 title: "Action",

--- a/netmanager/src/views/pages/CandidateList/components/CandidatesTable/CandidatesTable.js
+++ b/netmanager/src/views/pages/CandidateList/components/CandidatesTable/CandidatesTable.js
@@ -166,6 +166,20 @@ const CandidatesTable = (props) => {
       })
   }
 
+  const formatDate = date => {
+    if(!date) return '-';
+
+    date = new Date(date)
+    let day = date.getDate();
+    let month = date.getMonth()+1;
+    const year = date.getFullYear();
+
+    if (day < 10) day = `0${day}`
+    if (month < 10) month = `0${month}`
+
+    return `${day}-${month}-${year}`
+  }
+
   return (
     <Card {...rest} className={clsx(classes.root, className)}>
         <CustomMaterialTable
@@ -201,11 +215,23 @@ const CandidatesTable = (props) => {
               },
               {
                 title: "Organization",
-                field: "organization",
+                field: "long_organization",
               },
               {
                 title: "Job Title",
                 field: "jobTitle",
+              },
+              {
+                title: "Submitted",
+                field: "createdAt",
+                render: (candidate) => <span>{formatDate(candidate.createdAt)}</span>
+              },
+              {
+                title: "Rejected",
+                field: "updatedAt",
+                render: (candidate) => <span>
+                    {candidate.status === 'rejected'? formatDate(candidate.updatedAt) : '-' }
+                    </span>
               },
               {
                 title: "Status",

--- a/netmanager/src/views/pages/CandidateList/components/CandidatesTable/CandidatesTable.js
+++ b/netmanager/src/views/pages/CandidateList/components/CandidatesTable/CandidatesTable.js
@@ -20,6 +20,7 @@ import { Alert, AlertTitle } from "@material-ui/lab";
 
 import { Check} from "@material-ui/icons";
 import { getInitials } from "utils/users";
+import { formatDateString } from "utils/dateTime";
 import CandidateEditForm from "views/pages/UserList/components/UserEditForm";
 import CustomMaterialTable from "views/components/Table/CustomMaterialTable";
 import usersStateConnector from "views/stateConnectors/usersStateConnector";
@@ -166,20 +167,6 @@ const CandidatesTable = (props) => {
       })
   }
 
-  const formatDate = date => {
-    if(!date) return '-';
-
-    date = new Date(date)
-    let day = date.getDate();
-    let month = date.getMonth()+1;
-    const year = date.getFullYear();
-
-    if (day < 10) day = `0${day}`
-    if (month < 10) month = `0${month}`
-
-    return `${day}-${month}-${year}`
-  }
-
   return (
     <Card {...rest} className={clsx(classes.root, className)}>
         <CustomMaterialTable
@@ -224,13 +211,13 @@ const CandidatesTable = (props) => {
               {
                 title: "Submitted",
                 field: "createdAt",
-                render: (candidate) => <span>{formatDate(candidate.createdAt)}</span>
+                render: (candidate) => <span>{formatDateString(candidate.createdAt, 'DD-MM-YYYY HH:mm:ss')}</span>
               },
               {
                 title: "Rejected",
                 field: "updatedAt",
                 render: (candidate) => <span>
-                    {candidate.status === 'rejected'? formatDate(candidate.updatedAt) : '-' }
+                    {candidate.status === 'rejected'? formatDateString(candidate.updatedAt, 'DD-MM-YYYY HH:mm:ss') : '-' }
                     </span>
               },
               {

--- a/netmanager/src/views/pages/UserList/components/UsersTable/UsersTable.js
+++ b/netmanager/src/views/pages/UserList/components/UsersTable/UsersTable.js
@@ -19,6 +19,7 @@ import {
 import { RemoveRedEye } from '@material-ui/icons';
 
 import { getInitials } from "utils/users";
+import { formatDateString } from "utils/dateTime";
 import CustomMaterialTable from "views/components/Table/CustomMaterialTable";
 import usersStateConnector from "views/stateConnectors/usersStateConnector";
 import ConfirmDialog from "views/containers/ConfirmDialog";
@@ -183,6 +184,11 @@ const UsersTable = (props) => {
                 field: "privilege",
               },
               {
+                title: "Joined",
+                field: "createdAt",
+                render: (candidate) => <span>{formatDateString(candidate.createdAt, 'DD-MM-YYYY HH:mm:ss')}</span>
+              },
+              {
                 title: "More Details",                
                 render: (user) => <RemoveRedEye style={{color: "green"}} onClick={() => showMoreDetails(user)} />
               },
@@ -197,7 +203,7 @@ const UsersTable = (props) => {
                       >
                         Update
                       </Button>
-                      |
+
                       <Button  style={{color: "red"}} onClick={() => showDeleteDialog(user)}>
                         Delete
                       </Button>

--- a/netmanager/src/views/pages/UserList/components/UsersTable/UsersTable.js
+++ b/netmanager/src/views/pages/UserList/components/UsersTable/UsersTable.js
@@ -5,19 +5,19 @@ import PropTypes from "prop-types";
 import { makeStyles } from "@material-ui/styles";
 import {
   Card,
-  CardContent,
   Avatar,
   Typography,
   Button,
   Dialog,
   DialogTitle,
   DialogContent,
-  DialogContentText,
   TextField,
   DialogActions,
+  ListItemText,
+  Divider,
 } from "@material-ui/core";
+import { RemoveRedEye } from '@material-ui/icons';
 
-import { Alert, AlertTitle } from "@material-ui/lab";
 import { getInitials } from "utils/users";
 import CustomMaterialTable from "views/components/Table/CustomMaterialTable";
 import usersStateConnector from "views/stateConnectors/usersStateConnector";
@@ -81,14 +81,12 @@ const UsersTable = (props) => {
   const { className, mappeduserState, ...rest } = props;
   const [userDelState, setUserDelState] = useState({open: false, user: {}})
 
-  console.log("the mapped user state for UsersTable is here:");
-  console.dir(mappeduserState);
-
   const users = mappeduserState.users;
   const collaborators = mappeduserState.collaborators;
   const editUser = mappeduserState.userToEdit;
   const [updatedUser, setUpdatedUser] = useState({});
   const [showEditPopup, setShowEditPopup] = useState(false);
+  const [showMoreDetailsPopup, setShowMoreDetailsPopup] = useState(false);
   const userToDelete = mappeduserState.userToDelete;
 
   //the methods:
@@ -97,6 +95,16 @@ const UsersTable = (props) => {
     event.preventDefault();
     setUpdatedUser({ ...updatedUser, [field]: event.target.value });
   }
+
+  const showMoreDetails = (user) => {
+    props.mappedshowEditDialog(user);
+    setShowMoreDetailsPopup(true);
+  };
+
+  const hideMoreDetailsDialog = () => {
+    props.mappedhideEditDialog();
+    setShowMoreDetailsPopup(false)
+  };
 
   const showEditDialog = (userToEdit) => {
     props.mappedshowEditDialog(userToEdit);
@@ -175,6 +183,10 @@ const UsersTable = (props) => {
                 field: "privilege",
               },
               {
+                title: "More Details",                
+                render: (user) => <RemoveRedEye style={{color: "green"}} onClick={() => showMoreDetails(user)} />
+              },
+              {
                 title: "Action",
                 render: (user) => {
                   return (
@@ -201,6 +213,39 @@ const UsersTable = (props) => {
             }}
         />
 
+      {/*************************** the more details dialog **********************************************/}
+      {editUser &&
+      <Dialog
+          open={showMoreDetailsPopup}
+          onClose={hideMoreDetailsDialog}
+          aria-labelledby="form-dialog-title"
+      >
+        <DialogTitle>User request details</DialogTitle>
+        <DialogContent>
+            <div style={{ minWidth: 500 }} >
+                <ListItemText primary="Job Title" secondary={editUser.jobTitle || 'Not provided'} />
+                <Divider />
+                <ListItemText primary="Category" secondary={editUser.category || 'Not provided'} />
+                <Divider />
+                <ListItemText primary="Website" secondary={editUser.website || 'Not provided'} />
+                <Divider />
+                <ListItemText primary="Description" secondary={editUser.description || 'Not provided'} />
+            </div>
+        </DialogContent>
+        <DialogActions>
+          <div>
+            <Button
+                color="primary"
+                variant="outlined"
+                onClick={hideMoreDetailsDialog}
+            >
+              Close
+            </Button>
+          </div>
+        </DialogActions>
+      </Dialog>
+      }
+      
       {/*************************** the edit dialog **********************************************/}
       {editUser &&
       <Dialog
@@ -210,7 +255,6 @@ const UsersTable = (props) => {
       >
         <DialogTitle>Edit User</DialogTitle>
         <DialogContent>
-
           <div>
             <TextField
                 margin="dense"


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)
- Adds
  - Submission date and rejection date for requests in the candidate table
  - Replaces status column with rejection column that a date for rejected requests and `pending` for pending requests
  - Adds Joined column to the User table which is when the user was approved to join
  - Adds view more icon that shows a user's request infomation
- Closes #419 

#### Is this change ready to hit production in its current state?
- [x] Yes
- [ ] No

#### Status of maturity (all need to be checked before merging):

- [x] I consider this code done
- [x] I've tested this locally
- [ ] This branch has been LGTM'ed by a reviewer

#### How should this be manually tested?
* Follow the instructions in the README to run the application and checkout the users and candidates tables

#### What are the relevant tickets?
- [PLAT-1011](https://airqoteam.atlassian.net/browse/PLAT-1011?atlOrigin=eyJpIjoiMTUwOThlODY4YTBlNGI2MDkwYTA4NmVlYTlkMjNiOWUiLCJwIjoiaiJ9)
- #419 
- Depends on the API [PR here](https://github.com/airqo-platform/AirQo-api/pull/749)

#### Screenshots (optional)
**Candidates' table with dates for request submission and rejection(for rejected requests)**
![image](https://user-images.githubusercontent.com/41787587/157627805-3d3edfe0-df9e-4692-b901-2c0ea3ebaa6b.png)

**Users' table with date when user joined and button to view more info about the user**
![image](https://user-images.githubusercontent.com/41787587/157628267-7fb34d7c-84d4-4498-964e-dc3a9b984bbd.png)

**User with request information**
![image](https://user-images.githubusercontent.com/41787587/157628737-1466a222-4dfb-41f3-962f-2ba0301a1395.png)

**User without request information**
![image](https://user-images.githubusercontent.com/41787587/157628847-b9cf02fc-da56-4094-810f-1775773299a6.png)