### PR TITLE
Refactored service name and job name while removing netmanager preview

### DIFF
--- a/.github/workflows/remove-deploy-previews.yml
+++ b/.github/workflows/remove-deploy-previews.yml
@@ -69,9 +69,9 @@ jobs:
 
           done < files.txt
 
-  ### remove platform deploy preview ###
-  remove-platform-preview:
-    name: remove-platform-preview
+  ### remove netmanager deploy preview ###
+  remove-netmanager-preview:
+    name: remove-netmanager-preview
     needs: [check, branch-name]
     if: needs.check.outputs.remove_platform_preview == 'true'
     runs-on: ubuntu-latest
@@ -86,7 +86,7 @@ jobs:
 
       - name: Delete PR deploy preview
         run: |-
-          gcloud run services delete ${{ needs.branch-name.outputs.lowercase }}-platform-preview \
+          gcloud run services delete ${{ needs.branch-name.outputs.lowercase }}-netmanager-preview \
             --region=${{ secrets.REGION }} \
             --quiet
 


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)
- Refactored to job name and service name to netmanager-preview from platform-preview to match the created service. Closes #905 

#### Is this change ready to hit production in its current state?
- [x] Yes
- [ ] No

#### Status of maturity (all need to be checked before merging):

- [x] I consider this code done
- [ ] I've tested this locally
- [x] This branch has been LGTM'ed by a reviewer

#### How should this be manually tested?
* Once a PR related to netmanager is merged, it should automatically delete the service created for preview

#### What are the relevant tickets?
- #905

#### Screenshots (optional)