### PR TITLE
MOB-88 - MOB-88-disable-fa-qs-on-mobile-app

### DIFF
--- a/mobile/lib/screens/settings/settings_page.dart
+++ b/mobile/lib/screens/settings/settings_page.dart
@@ -134,8 +134,11 @@ class _SettingsPageState extends State<SettingsPage> {
                       child: const SettingsCard(text: 'FAQs'),
                     ),
                   ),
-                  Divider(
-                    color: CustomColors.appBodyColor,
+                  Visibility(
+                    visible: false,
+                    child: Divider(
+                      color: CustomColors.appBodyColor,
+                    ),
                   ),
                   GestureDetector(
                     onTap: () async {

--- a/mobile/lib/screens/settings/settings_page.dart
+++ b/mobile/lib/screens/settings/settings_page.dart
@@ -115,21 +115,24 @@ class _SettingsPageState extends State<SettingsPage> {
                   Divider(
                     color: CustomColors.appBodyColor,
                   ),
-                  GestureDetector(
-                    onTap: () async {
-                      await Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                          builder: (context) {
-                            return WebViewScreen(
-                              url: Config.faqsUrl,
-                              title: 'AirQo FAQs',
-                            );
-                          },
-                        ),
-                      );
-                    },
-                    child: const SettingsCard(text: 'FAQs'),
+                  Visibility(
+                    visible: false,
+                    child: GestureDetector(
+                      onTap: () async {
+                        await Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (context) {
+                              return WebViewScreen(
+                                url: Config.faqsUrl,
+                                title: 'AirQo FAQs',
+                              );
+                            },
+                          ),
+                        );
+                      },
+                      child: const SettingsCard(text: 'FAQs'),
+                    ),
                   ),
                   Divider(
                     color: CustomColors.appBodyColor,


### PR DESCRIPTION
Disabling FAQS

#### Summary of Changes (What does this PR do?)
* Hide FAQs section in mobile application until FAQs added to new website

#### Is this change ready to hit production in its current state?
- [x]  Yes
- [ ] No

#### Status of maturity (all need to be checked before merging):

- [x] I consider this code done
- [x] I've tested this locally
- [ ] This branch has been LGTM'ed by a reviewer

#### How should this be manually tested?
* Run application locally
* Open settings screen in profile section

#### What are the relevant tickets?
- [MOB-88](https://airqoteam.atlassian.net/browse/MOB-88)

#### Screenshots (optional)
![img](https://user-images.githubusercontent.com/60974514/174430263-e9aa1b16-8444-473d-b769-f188480e388c.jpg)
