### PR TITLE
[Netmanager] reduce size of map markers

### DIFF
--- a/netmanager/src/assets/css/overlay-map.css
+++ b/netmanager/src/assets/css/overlay-map.css
@@ -27,12 +27,13 @@
   justify-content: center;
   font-size: 1.1rem;
   background: blue;
-  width: 23px;
-  height: 23px;
+  width: 12px;
+  height: 12px;
   cursor: pointer;
   color: #f3f3f3;
   font-weight: 600;
   border-radius: 50% 50% 50% 0;
+  border: 1px solid black;
 }
 
 .marker-grey {
@@ -42,33 +43,33 @@
 
 .marker-good {
   background: #44e527;
-  box-shadow: 0 0 2px 2px #7eca71;
+  /* box-shadow: 0 0 2px 2px #7eca71; */
 }
 
 .marker-moderate {
   background: #f8fe39;
   color: #4b4747;
-  box-shadow: 0 0 2px 2px #e9ec7d;
+  /* box-shadow: 0 0 2px 2px #e9ec7d; */
 }
 
 .marker-uhfsg {
   background: #ee8327;
-  box-shadow: 0 0 2px 2px #f3a662;
+  /* box-shadow: 0 0 2px 2px #f3a662; */
 }
 
 .marker-unhealthy {
   background: #fe0023;
-  box-shadow: 0 0 2px 2px #ec3f56;
+  /* box-shadow: 0 0 2px 2px #ec3f56; */
 }
 
 .marker-v-unhealthy {
   background: #8639c0;
-  box-shadow: 0 0 2px 2px #8639c0;
+  /* box-shadow: 0 0 2px 2px #8639c0; */
 }
 
 .marker-hazardous {
   background: #81202e;
-  box-shadow: 0 0 2px 2px #81202e;
+  /* box-shadow: 0 0 2px 2px #81202e; */
 }
 
 .marker-unknown {
@@ -76,8 +77,8 @@
 }
 
 .map-popup {
-  font-family: "Trebuchet MS", "Lucida Sans Unicode", "Lucida Grande",
-    "Lucida Sans", Arial, sans-serif;
+  font-family: 'Trebuchet MS', 'Lucida Sans Unicode', 'Lucida Grande', 'Lucida Sans', Arial,
+    sans-serif;
 }
 
 .map-popup .mapboxgl-popup-content {
@@ -119,7 +120,7 @@
   color: #4b4747;
 }
 
-.popup-aqi span sub{
+.popup-aqi span sub {
   font-size: 11px;
 }
 
@@ -159,8 +160,8 @@
 }
 
 .popup-table {
-  font-family: "Trebuchet MS", "Lucida Sans Unicode", "Lucida Grande",
-    "Lucida Sans", Arial, sans-serif;
+  font-family: 'Trebuchet MS', 'Lucida Sans Unicode', 'Lucida Grande', 'Lucida Sans', Arial,
+    sans-serif;
   background-color: #d7dee2;
 }
 
@@ -267,9 +268,9 @@
 }
 
 /* MAP STYLE */
-.map-style{
-  font-family: "Trebuchet MS", "Lucida Sans Unicode", "Lucida Grande",
-      "Lucida Sans", Arial, sans-serif;
+.map-style {
+  font-family: 'Trebuchet MS', 'Lucida Sans Unicode', 'Lucida Grande', 'Lucida Sans', Arial,
+    sans-serif;
   width: auto;
   background-color: rgb(252, 241, 241);
   margin: 0;
@@ -278,7 +279,7 @@
   padding: 0 0 6px 3px;
   border-radius: 4px;
 }
-.map-style h4{
+.map-style h4 {
   display: flex;
   flex-direction: row;
   justify-content: flex-start;
@@ -286,7 +287,7 @@
   padding: 6px 4px;
   color: #0078ff;
 }
-.map-style h4 span{
+.map-style h4 span {
   font-size: 14px;
   line-height: 15px;
   text-align: left;
@@ -294,29 +295,29 @@
   font-weight: 600;
   text-transform: uppercase;
 }
-.map-style .map-style-cards{
+.map-style .map-style-cards {
   display: flex;
   flex-direction: column;
   align-items: center;
 }
-.map-style .map-style-cards div{
+.map-style .map-style-cards div {
   display: flex;
   align-items: center;
   justify-content: flex-start;
-  height:40px;
+  height: 40px;
   text-transform: capitalize;
   font-size: 14px;
   margin: 0 4px;
-  padding:4px 8px;
+  padding: 4px 8px;
   font-weight: 500;
   width: 130px;
   box-shadow: 0 1px 1px 0px #ccc;
   text-align: left;
 }
-.map-style .map-style-cards div svg{
+.map-style .map-style-cards div svg {
   height: 16px;
 }
-.map-style .map-style-cards div:hover{
+.map-style .map-style-cards div:hover {
   height: 44px;
   font-size: 15px;
   color: #0078ff;


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

- Reduces the size of the map nodes to improve visibility of nodes on map. Borrows concept from [airnow map](https://gispub.epa.gov/airnow/?monitors=ozonepm&xmin=-11618657.373986023&xmax=15111065.669219865&ymin=-3846593.3353269985&ymax=5135063.236291965)

#### Status of maturity (all need to be checked before merging):

- [x] I've tested this locally
- [x] I consider this code done
- [x] This change ready to hit production in its current state

#### How should this be manually tested?

- Please include the steps to be done inorder to setup and test this PR.

#### What are the relevant tickets?

- Closes #<enter issue number here>
- [Jira_card_number]() (If exists)

#### Screenshots (optional)
![image](https://github.com/airqo-platform/AirQo-frontend/assets/46527380/99880567-eb67-4bf3-9355-3062abbbef32)
