### PR TITLE
[Website] Removes duplicate metadata

### DIFF
--- a/website/frontend/src/pages/HomePage.js
+++ b/website/frontend/src/pages/HomePage.js
@@ -10,12 +10,18 @@ import ApiSection from '../components/ApiSection/ApiSection';
 import AirQuality from '../components/AirQuality/AirQuality';
 import Partners from '../components/Partners';
 import HighlightsSection from '../components/HighlightsSection';
+import SEO from 'utils/seo';
 
 const HomePage = () => {
     useInitScrollTop();
     return(
         <Page>
             <div className="HomePage">
+                <SEO
+                    title="AirQo Africa"
+                    siteTitle="Clean Air for all African Cities"
+                    description="AirQo is Africa's leading air quality monitoring, research and analytics network. We use low cost technologies and AI to close the gaps in air quality data across the continent. Work with us to find data-driven solutions to your air quality challenges."
+                />
                 <Hero />
                 <Partners />
                 <AirQuality />

--- a/website/frontend/standaloneIndex.html
+++ b/website/frontend/standaloneIndex.html
@@ -5,18 +5,12 @@
     <meta charset="UTF-8" />
     <link rel="icon" href="assets/favicon.png">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="description"
-        content="AirQo is Africa's leading air quality monitoring, research and analytics network. We use low cost technologies and AI to close the gaps in air quality data across the continent. Work with us to find data-driven solutions to your air quality challenges" />
-    <meta property="og:title" content="AirQo Africa | Clean Air for all African Cities" />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://www.airqo.net" />
     <meta property="og:image" content="assets/opengraph.png" />
     <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="400" />
     <meta property="og:image:height" content="300" />
-    <meta property="og:description"
-        content="AirQo is Africa's leading air quality monitoring, research and analytics network. Collaborate with us as we use data to achieve clean air for all African cities." />
-    <title>AirQo</title>
 </head>
 
 <body>

--- a/website/frontend/templates/index.html
+++ b/website/frontend/templates/index.html
@@ -4,7 +4,6 @@
     <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <meta name="description" content="AirQo is Africa's leading air quality monitoring, research and analytics network. We use low cost technologies and AI to close the gaps in air quality data across the continent. Work with us to find data-driven solutions to your air quality challenges" />
         <link rel="icon" type="image/x-icon" href="{% static "favicon.ico" %}">
         <link rel="apple-touch-icon" href="{% static "favicon-96x96.png" %}" />
         <!--
@@ -13,16 +12,12 @@
         -->
         <link rel="shortcut icon" href="{% static "favicon.png" %}" />
         <link rel="apple-touch-icon" sizes="76x76" href="{% static "favicon-96x96.png" %}" />
-        <meta property="og:title" content="AirQo Africa | Clean Air for all African Cities" />
         <meta property="og:type" content="website" />
         <meta property="og:url" content="https://www.airqo.net" />
         <meta property="og:image" content="{% static "opengraph.png" %}" />
         <meta property="og:image:type" content="image/png" />
         <meta property="og:image:width" content="400" />
         <meta property="og:image:height" content="300" />
-        <meta property="og:description"
-        content="AirQo is Africa's leading air quality monitoring, research and analytics network. Collaborate with us as we use data to achieve clean air for all African cities." />
-        <title>AirQo</title>
     </head>
 
     <body>

--- a/website/frontend/utils/seo.js
+++ b/website/frontend/utils/seo.js
@@ -7,16 +7,11 @@ const SEO = ({ title, description, siteTitle }) => {
             <Helmet>
                 <title>{`${title} | ${siteTitle}`}</title>
                 <meta name="description" content={description}></meta>
-                <meta property="og:type" content="website" />
                 <meta name="og:title" content={`${title} | ${siteTitle}`} />
                 <meta name="og:site_name" content={siteTitle} />
                 <meta name="twitter:card" content="summary" />
                 <meta name="twitter:title" content={title} />
                 <meta name="twitter:description" content={description} />
-                <meta property="og:url" content="https://www.airqo.net" />
-                <meta property="og:image" content="assets/opengraph.png" />
-                <meta name="viewport" content="width=device-width, initial-scale=1" />
-                <meta name="theme-color" content="#000000" />
             </Helmet>
         </div>
     );


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)
- Removes duplicate metadata by eliminating title and descriptions from the django template and standalonehtml template.

#### Is this change ready to hit production in its current state?
- [x] Yes
- [ ] No

#### Status of maturity (all need to be checked before merging):

- [x] I consider this code done
- [ ] I've tested this locally
- [ ] This branch has been LGTM'ed by a reviewer

#### How should this be manually tested?
* git pull origin staging
* git checkout origin/ft-page-metadata
* npm install
* npm run standalone
* Open your browser console to view page metadata

#### Screenshots
![website_metadata](https://user-images.githubusercontent.com/46527380/185347127-a529337f-665d-47f9-bf3c-1d60348914d8.png)

