### PR TITLE
update contribution guide to notify contributors they dont need to wait to be assigned issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,8 @@ If you spot a problem with any of our products, check the [existing issues](http
 
 Scan through the [existing issues](https://github.com/airqo-platform/AirQo-frontend/issues) to find one that interests you. You can narrow down the search using `labels` as filters. If you find an issue to work on, you are welcome to open a PR with a fix.
 
+Note that you don't need to be assigned to this issue to work on it. Simply raise a PR that address it and add Closes `#issue-number` in the PR description to automatically link your PR to the issue, or mention the PR in this issue.
+
 ### Make Changes
 
 #### Make changes locally

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ If you spot a problem with any of our products, check the [existing issues](http
 
 Scan through the [existing issues](https://github.com/airqo-platform/AirQo-frontend/issues) to find one that interests you. You can narrow down the search using `labels` as filters. If you find an issue to work on, you are welcome to open a PR with a fix.
 
-Note that you don't need to be assigned to this issue to work on it. Simply raise a PR that address it and add Closes `#issue-number` in the PR description to automatically link your PR to the issue, or mention the PR in this issue.
+**Note** that you don't need to be assigned to this issue to work on it. Simply raise a PR that address it and add `closes #issue-number` in the PR description to [automatically link your PR to the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
 
 ### Make Changes
 


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)
- This pr closes #913 

#### Is this change ready to hit production in its current state?
- [x] Yes
- [ ] No

#### Status of maturity (all need to be checked before merging):

- [x] I consider this code done
- [x] I've tested this locally
- [ ] This branch has been LGTM'ed by a reviewer

#### How should this be manually tested?
* Navigate to `/CONTRIBUTING.md` and there should be a new paragraph at line 36
**Note that you don't need to be assigned to this issue to work on it. Simply raise a PR that address it and add Closes `#issue-number` in the PR description to automatically link your PR to the issue, or mention the PR in this issue.**


#### What are the relevant tickets?
- [#913](#913)

#### Screenshots (optional)
![Screenshot from 2022-11-10 07-26-40](https://user-images.githubusercontent.com/65954740/201000656-b528ac88-2748-4430-97a5-37df7a445f9c.png)
