### PR TITLE
[Netmanager] LOGGING USERS WHO PERFORM DATA EXPORTS

### DIFF
--- a/netmanager/src/config/urls/analytics.js
+++ b/netmanager/src/config/urls/analytics.js
@@ -3,12 +3,13 @@ import { stripTrailingSlash } from '../utils';
 const BASE_ANALYTICS_URL = stripTrailingSlash(
   process.env.REACT_APP_BASE_ANALYTICS_URL || process.env.REACT_APP_BASE_URL
 );
+const BASE_ANALYTICS_URL_V2 = stripTrailingSlash(process.env.REACT_APP_BASE_URL_V2);
 
 export const GENERATE_CUSTOMISABLE_CHARTS_URI = `${BASE_ANALYTICS_URL}/analytics/dashboard/chart/data`;
 
 export const DAILY_MEAN_AVERAGES_URI = `${BASE_ANALYTICS_URL}/analytics/dashboard/historical/daily-averages`;
 
-export const DOWNLOAD_CUSTOMISED_DATA_URI = `${BASE_ANALYTICS_URL}/analytics/data-download`;
+export const DOWNLOAD_CUSTOMISED_DATA_URI = `${BASE_ANALYTICS_URL_V2}/analytics/data-download`;
 
 export const D3_CHART_DATA_URI = `${BASE_ANALYTICS_URL}/analytics/dashboard/chart/d3/data`;
 
@@ -24,5 +25,3 @@ export const DOWNLOAD_DATA = `${BASE_ANALYTICS_URL}/analytics/data/download?type
 export const GET_MONITORING_SITES_URI = `${BASE_ANALYTICS_URL}/analytics/dashboard/sites?organisation_name=KCCA`;
 
 export const GET_DATA_MAP = `${BASE_ANALYTICS_URL}/analytics/dashboard/sites?organisation_name=KCCA`;
-
-export const URBAN_BETTER_DOWNLOAD_DATA_URI = `${BASE_ANALYTICS_URL}/analytics/data/download?tenant=urbanbetter`;

--- a/netmanager/src/views/apis/analytics.js
+++ b/netmanager/src/views/apis/analytics.js
@@ -5,7 +5,6 @@ import {
   DOWNLOAD_CUSTOMISED_DATA_URI,
   D3_CHART_DATA_URI
 } from 'config/urls/analytics';
-import { URBAN_BETTER_DOWNLOAD_DATA_URI } from '../../config/urls/analytics';
 
 axios.defaults.headers.common.Authorization = `JWT ${process.env.REACT_APP_AUTHORIZATION_TOKEN}`;
 
@@ -29,8 +28,4 @@ export const downloadDataApi = async (data) => {
 
 export const loadD3ChartDataApi = async (data) => {
   return await axios.post(D3_CHART_DATA_URI, data).then((response) => response.data);
-};
-
-export const downloadUrbanBetterDataApi = async (data) => {
-  return await axios.post(URBAN_BETTER_DOWNLOAD_DATA_URI, data).then((response) => response.data);
 };

--- a/netmanager/src/views/apis/analytics.js
+++ b/netmanager/src/views/apis/analytics.js
@@ -18,7 +18,13 @@ export const getSitesApi = async () => {
 };
 
 export const downloadDataApi = async (data) => {
-  return axios.post(DOWNLOAD_CUSTOMISED_DATA_URI, data).then((response) => response.data);
+  const headers = {
+    service: 'data-export'
+  };
+
+  return axios
+    .post(DOWNLOAD_CUSTOMISED_DATA_URI, data, { headers })
+    .then((response) => response.data);
 };
 
 export const loadD3ChartDataApi = async (data) => {


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

- Added service to data export api headers to enable logging of user activity

#### Status of maturity (all need to be checked before merging):

- [ ] I've tested this locally
- [ ] I consider this code done
- [ ] This change ready to hit production in its current state

#### How should this be manually tested?

- Please include the steps to be done inorder to setup and test this PR.

#### What are the relevant tickets?
- [AN-376](https://airqoteam.atlassian.net/browse/AN-376) 

#### Screenshots (optional)


[AN-376]: https://airqoteam.atlassian.net/browse/AN-376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ