### PR TITLE
[Calibrate] Hotfix - Add standard pollutant mappers

### DIFF
--- a/calibrate/src/views/components/Calibrate.js
+++ b/calibrate/src/views/components/Calibrate.js
@@ -127,6 +127,11 @@ const Calibrate = () => {
     humidity: null,
   });
 
+  const refPollutantMapper = {
+    "PM 2.5": "pm2_5",
+    "PM 10": "pm10",
+  };
+
   const [refData, setRefData] = useState({
     pollutant: null,
     ref_data: null,
@@ -201,8 +206,10 @@ const Calibrate = () => {
     }
 
     if (checkHasReference()) {
-      for (let key in refData) {
-        formData.append(key, refData[key]);
+      const modifiedRefData = refData;
+      modifiedRefData.pollutant = refPollutantMapper[modifiedRefData.pollutant];
+      for (let key in modifiedRefData) {
+        formData.append(key, modifiedRefData[key]);
       }
       const responseData = await trainAndCalibrateDataApi(formData);
       downloadCSVData(filename, responseData);


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)
- Change the pollutant values sent to the backend to `pm2_5` and `pm10` for PM 2.5 and PM 10 pollutants respectively.
**NOTE** A corresponding backend will be made by @Priscilla-AL to support these frontend changes

Back end PR: https://github.com/airqo-platform/AirQo-api/pull/867

#### Is this change ready to hit production in its current state?
- [x] Yes
- [ ] No

#### Status of maturity (all need to be checked before merging):

- [x] I consider this code done
- [x] I've tested this locally
- [ ] This branch has been LGTM'ed by a reviewer

#### How should this be manually tested?
* Please include the steps to be done inorder to setup and test this PR.

#### What are the relevant tickets?
- [N/A]()
