### PR TITLE
[Netmanager] Fixed device deployment date in device table

### DIFF
--- a/netmanager/src/views/components/DataDisplay/DeviceView/DeviceDeployStatus.js
+++ b/netmanager/src/views/components/DataDisplay/DeviceView/DeviceDeployStatus.js
@@ -271,7 +271,7 @@ export default function DeviceDeployStatus({ deviceData, siteOptions }) {
   const [height, setHeight] = useState((deviceData.height && String(deviceData.height)) || '');
   const [power, setPower] = useState(capitalize(deviceData.powerType || ''));
   const [installationType, setInstallationType] = useState(deviceData.mountType || '');
-  const [deploymentDate, setDeploymentDate] = useState(getDateString(deviceData.createdAt));
+  const [deploymentDate, setDeploymentDate] = useState(getDateString(deviceData.deployment_date));
   const [primaryChecked, setPrimaryChecked] = useState(deviceData.isPrimaryInLocation || false);
 
   const checkColocation = () => {

--- a/netmanager/src/views/components/DataDisplay/Devices.js
+++ b/netmanager/src/views/components/DataDisplay/Devices.js
@@ -140,9 +140,9 @@ const createDeviceColumns = (history, setDelState) => [
     )
   },
   {
-    title: 'Registration Date',
+    title: 'Deployment Date',
     field: 'createdAt',
-    render: (data) => <Cell data={data} fieldValue={humanReadableDate(data.createdAt)} />
+    render: (data) => <Cell data={data} fieldValue={humanReadableDate(data.deployment_date)} />
   },
   {
     title: 'Deployment status',


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

- Replaced device registration date with device deployment date in device registry date & device deployment form

#### Status of maturity (all need to be checked before merging):

- [x] I've tested this locally
- [x] I consider this code done
- [x] This change ready to hit production in its current state
- [x] The title of the PR states what changed and the related issues number (used for the release note).

#### How should this be manually tested?

- Click deploy preview and check device registry table & deployment form for the deployment date


#### Screenshots
![image](https://user-images.githubusercontent.com/46527380/226299685-3b8d43ac-a1c1-4419-8573-db7913370cdd.png)
