### PR TITLE
[Website] Fix webpack staticfiles loading

### DIFF
--- a/website/backend/settings.py
+++ b/website/backend/settings.py
@@ -134,7 +134,7 @@ USE_TZ = True
 
 # Static
 # Default to using webpack-dev-server on port 8081
-STATIC_HOST = config('WEB_STATIC_HOST', default='http://localhost:8081/')
+STATIC_HOST = config('REACT_WEB_STATIC_HOST', default='http://localhost:8081/')
 
 STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.StaticFilesStorage'
 

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -3413,6 +3413,12 @@
                 "tslib": "^2.0.3"
             }
         },
+        "dotenv": {
+            "version": "16.0.0",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.0.tgz",
+            "integrity": "sha512-qD9WU0MPM4SWLPJy/r2Be+2WgQj8plChsyrCNQzW/0WjvcJQiKQJ9mH3ZgB3fxbUUxgc/11ZJ0Fi5KiimWGz2Q==",
+            "dev": true
+        },
         "ecc-jsbn": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",

--- a/website/package.json
+++ b/website/package.json
@@ -28,6 +28,7 @@
         "babel-loader": "^8.2.2",
         "classnames": "^2.3.1",
         "css-loader": "^6.2.0",
+        "dotenv": "^16.0.0",
         "eslint": "^7.32.0",
         "eslint-config-airbnb": "^18.2.1",
         "eslint-plugin-import": "^2.24.2",

--- a/website/webpack.config.js
+++ b/website/webpack.config.js
@@ -31,8 +31,18 @@ function postCSSLoader() {
   };
 }
 
+function removeTrailingSlash(str) {
+  return str.replace(/\/+$/, '');
+}
+
 const config = () => {
   const NODE_ENV = process.env.NODE_ENV || 'local';
+
+  const env = dotenv.config().parsed;
+
+  const STATIC_URL = removeTrailingSlash(env.REACT_WEB_STATIC_HOST);
+
+  const PUBLIC_PATH = `${STATIC_URL}/static/frontend/`;
 
   const STATIC_DIR = 'frontend/static/frontend';
 
@@ -58,7 +68,7 @@ const config = () => {
     output: {
       path: DIST_DIR,
       filename: '[name].bundle.js',
-      publicPath: `/${STATIC_DIR}/`,
+      publicPath: PUBLIC_PATH,
     },
 
     // webpack 5 comes with devServer which loads in development mode

--- a/website/webpack.config.js
+++ b/website/webpack.config.js
@@ -1,4 +1,6 @@
 const path = require('path');
+const dotenv = require('dotenv');
+const webpack = require('webpack');
 // const autoprefixer = require('autoprefixer');
 // const webpack = require('webpack');
 // const TerserPlugin = require('terser-webpack-plugin');
@@ -35,6 +37,16 @@ const config = () => {
   const STATIC_DIR = 'frontend/static/frontend';
 
   const DIST_DIR = path.resolve(__dirname, STATIC_DIR);
+
+  const env = dotenv.config().parsed;
+
+  const envKeys = Object.keys(env).reduce((prev, next) => {
+    if (next.startsWith('REACT_')) {
+      prev[`process.env.${next}`] = JSON.stringify(env[next]);
+    }
+
+    return prev;
+  }, {});
 
   function prodOnly(x) {
     return NODE_ENV === 'production' ? x : undefined;
@@ -116,7 +128,9 @@ const config = () => {
       ],
     },
 
-    plugins: [],
+    plugins: [
+      new webpack.DefinePlugin(envKeys),
+    ],
   };
 };
 

--- a/website/webpack.config.js
+++ b/website/webpack.config.js
@@ -38,8 +38,6 @@ const config = () => {
 
   const DIST_DIR = path.resolve(__dirname, STATIC_DIR);
 
-  const env = dotenv.config().parsed;
-
   const envKeys = Object.keys(env).reduce((prev, next) => {
     if (next.startsWith('REACT_')) {
       prev[`process.env.${next}`] = JSON.stringify(env[next]);
@@ -117,14 +115,7 @@ const config = () => {
         // Images
         {
           test: /\.(png|jpe?g|ico)$/i,
-          use: compact([
-            {
-              loader: 'url-loader',
-              options: { name: '[path][name].[ext]' },
-            },
-          ]),
-          // TODO: We are migrating to using asset/resource module
-          // type: 'asset/resource',
+          type: 'asset/resource',
         },
       ],
     },

--- a/website/webpack.config.js
+++ b/website/webpack.config.js
@@ -69,6 +69,7 @@ const config = () => {
       headers: { 'Access-Control-Allow-Origin': '*' },
       compress: true,
       hot: true,
+      historyApiFallback: true,
       static: {
         directory: './static',
       },


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)
- Enable webpack to pick staticfiles/assets from the static host server
- Add historyAPI fallback to webpack dev-server to resolve `cannot get paths` issue during development
- Renames the host url env key to `REACT_WEB_STATIC_HOST` (previously called `WEB_STATIC_HOST`) to enable the key to be picked up by both the frontend and backend apps.

#### Is this change ready to hit production in its current state?
- [x] Yes
- [ ] No

#### Status of maturity (all need to be checked before merging):

- [x] I consider this code done
- [ ] I've tested this locally
- [ ] This branch has been LGTM'ed by a reviewer

#### How should this be manually tested?
* Fetch and checkout to this branch locally
* Install requirements `npm install`
* Start the staging application `npm run stage`
* Confirm the summary of changes listed above

#### What are the relevant tickets?
- [WEB-163](https://airqoteam.atlassian.net/browse/WEB-163)
