### PR TITLE
aqcsv standard alternative approach added on export feature

### DIFF
--- a/netmanager/src/views/apis/analytics.js
+++ b/netmanager/src/views/apis/analytics.js
@@ -16,18 +16,18 @@ export const getSitesApi = async () => {
   return await axios.get(GET_SITES).then((response) => response.data);
 };
 
-export const downloadDataApi = async (downloadType, data, blobType) => {
+export const downloadDataApi = async (downloadType, data, blobType, outputFormat) => {
   if (blobType) {
     return axios.request({
       url: DOWNLOAD_CUSTOMISED_DATA_URI,
       method: "POST",
       data: data,
-      params: { downloadType },
+      params: { downloadType, outputFormat },
       responseType: "blob", //important
     });
   }
   return axios
-    .post(DOWNLOAD_CUSTOMISED_DATA_URI, data, { params: { downloadType } })
+    .post(DOWNLOAD_CUSTOMISED_DATA_URI, data, { params: { downloadType,  outputFormat } })
     .then((response) => response.data);
 };
 

--- a/netmanager/src/views/pages/Download/Download.js
+++ b/netmanager/src/views/pages/Download/Download.js
@@ -71,6 +71,7 @@ const Download = (props) => {
     label: "Hourly",
   });
   const [fileType, setFileType] = useState(null);
+  const [outputFormat, setOutputFormat] = useState(null);
 
   const frequencyOptions = [
     { value: "hourly", label: "Hourly" },
@@ -83,6 +84,12 @@ const Download = (props) => {
   const typeOptions = [
     { value: "json", label: "JSON" },
     { value: "csv", label: "CSV" },
+    //{ value: "aqcsv", label: "AQCSV" },
+  ];
+
+  const typeOutputFormatOptions = [
+    { value: "aqcsv", label: "AQCSV" },
+    { value: "usual", label: "Usual" },
   ];
 
   useEffect(() => {
@@ -121,6 +128,7 @@ const Download = (props) => {
       pollutants: getValues(pollutants),
       fileType: fileType.value,
       fromBigQuery: true,
+      outputFormat: outputFormat.value,
     };
 
     // const dateDiff = moment(data.endDate).diff(moment(data.startDate), "days");
@@ -137,7 +145,7 @@ const Download = (props) => {
     //   return;
     // }
 
-    await downloadDataApi(fileType.value, data, fileType.value === "csv")
+    await downloadDataApi(fileType.value, data, fileType.value === "csv" , outputFormat.value)
       .then((response) => response.data)
       .then((resData) => {
         let filename = `airquality-${frequency.value}-data.${fileType.value}`;
@@ -281,6 +289,22 @@ const Download = (props) => {
                         value={fileType}
                         options={typeOptions}
                         onChange={(options) => setFileType(options)}
+                        variant="outlined"
+                        margin="dense"
+                        required
+                      />
+                    </Grid>
+
+                    <Grid item md={6} xs={12}>
+                      <Select
+                        fullWidth
+                        label="File Output Standard"
+                        className="reactSelect"
+                        name="file-output-format"
+                        placeholder="File Output Standard"
+                        value={outputFormat}
+                        options={typeOutputFormatOptions}
+                        onChange={(options) => setOutputFormat(options)}
                         variant="outlined"
                         margin="dense"
                         required


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)
-  added support fo aqcsv standard

#### Is this change ready to hit production in its current state?
- [ ] Yes
- [ ] No

#### Status of maturity (all need to be checked before merging):

- [ ] I consider this code done
- [ ] I've tested this locally
- [ ] This branch has been LGTM'ed by a reviewer

#### How should this be manually tested?
* go to export feature in netmanager and while downloading, select the aqcsv format

#### What are the relevant tickets?
- [ticket_id]()

#### Screenshots (optional)