### PR TITLE
Allows admin to send user feedback on reject data access

### DIFF
--- a/netmanager/src/config/urls/authService.js
+++ b/netmanager/src/config/urls/authService.js
@@ -1,4 +1,4 @@
-import { stripTrailingSlash } from "../utils";
+import { stripTrailingSlash } from '../utils';
 
 const BASE_AUTH_SERVICE_URL = stripTrailingSlash(
   process.env.REACT_APP_BASE_AUTH_SERVICE_URL || process.env.REACT_APP_BASE_URL
@@ -35,3 +35,5 @@ export const CHART_DEFAULTS_URI = `${BASE_AUTH_SERVICE_URL}/users/defaults`;
 export const CONFIRM_CANDIDATE_URI = `${BASE_AUTH_SERVICE_URL}/users/candidates/confirm`;
 
 export const DELETE_CANDIDATE_URI = `${BASE_AUTH_SERVICE_URL}/users/candidates`;
+
+export const USER_FEEDBACK_URI = `${BASE_AUTH_SERVICE_URL}/users/feedback`;

--- a/netmanager/src/views/apis/authService.js
+++ b/netmanager/src/views/apis/authService.js
@@ -1,4 +1,4 @@
-import axios from "axios";
+import axios from 'axios';
 import {
   CONFIRM_CANDIDATE_URI,
   UPDATE_PWD_IN_URI,
@@ -8,12 +8,13 @@ import {
   REGISTER_USER_URI,
   CHART_DEFAULTS_URI,
   CANDIDATES_URI,
-} from "config/urls/authService";
+  USER_FEEDBACK_URI
+} from 'config/urls/authService';
 
 export const updateUserPasswordApi = async (userId, tenant, userData) => {
   return await axios
     .put(UPDATE_PWD_IN_URI, userData, {
-      params: { tenant, id: userId },
+      params: { tenant, id: userId }
     })
     .then((response) => response.data);
 };
@@ -32,9 +33,7 @@ export const forgotPasswordResetApi = async (userData) => {
 };
 
 export const confirmCandidateApi = async (candidateData) => {
-  return await axios
-    .post(CONFIRM_CANDIDATE_URI, candidateData)
-    .then((response) => response.data);
+  return await axios.post(CONFIRM_CANDIDATE_URI, candidateData).then((response) => response.data);
 };
 
 export const updateCandidateApi = async (id, newData) => {
@@ -44,9 +43,7 @@ export const updateCandidateApi = async (id, newData) => {
 };
 
 export const deleteUserApi = async (id) => {
-  return await axios
-    .delete(GET_USERS_URI, { params: { id } })
-    .then((response) => response.data);
+  return await axios.delete(GET_USERS_URI, { params: { id } }).then((response) => response.data);
 };
 
 export const deleteCandidateApi = async (id) => {
@@ -56,32 +53,25 @@ export const deleteCandidateApi = async (id) => {
 };
 
 export const addUserApi = async (userData) => {
-  return await axios
-    .post(REGISTER_USER_URI, userData)
-    .then((response) => response.data);
+  return await axios.post(REGISTER_USER_URI, userData).then((response) => response.data);
 };
 
 export const getUserChartDefaultsApi = async (userID, airqloudID) => {
   return await axios
     .get(CHART_DEFAULTS_URI, {
-      params: { user: userID, airqloud: airqloudID },
+      params: { user: userID, airqloud: airqloudID }
     })
     .then((response) => response.data);
 };
 
 export const createUserChartDefaultsApi = async (defaultsData) => {
-  return await axios
-    .post(CHART_DEFAULTS_URI, defaultsData)
-    .then((response) => response.data);
+  return await axios.post(CHART_DEFAULTS_URI, defaultsData).then((response) => response.data);
 };
 
-export const updateUserChartDefaultsApi = async (
-  chartDefaultID,
-  defaultsData
-) => {
+export const updateUserChartDefaultsApi = async (chartDefaultID, defaultsData) => {
   return await axios
     .put(CHART_DEFAULTS_URI, defaultsData, {
-      params: { id: chartDefaultID },
+      params: { id: chartDefaultID }
     })
     .then((response) => response.data);
 };
@@ -90,4 +80,8 @@ export const deleteUserChartDefaultsApi = async (chartDefaultID) => {
   return await axios
     .delete(CHART_DEFAULTS_URI, { params: { id: chartDefaultID } })
     .then((response) => response.data);
+};
+
+export const sendUserFeedbackApi = async (feedbackData) => {
+  return await axios.post(USER_FEEDBACK_URI, feedbackData).then((response) => response.data);
 };


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

- When admin clicks reject, popup with text input is opened for the admin to enter reason of rejecting request.

#### Status of maturity (all need to be checked before merging):

- [x] I've tested this locally
- [x] I consider this code done
- [x] This change ready to hit production in its current state
- [x] The title of the PR states what changed and the related issues number (used for the release note).
- [ ] I've included issue number in the "Closes #ISSUE-NUMBER" part of the "[What are the relevant tickets?](#what-are-the-relevant-tickets)" section to [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [ ] I've updated corresponding documentation for the changes in this PR.
- [ ] I have written unit and/or e2e tests for my change(s).

#### How should this be manually tested?

- git pull origin staging
- git checkout ft-data-access-feedback
- npm run stage
- Visit the candidates' table, its best you reject your own past request which has your email so you are able to receive the feedback in your mailbox

#### What are the relevant tickets?

- [AN-234](https://airqoteam.atlassian.net/browse/AN-234?atlOrigin=eyJpIjoiNTZjYTk0OGQ0YTZiNGVlZTk0ZDRhODEwZWNiMzU3MmMiLCJwIjoiaiJ9)

#### Screenshots
![feedback](https://user-images.githubusercontent.com/46527380/203548925-2f99a0f3-1cda-4ef7-ac46-8cbcdb02fc36.png)

![feedback](https://user-images.githubusercontent.com/46527380/203549989-568061a3-946b-48e9-a67b-b10453b19720.png)

