### PR TITLE
[NETMANAGER] Error on the device registry screen 

### DIFF
--- a/netmanager/src/views/components/DataDisplay/Devices.js
+++ b/netmanager/src/views/components/DataDisplay/Devices.js
@@ -664,7 +664,7 @@ const DevicesTable = (props) => {
           title="Device Registry"
           userPreferencePaginationKey={'devices'}
           columns={deviceColumns}
-          data={deviceList}
+          data={deviceList.map((x) => Object.assign({}, x))}
           isLoading={loading}
           onRowClick={(event, rowData) => {
             event.preventDefault();


### PR DESCRIPTION
#### Issue
- when a user clicks the back button in the device overview screen they get an error.

#### Possible cause 
- The possible cause of the error was the material tables that modify their own props and may cause conflicts with the objects when the user clicked the back button on the device overview screen.

#### Summary of Changes (What does this PR do?)
- used a map function to clone the device list data to a certain variable before it's passed into the material table to avoid it modifying the data.

#### Status of maturity (all need to be checked before merging):
- [x] I've tested this locally
- [x] I consider this code done

#### What are the relevant tickets?
- [Jira_card_number]() [AN-452](https://airqoteam.atlassian.net/browse/AN-452)

#### Screenshots (optional)
![image](https://github.com/airqo-platform/AirQo-frontend/assets/97807374/28dde79d-4317-4a7a-8fec-8a5c3c1b5b10)

![image](https://github.com/airqo-platform/AirQo-frontend/assets/97807374/3d4fd21e-a303-482c-a511-467da85bd9cc)


[AN-452]: https://airqoteam.atlassian.net/browse/AN-452?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ