### PR TITLE
[NetManager] Add CSV Map Data Download Capability

### DIFF
--- a/netmanager/src/assets/css/map-download.css
+++ b/netmanager/src/assets/css/map-download.css
@@ -1,0 +1,180 @@
+@import url(https://fonts.googleapis.com/css?family=Open+Sans);
+
+.map-download-search {
+  width: 100%;
+  position: relative;
+  display: flex;
+  justify-content: flex-start;
+}
+
+.map-download-searchTerm {
+  width: 100%;
+  /*border: 3px solid #00B4CC;*/
+  /*border-right: none;*/
+  /*padding: 5px;*/
+  /*height: 20px;*/
+  /*border-radius: 5px 0 0 5px;*/
+  outline: none;
+    margin: 0 !important;
+    /*border: 1px solid red !important;*/
+    height: 31px !important;
+    /*line-height: 20px;*/
+    padding: 2px !important;
+  color: #9DBFAF;
+}
+
+.map-download-searchTerm:focus{
+  /*color: #00B4CC;*/
+  color: #2f67e2;
+    border-bottom: 1px solid #2f67e2 !important;
+}
+
+.map-download-searchButton {
+  position: relative;
+  width: 48px;
+  height: 42px;
+  /*border: 1px solid #00B4CC;*/
+  border: 1.5px solid #bbb;
+  /*background: #00B4CC;*/
+  background: #fff;
+  text-align: center;
+  color: #fff;
+  border-radius: 0 6px 6px 0;
+  cursor: pointer;
+  font-size: 20px;
+  box-shadow: 0px 0px 3px 4px #eee;
+  z-index: 100;
+}
+
+.map-download-searchButton:hover{
+  box-shadow: 0px 0px 2px 4px #ddd;
+  border: 1.5px solid #aaa;
+  width:44px;
+  height: 38px;
+}
+
+.map-download-searchButton:focus{
+  border: 1.8px solid #aaa;
+  background-color: #f4f4f4;
+  transition: .1s ease;
+}
+
+
+/*Resize the wrap to see the search bar change!*/
+.map-download-container {
+    width: 30%;
+    max-width: 400px;
+    position: absolute;
+    bottom: 20px;
+    left: 10px;
+    font-family: 'Open Sans', sans-serif;
+    z-index: 200;
+}
+.map-download-wrapper{
+    font-family: 'Open Sans', sans-serif;
+    background-color: transparent;
+    /*background-color: #ffffff;*/
+    border-radius: 5px;
+}
+
+.dropup {
+  display: inline-block;
+  position: relative;
+  width: 100%;
+}
+
+.du-input {
+  display: none;
+}
+
+.du-menu {
+  position: absolute;
+  bottom: 100%;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  padding: 0;
+  margin: 2px 0 0 0;
+  box-shadow: 0 0 6px 0 rgba(0,0,0,0.1);
+  background-color: #ffffff;
+  list-style-type: none;
+  width: 100%;
+  z-index: 2000;
+}
+
+.du-input + .du-menu {
+  display: none;
+}
+
+.du-input:checked + .du-menu {
+  display: block;
+}
+
+.du-menu li {
+  padding: 10px 20px;
+  cursor: pointer;
+  white-space: nowrap;
+  color: #151515;
+}
+
+.du-menu li span {
+  color: green;
+  font-size: 0.6rem;
+}
+
+.du-menu li:hover {
+  background-color: #f6f6f6;
+  color: #646262
+}
+
+.du-menu li a {
+  display: block;
+  margin: -10px -20px;
+  padding: 10px 20px;
+}
+
+.du-menu li.divider{
+  padding: 0;
+  border-bottom: 1px solid #cccccc;
+}
+
+.du-menu li.download {
+  /*cursor: not-allowed;*/
+  display: flex;
+  background-color: #f6f6f6;
+  color: #646262
+}
+
+.du-menu li.download span {
+  display: flex;
+  align-items: center;
+  width: 25%;
+  color: #646262;
+  font-size: 1.1rem;
+  height: 50px;
+}
+
+.du-menu li.download input {
+  width: 75%;
+  height: 50px;
+}
+
+.du-menu .selected {
+  color: #069be5;
+}
+
+.map-download-item {
+  display: grid;
+  grid-template-columns: 40px 1fr 40px;
+  align-content: center;
+  justify-content: space-between;
+  height: 30px;
+  margin: 2px;
+  background-color: #ffffff;
+  border-radius: 2px;
+  cursor: default;
+}
+
+.grid-align-right {
+  justify-self: end;
+  cursor: pointer;
+}

--- a/netmanager/src/assets/css/map-filter.css
+++ b/netmanager/src/assets/css/map-filter.css
@@ -63,9 +63,10 @@
     width: 30%;
     max-width: 350px;
     position: absolute;
-    bottom:60px;
-    left:10px;
+    bottom: 20px;
+    left: 10px;
     font-family: 'Open Sans', sans-serif;
+    z-index: 20;
 }
 .map-filter-wrapper{
     font-family: 'Open Sans', sans-serif;

--- a/netmanager/src/assets/css/map-filter.css
+++ b/netmanager/src/assets/css/map-filter.css
@@ -63,7 +63,7 @@
     width: 30%;
     max-width: 350px;
     position: absolute;
-    bottom: 20px;
+    bottom: 70px;
     left: 10px;
     font-family: 'Open Sans', sans-serif;
     z-index: 20;
@@ -77,7 +77,6 @@
 
 .dropup {
   display: inline-block;
-  position: relative;
   width: 100%;
 }
 

--- a/netmanager/src/views/components/DataDisplay/Map/MapBoxMap.js
+++ b/netmanager/src/views/components/DataDisplay/Map/MapBoxMap.js
@@ -3,6 +3,7 @@ import ReactMapGL, { Marker, Popup } from "react-map-gl";
 import { useHistory } from "react-router-dom";
 import { MapKey } from "./MapKey";
 import MapFilter from "./MapFilter";
+import MapDownload from "./MapDownload";
 import { useManagementFilteredDevicesData } from "redux/DeviceManagement/selectors";
 import ErrorBoundary from "views/ErrorBoundary/ErrorBoundary";
 
@@ -116,6 +117,7 @@ const MapBoxMap = () => {
               </div>
             </Popup>
           )}
+          <MapDownload />
           <MapFilter />
           <MapKey />
         </ReactMapGL>

--- a/netmanager/src/views/components/DataDisplay/Map/MapBoxMap.js
+++ b/netmanager/src/views/components/DataDisplay/Map/MapBoxMap.js
@@ -58,10 +58,9 @@ const MapBoxMap = () => {
           mapStyle={"mapbox://styles/mapbox/streets-v11"}
           mapboxApiAccessToken={process.env.REACT_APP_MAPBOX_TOKEN}
         >
-          {devices.map(
-            (device) =>
-              device.latitude &&
-              device.longitude && (
+          {devices.map((device) => {
+            if (device.latitude && device.longitude) {
+              return (
                 <Marker
                   key={device.name}
                   longitude={parseFloat(device.longitude)}
@@ -74,8 +73,9 @@ const MapBoxMap = () => {
                     )} ${maintenanceClassGenerator(device.maintenance_status)}`}
                   />
                 </Marker>
-              )
-          )}
+              );
+            }
+          })}
           {selectedDevice && (
             <Popup
               longitude={parseFloat(selectedDevice.longitude)}

--- a/netmanager/src/views/components/DataDisplay/Map/MapDownload.js
+++ b/netmanager/src/views/components/DataDisplay/Map/MapDownload.js
@@ -1,0 +1,144 @@
+import React, { useEffect, useRef, useState } from "react";
+import { Parser } from "json2csv";
+
+import { useManagementFilteredDevicesData } from "redux/DeviceManagement/selectors";
+
+// css styles
+import "assets/css/map-download.css";
+
+const DownloadIcon = ({ fill }) => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      version="1.1"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+    >
+      <path
+        fill={fill || "#000000"}
+        d="M5,20H19V18H5M19,9H15V3H9V9H5L12,16L19,9Z"
+      />
+    </svg>
+  );
+};
+
+const MapDownload = () => {
+  const ref = useRef();
+  const inputRef = useRef();
+  const devices = useManagementFilteredDevicesData();
+  const [filename, setFilename] = useState("");
+  const [show, setShow] = useState(false);
+
+  const toggleShow = () => setShow(!show);
+
+  const onDownloadClick = () => {
+    if (filename) {
+      toggleShow();
+      const exportFilename = filename.endsWith(".csv")
+        ? filename
+        : `${filename}.csv`;
+
+      const fields = [
+        "name",
+        "device_number",
+        "isActive",
+        "isOnline",
+        "latitude",
+        "longitude",
+        "maintenance_status",
+        "nextMaintenance",
+        "powerType",
+      ];
+      const opts = { fields };
+
+      try {
+        const parser = new Parser(opts);
+        const csv = parser.parse(devices);
+
+        const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+
+        if (navigator.msSaveBlob) {
+          // IE 10+
+          navigator.msSaveBlob(blob, exportFilename);
+        } else {
+          const link = document.createElement("a");
+          if (link.download !== undefined) {
+            // feature detection
+            // Browsers that support HTML5 download attribute
+            const url = URL.createObjectURL(blob);
+            link.setAttribute("href", url);
+            link.setAttribute("download", exportFilename);
+            link.style.visibility = "hidden";
+            document.body.appendChild(link);
+            link.click();
+            document.body.removeChild(link);
+          }
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    }
+  };
+
+  const onChange = (event) => {
+    setFilename(event.target.value);
+  };
+
+  useEffect(() => {
+    const onEnterHandler = (event) => {
+      if (event.keyCode === 13) {
+        // Cancel the default action, if needed
+        event.preventDefault();
+        // Trigger the button element with a click
+        inputRef.current && inputRef.current.click();
+      }
+    };
+    const checkIfClickedOutside = (e) => {
+      // If the menu is open and the clicked target is not within the menu,
+      // then close the menu
+      if (show && ref.current && !ref.current.contains(e.target))
+        setShow(false);
+    };
+    inputRef.current &&
+      inputRef.current.addEventListener("keyup", onEnterHandler);
+    document.addEventListener("mousedown", checkIfClickedOutside);
+
+    return () => {
+      // Cleanup the event listener
+      inputRef.current &&
+        inputRef.current.removeEventListener("keyup", onEnterHandler);
+      document.removeEventListener("mousedown", checkIfClickedOutside);
+    };
+  }, [show]);
+  return (
+    <div className="map-download-container">
+      <label className="dropup" ref={ref}>
+        <ul className={`du-menu ${(!show && "du-input") || ""}`}>
+          <li className="download">
+            <span>File Name</span>{" "}
+            <input
+              ref={inputRef}
+              onClick={onDownloadClick}
+              onChange={onChange}
+            />
+          </li>
+        </ul>
+      </label>
+      <div className="map-download-wrapper">
+        <div className="map-download-search">
+          <button
+            type="submit"
+            className="map-download-searchButton"
+            onClick={toggleShow}
+          >
+            <DownloadIcon fill="#2f67e2" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default MapDownload;


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)
- Removes `00` from netmanager map
- Aligns map components
- Adds csv download to map

#### Is this change ready to hit production in its current state?
- [x] Yes
- [ ] No

#### Status of maturity (all need to be checked before merging):

- [x] I consider this code done
- [ ] I've tested this locally
- [ ] This branch has been LGTM'ed by a reviewer

#### How should this be manually tested?
* Fetch and checkout to this branch locally
* Install requirements `npm install`
* Start netmanager staging application `npm run stage`
* Confirm the summary of changes listed above

#### What are the relevant tickets?
- [PLAT-1079](https://airqoteam.atlassian.net/browse/PLAT-1079)
