### PR TITLE
Ft docs enhancement

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,11 @@
 # AirQo Documentation
 
 With this reference, you can explore and interact with all publicly availed AirQo resources.
+
+Jump straight to your desired documentation
+
+- [API](api/)
+- [Calibration](calibration/)
+- [Hardware](hardware/)
+- [Mobile App](mobile_app/)
+- [Platform](platform/)

--- a/docs/calibration/README.md
+++ b/docs/calibration/README.md
@@ -6,7 +6,7 @@ Low-cost air quality monitors are relied on to increase the geographical coverag
 
 However, low-cost sensors require field calibration to improve their performance. In this document, we provide users with a guide on how to calibrate low-cost sensors based on the AirQo experience and help the reader appreciate the various factors involved in field calibration.
 
-We also introduce AirQualibrate, a tool that enables users without access to reference grade monitors or technical expertise to develop a calibration model to calibrate data (PM<small>2.5</small> and PM<small>10</small>) from their low-cost monitors.
+We also introduce AirQalibrate, a tool that enables users without access to reference grade monitors or technical expertise to develop a calibration model to calibrate data (PM<small>2.5</small> and PM<small>10</small>) from their low-cost monitors.
 
 ## The need for calibration
 

--- a/docs/cypress/e2e/tests/index.cy.js
+++ b/docs/cypress/e2e/tests/index.cy.js
@@ -5,27 +5,27 @@ describe("Verify AirQo Documentation Home Page", () => {
     cy.visit("http://localhost:3000/#/");
   });
 
-  it("Verify Side Menu Button is functional", () => {
-    cy.get(".sidebar-toggle").click();
-  });
-
-  it("Verify AirQo logo is present and visible", () => {
+  it.skip("Verify AirQo logo is present and visible", () => {
     cy.get("section > .cover-main").eq(0).should("be.visible");
   });
 
-  it("Verify Header is present", () => {
+  it.skip("Verify Header is present", () => {
     cy.get("blockquote")
       .first()
       .should("be.exist")
       .contains("Clean Air for all African Cities");
   });
 
-  it("Verify GitHub Call-To-Action is functional", () => {
+  it.skip("Verify GitHub Call-To-Action is functional", () => {
     cy.get('[href="https://github.com/airqo-platform"]').click();
   });
 
-  it("Verify Explore Data Call-To-Action is functional", () => {
+  it.skip("Verify Explore Data Call-To-Action is functional", () => {
     cy.get('[href="https://airqo.net/explore-data"]').click();
+  });
+
+  it("Verify Side Menu Button is functional", () => {
+    cy.get(".sidebar-toggle").click();
   });
 
   it("Verify Side Bar menu sections exist", () => {

--- a/docs/cypress/e2e/tests/index.cy.js
+++ b/docs/cypress/e2e/tests/index.cy.js
@@ -1,11 +1,10 @@
 /// <reference types="cypress" />
 
 describe("Verify AirQo Documentation Home Page", () => {
-
   it("Verify page is reachable", () => {
     cy.visit("http://localhost:3000/#/");
   });
-  
+
   it("Verify Side Menu Button is functional", () => {
     cy.get(".sidebar-toggle").click();
   });
@@ -40,15 +39,16 @@ describe("Verify AirQo Documentation Home Page", () => {
     cy.get("a[title='Calibration']").first().should("be.exist");
     cy.get("a[title='Hardware']").first().should("be.exist");
     cy.get("a[title='Mobile App']").first().should("be.exist");
-    cy.get("a[title='Platform']").first().should("be.exist");    
+    cy.get("a[title='Platform']").first().should("be.exist");
   });
-it("Verify ability to Search", () => {
-    cy.get(".input-wrap  > input").type("AirQo");
+
+  it("Verify ability to Search", () => {
+    cy.get(".input-wrap  > input").type("AirQo", { force: true });
     cy.get(".results-panel").should(($lis) => {
       expect($lis.eq(0), "first item").to.contain("AirQo");
     });
   });
-  
+
   it("Verify Edit On GitHub Button is clickable", () => {
     cy.contains("Edit On GitHub").click();
   });

--- a/docs/cypress/e2e/tests/index.cy.js
+++ b/docs/cypress/e2e/tests/index.cy.js
@@ -34,7 +34,7 @@ describe("Verify AirQo Documentation Home Page", () => {
     cy.get(".sidebar > .sidebar-nav").should("be.exist");
   });
 
-  it("Verify Side Bar Navigation menu Links are present", () => {
+  it("Verify Navigation Links are present", () => {
     cy.get("a[title='API']").first().should("be.exist");
     cy.get("a[title='Calibration']").first().should("be.exist");
     cy.get("a[title='Hardware']").first().should("be.exist");

--- a/docs/index.html
+++ b/docs/index.html
@@ -24,7 +24,7 @@
         name: "Home",
         repo: "https://github.com/airqo-platform/AirQo-frontend/tree/master/docs",
         themeColor: "#145dff",
-        coverpage: true,
+        coverpage: false,
         loadNavbar: true,
         loadSidebar: true,
         subMaxLevel: 3,


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)
- Removes the coverpage of the docs
- Adds the respective links for the docs on the new landing page, thus
- Making the docs site more intuitive to use

#### Status of maturity (all need to be checked before merging):
- [x] I've tested this locally
- [x] I consider this code done
- [x] This change ready to hit production in its current state
- [x] The title of the PR states what changed and the related issues number (used for the release note).
- [ ] I've included issue number in the "Closes #ISSUE-NUMBER" part of the "[What are the relevant tickets?](#what-are-the-relevant-tickets)" section to [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] I've updated corresponding documentation for the changes in this PR.
- [x] I have written unit and/or e2e tests for my change(s).

#### How should this be manually tested?
- Checkout the landing page in the [link](https://ft-docsenhancement-docs-preview-w7kzhvlewq-ew.a.run.app/) on PR preview comment

#### What are the relevant tickets?

#### Screenshots (optional)
![image](https://user-images.githubusercontent.com/41787587/208438378-2866f075-aaa8-4b19-b661-eccf36457ae7.png)