### PR TITLE
[CI/942]: Update actions checkout version from v2 to v3

### DIFF
--- a/.github/workflows/deploy-frontend-pr-previews.yml
+++ b/.github/workflows/deploy-frontend-pr-previews.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 2
 
@@ -83,7 +83,7 @@ jobs:
       url: ${{ steps.preview-url.outputs.url }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Google login
         uses: google-github-actions/auth@v0
@@ -97,9 +97,9 @@ jobs:
         run: gcloud secrets versions access latest --secret="sta-env-netmanager" > netmanager/.env
 
       - name: npm Install and Build
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: "12"
+          node-version: "16"
       - run: |
           cd netmanager/
           npm install
@@ -182,7 +182,7 @@ jobs:
       url: ${{ steps.preview-url.outputs.url }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Google login
         uses: google-github-actions/auth@v0
@@ -196,9 +196,9 @@ jobs:
         run: gcloud secrets versions access latest --secret="sta-env-calibrate-app" > calibrate/.env
 
       - name: npm Install and Build
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: "12"
+          node-version: "16"
       - run: |
           cd calibrate/
           npm install
@@ -281,7 +281,7 @@ jobs:
       url: ${{ steps.preview-url.outputs.url }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Google login
         uses: google-github-actions/auth@v0
@@ -369,7 +369,7 @@ jobs:
       url: ${{ steps.preview-url.outputs.url }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Google login
         uses: google-github-actions/auth@v0
@@ -452,7 +452,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Login to GCR
         uses: docker/login-action@v1

--- a/.github/workflows/deploy-frontend-pr-previews.yml
+++ b/.github/workflows/deploy-frontend-pr-previews.yml
@@ -97,9 +97,9 @@ jobs:
         run: gcloud secrets versions access latest --secret="sta-env-netmanager" > netmanager/.env
 
       - name: npm Install and Build
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v2
         with:
-          node-version: "16"
+          node-version: "12"
       - run: |
           cd netmanager/
           npm install
@@ -196,9 +196,9 @@ jobs:
         run: gcloud secrets versions access latest --secret="sta-env-calibrate-app" > calibrate/.env
 
       - name: npm Install and Build
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v2
         with:
-          node-version: "16"
+          node-version: "12"
       - run: |
           cd calibrate/
           npm install

--- a/.github/workflows/deploy-frontends-to-production.yml
+++ b/.github/workflows/deploy-frontends-to-production.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Google login
         uses: google-github-actions/auth@v0
@@ -63,9 +63,9 @@ jobs:
         run: gcloud secrets versions access latest --secret="prod-env-netmanager" > netmanager/.env
 
       - name: NPM Setup and Build
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: "12"
+          node-version: "16"
       - run: |
           cd netmanager/
           npm install
@@ -120,7 +120,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Login to GCR
         uses: docker/login-action@v1
@@ -202,7 +202,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Google login
         uses: google-github-actions/auth@v0
@@ -216,9 +216,9 @@ jobs:
         run: gcloud secrets versions access latest --secret="prod-env-calibrate-app" > calibrate/.env
 
       - name: NPM Setup and Build
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: "12"
+          node-version: "16"
       - run: |
           cd calibrate/
           npm install
@@ -272,7 +272,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Google login
         uses: google-github-actions/auth@v0
@@ -333,7 +333,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Login to GCR
         uses: docker/login-action@v1

--- a/.github/workflows/deploy-frontends-to-production.yml
+++ b/.github/workflows/deploy-frontends-to-production.yml
@@ -63,9 +63,9 @@ jobs:
         run: gcloud secrets versions access latest --secret="prod-env-netmanager" > netmanager/.env
 
       - name: NPM Setup and Build
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v2
         with:
-          node-version: "16"
+          node-version: "12"
       - run: |
           cd netmanager/
           npm install
@@ -216,9 +216,9 @@ jobs:
         run: gcloud secrets versions access latest --secret="prod-env-calibrate-app" > calibrate/.env
 
       - name: NPM Setup and Build
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v2
         with:
-          node-version: "16"
+          node-version: "12"
       - run: |
           cd calibrate/
           npm install

--- a/.github/workflows/deploy-frontends-to-staging.yml
+++ b/.github/workflows/deploy-frontends-to-staging.yml
@@ -105,9 +105,9 @@ jobs:
         run: gcloud secrets versions access latest --secret="sta-env-netmanager" > netmanager/.env
 
       - name: NPM Setup and Build
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v2
         with:
-          node-version: "16"
+          node-version: "12"
       - run: |
           cd netmanager/
           npm install
@@ -255,9 +255,9 @@ jobs:
         run: gcloud secrets versions access latest --secret="sta-env-calibrate-app" > calibrate/.env
 
       - name: NPM Setup and Build
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v2
         with:
-          node-version: "16"
+          node-version: "12"
       - run: |
           cd calibrate/
           npm install

--- a/.github/workflows/deploy-frontends-to-staging.yml
+++ b/.github/workflows/deploy-frontends-to-staging.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 2
 
@@ -91,7 +91,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Google login
         uses: google-github-actions/auth@v0
@@ -105,9 +105,9 @@ jobs:
         run: gcloud secrets versions access latest --secret="sta-env-netmanager" > netmanager/.env
 
       - name: NPM Setup and Build
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: "12"
+          node-version: "16"
       - run: |
           cd netmanager/
           npm install
@@ -162,7 +162,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Login to GCR
         uses: docker/login-action@v1
@@ -241,7 +241,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Google login
         uses: google-github-actions/auth@v0
@@ -255,9 +255,9 @@ jobs:
         run: gcloud secrets versions access latest --secret="sta-env-calibrate-app" > calibrate/.env
 
       - name: NPM Setup and Build
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: "12"
+          node-version: "16"
       - run: |
           cd calibrate/
           npm install
@@ -311,7 +311,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Google login
         uses: google-github-actions/auth@v0
@@ -372,7 +372,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Login to GCR
         uses: docker/login-action@v1

--- a/.github/workflows/deploy-k8s-changes-to-production.yml
+++ b/.github/workflows/deploy-k8s-changes-to-production.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 2
 
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Login to K8S
         uses: azure/k8s-set-context@v1
@@ -94,7 +94,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Login to K8S
         uses: azure/k8s-set-context@v1

--- a/.github/workflows/deploy-k8s-changes-to-staging.yml
+++ b/.github/workflows/deploy-k8s-changes-to-staging.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 2
 
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Login to K8S
         uses: azure/k8s-set-context@v1
@@ -94,7 +94,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Login to K8S
         uses: azure/k8s-set-context@v1
@@ -113,7 +113,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Login to K8S
         uses: azure/k8s-set-context@v1

--- a/.github/workflows/remove-deploy-previews.yml
+++ b/.github/workflows/remove-deploy-previews.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 2
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 2
 
@@ -46,7 +46,7 @@ jobs:
     container: cypress/browsers:node16.14.0-chrome99-ff97
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Google login
         uses: google-github-actions/auth@v0


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

- Updated actions checkout version from `v2` to use `v3` following `Nodejs 12 actions are deprecated` warning from GitHub.
- Updated `setup-node` to `v3` with node version `16`

#### Status of maturity (all need to be checked before merging):

- [ ] I've tested this locally
- [x] I consider this code done
- [x] This change ready to hit production in its current state
- [x] The title of the PR states what changed and the related issues number (used for the release note).
- [x] I've included the issue number in the "Closes #ISSUE-NUMBER" part of the "[What are the relevant tickets?](#what-are-the-relevant-tickets)" section to [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [ ] I've updated corresponding documentation for the changes in this PR.
- [ ] I have written unit and/or e2e tests for my change(s).

#### How should this be manually tested?

- Static code analysis

#### What are the relevant tickets?

- Closes #942

#### Screenshots (optional)
