### PR TITLE
Fix path issues for play store service account 

### DIFF
--- a/.github/workflows/deploy-android-to-play-store.yml
+++ b/.github/workflows/deploy-android-to-play-store.yml
@@ -82,8 +82,10 @@ jobs:
       - name: Deploy to play store
         run: |
           cd android/
+          echo $MOBILE_ANDROID_PLAYSTORE_SA > play-store-service-account.json
           bundle exec fastlane supply init
           bundle exec fastlane android production
         env:
-          MOBILE_ANDROID_ID_FIREBASE: ${{secrets.MOBILE_ANDROID_PLAYSTORE_SA}}
-          
+          MOBILE_ANDROID_PLAYSTORE_SA: ${{secrets.MOBILE_ANDROID_PLAYSTORE_SA}}
+
+

--- a/mobile/android/fastlane/Appfile
+++ b/mobile/android/fastlane/Appfile
@@ -1,0 +1,2 @@
+json_key_file("play-store-service-account.json")
+package_name("com.airqo.app")

--- a/mobile/android/fastlane/Fastfile
+++ b/mobile/android/fastlane/Fastfile
@@ -17,7 +17,7 @@ platform :android do
     sh "flutter build appbundle --build-number #{_new_build_number} --flavor airqo"
     upload_to_play_store(
       track: "production",
-      release_status: "completed",
+      release_status: "draft",
       json_key_data: ENV['MOBILE_ANDROID_PLAYSTORE_SA'],
       package_name:"com.airqo.app",
       aab: "../build/app/outputs/bundle/airqoRelease/app-airqo-release.aab",


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

- This PR fixes the issue of failing to access the play store service account path which is needed for getting metadata for the application. 


#### Status of maturity (all need to be checked before merging):

- [x] I've tested this locally
- [x] I consider this code done
- [x] This change ready to hit production in its current state
- [x] The title of the PR states what changed and the related issues number (used for the release note).
- [ ] I've included issue number in the "Closes #ISSUE-NUMBER" part of the "[What are the relevant tickets?](#what-are-the-relevant-tickets)" section to [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [ ] I've updated corresponding documentation for the changes in this PR.
- [ ] I have written unit and/or e2e tests for my change(s).

#### How should this be manually tested?

#### What are the relevant tickets?

- Closes #<enter issue number here>
- [Jira_card_number]() (If exists)

#### Screenshot
![Screenshot 2023-05-02 at 12 31 22](https://user-images.githubusercontent.com/60974514/235632299-836e9409-cb81-4df3-baeb-e350f84d7fa5.png)
s (optional)
