### PR TITLE
only pull images when they are not present locally

### DIFF
--- a/k8s/calibrate/prod-airqo-calibrate-app.yaml
+++ b/k8s/calibrate/prod-airqo-calibrate-app.yaml
@@ -36,7 +36,7 @@ spec:
       containers:
         - name: prod-calibrate-app
           image: eu.gcr.io/airqo-250220/airqo-calibrate-app:latest
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 80
               name: prod-calibrate

--- a/k8s/calibrate/stage-airqo-calibrate-app.yaml
+++ b/k8s/calibrate/stage-airqo-calibrate-app.yaml
@@ -36,7 +36,7 @@ spec:
       containers:
         - name: sta-calibrate-app
           image: eu.gcr.io/airqo-250220/airqo-stage-calibrate-app:latest
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 80
               name: sta-calibrate

--- a/k8s/docs/prod-airqo-docs.yaml
+++ b/k8s/docs/prod-airqo-docs.yaml
@@ -29,7 +29,7 @@ spec:
       containers:
         - name: airqo-prod-docs
           image: eu.gcr.io/airqo-250220/airqo-prod-docs:latest
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3000
               name: docs

--- a/k8s/docs/stage-airqo-docs.yaml
+++ b/k8s/docs/stage-airqo-docs.yaml
@@ -29,7 +29,7 @@ spec:
       containers:
         - name: sta-docs
           image: eu.gcr.io/airqo-250220/airqo-stage-docs:latest
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3000
               name: docs

--- a/k8s/netmanager/prod-airqo-platform-frontend.yaml
+++ b/k8s/netmanager/prod-airqo-platform-frontend.yaml
@@ -36,7 +36,7 @@ spec:
       containers:
         - name: airqo-platform
           image: eu.gcr.io/airqo-250220/airqo-platform-frontend:latest
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 80
               name: airqo-platform

--- a/k8s/netmanager/stage-airqo-platform-frontend.yaml
+++ b/k8s/netmanager/stage-airqo-platform-frontend.yaml
@@ -36,7 +36,7 @@ spec:
       containers:
         - name: sta-platform-ui
           image: eu.gcr.io/airqo-250220/airqo-stage-platform-frontend:latest
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 80
               name: sta-platform-ui

--- a/k8s/platform/prod-airqo-next-platform.yaml
+++ b/k8s/platform/prod-airqo-next-platform.yaml
@@ -19,7 +19,7 @@ spec:
       containers:
         - name: airqo-next-platform
           image: eu.gcr.io/airqo-250220/airqo-next-platform:latest
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3000
               name: next-platform

--- a/k8s/platform/stage-airqo-next-platform.yaml
+++ b/k8s/platform/stage-airqo-next-platform.yaml
@@ -19,7 +19,7 @@ spec:
       containers:
         - name: sta-next-platform
           image: eu.gcr.io/airqo-250220/airqo-stage-next-platform:latest
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3000
               name: next-platform


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)
- Changes the image pull policy to only download images when they are not present locally
- This can help us reduce on costs by reducing image downloads

#### Status of maturity (all need to be checked before merging):
- [ ] I've tested this locally
- [x] I consider this code done
- [x] This change ready to hit production in its current state
- [x] The title of the PR states what changed and the related issues number (used for the release note).
- [ ] I've included issue number in the "Closes #ISSUE-NUMBER" part of the "[What are the relevant tickets?](#what-are-the-relevant-tickets)" section to [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [ ] I've updated corresponding documentation for the changes in this PR.
- [ ] I have written unit and/or e2e tests for my change(s).

#### How should this be manually tested?
- n/a
- Study the code changes to ensure they are in line with the description

#### Related PRs
- [This API PR](https://github.com/airqo-platform/AirQo-api/pull/1330)
