### PR TITLE
[Mobile App]Fix Color of text on notifications page

### DIFF
--- a/mobile/lib/screens/notification/notification_widgets.dart
+++ b/mobile/lib/screens/notification/notification_widgets.dart
@@ -264,12 +264,18 @@ class EmptyNotifications extends StatelessWidget {
             Text(
               'No notifications',
               textAlign: TextAlign.center,
-              style: CustomTextStyle.headline7(context),
+              style: CustomTextStyle.headline7(context)?.copyWith(
+                fontSize: 21,
+                fontWeight: FontWeight.w600,
+              ),
             ),
             const SizedBox(height: 23),
             Text(
               textAlign: TextAlign.center,
-              style: Theme.of(context).textTheme.bodyText2,
+              style: Theme.of(context).textTheme.bodyText2?.copyWith(
+                    fontSize: 15.0,
+                    color: CustomColors.emptyNotificationScreenTextColor,
+                  ),
               'Here you’ll find all updates on our Air Quality network.',
             ),
             const Spacer(),

--- a/mobile/lib/themes/colors.dart
+++ b/mobile/lib/themes/colors.dart
@@ -237,4 +237,6 @@ class CustomColors {
   static Color get aqiMaroon => const Color(0xffA51F3F);
 
   static Color get aqiMaroonTextColor => const Color(0xffDBA5B2);
+
+  static Color get emptyNotificationScreenTextColor => const Color(0xff6D7175);
 }


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

- Fix color of text on notifications page (empty state) to reflect the designs on [figma](https://www.figma.com/file/agN9GOkAbhXfGDEXYCKwBu/Mobile-App?node-id=65%3A11883&t=0rF301BFWYlsZAO4-0).

#### Status of maturity (all need to be checked before merging):

- [x] I've tested this locally
- [x] I consider this code done
- [x] This change ready to hit production in its current state
- [x] The title of the PR states what changed and the related issues number (used for the release note).
- [ ] I've included issue number in the "Closes #ISSUE-NUMBER" part of the "[What are the relevant tickets?](#what-are-the-relevant-tickets)" section to [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [ ] I've updated corresponding documentation for the changes in this PR.
- [ ] I have written unit and/or e2e tests for my change(s).

#### How should this be manually tested?
- Checkout the branch
- Run the app and proceed to the notifications page.
- The content should reflect that on [figma.](https://www.figma.com/file/agN9GOkAbhXfGDEXYCKwBu/Mobile-App?node-id=65%3A11883&t=0rF301BFWYlsZAO4-0)

#### What are the relevant tickets?

- Closes #<enter issue number here>
- [Jira_card_number]() (If exists)

#### Screenshots (optional)
<img src = "https://user-images.githubusercontent.com/86492979/201990862-d6c86523-2b66-4040-a53a-68f94e556277.jpg" height =600 width=300>

