### PR TITLE
[Legacy platform] Ignores empty device keys

### DIFF
--- a/netmanager/src/views/components/DataDisplay/DeviceView/DeviceOverview/DeviceDetails.js
+++ b/netmanager/src/views/components/DataDisplay/DeviceView/DeviceOverview/DeviceDetails.js
@@ -31,8 +31,10 @@ const DeviceDetails = ({ deviceData }) => {
 
   useEffect(() => {
     if (!isEmpty(deviceData)) {
-      decryptKey(deviceData.readKey, setReadKey);
-      decryptKey(deviceData.writeKey, setWriteKey);
+      if (!isEmpty(deviceData.readKey) && !isEmpty(deviceData.writeKey)) {
+        decryptKey(deviceData.readKey, setReadKey);
+        decryptKey(deviceData.writeKey, setWriteKey);
+      }
     }
   }, []);
 


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)
- Issue: Devices without write/read keys were being passed to the decryptKey method which was throwing errors that can be seen in the device registry slack channel.
- Solution: Those devices are now ignored

![decrypt](https://user-images.githubusercontent.com/46527380/194578672-94941ca0-839a-40f8-8d5a-273a64902f8d.png)

#### Is this change ready to hit production in its current state?
- [x] Yes
- [ ] No

#### Status of maturity (all need to be checked before merging):

- [x] I consider this code done
- [ ] I've tested this locally
- [ ] This branch has been LGTM'ed by a reviewer

#### How should this be manually tested?
* git pull origin staging
* git checkout plat-empty-device-keys
* npm run stage
* Go to [aq_g1_1 device details page in your local environment](http://localhost:5000/device/aq_g1_1/overview). This will not throw an encryption error in the slack channel. Compare that with the corresponding staging link.

#### What are the relevant tickets?
- [AN-168](https://airqoteam.atlassian.net/browse/AN-168)