### PR TITLE
Restrict production workflow actors

### DIFF
--- a/.github/workflows/deploy-frontends-to-production.yml
+++ b/.github/workflows/deploy-frontends-to-production.yml
@@ -35,6 +35,8 @@ jobs:
     outputs:
       build_id: ${{ steps.prep.outputs.build_id }} # build id
       datetime: ${{ steps.prep.outputs.datetime }} # build date
+    # This job will only run if triggered by Baalmart
+    if: github.triggering_actor == 'Baalmart'
     steps:
       - name: generate build ID
         id: prep


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)
- Restrict deploy to production workflow run to only @Baalmart

#### Status of maturity (all need to be checked before merging):

- [x] I've tested this locally
- [x] I consider this code done
- [x] This change ready to hit production in its current state
- [x] The title of the PR states what changed and the related issues number (used for the release note).
- [ ] I've included issue number in the "Closes #ISSUE-NUMBER" part of the "[What are the relevant tickets?](#what-are-the-relevant-tickets)" section to [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [ ] I've updated corresponding documentation for the changes in this PR.
- [ ] I have written unit and/or e2e tests for my change(s).

#### How should this be manually tested?
- Static code analysis

#### What are the relevant tickets?
- n/a

#### Screenshots (optional)
- When a non-permitted user runs the workflow
  ![image](https://user-images.githubusercontent.com/41787587/206432377-1f3a0f98-d55a-436f-bb2c-8718c152306a.png)