### PR TITLE
[Website] fixed hero section buttons - overflow on mobile

### DIFF
--- a/website/frontend/styles/Hero.scss
+++ b/website/frontend/styles/Hero.scss
@@ -370,7 +370,7 @@
 
     .hero-buttons {
       flex-direction: column;
-      // align-items: center;
+      align-items: center;
       width: 100%;
       margin: 0 auto;
     }


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)
- On staging, the buttons on the hero section overflow for mobile. Fixed that.

#### Is this change ready to hit production in its current state?
- [x] Yes
- [ ] No

#### Status of maturity (all need to be checked before merging):

- [x] I consider this code done
- [ ] I've tested this locally
- [ ] This branch has been LGTM'ed by a reviewer

#### How should this be manually tested?
* Please include the steps to be done inorder to setup and test this PR.

#### What are the relevant tickets?
- [WEB-248](https://airqoteam.atlassian.net/browse/WEB-248)

#### Screenshots
![hero-button-mobile](https://user-images.githubusercontent.com/46527380/176882664-120e9b01-ecf0-480b-a225-e40c5bba257c.PNG)

