### PR TITLE
fix: Fix GitHub workflows to upgrade deprecated set-output

### DIFF
--- a/.github/workflows/dart-code-metrics.yaml
+++ b/.github/workflows/dart-code-metrics.yaml
@@ -24,13 +24,13 @@ jobs:
           echo "========== check paths of modified files =========="
           git diff --name-only HEAD^ HEAD > files.txt
 
-          echo "::set-output name=run_app_metrics::false"
+          echo "run_app_metrics=false" >>$GITHUB_OUTPUT 
 
           while IFS= read -r file
           do
             echo $file
             if [[ $file == mobile/* ]]; then
-              echo "::set-output name=run_app_metrics::true"
+              echo "run_app_metrics=true" >>$GITHUB_OUTPUT
             fi
 
           done < files.txt

--- a/.github/workflows/deploy-frontend-to-preview-env.yml
+++ b/.github/workflows/deploy-frontend-to-preview-env.yml
@@ -42,33 +42,33 @@ jobs:
           echo "========== check paths of modified files =========="
           git diff --name-only HEAD^ HEAD > files.txt
 
-          echo "::set-output name=run_platform::false"
-          echo "::set-output name=run_calibrate_app::false"
-          echo "::set-output name=run_next_platform::false"
-          echo "::set-output name=run_docs::false"    
-          echo "::set-output name=run_website::false"    
+          echo "run_platform=false" >>$GITHUB_OUTPUT
+          echo "run_calibrate_app=false" >>$GITHUB_OUTPUT
+          echo "run_next_platform=false" >>$GITHUB_OUTPUT
+          echo "run_docs=false" >>$GITHUB_OUTPUT    
+          echo "run_website=false" >>$GITHUB_OUTPUT    
 
           while IFS= read -r file
           do
             echo $file
             if [[ $file == netmanager/* ]]; then
-              echo "::set-output name=run_platform::true"
+              echo "run_platform=true" >>$GITHUB_OUTPUT
             fi
 
             if [[ $file == calibrate/* ]]; then
-              echo "::set-output name=run_calibrate_app::true"
+              echo "run_calibrate_app=true" >>$GITHUB_OUTPUT
             fi
 
             if [[ $file == platform/* ]]; then
-              echo "::set-output name=run_next_platform::true"
+              echo "run_next_platform=true" >>$GITHUB_OUTPUT
             fi
 
             if [[ $file == docs/* ]]; then
-              echo "::set-output name=run_docs::true"
+              echo "run_docs=true" >>$GITHUB_OUTPUT
             fi
 
             if [[ $file == website/* ]]; then
-              echo "::set-output name=run_website::true"
+              echo "run_website=true" >>$GITHUB_OUTPUT
             fi
 
           done < files.txt
@@ -143,7 +143,7 @@ jobs:
             --format='value(status.url)' \
             --platform managed \
             --region ${{ secrets.REGION }})
-          echo "::set-output name=url::${service_url}"
+          echo "url=${service_url}" >>$GITHUB_OUTPUT
 
   netmanager-pr-comment:
     name: netmanager-preview-link-comment
@@ -231,7 +231,7 @@ jobs:
             --format='value(status.url)' \
             --platform managed \
             --region ${{ secrets.REGION }})
-          echo "::set-output name=url::${service_url}"
+          echo "url=${service_url}" >>$GITHUB_OUTPUT
 
   calibrate-app-pr-comment:
     name: calibrate-app-preview-link-comment
@@ -308,7 +308,7 @@ jobs:
             --format='value(status.url)' \
             --platform managed \
             --region ${{ secrets.REGION }})
-          echo "::set-output name=url::${service_url}"
+          echo "url=${service_url}" >>$GITHUB_OUTPUT
 
   next-platform-pr-comment:
     name: next-platform-preview-link-comment
@@ -382,7 +382,7 @@ jobs:
             --format='value(status.url)' \
             --platform managed \
             --region ${{ secrets.REGION }})
-          echo "::set-output name=url::${service_url}"
+          echo "url=${service_url}" >>$GITHUB_OUTPUT
 
   docs-pr-comment:
     name: docs-preview-link-comment

--- a/.github/workflows/deploy-frontends-to-production.yml
+++ b/.github/workflows/deploy-frontends-to-production.yml
@@ -38,8 +38,8 @@ jobs:
           sha=${GITHUB_SHA::8}
           timestamp=$(date +%s)
           datetime=$(date)
-          echo "::set-output name=build_id::prod-${sha}-${timestamp}"
-          echo "::set-output name=datetime::${datetime}"
+          echo "build_id=prod-${sha}-${timestamp}" >>$GITHUB_OUTPUT
+          echo "datetime=${datetime}" >>$GITHUB_OUTPUT
 
   ### deploy platform ###
   platform:

--- a/.github/workflows/deploy-frontends-to-staging.yml
+++ b/.github/workflows/deploy-frontends-to-staging.yml
@@ -22,8 +22,8 @@ jobs:
           sha=${GITHUB_SHA::8}
           timestamp=$(date +%s)
           datetime=$(date)
-          echo "::set-output name=build_id::stage-${sha}-${timestamp}"
-          echo "::set-output name=datetime::${datetime}"
+          echo "build_id=stage-${sha}-${timestamp}" >>$GITHUB_OUTPUT
+          echo "datetime=${datetime}" >>$GITHUB_OUTPUT
 
   check:
     # this job will only run if the PR has been merged
@@ -52,33 +52,33 @@ jobs:
           echo "========== check paths of modified files =========="
           git diff --name-only HEAD^ HEAD > files.txt
 
-          echo "::set-output name=run_platform::false"
-          echo "::set-output name=run_website::false" 
-          echo "::set-output name=run_calibrate_app::false"
-          echo "::set-output name=run_next_platform::false"  
-          echo "::set-output name=run_docs::false"  
+          echo "run_platform=false" >>$GITHUB_OUTPUT
+          echo "run_website=false" >>$GITHUB_OUTPUT
+          echo "run_calibrate_app=false" >>$GITHUB_OUTPUT
+          echo "run_next_platform=false" >>$GITHUB_OUTPUT
+          echo "run_docs=false" >>$GITHUB_OUTPUT
 
           while IFS= read -r file
           do
             echo $file
             if [[ $file == netmanager/* ]]; then
-              echo "::set-output name=run_platform::true"
+              echo "run_platform=true" >>$GITHUB_OUTPUT
             fi
 
             if [[ $file == website/* ]]; then
-              echo "::set-output name=run_website::true"
+              echo "run_website=true" >>$GITHUB_OUTPUT
             fi
 
             if [[ $file == calibrate/* ]]; then
-              echo "::set-output name=run_calibrate_app::true"
+              echo "run_calibrate_app=true" >>$GITHUB_OUTPUT
             fi
 
             if [[ $file == platform/* ]]; then
-              echo "::set-output name=run_next_platform::true"
+              echo "run_next_platform=true" >>$GITHUB_OUTPUT
             fi
 
             if [[ $file == docs/* ]]; then
-              echo "::set-output name=run_docs::true"
+              echo "run_docs=true" >>$GITHUB_OUTPUT
             fi
 
           done < files.txt

--- a/.github/workflows/deploy-k8s-changes-to-production.yml
+++ b/.github/workflows/deploy-k8s-changes-to-production.yml
@@ -33,36 +33,36 @@ jobs:
           echo "========== check paths of modified files =========="
           git diff --name-only HEAD^ HEAD > files.txt
 
-          echo "::set-output name=run_platform::false"
-          echo "::set-output name=run_calibrate_app::false"  
-          echo "::set-output name=run_docs::false"  
+          echo "run_platform=false" >>$GITHUB_OUTPUT
+          echo "run_calibrate_app=false" >>$GITHUB_OUTPUT
+          echo "run_docs=false" >>$GITHUB_OUTPUT
 
           while IFS= read -r file
           do
             echo $file
 
             if [[ $file == k8s/platform/* ]]; then
-              echo "::set-output name=run_platform::true"
+              echo "run_platform=true" >>$GITHUB_OUTPUT
             fi
 
             if [[ $file == platform/* ]]; then
-              echo "::set-output name=run_platform::false"
+              echo "run_platform=false" >>$GITHUB_OUTPUT
             fi
 
             if [[ $file == k8s/calibrate/* ]]; then
-              echo "::set-output name=run_calibrate_app::true"
+              echo "run_calibrate_app=true" >>$GITHUB_OUTPUT
             fi
 
             if [[ $file == calibrate/* ]]; then
-              echo "::set-output name=run_calibrate_app::false"
+              echo "run_calibrate_app=false" >>$GITHUB_OUTPUT
             fi
 
             if [[ $file == k8s/docs/* ]]; then
-              echo "::set-output name=run_docs::true"
+              echo "run_docs=true" >>$GITHUB_OUTPUT
             fi
 
             if [[ $file == docs/* ]]; then
-              echo "::set-output name=run_docs::false"
+              echo "run_docs=false" >>$GITHUB_OUTPUT
             fi
 
           done < files.txt

--- a/.github/workflows/deploy-k8s-changes-to-staging.yml
+++ b/.github/workflows/deploy-k8s-changes-to-staging.yml
@@ -33,36 +33,36 @@ jobs:
           echo "========== check paths of modified files =========="
           git diff --name-only HEAD^ HEAD > files.txt
 
-          echo "::set-output name=run_platform::false"
-          echo "::set-output name=run_calibrate_app::false" 
-          echo "::set-output name=run_docs::false"  
+          echo "run_platform=false" >>$GITHUB_OUTPUT
+          echo "run_calibrate_app=false" >>$GITHUB_OUTPUT
+          echo "run_docs=false" >>$GITHUB_OUTPUT
 
           while IFS= read -r file
           do
             echo $file
 
             if [[ $file == k8s/platform/* ]]; then
-              echo "::set-output name=run_platform::true"
+              echo "run_platform=true" >>$GITHUB_OUTPUT
             fi
 
             if [[ $file == platform/* ]]; then
-              echo "::set-output name=run_platform::false"
+              echo "run_platform=false" >>$GITHUB_OUTPUT
             fi
 
             if [[ $file == k8s/calibrate/* ]]; then
-              echo "::set-output name=run_calibrate_app::true"
+              echo "run_calibrate_app=true" >>$GITHUB_OUTPUT
             fi
 
             if [[ $file == calibrate/* ]]; then
-              echo "::set-output name=run_calibrate_app::false"
+              echo "run_calibrate_app=false" >>$GITHUB_OUTPUT
             fi
 
             if [[ $file == k8s/docs/* ]]; then
-              echo "::set-output name=run_docs::true"
+              echo "run_docs=true" >>$GITHUB_OUTPUT
             fi
 
             if [[ $file == docs/* ]]; then
-              echo "::set-output name=run_docs::false"
+              echo "run_docs=false" >>$GITHUB_OUTPUT
             fi
 
           done < files.txt

--- a/.github/workflows/remove-deploy-previews.yml
+++ b/.github/workflows/remove-deploy-previews.yml
@@ -43,28 +43,28 @@ jobs:
           echo "========== check paths of modified files =========="
           git diff --name-only HEAD^ HEAD > files.txt
 
-          echo "::set-output name=remove_platform_preview::false"  
-          echo "::set-output name=remove_calibrate_app_preview::false"
-          echo "::set-output name=remove_next_platform::false"  
-          echo "::set-output name=remove_docs::false"   
+          echo "remove_platform_preview=false" >>$GITHUB_OUTPUT
+          echo "remove_calibrate_app_preview=false" >>$GITHUB_OUTPUT
+          echo "remove_next_platform=false" >>$GITHUB_OUTPUT
+          echo "remove_docs=false" >>$GITHUB_OUTPUT
 
           while IFS= read -r file
           do
             echo $file
             if [[ $file == netmanager/* ]]; then
-              echo "::set-output name=remove_platform_preview::true"
+              echo "remove_platform_preview=true" >>$GITHUB_OUTPUT
             fi
 
             if [[ $file == calibrate/* ]]; then
-              echo "::set-output name=remove_calibrate_app_preview::true"  
+              echo "remove_calibrate_app_preview=true" >>$GITHUB_OUTPUT
             fi
 
             if [[ $file == platform/* ]]; then
-              echo "::set-output name=remove_next_platform::true"
+              echo "remove_next_platform=true" >>$GITHUB_OUTPUT
             fi
 
             if [[ $file == docs/* ]]; then
-              echo "::set-output name=remove_docs::true"
+              echo "remove_docs=true" >>$GITHUB_OUTPUT
             fi
 
           done < files.txt

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -27,12 +27,12 @@ jobs:
           echo "========== check paths of modified files =========="
           git diff --name-only HEAD^ HEAD > files.txt
 
-          echo "::set-output name=run_next_platform::false"  
+          echo "run_next_platform=false" >>$GITHUB_OUTPUT
 
           while IFS= read -r file
           do
             if [[ $file == platform/* ]]; then
-              echo "::set-output name=run_next_platform::true"
+              echo "run_next_platform=true" >>$GITHUB_OUTPUT
             fi
 
           done < files.txt


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)
- Upgraded GitHub workflows from deprecated `set-output` to `"{name}={value}" >>$GITHUB_OUTPUT`
- Closes #885

#### Is this change ready to hit production in its current state?
- [x] Yes
- [ ] No

#### Status of maturity (all need to be checked before merging):

- [x] I consider this code done
- [x] I've tested this locally
- [x] This branch has been LGTM'ed by a reviewer