### PR TITLE
Change image host to eu.gcr.io

### DIFF
--- a/.github/workflows/deploy-frontend-pr-previews.yml
+++ b/.github/workflows/deploy-frontend-pr-previews.yml
@@ -6,7 +6,7 @@ on:
       - staging
 
 env:
-  REGISTRY_URL: gcr.io
+  REGISTRY_URL: eu.gcr.io
   PROJECT_ID: airqo-250220
 
 jobs:

--- a/.github/workflows/deploy-frontends-to-production.yml
+++ b/.github/workflows/deploy-frontends-to-production.yml
@@ -25,7 +25,7 @@ on:
         type: boolean
 
 env:
-  REGISTRY_URL: gcr.io
+  REGISTRY_URL: eu.gcr.io
   PROJECT_ID: airqo-250220
 
 jobs:

--- a/.github/workflows/deploy-frontends-to-staging.yml
+++ b/.github/workflows/deploy-frontends-to-staging.yml
@@ -8,7 +8,7 @@ on:
       - closed
 
 env:
-  REGISTRY_URL: gcr.io
+  REGISTRY_URL: eu.gcr.io
   PROJECT_ID: airqo-250220
 
 jobs:

--- a/k8s/calibrate/prod-airqo-calibrate-app.yaml
+++ b/k8s/calibrate/prod-airqo-calibrate-app.yaml
@@ -35,7 +35,7 @@ spec:
                       - high-memory
       containers:
         - name: prod-calibrate-app
-          image: us.gcr.io/airqo-250220/airqo-calibrate-app:latest
+          image: eu.gcr.io/airqo-250220/airqo-calibrate-app:latest
           imagePullPolicy: Always
           ports:
             - containerPort: 80

--- a/k8s/calibrate/stage-airqo-calibrate-app.yaml
+++ b/k8s/calibrate/stage-airqo-calibrate-app.yaml
@@ -35,7 +35,7 @@ spec:
                       - high-memory
       containers:
         - name: sta-calibrate-app
-          image: us.gcr.io/airqo-250220/airqo-stage-calibrate-app:latest
+          image: eu.gcr.io/airqo-250220/airqo-stage-calibrate-app:latest
           imagePullPolicy: Always
           ports:
             - containerPort: 80

--- a/k8s/calibrate/values-dev.yaml
+++ b/k8s/calibrate/values-dev.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 
 image:
-  repository: gcr.io/airqo-250220/pr-previews/calibrate-app-pr-previews
+  repository: eu.gcr.io/airqo-250220/pr-previews/calibrate-app-pr-previews
   pullPolicy: Always
   tag: latest
 

--- a/k8s/calibrate/values-prod.yaml
+++ b/k8s/calibrate/values-prod.yaml
@@ -5,7 +5,7 @@
 replicaCount: 2
 
 image:
-  repository: gcr.io/airqo-250220/airqo-calibrate-app
+  repository: eu.gcr.io/airqo-250220/airqo-calibrate-app
   pullPolicy: Always
   tag: latest
 

--- a/k8s/calibrate/values-stage.yaml
+++ b/k8s/calibrate/values-stage.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 
 image:
-  repository: gcr.io/airqo-250220/airqo-stage-calibrate-app
+  repository: eu.gcr.io/airqo-250220/airqo-stage-calibrate-app
   pullPolicy: Always
   tag: latest
 

--- a/k8s/docs/prod-airqo-docs.yaml
+++ b/k8s/docs/prod-airqo-docs.yaml
@@ -28,7 +28,7 @@ spec:
                       - general-purpose
       containers:
         - name: airqo-prod-docs
-          image: us.gcr.io/airqo-250220/airqo-prod-docs:latest
+          image: eu.gcr.io/airqo-250220/airqo-prod-docs:latest
           imagePullPolicy: Always
           ports:
             - containerPort: 3000

--- a/k8s/docs/stage-airqo-docs.yaml
+++ b/k8s/docs/stage-airqo-docs.yaml
@@ -28,7 +28,7 @@ spec:
                       - general-purpose
       containers:
         - name: sta-docs
-          image: us.gcr.io/airqo-250220/airqo-stage-docs:latest
+          image: eu.gcr.io/airqo-250220/airqo-stage-docs:latest
           imagePullPolicy: Always
           ports:
             - containerPort: 3000

--- a/k8s/docs/values-dev.yaml
+++ b/k8s/docs/values-dev.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 
 image:
-  repository: gcr.io/airqo-250220/pr-previews/docs-pr-previews
+  repository: eu.gcr.io/airqo-250220/pr-previews/docs-pr-previews
   pullPolicy: Always
   tag: latest
 

--- a/k8s/docs/values-prod.yaml
+++ b/k8s/docs/values-prod.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 
 image:
-  repository: gcr.io/airqo-250220/airqo-prod-docs
+  repository: eu.gcr.io/airqo-250220/airqo-prod-docs
   pullPolicy: Always
   tag: latest
 

--- a/k8s/docs/values-stage.yaml
+++ b/k8s/docs/values-stage.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 image:
-  repository: gcr.io/airqo-250220/airqo-stage-docs
+  repository: eu.gcr.io/airqo-250220/airqo-stage-docs
   pullPolicy: Always
   tag: stage-090ad16f-1667922055
 

--- a/k8s/netmanager/prod-airqo-platform-frontend.yaml
+++ b/k8s/netmanager/prod-airqo-platform-frontend.yaml
@@ -35,7 +35,7 @@ spec:
                       - high-memory
       containers:
         - name: airqo-platform
-          image: us.gcr.io/airqo-250220/airqo-platform-frontend:latest
+          image: eu.gcr.io/airqo-250220/airqo-platform-frontend:latest
           imagePullPolicy: Always
           ports:
             - containerPort: 80

--- a/k8s/netmanager/stage-airqo-platform-frontend.yaml
+++ b/k8s/netmanager/stage-airqo-platform-frontend.yaml
@@ -35,7 +35,7 @@ spec:
                       - high-memory
       containers:
         - name: sta-platform-ui
-          image: us.gcr.io/airqo-250220/airqo-stage-platform-frontend:latest
+          image: eu.gcr.io/airqo-250220/airqo-stage-platform-frontend:latest
           imagePullPolicy: Always
           ports:
             - containerPort: 80

--- a/k8s/netmanager/values-dev.yaml
+++ b/k8s/netmanager/values-dev.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 
 image:
-  repository: gcr.io/airqo-250220/pr-previews/netmanager-pr-previews
+  repository: eu.gcr.io/airqo-250220/pr-previews/netmanager-pr-previews
   tag: latest
   pullPolicy: Always
 

--- a/k8s/netmanager/values-prod.yaml
+++ b/k8s/netmanager/values-prod.yaml
@@ -5,7 +5,7 @@
 replicaCount: 2
 
 image:
-  repository: gcr.io/airqo-250220/airqo-platform-frontend
+  repository: eu.gcr.io/airqo-250220/airqo-platform-frontend
   tag: latest
   pullPolicy: Always
 

--- a/k8s/netmanager/values-stage.yaml
+++ b/k8s/netmanager/values-stage.yaml
@@ -4,7 +4,7 @@
 
 replicaCount: 2
 image:
-  repository: gcr.io/airqo-250220/airqo-stage-platform-frontend
+  repository: eu.gcr.io/airqo-250220/airqo-stage-platform-frontend
   tag: stage-45ddd0db-1667922355
   pullPolicy: Always
 imagePullSecrets: []

--- a/k8s/platform/prod-airqo-next-platform.yaml
+++ b/k8s/platform/prod-airqo-next-platform.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: airqo-next-platform
-          image: us.gcr.io/airqo-250220/airqo-next-platform:latest
+          image: eu.gcr.io/airqo-250220/airqo-next-platform:latest
           imagePullPolicy: Always
           ports:
             - containerPort: 3000

--- a/k8s/platform/stage-airqo-next-platform.yaml
+++ b/k8s/platform/stage-airqo-next-platform.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: sta-next-platform
-          image: us.gcr.io/airqo-250220/airqo-stage-next-platform:latest
+          image: eu.gcr.io/airqo-250220/airqo-stage-next-platform:latest
           imagePullPolicy: Always
           ports:
             - containerPort: 3000

--- a/k8s/platform/values-dev.yaml
+++ b/k8s/platform/values-dev.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 
 image:
-  repository: gcr.io/airqo-250220/pr-previews/analytics-platform-pr-previews
+  repository: eu.gcr.io/airqo-250220/pr-previews/analytics-platform-pr-previews
   pullPolicy: Always
   tag: latest
 

--- a/k8s/platform/values-prod.yaml
+++ b/k8s/platform/values-prod.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 
 image:
-  repository: gcr.io/airqo-250220/airqo-next-platform
+  repository: eu.gcr.io/airqo-250220/airqo-next-platform
   pullPolicy: Always
   tag: latest
 

--- a/k8s/platform/values-stage.yaml
+++ b/k8s/platform/values-stage.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 
 image:
-  repository: gcr.io/airqo-250220/airqo-stage-next-platform
+  repository: eu.gcr.io/airqo-250220/airqo-stage-next-platform
   pullPolicy: Always
   tag: latest
 


### PR DESCRIPTION
**_WHAT DOES THIS PR DO?_**
- Change from gcr.io to eu.gcr.io
- Change from us.gcr.io to eu.gcr.io
We are charged more when transferring our images from us.gcr.io host to our infrastructure in Europe. This PR changes the image host to Europe to benefit from the lower costs

**_WHAT ISSUES ARE RELATED TO THIS PR?_**
- [PLATOPS-16](https://airqoteam.atlassian.net/browse/PLATOPS-16?atlOrigin=eyJpIjoiODllY2UyMTc1ODVmNDI1ZDg4ZTNlZjRiNmVhNDUwNGMiLCJwIjoiaiJ9)

**_ARE THERE ANY RELATED PRs?_**
- API PR [#1271](https://github.com/airqo-platform/AirQo-api/pull/1275)

[PLATOPS-16]: https://airqoteam.atlassian.net/browse/PLATOPS-16?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ