### PR TITLE
worked on network statistics view

### DIFF
--- a/netmanager/src/views/charts/ApexChart.js
+++ b/netmanager/src/views/charts/ApexChart.js
@@ -43,6 +43,11 @@ class ApexChart extends Component {
   }
 
   updateChartData() {
+    // Check if series array is empty
+    if (this.state.series.length === 0) {
+      // it will return nothing
+      return;
+    }
     const newData = Math.random() * 100;
     const series = this.state.series.slice();
     const lastDataPoint =
@@ -63,7 +68,7 @@ class ApexChart extends Component {
       x: new Date().getTime(),
       y: newData
     });
-    
+
     this.setState({ series });
   }
 

--- a/netmanager/src/views/components/Sites/SiteView.js
+++ b/netmanager/src/views/components/Sites/SiteView.js
@@ -142,6 +142,12 @@ const SiteForm = ({ site }) => {
             helperText={errors.name}
             fullWidth
             required
+            disabled
+            InputProps={{
+              classes: {
+                disabled: useStyles().disabled
+              }
+            }}
           />
         </Grid>
         <Grid items xs={12} sm={6} style={gridItemStyle}>


### PR DESCRIPTION
### Issue
### (Based on my observation of the error!!!)
- I found that some series arrays for the two charts were empty, which caused an error of undefined data and prevented the screen from loading the data correctly. You can see this issue in the first screenshot below. 

#### Summary of Changes (What does this PR do?)
- Added a conditional statement to check for empty series arrays for each chart i.e. pie and area chart when updating the charts.
- I have also disabled the name field in the site registry view.

jira card No [AN-436](https://airqoteam.atlassian.net/browse/AN-436)

#### Status of maturity 
- [X] I've tested this locally and it's working.
- [x] Disabled the name field on the site registry view.
- [x] View of the network statistics screen now working.

#### Screenshots (optional)
### non-working version
![Screenshot (56)](https://github.com/airqo-platform/AirQo-frontend/assets/97807374/4f00dc62-1e2b-4690-bff3-b733946f13be)

### working version
![image](https://github.com/airqo-platform/AirQo-frontend/assets/97807374/e593b3d9-3020-4be2-b51e-28d3186a73ef)

[AN-436]: https://airqoteam.atlassian.net/browse/AN-436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ