### PR TITLE
[Netmanager]Making the colors of the button and the selected network to be uniform

### DIFF
--- a/netmanager/src/views/layouts/common/Sidebar/components/NetworkDropdown.js
+++ b/netmanager/src/views/layouts/common/Sidebar/components/NetworkDropdown.js
@@ -42,7 +42,7 @@ const StyledMenu = withStyles({
 const StyledMenuItem = withStyles((theme) => ({
   root: {
     '&:focus': {
-      backgroundColor: '#175df5',
+      backgroundColor: '#2a3daa',
       color: 'black',
       '& .MuiListItemIcon-root, & .MuiListItemText-primary': {
         color: theme.palette.common.white


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

- I have made the colors of the network dropdown button and the current network in the dropdown to be uniform

#### Status of maturity (all need to be checked before merging):

- [x] I've tested this locally
- [x] I consider this code done
- [x] This change ready to hit production in its current state

#### What are the relevant tickets?

- [AN-481](https://airqoteam.atlassian.net/browse/AN-481)

#### Screenshots (optional)
![test](https://github.com/airqo-platform/AirQo-frontend/assets/103020028/fdc408f7-fc64-4ab9-bb9f-948d4f36a625)
