### PR TITLE
[Netmanager] Improving Network map overview card responsiveness on Mobile view

### DIFF
--- a/netmanager/src/assets/scss/device-management.sass
+++ b/netmanager/src/assets/scss/device-management.sass
@@ -18,13 +18,12 @@
     cursor: pointer
 
 .card-container-mini
-  width: 10%
-  min-width: 70px
-  height: 60px
-  padding: 0
+    width: auto
+    height: auto
+    padding: 0.5rem
 
-  &:hover
-    cursor: pointer
+    &:hover
+      cursor: pointer
 
 .card-title-wrapper
   display: grid
@@ -47,11 +46,7 @@
   flex-wrap: wrap
   align-items: center
   justify-content: space-between
-  padding: 0 4px
-  width: 100%
-  height: 55px
-  border-radius: 0
-
+  padding: 0.5rem
 
 .card-title-icon
   display: flex
@@ -60,7 +55,6 @@
   width: 40px
   height: 40px
   background: #2f67e2
-  border-radius: 3px
 
   svg
     color: #fff
@@ -70,9 +64,11 @@
   display: flex
   align-items: center
   justify-content: center
-  width: 26px
-  height: 26px
+  width: auto
+  height: auto
   background: #2f67e2
+  border-radius: 3px
+  padding: 0.3rem
 
   svg
     color: #fff
@@ -104,7 +100,8 @@
   font-size: 1.6rem
   font-family: 'Roboto', 'Helvetica', 'Arial', sans-serif
   text-decoration: none
-  height: 100%
+  margin-left: 0.5rem
+  border-radius: 5px
 
 .card-category
   color: #777
@@ -179,3 +176,6 @@
   &:hover
     fill: #fecc50
     cursor: pointer
+
+
+    

--- a/netmanager/src/views/components/DataDisplay/DeviceManagement/ManagementMap.js
+++ b/netmanager/src/views/components/DataDisplay/DeviceManagement/ManagementMap.js
@@ -58,13 +58,11 @@ const OverviewCardMini = ({ label, icon, value, filterActive, onClick }) => {
             filterActive
               ? { margin: 0, borderRadius: 0 }
               : { margin: 0, background: '#f2f2f2', borderRadius: 0 }
-          }
-        >
+          }>
           <div className={'card-title-wrapper-mini'}>
             <span
               className={'card-title-icon-mini'}
-              style={filterActive ? {} : { background: '#6d94ea' }}
-            >
+              style={filterActive ? {} : { background: '#6d94ea' }}>
               {icon}
             </span>
             <h3 className={'card-title-mini'} style={filterActive ? {} : { color: '#999' }}>
@@ -254,8 +252,7 @@ function ManagementMap() {
             position: 'absolute',
             width: '100%',
             zIndex: 20
-          }}
-        >
+          }}>
           <Hidden mdDown>
             {cardsData.map((data, key) => {
               return (

--- a/netmanager/src/views/components/Sites/SiteToolbar.js
+++ b/netmanager/src/views/components/Sites/SiteToolbar.js
@@ -189,7 +189,6 @@ const SiteToolbar = (props) => {
               helperText={errors.name}
             />
             <TextField
-              autoFocus
               margin="dense"
               label="Latitude"
               variant="outlined"
@@ -201,7 +200,6 @@ const SiteToolbar = (props) => {
               required
             />
             <TextField
-              autoFocus
               margin="dense"
               label="Longitude"
               variant="outlined"


### PR DESCRIPTION
#### Summary of Changes 
- This PR is solving two issues raised. 
1. Responsiveness of the network map overview cards
2. Changing the autofocus field to site name field.
- The cards are now fully responsive and the contents are no longer overflowing through the container that holds them.
- Made adjustments on the sass files to improve the responsiveness of the map Overview Cards on mobile views
- Changed the autofocus field on add site registry to the site name field instead of the longitude field.

#### Status of maturity (all need to be checked before merging):
- [x] I've tested this locally
- [x] I consider this code done


- [Jira_card_number]() [AN-474](https://airqoteam.atlassian.net/browse/AN-474)

#### Screenshots (optional)
![image](https://github.com/airqo-platform/AirQo-frontend/assets/97807374/684768bc-fc77-4a15-bc26-1f9864bf3163)
![image](https://github.com/airqo-platform/AirQo-frontend/assets/97807374/e9fd2c0e-06b9-42bc-a9c9-150f453f6a58)
![image](https://github.com/airqo-platform/AirQo-frontend/assets/97807374/929bc88d-49ab-4d8e-8538-a00e318e9052)


[AN-474]: https://airqoteam.atlassian.net/browse/AN-474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ