### PR TITLE
[Netmanager] Fixing the "Invalid date" text issue On loading.

### DIFF
--- a/netmanager/src/views/layouts/common/Topbar.js
+++ b/netmanager/src/views/layouts/common/Topbar.js
@@ -172,7 +172,8 @@ const Topbar = (props) => {
     setAnchorEl(null);
   };
 
-  const [date, setDate] = React.useState(new Date());
+  const [isLoading, setIsLoading] = React.useState(true);
+  const [date, setDate] = React.useState('');
   useEffect(() => {
     var timerID = setInterval(() => tick(), 1000);
 
@@ -203,6 +204,7 @@ const Topbar = (props) => {
       ':' +
       appendLeadingZeroes(newTime.getSeconds());
     setDate(time);
+    setIsLoading(false);
   }
 
   useEffect(() => {
@@ -284,7 +286,7 @@ const Topbar = (props) => {
 
         <Hidden mdDown>
           <p style={timer_style}>
-            <span>{formatDateString(date.toUTCString)}</span>
+            <span>{isLoading ? 'Loading...' : date}</span>
           </p>
         </Hidden>
 


### PR DESCRIPTION
#### Note
-This PR is associated with fixing the date issue

#### Summary of Changes 

- I initialized a new state for date when the page is loading.
- initially it could bring "Invalid date" text on loading but now it uses the text "Loading....".

#### Tasks:
- I looked the way to replace the "Invalid date"  text On Loading.

#### Status of maturity:

- [x] I've tested this locally
- [x] I consider this code done

#### What are the relevant tickets?

- [Jira_card_number]() (If exists)

#### Screenshots (optional)
![date](https://github.com/airqo-platform/AirQo-frontend/assets/103020028/c77e71a1-b4ed-42c9-b4b0-ae3cb20df9a6)
