### PR TITLE
[Netmanager] Shows add device button only within the airqo organisation

### DIFF
--- a/netmanager/src/views/components/DataDisplay/Devices.js
+++ b/netmanager/src/views/components/DataDisplay/Devices.js
@@ -131,7 +131,8 @@ const createDeviceColumns = (history, setDelState) => [
               className={'underline-hover'}
               onClick={(event) => {
                 event.stopPropagation();
-              }}>
+              }}
+            >
               {data.site && data.site.description}
             </Link>
           )
@@ -161,7 +162,8 @@ const createDeviceColumns = (history, setDelState) => [
               style={{
                 color: deviceStatus === 'deployed' ? 'green' : 'red',
                 textTransform: 'capitalize'
-              }}>
+              }}
+            >
               {deviceStatus}
             </span>
           }
@@ -305,7 +307,8 @@ const CreateDevice = ({ open, setOpen }) => {
       open={open}
       onClose={handleRegisterClose}
       aria-labelledby="form-dialog-title"
-      aria-describedby="form-dialog-description">
+      aria-describedby="form-dialog-description"
+    >
       <DialogTitle id="form-dialog-title" style={{ textTransform: 'uppercase' }}>
         Add a device
       </DialogTitle>
@@ -338,7 +341,8 @@ const CreateDevice = ({ open, setOpen }) => {
             variant="outlined"
             error={!!errors.category}
             helperText={errors.category}
-            required>
+            required
+          >
             {CATEGORIES.map((option, index) => (
               <option key={index} value={option.value}>
                 {option.name}
@@ -353,7 +357,8 @@ const CreateDevice = ({ open, setOpen }) => {
             variant="outlined"
             error={!!errors.network}
             helperText={errors.network}
-            disabled></TextField>
+            disabled
+          ></TextField>
         </form>
       </DialogContent>
 
@@ -367,7 +372,8 @@ const CreateDevice = ({ open, setOpen }) => {
             color="primary"
             type="submit"
             onClick={handleRegisterSubmit}
-            style={{ margin: '0 15px' }}>
+            style={{ margin: '0 15px' }}
+          >
             Register
           </Button>
         </Grid>
@@ -470,7 +476,8 @@ const SoftCreateDevice = ({ open, setOpen, network }) => {
       open={open}
       onClose={handleRegisterClose}
       aria-labelledby="form-dialog-title"
-      aria-describedby="form-dialog-description">
+      aria-describedby="form-dialog-description"
+    >
       <DialogTitle id="form-dialog-title" style={{ textTransform: 'uppercase' }}>
         Soft add a device
       </DialogTitle>
@@ -503,7 +510,8 @@ const SoftCreateDevice = ({ open, setOpen, network }) => {
             variant="outlined"
             error={!!errors.category}
             helperText={errors.category}
-            required>
+            required
+          >
             {CATEGORIES.map((option, index) => (
               <option key={index} value={option.value}>
                 {option.name}
@@ -518,7 +526,8 @@ const SoftCreateDevice = ({ open, setOpen, network }) => {
             variant="outlined"
             error={!!errors.network}
             helperText={errors.network}
-            disabled></TextField>
+            disabled
+          ></TextField>
         </form>
       </DialogContent>
 
@@ -532,7 +541,8 @@ const SoftCreateDevice = ({ open, setOpen, network }) => {
             color="primary"
             type="submit"
             onClick={handleRegisterSubmit}
-            style={{ margin: '0 15px' }}>
+            style={{ margin: '0 15px' }}
+          >
             Register
           </Button>
         </Grid>
@@ -639,23 +649,28 @@ const DevicesTable = (props) => {
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'flex-end'
-          }}>
+          }}
+        >
+          {activeNetwork.net_name === 'airqo' && (
+            <Button
+              variant="contained"
+              color="primary"
+              type="submit"
+              align="right"
+              onClick={() => setRegisterOpen(true)}
+            >
+              {' '}
+              Add Device
+            </Button>
+          )}
           <Button
-            variant="contained"
-            color="primary"
-            type="submit"
-            align="right"
-            onClick={() => setRegisterOpen(true)}>
-            {' '}
-            Add Device
-          </Button>
-          <Button
-            variant="outlined"
+            variant={activeNetwork.net_name === 'airqo' ? 'outlined' : 'contained'}
             color="primary"
             type="submit"
             style={{ marginLeft: '20px' }}
-            onClick={() => setSoftRegisterOpen(true)}>
-            Soft Add Device
+            onClick={() => setSoftRegisterOpen(true)}
+          >
+            {activeNetwork.net_name === 'airqo' ? 'Soft Add Device' : 'Add Device'}
           </Button>
         </div>
         <br />


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

- Show add device button only within the airqo organisation, hides for the rest but uses soft add device functionality to add new devices for other organisations

#### Status of maturity (all need to be checked before merging):

- [x] I've tested this locally
- [x] I consider this code done
- [x] This change ready to hit production in its current state
- [x] The title of the PR states what changed and the related issues number (used for the release note).

#### How should this be manually tested?

- Please include the steps to be done inorder to setup and test this PR.

#### What are the relevant tickets?

- Closes #<enter issue number here>
- [AN-453](https://airqoteam.atlassian.net/browse/AN-453) (If exists)

#### Screenshots (optional)
![image](https://github.com/airqo-platform/AirQo-frontend/assets/46527380/9d61ed81-80c6-4142-8c22-61b87ee2a738)
![image](https://github.com/airqo-platform/AirQo-frontend/assets/46527380/a9878e5d-0e40-494f-b885-561791ba4350)


[AN-453]: https://airqoteam.atlassian.net/browse/AN-453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ