### PR TITLE
[Netmanager] set default network to airqo when user logins

### DIFF
--- a/netmanager/src/views/layouts/common/Sidebar/Sidebar.js
+++ b/netmanager/src/views/layouts/common/Sidebar/Sidebar.js
@@ -199,8 +199,12 @@ const Sidebar = (props) => {
         localStorage.setItem('currentUser', JSON.stringify(res.users[0]));
 
         if (isEmpty(activeNetwork)) {
-          localStorage.setItem('activeNetwork', JSON.stringify(res.users[0].networks[0]));
-          dispatch(addActiveNetwork(res.users[0].networks[0]));
+          res.users[0].networks.map((network) => {
+            if (network.net_name === 'airqo') {
+              localStorage.setItem('activeNetwork', JSON.stringify(network));
+              dispatch(addActiveNetwork(network));
+            }
+          });
         }
 
         getRoleDetailsApi(res.users[0].role._id)


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

- set default network to airqo when user logins

#### Status of maturity (all need to be checked before merging):

- [x] I've tested this locally
- [x] I consider this code done
- [x] This change ready to hit production in its current state

#### How should this be manually tested?

- Please include the steps to be done inorder to setup and test this PR.

#### What are the relevant tickets?

- Closes #<enter issue number here>
- [AN-444](https://airqoteam.atlassian.net/browse/AN-444)


[AN-444]: https://airqoteam.atlassian.net/browse/AN-444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ