### PR TITLE
[Netmanager] Loading state in Device Registry view

### DIFF
--- a/netmanager/src/views/components/DataDisplay/Devices.js
+++ b/netmanager/src/views/components/DataDisplay/Devices.js
@@ -625,11 +625,9 @@ const DevicesTable = (props) => {
       setTimeout(() => {
         setLoading(false);
       }, 1500);
-    }
-
-    return () => {
+    } else {
       setLoading(false);
-    };
+    }
   }, [devices]);
 
   return (

--- a/netmanager/src/views/components/DataDisplay/Devices.js
+++ b/netmanager/src/views/components/DataDisplay/Devices.js
@@ -558,6 +558,9 @@ const DevicesTable = (props) => {
 
   const deviceColumns = createDeviceColumns(history, setDelDevice);
 
+  // setting the loading state
+  const [loading, setLoading] = useState(true);
+
   const handleDeleteDevice = async () => {
     if (delDevice.name) {
       deleteDeviceApi(delDevice.name)
@@ -616,6 +619,19 @@ const DevicesTable = (props) => {
     setDeviceList(Object.values(devices));
   }, [devices]);
 
+  // for handling the loading state
+  useEffect(() => {
+    if (isEmpty(devices)) {
+      setTimeout(() => {
+        setLoading(false);
+      }, 1500);
+    }
+
+    return () => {
+      setLoading(false);
+    };
+  }, [devices]);
+
   return (
     <ErrorBoundary>
       <div className={classes.root}>
@@ -651,7 +667,7 @@ const DevicesTable = (props) => {
           userPreferencePaginationKey={'devices'}
           columns={deviceColumns}
           data={deviceList}
-          isLoading={isEmpty(devices)}
+          isLoading={loading}
           onRowClick={(event, rowData) => {
             event.preventDefault();
             dispatch(updateDeviceDetails(rowData));


### PR DESCRIPTION
### Key issue
- The loader on the device registry view continues to show even though no devices are available from the backend to display.

#### Summary of Changes 
- Used a useState hook to handle the loading state with a timeout method to stop the loading after a set interval. 
- If there are devices, it will show the loading state and then display the available devices from the backend.

#### Task
- [x] I've tested this locally
- [x] Stop the continuous loading state.

#### Screenshots (optional)
Area of interest
![Screenshot (55)](https://github.com/airqo-platform/AirQo-frontend/assets/97807374/3b971faf-e2ba-4394-b9c5-16643ba7e206)
