### PR TITLE
Fix Broken link in mobile README file  #1010

### DIFF
--- a/mobile/README.md
+++ b/mobile/README.md
@@ -37,7 +37,7 @@
 For example if `airqo-dev-keystore.jks` is located under `/Users/example/` then `storeFile=/Users/example/airqo-dev-keystore.jks`
 
 ### **For Contributors:**
-  - It's important to first read our guidelines [here](/../CONTRIBUTING.md).
+  - It's important to first read our guidelines [here](/CONTRIBUTING.md).
   - Thereafter, proceed to create your own necessary configuration files. These include;
     - Add an `.env file`, which contain credentials in key-value format for services used by the app. For development, save the file as `.env.dev` while for production, save it as `.env.prod`. 
       - Here's what your .env file would look like;


### PR DESCRIPTION
Summary of Changes (What does this PR do?)

- Fix the broken link to the [contributing guide](https://github.com/airqo-platform/AirQo-frontend/blob/staging/CONTRIBUTING.md) under the [README.md](https://github.com/airqo-platform/AirQo-frontend/blob/staging/mobile/README.md) mobile file results in a 404 not found page.

Status of maturity (all need to be checked before merging):

- [x] -  I've tested this locally
- [x] -  I consider this code done
- [x] -  This change ready to hit production in its current state
- [x] -  The title of the PR states what changed and the related issues number (used for the release note).

How should this be manually tested?

- go to [/mobile/README.md](https://github.com/airqo-platform/AirQo-frontend/blob/staging/mobile/README.md)
- click the here link under the section For Contributors

What are the relevant tickets?

- https://github.com/airqo-platform/AirQo-frontend/issues/1010
