### PR TITLE
[platform] added-dropdown-to-devicetable

### DIFF
--- a/platform/flowbite.d.ts
+++ b/platform/flowbite.d.ts
@@ -1,0 +1,1 @@
+declare module 'flowbite/plugin';

--- a/platform/public/icons/Actions/menuIcon.svg
+++ b/platform/public/icons/Actions/menuIcon.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg width="800px" height="800px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M19 13C19.5523 13 20 12.5523 20 12C20 11.4477 19.5523 11 19 11C18.4477 11 18 11.4477 18 12C18 12.5523 18.4477 13 19 13Z" stroke="#000000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12 13C12.5523 13 13 12.5523 13 12C13 11.4477 12.5523 11 12 11C11.4477 11 11 11.4477 11 12C11 12.5523 11.4477 13 12 13Z" stroke="#000000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M5 13C5.55228 13 6 12.5523 6 12C6 11.4477 5.55228 11 5 11C4.44772 11 4 11.4477 4 12C4 12.5523 4.44772 13 5 13Z" stroke="#000000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/platform/src/common/components/Collocation/AddMonitor/Table/DataTable.jsx
+++ b/platform/src/common/components/Collocation/AddMonitor/Table/DataTable.jsx
@@ -85,6 +85,9 @@ const DataTable = ({ paginatedData, collocationDevices }) => {
           <th scope='col' className='font-normal w-[209px] px-4 pb-3 opacity-40'>
             Comments
           </th>
+          <th scope='col' className='font-normal w-[120px] px-4 pb-3 opacity-40'>
+            Action
+          </th>
         </tr>
       </thead>
       <tbody>
@@ -110,7 +113,7 @@ const DataTable = ({ paginatedData, collocationDevices }) => {
                   {' '}
                 </td>
                 <td scope='row' className='w-[145px] px-4 py-3'></td>
-                <td scope='row' className='w-[209px] px-4 py-3'>
+                <td scope='row' className='w-[120px] px-4 py-3'>
                   {/* dropdown menu */}
                   <Dropdown menu={menu} device={device.id} />
                 </td>

--- a/platform/src/common/components/Collocation/AddMonitor/Table/DataTable.jsx
+++ b/platform/src/common/components/Collocation/AddMonitor/Table/DataTable.jsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import {
   addDevices,
@@ -6,6 +6,9 @@ import {
   addDevice,
 } from '@/lib/store/services/collocation/selectedCollocateDevicesSlice';
 import moment from 'moment';
+
+// dropdown
+import Dropdown from './Dropdown';
 
 const DataTable = ({ paginatedData, collocationDevices }) => {
   const dispatch = useDispatch();
@@ -38,11 +41,29 @@ const DataTable = ({ paginatedData, collocationDevices }) => {
     }
   };
 
+  // dropdown menu list
+  const [menu, setMenu] = useState([
+    {
+      id: 1,
+      name: 'View Reports',
+      link: '#',
+    },
+    {
+      id: 2,
+      name: 'Edit device',
+      link: '#',
+    },
+    {
+      id: 3,
+      name: 'Delete batch',
+      link: '#',
+    },
+  ]);
+
   return (
     <table
       className='border-collapse text-xs text-left w-full mb-6'
-      data-testid='collocation-device-selection-table'
-    >
+      data-testid='collocation-device-selection-table'>
       <thead>
         <tr className='border-b border-b-slate-300 text-black'>
           <th scope='col' className='font-normal w-[61px] pb-3 px-6'>
@@ -89,6 +110,10 @@ const DataTable = ({ paginatedData, collocationDevices }) => {
                   {' '}
                 </td>
                 <td scope='row' className='w-[145px] px-4 py-3'></td>
+                <td scope='row' className='w-[209px] px-4 py-3'>
+                  {/* dropdown menu */}
+                  <Dropdown menu={menu} device={device.id} />
+                </td>
               </tr>
             );
           })}

--- a/platform/src/common/components/Collocation/AddMonitor/Table/Dropdown.jsx
+++ b/platform/src/common/components/Collocation/AddMonitor/Table/Dropdown.jsx
@@ -1,0 +1,46 @@
+import React, { useEffect } from 'react';
+
+// menu icon
+import Menu from '@/icons/Actions/menuIcon.svg';
+
+// flowbite
+import { initFlowbite } from 'flowbite';
+
+const Dropdown = ({ device, menu }) => {
+  // initializing flowbite js
+  useEffect(() => {
+    initFlowbite();
+  }, []);
+
+  return (
+    <div className='Menu_dropdown'>
+      <button
+        id='dropdownMenuIconHorizontalButton'
+        data-dropdown-toggle='dropdownDotsHorizontal'
+        className='inline-flex items-center p-2 text-sm font-medium text-center text-gray-900 bg-white rounded-lg hover:bg-gray-100 focus:ring-4 focus:outline-none dark:text-white focus:ring-gray-50 dark:bg-gray-800 dark:hover:bg-gray-700 dark:focus:ring-gray-600'
+        type='button'>
+        <Menu className='w-5 h-5' />
+      </button>
+      {/* Dropdown menu */}
+      <div
+        id='dropdownDotsHorizontal'
+        className='z-10 hidden bg-white divide-y divide-gray-100 rounded-lg shadow w-44 dark:bg-gray-700 dark:divide-gray-600'>
+        <ul
+          className='py-2 text-sm text-gray-700 dark:text-gray-200'
+          aria-labelledby='dropdownMenuIconHorizontalButton'>
+          {menu.map((item) => (
+            <li key={item.id}>
+              <a
+                href={(item.link, { device })}
+                className='flex items-center px-3 py-2 hover:bg-gray-100 dark:hover:bg-gray-600'>
+                {item.name}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+};
+
+export default Dropdown;


### PR DESCRIPTION
#### key issue
- No dropdown menu on the device status table

#### Notice
- On my view of the platform I was only able to view and work on the AddMonitor DataTable, not the device status table as earlier mentioned (not sure why though!)
- Didn't get the actual endpoints for the dropdown items yet but can still be added later for now I included the following items -> view reports, edit device and delete batch.
- The dropdown is functional.
- Also in my .env.local file I used the following so that I was able to view the table list items.
used 1 instead of 2 with the provided access token by @Baalmart Martin
1. NEXT_PUBLIC_API_BASE_URL=https://staging-platform.airqo.net/api/v1/
2. NEXT_PUBLIC_API_BASE_URL=https://staging-platform.airqo.net/api/v2/

#### Summary of Changes
- I added the dropdown menu on the AddMonitor data table.
- Downloaded an SVG icon for the menu and added it to the actions folder under icons in the public folder.
- imported the icon into the dropdown file as a component.
- Included a new column on the DataTable called Action for the dropdown menu.
- Created a dropdown component within the Table folder under AddMonitor. this was to allow for the reuse of this dropdown component on different tables if needed and avoid repetition of code.
- initialized flowbite js on the component.
- included flowbite.d.ts file to allow the use of Flowbite with TypeScript

#### Status of maturity
- [x] I've tested this locally and it's working

#### Screenshots

Table
![image](https://github.com/airqo-platform/AirQo-frontend/assets/97807374/9fc72ac8-39ef-4c98-9818-869476b5ca4d)

dropdown
![image](https://github.com/airqo-platform/AirQo-frontend/assets/97807374/fa718f5f-990f-4651-8ce7-e77d8a95bbde)
