### PR TITLE
[Netmanager] Assign Users table refresh issue on delete of user

### DIFF
--- a/netmanager/package-lock.json
+++ b/netmanager/package-lock.json
@@ -14648,6 +14648,11 @@
         }
       }
     },
+    "react-top-loading-bar": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/react-top-loading-bar/-/react-top-loading-bar-2.3.1.tgz",
+      "integrity": "sha512-rQk2Nm+TOBrM1C4E3e6KwT65iXyRSgBHjCkr2FNja1S51WaPulRA5nKj/xazuQ3x89wDDdGsrqkqy0RBIfd0xg=="
+    },
     "react-transition-group": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.3.0.tgz",

--- a/netmanager/package.json
+++ b/netmanager/package.json
@@ -90,6 +90,7 @@
     "react-to-pdf": "0.0.11",
     "react-to-print": "^2.10.0",
     "react-tooltip": "^4.2.9",
+    "react-top-loading-bar": "^2.3.1",
     "redux": "^4.0.5",
     "redux-devtools-extension": "^2.13.8",
     "redux-thunk": "^2.3.0",

--- a/netmanager/src/views/components/DataDisplay/Devices.js
+++ b/netmanager/src/views/components/DataDisplay/Devices.js
@@ -30,6 +30,44 @@ import { softCreateDeviceApi } from '../../apis/deviceRegistry';
 import { withPermission } from '../../containers/PageAccess';
 import { updateDeviceDetails } from '../../../redux/DeviceOverview/OverviewSlice';
 
+// dropdown component
+import Select from 'react-select';
+
+// dropdown component styles
+const customStyles = {
+  control: (base, state) => ({
+    ...base,
+    height: '45px',
+    marginTop: '8px',
+    marginBottom: '8px',
+    borderColor: state.isFocused ? '#3f51b5' : '#9a9a9a',
+    '&:hover': {
+      borderColor: state.isFocused ? 'black' : 'black'
+    },
+    boxShadow: state.isFocused ? '0 0 1px 1px #3f51b5' : null
+  }),
+  option: (provided, state) => ({
+    ...provided,
+    borderBottom: '1px dotted pink',
+    color: state.isSelected ? 'white' : 'blue',
+    textAlign: 'left'
+  }),
+  input: (provided, state) => ({
+    ...provided,
+    height: '40px',
+    borderColor: state.isFocused ? '#3f51b5' : 'black'
+  }),
+  placeholder: (provided, state) => ({
+    ...provided,
+    color: '#000'
+  }),
+  menu: (provided, state) => ({
+    ...provided,
+    position: 'relative',
+    zIndex: 9999
+  })
+};
+
 const useStyles = makeStyles((theme) => ({
   root: {
     padding: theme.spacing(3)
@@ -206,6 +244,9 @@ const CATEGORIES = [
   { value: 'bam', name: 'BAM' }
 ];
 
+// dropdown options
+const options = CATEGORIES.map((option) => ({ value: option.value, label: option.name }));
+
 const CreateDevice = ({ open, setOpen }) => {
   const selectedNetwork = JSON.parse(localStorage.getItem('activeNetwork')).net_name;
   const classes = useStyles();
@@ -229,6 +270,11 @@ const CreateDevice = ({ open, setOpen }) => {
 
   const handleDeviceDataChange = (key) => (event) => {
     return setNewDevice({ ...newDevice, [key]: event.target.value });
+  };
+
+  // dropdown change handler
+  const handleChange = (selectedOption) => {
+    setNewDevice({ ...newDevice, category: selectedOption.value });
   };
 
   const handleRegisterClose = () => {
@@ -324,27 +370,20 @@ const CreateDevice = ({ open, setOpen }) => {
             error={!!errors.long_name}
             helperText={errors.long_name}
           />
-          <TextField
-            select
+          {/* dropdown */}
+          <Select
             fullWidth
             label="Category"
-            style={{ margin: '10px 0' }}
-            defaultValue={newDevice.category}
-            onChange={handleDeviceDataChange('category')}
-            SelectProps={{
-              native: true,
-              style: { width: '100%', height: '50px' }
-            }}
+            styles={customStyles}
+            defaultValue={options.find((option) => option.value === newDevice.category)}
+            onChange={handleChange}
+            isSearchable
+            options={options}
             variant="outlined"
             error={!!errors.category}
             helperText={errors.category}
-            required>
-            {CATEGORIES.map((option, index) => (
-              <option key={index} value={option.value}>
-                {option.name}
-              </option>
-            ))}
-          </TextField>
+            required
+          />
           <TextField
             fullWidth
             margin="dense"

--- a/netmanager/src/views/pages/UserList/components/UsersTable/UsersTable.js
+++ b/netmanager/src/views/pages/UserList/components/UsersTable/UsersTable.js
@@ -34,6 +34,9 @@ import UsersListBreadCrumb from '../Breadcrumb';
 // dropdown component
 import Dropdown from 'react-select';
 
+// loading bar
+import LoadingBar from 'react-top-loading-bar';
+
 const useStyles = makeStyles((theme) => ({
   root: {},
   content: {
@@ -116,6 +119,8 @@ const UsersTable = (props) => {
   const [isLoading, setLoading] = useState(false);
   const classes = useStyles();
   const users = useSelector((state) => state.accessControl.networkUsers);
+  // loading bar
+  const [progress, setProgress] = useState(0);
 
   //the methods:
 
@@ -189,9 +194,20 @@ const UsersTable = (props) => {
     setUserDelState({ open: false, user: {} });
   };
 
-  const deleteUser = () => {
-    props.mappedConfirmDeleteUser(userDelState.user);
-    setUserDelState({ open: false, user: {} });
+  const deleteUser = async () => {
+    setProgress(50);
+    try {
+      await props.mappedConfirmDeleteUser(userDelState.user);
+      setUserDelState({ open: false, user: {} });
+      setProgress(100);
+      setTimeout(() => {
+        // reseting the loading bar
+        setProgress(0);
+      }, 1000);
+    } catch (error) {
+      console.error(error);
+      setProgress(0);
+    }
   };
 
   useEffect(() => {
@@ -200,7 +216,7 @@ const UsersTable = (props) => {
       dispatch(fetchNetworkUsers(activeNetwork._id));
     }
     setLoading(false);
-  }, []);
+  }, [activeNetwork]);
 
   // If roles is null or undefined will return empty array
   const options = roles?.map((role) => ({ value: role._id, label: role.role_name })) ?? [];
@@ -224,6 +240,7 @@ const UsersTable = (props) => {
     <>
       <UsersListBreadCrumb category={'Users'} usersTable={'Assigned Users'} />
       <Card {...rest} className={clsx(classes.root, className)}>
+        <LoadingBar color="#f11946" progress={progress} />
         <CustomMaterialTable
           title={'Users'}
           userPreferencePaginationKey={'users'}

--- a/netmanager/src/views/pages/UserList/components/UsersTable/UsersTable.js
+++ b/netmanager/src/views/pages/UserList/components/UsersTable/UsersTable.js
@@ -195,18 +195,15 @@ const UsersTable = (props) => {
   };
 
   const deleteUser = async () => {
-    setProgress(50);
+    setProgress(10);
     try {
+      setProgress(50);
       await props.mappedConfirmDeleteUser(userDelState.user);
       setUserDelState({ open: false, user: {} });
       setProgress(100);
-      setTimeout(() => {
-        // reseting the loading bar
-        setProgress(0);
-      }, 1000);
     } catch (error) {
       console.error(error);
-      setProgress(0);
+      setProgress(-10);
     }
   };
 
@@ -240,7 +237,7 @@ const UsersTable = (props) => {
     <>
       <UsersListBreadCrumb category={'Users'} usersTable={'Assigned Users'} />
       <Card {...rest} className={clsx(classes.root, className)}>
-        <LoadingBar color="#f11946" progress={progress} />
+        <LoadingBar color="#f11946" progress={progress} onLoaderFinished={() => setProgress(0)} />
         <CustomMaterialTable
           title={'Users'}
           userPreferencePaginationKey={'users'}

--- a/netmanager/src/views/pages/UserList/components/UsersTable/UsersTable.js
+++ b/netmanager/src/views/pages/UserList/components/UsersTable/UsersTable.js
@@ -200,6 +200,7 @@ const UsersTable = (props) => {
       setProgress(50);
       await props.mappedConfirmDeleteUser(userDelState.user);
       setUserDelState({ open: false, user: {} });
+      dispatch(fetchNetworkUsers(activeNetwork._id));
       setProgress(100);
     } catch (error) {
       console.error(error);


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)
- Improved the Assigned users table reloading when deleting a user by adjusting the use effect hook to detect any change continuously with an indicator at the top to show the progress during the delete process, as shown in the screenshot below.
- Changed the dropdown on the add new Device modal to the currently used dropdown for the project.
- I also used a well-known package, which is well-documented on this site, to make it simple to manage the horizontal top loader and aid improve UX on the page:
https://www.npmjs.com/package/react-top-loading-bar
- The loader color used is red.

#### CHECKED
-  (This package has no conflicts with any dependency in the project !!!)

#### Status of maturity (all need to be checked before merging):
- [x] I've tested this locally
- [x] I consider this code done
- [x] UX improvement
- [x] Refresh of the table enhanced 

#### What are the relevant tickets?
- [Jira_card_number]() [AN-456](https://airqoteam.atlassian.net/browse/AN-456)

#### Screenshots (optional)
![image](https://github.com/airqo-platform/AirQo-frontend/assets/97807374/eeb6ce7b-4ba4-4a03-9048-499849c2c986)

![Screenshot (68)](https://github.com/airqo-platform/AirQo-frontend/assets/97807374/7e529588-c2ac-4afb-8c4b-ec8059a895bb)



[AN-456]: https://airqoteam.atlassian.net/browse/AN-456?
![Screenshot (66)](https://github.com/airqo-platform/AirQo-frontend/assets/97807374/9eeee57e-28ff-4406-a01d-e1139dae0c52)
