### PR TITLE
[Legacy platform] Missing device status fields resolved

### DIFF
--- a/netmanager/src/views/components/DataDisplay/DeviceView/DeviceDeployStatus.js
+++ b/netmanager/src/views/components/DataDisplay/DeviceView/DeviceDeployStatus.js
@@ -336,6 +336,12 @@ export default function DeviceDeployStatus({ deviceData, siteOptions }) {
     site_id: "",
   });
 
+  const deviceStatus = !deviceData.status
+    ? deviceData.isActive === true
+      ? "deployed"
+      : "not deployed"
+    : deviceData.status;
+
   useEffect(() => {
     if (recentFeed.longitude && recentFeed.latitude) {
       setLongitude(recentFeed.longitude);
@@ -566,11 +572,11 @@ export default function DeviceDeployStatus({ deviceData, siteOptions }) {
             </span>{" "}
             <span
               style={{
-                color: deviceData.status === "deployed" ? "green" : "red",
+                color: deviceStatus === "deployed" ? "green" : "red",
                 textTransform: "capitalize",
               }}
             >
-              {deviceData.status}
+              {deviceStatus}
             </span>
           </span>
           <Tooltip
@@ -836,7 +842,7 @@ export default function DeviceDeployStatus({ deviceData, siteOptions }) {
             <Tooltip
               arrow
               title={
-                deviceData.status === "deployed"
+                deviceStatus === "deployed"
                   ? "Device already deployed"
                   : "Run device test to activate"
               }

--- a/netmanager/src/views/components/DataDisplay/DeviceView/DeviceOverview/DeviceDetails.js
+++ b/netmanager/src/views/components/DataDisplay/DeviceView/DeviceOverview/DeviceDetails.js
@@ -23,6 +23,12 @@ const DeviceDetails = ({ deviceData }) => {
     });
   };
 
+  const deviceStatus = !deviceData.status
+    ? deviceData.isActive === true
+      ? "deployed"
+      : "not deployed"
+    : deviceData.status;
+
   useEffect(() => {
     if (!isEmpty(deviceData)) {
       decryptKey(deviceData.readKey, setReadKey);
@@ -50,11 +56,11 @@ const DeviceDetails = ({ deviceData }) => {
               <TableCell>
                 <span
                   style={{
-                    color: deviceData.status === "deployed" ? "green" : "red",
+                    color: deviceStatus === "deployed" ? "green" : "red",
                     textTransform: "capitalize",
                   }}
                 >
-                  {deviceData.status}
+                  {deviceStatus}
                 </span>
               </TableCell>
             </TableRow>

--- a/netmanager/src/views/components/DataDisplay/Devices.js
+++ b/netmanager/src/views/components/DataDisplay/Devices.js
@@ -158,20 +158,28 @@ const createDeviceColumns = (history, setDelState) => [
   {
     title: "Deployment status",
     field: "isActive",
-    render: (data) => (
-      <Cell
-        fieldValue={
-          <span
-            style={{
-              color: data.status === "deployed" ? "green" : "red",
-              textTransform: "capitalize",
-            }}
-          >
-            {data.status}
-          </span>
-        }
-      />
-    ),
+    render: (data) => {
+      const deviceStatus = !data.status
+        ? data.isActive === true
+          ? "deployed"
+          : "not deployed"
+        : data.status;
+
+      return (
+        <Cell
+          fieldValue={
+            <span
+              style={{
+                color: deviceStatus === "deployed" ? "green" : "red",
+                textTransform: "capitalize",
+              }}
+            >
+              {deviceStatus}
+            </span>
+          }
+        />
+      );
+    },
   },
 
   {


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)
- Missing deployment status on prod. This has been resolved.

#### Is this change ready to hit production in its current state?
- [x] Yes
- [ ] No

#### Status of maturity (all need to be checked before merging):

- [x] I consider this code done
- [ ] I've tested this locally
- [ ] This branch has been LGTM'ed by a reviewer

#### How should this be manually tested?
* git pull origin staging
* git checkout ft-device-deploy-statuses
* npm run stage

#### Screenshots
These devices had empty fields on staging;
![before-device-registry](https://user-images.githubusercontent.com/46527380/191951244-b7b0db5c-29e3-4b44-8d24-53613cbaaba8.png)

In the new updates;
![after-device-registry](https://user-images.githubusercontent.com/46527380/191951382-cb542fd6-1bb7-4393-8e03-4fd2539cfd9d.png)
