### PR TITLE
[Website] Get Involved Modal Responsiveness

### DIFF
--- a/website/frontend/styles/GetInvolvedModal.scss
+++ b/website/frontend/styles/GetInvolvedModal.scss
@@ -1,10 +1,21 @@
 @import "lib/variables";
+@import "lib/colors";
 
 .GetInvolvedModalWrapper {
-  display: flex;
-  width: 100vw;
-  height: 100vh;
-  outline: none;
+  z-index: 999;
+  overflow-x: hidden;
+
+  align-items: center;
+  justify-content: center;
+
+  position: fixed;
+  top: 0;
+  left: 0;
+  margin: 0 auto;
+  height: 100%;
+  width: 100%;
+  background-color: rgba(12, 30, 68, 0.39);
+  transition: opacity 250ms 750ms ease;
 }
 
 .tab-active {
@@ -65,7 +76,6 @@
   max-height: 900px;
   margin: auto;
   outline: none;
-  overflow-y: scroll;
 
   .banner {
     display: flex;
@@ -122,6 +132,25 @@
     height: 100%;
     background: white;
     padding: 30px;
+    overflow-y: scroll;
+
+    ::-webkit-scrollbar{
+        width:10px;
+    }
+    ::-webkit-scrollbar-button{
+        display:none;
+    }
+    ::-webkit-scrollbar-track{
+        background: $aq-white-3;
+        opacity:0.2;
+    }
+    ::-webkit-scrollbar-thumb{
+        background: $aq-blue-0;
+        border-radius: 10px;
+    }
+    ::-webkit-scrollbar-corner{
+        border-radius: 10px;
+    }
 
     >span {
       display: flex;


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

- Features responsiveness of get involved modal

#### Status of maturity (all need to be checked before merging):

- [x] I've tested this locally
- [x] I consider this code done
- [x] This change ready to hit production in its current state
- [x] The title of the PR states what changed and the related issues number (used for the release note).
- [x] I've included issue number in the "Closes #ISSUE-NUMBER" part of the "[What are the relevant tickets?](#what-are-the-relevant-tickets)" section to [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

#### How should this be manually tested?

- View get involved modal from deploy preview. Change view ports

#### What are the relevant tickets?

- [WEB-346]

#### Screenshots
![image](https://user-images.githubusercontent.com/53012890/207576687-d68cb958-3410-44ef-a100-c2f89c6b6642.png)

