### PR TITLE
Deploy to production:manual workflow trigger

### DIFF
--- a/.github/workflows/deploy-frontends-to-production.yml
+++ b/.github/workflows/deploy-frontends-to-production.yml
@@ -1,15 +1,31 @@
-name: deploy-frontends-to-production
+name: deploy-to-production
 
 on:
-  pull_request:
-    branches:
-      - master
-    types:
-      - closed
+  workflow_dispatch:
+    inputs:
+      platform:
+        description: "Deploy [Legacy] Platform"
+        required: false
+        type: boolean
+      website:
+        description: "Deploy Website"
+        required: false
+        type: boolean
+      calibrate_app:
+        description: "Deploy Calibrate app"
+        required: false
+        type: boolean
+      next_platform:
+        description: "Deploy Analytics Platform"
+        required: false
+        type: boolean
+      docs:
+        description: "Deploy Docs"
+        required: false
+        type: boolean
 
 jobs:
   image-tag:
-    if: github.event.pull_request.merged == true
     name: create image tag
     runs-on: ubuntu-latest
     outputs:
@@ -25,69 +41,11 @@ jobs:
           echo "::set-output name=build_id::prod-${sha}-${timestamp}"
           echo "::set-output name=datetime::${datetime}"
 
-  check:
-    # this job will only run if the PR has been merged
-    if: github.event.pull_request.merged == true
-    name: check for changed frontends
-    outputs:
-      run_platform: ${{ steps.check_files.outputs.run_platform }} # platform
-      run_website: ${{ steps.check_files.outputs.run_website }} # website
-      run_calibrate_app: ${{ steps.check_files.outputs.run_calibrate_app }} # calibrate app
-      run_next_platform: ${{ steps.check_files.outputs.run_next_platform }} # next platform
-      run_docs: ${{ steps.check_files.outputs.run_docs }} # docs
-
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 2
-
-      - name: check modified frontends
-        id: check_files
-        run: |
-          echo "=============== list modified files ==============="
-          git diff --name-only HEAD^ HEAD
-
-          echo "========== check paths of modified files =========="
-          git diff --name-only HEAD^ HEAD > files.txt
-
-          echo "::set-output name=run_platform::false"
-          echo "::set-output name=run_website::false"
-          echo "::set-output name=run_calibrate_app::false"
-          echo "::set-output name=run_next_platform::false"   
-          echo "::set-output name=run_docs::false"   
-
-          while IFS= read -r file
-          do
-            echo $file
-            if [[ $file == netmanager/* ]]; then
-              echo "::set-output name=run_platform::true"
-            fi
-
-            if [[ $file == website/* ]]; then
-              echo "::set-output name=run_website::true"
-            fi
-
-            if [[ $file == calibrate/* ]]; then
-              echo "::set-output name=run_calibrate_app::true"
-            fi
-
-            if [[ $file == platform/* ]]; then
-              echo "::set-output name=run_next_platform::true"
-            fi
-
-            if [[ $file == docs/* ]]; then
-              echo "::set-output name=run_docs::true"
-            fi
-
-          done < files.txt
-
   ### deploy platform ###
   platform:
     name: build-push-deploy-netmanager
-    needs: [check, image-tag]
-    if: needs.check.outputs.run_platform == 'true'
+    needs: [image-tag]
+    if: inputs.platform == true
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -146,8 +104,8 @@ jobs:
   ### deploy website ###
   website:
     name: build-push-deploy-website
-    needs: [check, image-tag]
-    if: needs.check.outputs.run_website == 'true'
+    needs: [image-tag]
+    if: inputs.website == true
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -228,8 +186,8 @@ jobs:
   ### calibrate app ###
   calibrate-app:
     name: build-push-deploy-calibrate-app
-    needs: [check, image-tag]
-    if: needs.check.outputs.run_calibrate_app == 'true'
+    needs: [image-tag]
+    if: inputs.calibrate_app == true
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -288,8 +246,8 @@ jobs:
   ### deploy next platform ###
   next-platform:
     name: build-push-deploy-next-platform
-    needs: [check, image-tag]
-    if: needs.check.outputs.run_next_platform == 'true'
+    needs: [image-tag]
+    if: inputs.next_platform == true
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -339,8 +297,8 @@ jobs:
   ### deploy docs ###
   docs:
     name: build-push-deploy-docs
-    needs: [check, image-tag]
-    if: needs.check.outputs.run_docs == 'true'
+    needs: [image-tag]
+    if: inputs.docs == true
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/deploy-k8s-changes-to-production.yml
+++ b/.github/workflows/deploy-k8s-changes-to-production.yml
@@ -1,4 +1,4 @@
-name: deploy-k8s-manifest-updates-to-master
+name: deploy-k8s-manifest-updates-to-production
 
 on:
   pull_request:


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)
- Closes #884 
- Enables deployment of individual frontends to production

#### Is this change ready to hit production in its current state?
- [x] Yes
- [ ] No

#### Status of maturity (all need to be checked before merging):
- [x] I consider this code done
- [x] I've tested this locally
- [ ] This branch has been LGTM'ed by a reviewer

#### How should this be manually tested?
* Fork the repo
* Merge this PR into your fork's default branch
* Go to the Actions of your fork, > select the `deploy-to-production` workflow, > Click `trigger workflow`, > select the apps you wish to deploy via the checkboxes, click `Run workflow`.
* Only the selected apps will be deployed

#### What are the relevant tickets?
- [PLATOPS-28](https://airqoteam.atlassian.net/browse/PLATOPS-28?atlOrigin=eyJpIjoiZGU5OWEzM2JkZDExNGY5MThjYmMwNWQwZWE0OTcwYjkiLCJwIjoiaiJ9)
- #884

#### Screenshots (optional)
![image](https://user-images.githubusercontent.com/41787587/197553445-dab72227-d7f7-4575-8b51-6375d625625f.png)