### PR TITLE
[Netmanager] Changed Leaderboard time period

### DIFF
--- a/netmanager/src/views/charts/ChartContainer.js
+++ b/netmanager/src/views/charts/ChartContainer.js
@@ -1,11 +1,12 @@
-import React from "react";
-import PropTypes from "prop-types";
-import FullscreenIcon from "@material-ui/icons/Fullscreen";
-import AccessTime from "@material-ui/icons/AccessTime";
-import { humanReadableDate } from "utils/dateTime";
+import React from 'react';
+import PropTypes from 'prop-types';
+import FullscreenIcon from '@material-ui/icons/Fullscreen';
+import AccessTime from '@material-ui/icons/AccessTime';
+import { humanReadableDate } from 'utils/dateTime';
 
 // css
-import "assets/css/chart-container.css";
+import 'assets/css/chart-container.css';
+import { CircularProgress } from '@material-ui/core';
 
 const ChartContainer = ({
   className,
@@ -17,37 +18,33 @@ const ChartContainer = ({
   footerContent,
   controller,
   children,
+  loading
 }) => {
-  const titleStyle =
-    (blue && "title-blue") || (green && "title-green") || "title-default";
+  const titleStyle = (blue && 'title-blue') || (green && 'title-green') || 'title-default';
   return (
-    <div className={className || "chart-container-wrapper"}>
+    <div className={className || 'chart-container-wrapper'}>
       <div className={`chart-title-wrapper ${titleStyle}`}>
-        <span className={"chart-title"}>{title}</span>
-        <span className={"chart-control"}>
+        <span className={'chart-title'}>{title}</span>
+        <span className={'chart-control'}>
           {controller}
           <FullscreenIcon />
         </span>
       </div>
-      <div
-        className={`chart-body ${
-          (centerItems && "chart-flex-center-body") || ""
-        }`}
-      >
-        {children}
+      <div className={`chart-body ${(centerItems && 'chart-flex-center-body') || ''}`}>
+        {loading ? <CircularProgress /> : children}
       </div>
-      <div className={"chart-footer"}>
+      <div className={'chart-footer'}>
         {lastUpdated && (
           <span>
-            <AccessTime /> Last updated{" "}
+            <AccessTime /> Last updated{' '}
             {humanReadableDate(lastUpdated, {
               format: {
-                year: "numeric",
-                month: "long",
-                day: "numeric",
-                hour: "numeric",
-                minute: "numeric",
-              },
+                year: 'numeric',
+                month: 'long',
+                day: 'numeric',
+                hour: 'numeric',
+                minute: 'numeric'
+              }
             })}
           </span>
         )}
@@ -69,7 +66,7 @@ ChartContainer.propTypes = {
   centerItems: PropTypes.bool,
   footerContent: PropTypes.any,
   controller: PropTypes.any,
-  children: PropTypes.element,
+  children: PropTypes.element
 };
 
 export default ChartContainer;

--- a/netmanager/src/views/components/DataDisplay/DeviceManagement/ManagementStats.js
+++ b/netmanager/src/views/components/DataDisplay/DeviceManagement/ManagementStats.js
@@ -121,7 +121,7 @@ export default function ManagementStat() {
     if (isEmpty(allDevices)) dispatch(loadDevicesData());
 
     dispatch(updateDeviceBackUrl(location.pathname));
-  }, [leaderboardData]);
+  }, []);
 
   useEffect(() => {
     let lineLabel = [];
@@ -164,11 +164,13 @@ export default function ManagementStat() {
   ];
 
   const updateLeaderboardDateRange = (e) => {
+    e.preventDefault();
     setLoading(true);
-    let dateRange = e.target.value;
-    setLeaderboardDateRange(dateRange);
+    const { value } = e.target;
 
-    if (dateRange === '1') {
+    setLeaderboardDateRange(value);
+
+    if (value === '1') {
       dispatch(
         loadUptimeLeaderboardData({
           startDate: roundToStartOfDay(new Date().toISOString()).toISOString(),
@@ -179,7 +181,7 @@ export default function ManagementStat() {
       dispatch(
         loadUptimeLeaderboardData({
           startDate: roundToStartOfDay(
-            moment(new Date()).subtract(parseInt(dateRange), 'days').toISOString()
+            moment(new Date()).subtract(parseInt(value), 'days').toISOString()
           ).toISOString(),
           endDate: roundToEndOfDay(new Date().toISOString()).toISOString()
         })
@@ -258,7 +260,7 @@ export default function ManagementStat() {
                     </div>
                   }
                   open={leaderboardDateMenu}
-                  onClose={() => toggleLeaderboardDateMenu(!leaderboardDateMenu)}
+                  onClose={() => toggleLeaderboardDateMenu(false)}
                   placement="bottom-end"
                 >
                   <EditIcon onClick={() => toggleLeaderboardDateMenu(!leaderboardDateMenu)} />

--- a/netmanager/src/views/components/DataDisplay/DeviceManagement/ManagementStats.js
+++ b/netmanager/src/views/components/DataDisplay/DeviceManagement/ManagementStats.js
@@ -25,6 +25,7 @@ import ErrorBoundary from 'views/ErrorBoundary/ErrorBoundary';
 import 'chartjs-plugin-annotation';
 import 'assets/scss/device-management.sass';
 import 'assets/css/device-view.css'; // there are some shared styles here too :)
+import { loadUptimeLeaderboardData } from 'redux/DeviceManagement/operations';
 
 export default function ManagementStat() {
   useInitScrollTop();
@@ -94,7 +95,20 @@ export default function ManagementStat() {
     if (isEmpty(networkUptimeData)) {
       dispatch(
         loadNetworkUptimeData({
-          startDate: roundToStartOfDay(moment(new Date()).toISOString()).toISOString(),
+          startDate: roundToStartOfDay(
+            moment(new Date()).subtract(28, 'days').toISOString()
+          ).toISOString(),
+          endDate: roundToEndOfDay(new Date().toISOString()).toISOString()
+        })
+      );
+    }
+
+    if (isEmpty(leaderboardData)) {
+      dispatch(
+        loadUptimeLeaderboardData({
+          startDate: roundToStartOfDay(
+            moment(new Date()).subtract(1, 'days').toISOString()
+          ).toISOString(),
           endDate: roundToEndOfDay(new Date().toISOString()).toISOString()
         })
       );
@@ -176,7 +190,7 @@ export default function ManagementStat() {
           />
 
           <ChartContainer
-            title={'Leaderboard in the last 24hours'}
+            title={'Leaderboard in the last 24 hours'}
             controller={
               devicesUptimeDescending ? (
                 <SortAscendingIcon onClick={handleSortIconClick} style={{ fill: 'white' }} />


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

- Corrected the network uptime to return uptime for the past 28 days as was
- Updated the length of time for the leaderboard to 24 hours
- User can also toggle length of days on leaderboard

#### Status of maturity (all need to be checked before merging):

- [x] I've tested this locally
- [x] I consider this code done
- [x] This change ready to hit production in its current state
- [x] The title of the PR states what changed and the related issues number (used for the release note).
- [x] I've included issue number in the "Closes #ISSUE-NUMBER" part of the "[What are the relevant tickets?](#what-are-the-relevant-tickets)" section to [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [ ] I've updated corresponding documentation for the changes in this PR.
- [ ] I have written unit and/or e2e tests for my change(s).

#### How should this be manually tested?

- git pull origin staging
- git checkout ft-sprint5-feedback
- npm run stage
- To confirm the uptime is correct, click the device and scroll to the device uptime chart to view if the uptime correlates with the one on the leaderboard

#### What are the relevant tickets?

- [AN-254](https://airqoteam.atlassian.net/browse/AN-254?atlOrigin=eyJpIjoiZWE5MTEyNzRkM2UzNDg0YmI5OTY2MTE3MzE4OGM0MTQiLCJwIjoiaiJ9)

#### Screenshots
![Screenshot from 2023-01-04 13-41-12](https://user-images.githubusercontent.com/46527380/210537828-1d03a784-cf31-4ba0-82fe-36ad3198a4cb.png)

![Screenshot from 2023-01-04 11-46-08](https://user-images.githubusercontent.com/46527380/210517158-5e5e2a8f-a18f-4f23-ad7e-9d1f34e1ccb1.png)


[AN-254]: https://airqoteam.atlassian.net/browse/AN-254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ