### PR TITLE
Net prefill network field

### DIFF
--- a/netmanager/package-lock.json
+++ b/netmanager/package-lock.json
@@ -16656,7 +16656,7 @@
     "svg.easing.js": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/svg.easing.js/-/svg.easing.js-2.0.0.tgz",
-      "integrity": "sha512-//ctPdJMGy22YoYGV+3HEfHbm6/69LJUTAqI2/5qBvaNHZ9uUFVC82B0Pl299HzgH13rKrBgi4+XyXXyVWWthA==",
+      "integrity": "sha1-iqmUawqOJ4V6XEChDrpAkeVpHxI=",
       "requires": {
         "svg.js": ">=2.3.x"
       }
@@ -16664,7 +16664,7 @@
     "svg.filter.js": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/svg.filter.js/-/svg.filter.js-2.0.2.tgz",
-      "integrity": "sha512-xkGBwU+dKBzqg5PtilaTb0EYPqPfJ9Q6saVldX+5vCRy31P6TlRCP3U9NxH3HEufkKkpNgdTLBJnmhDHeTqAkw==",
+      "integrity": "sha1-kQCOFROJ3ZIwd5/L5uLJo2LRwgM=",
       "requires": {
         "svg.js": "^2.2.5"
       }

--- a/netmanager/src/views/components/Sites/SiteView.js
+++ b/netmanager/src/views/components/Sites/SiteView.js
@@ -15,6 +15,9 @@ import { useSiteBackUrl } from 'redux/Urls/selectors';
 import { updateSiteApi } from 'views/apis/deviceRegistry';
 import { updateMainAlert } from 'redux/MainAlert/operations';
 
+// styles
+import { makeStyles } from '@material-ui/core/styles';
+
 // css
 import 'react-leaflet-fullscreen/dist/styles.css';
 import 'assets/css/location-registry.css';
@@ -28,6 +31,14 @@ const gridItemStyle = {
 const Cell = ({ fieldValue }) => {
   return <div>{fieldValue || 'N/A'}</div>;
 };
+
+// this is style for the cursor to show disabled
+const useStyles = makeStyles({
+  disabled: {
+    cursor: 'not-allowed',
+    opacity: 0.5
+  }
+});
 
 const SiteForm = ({ site }) => {
   const history = useHistory();
@@ -97,8 +108,7 @@ const SiteForm = ({ site }) => {
         minHeight: '400px',
         padding: '20px 20px',
         maxWidth: '1500px'
-      }}
-    >
+      }}>
       <div
         style={{
           display: 'flex',
@@ -106,15 +116,13 @@ const SiteForm = ({ site }) => {
           fontSize: '1.2rem',
           fontWeight: 'bold',
           margin: '20px 0'
-        }}
-      >
+        }}>
         <div
           style={{
             display: 'flex',
             alignItems: 'center',
             padding: '5px'
-          }}
-        >
+          }}>
           <ArrowBackIosRounded
             style={{ color: '#3f51b5', cursor: 'pointer' }}
             onClick={() => history.push(goBackUrl)}
@@ -173,6 +181,12 @@ const SiteForm = ({ site }) => {
             helperText={errors.latitude}
             fullWidth
             required
+            disabled
+            InputProps={{
+              classes: {
+                disabled: useStyles().disabled
+              }
+            }}
           />
         </Grid>
         <Grid items xs={12} sm={6} style={gridItemStyle}>
@@ -185,6 +199,12 @@ const SiteForm = ({ site }) => {
             error={!!errors.longitude}
             helperText={errors.longitude}
             fullWidth
+            disabled
+            InputProps={{
+              classes: {
+                disabled: useStyles().disabled
+              }
+            }}
           />
         </Grid>
         <Grid items xs={12} sm={6} style={gridItemStyle}>
@@ -352,8 +372,7 @@ const SiteForm = ({ site }) => {
           alignContent="flex-end"
           justify="flex-end"
           xs={12}
-          style={{ margin: '10px 0' }}
-        >
+          style={{ margin: '10px 0' }}>
           <Button variant="contained" onClick={handleCancel}>
             Cancel
           </Button>
@@ -363,8 +382,7 @@ const SiteForm = ({ site }) => {
             color="primary"
             disabled={weightedBool(loading, isEmpty(siteInfo))}
             onClick={handleSubmit}
-            style={{ marginLeft: '10px' }}
-          >
+            style={{ marginLeft: '10px' }}>
             Save Changes
           </Button>
         </Grid>
@@ -393,8 +411,7 @@ const SiteView = (props) => {
       style={{
         width: '96%',
         margin: ' 20px auto'
-      }}
-    >
+      }}>
       <SiteForm site={site} key={`${site._id}`} />
 
       <div>
@@ -403,8 +420,7 @@ const SiteView = (props) => {
             margin: '50px auto',
             // minHeight: "400px",
             maxWidth: '1500px'
-          }}
-        >
+          }}>
           <CustomMaterialTable
             title="Site Devices details"
             userPreferencePaginationKey={'siteDevices'}


### PR DESCRIPTION
#### Summary of Changes
- disabled longitude and latitude fields in the siteView 
- prefilled network field when creating site

#### Tasks completed
- [x] Prefilled network field when creating a site.
- [x] Longitude and latitude fields in the site view have been disabled as well.

#### How should this be manually tested?
- This PR is updated with the latest from staging you might have an issue of redux undefined, if your running on your local machine, run "npm install" to update the corrupt package-lock.json file for it to run well.

#### What are the relevant tickets?
- [Jira_card_number]() [AN-426](https://airqoteam.atlassian.net/browse/AN-426)

#### Screenshots (optional)

![Screenshot (54)](https://github.com/airqo-platform/AirQo-frontend/assets/97807374/933062ce-8f06-4347-970c-4e6eb7a4757b)

![image](https://github.com/airqo-platform/AirQo-frontend/assets/97807374/56f3a74e-f16f-4f3c-8569-bb6b97f4b321)

