### PR TITLE
[Netmanager] reduce network uptime time interval to 7 days

### DIFF
--- a/netmanager/src/views/components/DataDisplay/DeviceManagement/ManagementStats.js
+++ b/netmanager/src/views/components/DataDisplay/DeviceManagement/ManagementStats.js
@@ -103,7 +103,7 @@ function ManagementStat() {
       dispatch(
         loadNetworkUptimeData({
           startDate: roundToStartOfDay(
-            moment(new Date()).subtract(28, 'days').toISOString()
+            moment(new Date()).subtract(7, 'days').toISOString()
           ).toISOString(),
           endDate: roundToEndOfDay(new Date().toISOString()).toISOString()
         })


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

- modified network uptime request interval from 28 to 7 days to reduce clutter in graph
- However, this still requires backend implementation to take effect ie returning an average value for a day instead of 30 mins intervals data

#### Status of maturity (all need to be checked before merging):

- [x] I've tested this locally
- [x] I consider this code done
- [x] This change ready to hit production in its current state
- [x] The title of the PR states what changed and the related issues number (used for the release note).

#### How should this be manually tested?

- Please include the steps to be done inorder to setup and test this PR.

#### What are the relevant tickets?

- Closes #<enter issue number here>
- [AN-413](https://airqoteam.atlassian.net/browse/AN-413)

#### Screenshots (optional)
![image](https://github.com/airqo-platform/AirQo-frontend/assets/46527380/940652dd-2d48-49bf-a32f-eab21aac1bfc)


[AN-413]: https://airqoteam.atlassian.net/browse/AN-413?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ