### PR TITLE
[Netmanager] Responsiveness of the y-axis on the Exceedance chart

### DIFF
--- a/netmanager/src/views/pages/Dashboard/components/ExceedancesChart/ExceedancesChart.js
+++ b/netmanager/src/views/pages/Dashboard/components/ExceedancesChart/ExceedancesChart.js
@@ -195,7 +195,9 @@ const ExceedancesChart = (props) => {
   
         myDataset = labels.map((label, index) => ({
           label,
-          data: exceedanceData.map((element) => element.exceedance[properties[index]]),
+          data: exceedanceData
+            .map((element) => element.exceedance[properties[index]])
+            .slice(0, maxLocations),
           backgroundColor: colors[index],
           borderColor: "rgba(0,0,0,1)",
           borderWidth: 1,
@@ -204,7 +206,9 @@ const ExceedancesChart = (props) => {
         myDataset = [
           {
             label: "Exceedances",
-            data: exceedanceData.map((element) => element.exceedance),
+            data: exceedanceData
+              .map((element) => element.exceedance)
+              .slice(0, maxLocations),
             backgroundColor: palette.primary.main,
             //borderColor: 'rgba(0,0,0,1)',
             borderWidth: 1,
@@ -407,6 +411,13 @@ const ExceedancesChart = (props) => {
                           fontColor: palette.text.secondary,
                           beginAtZero: true,
                           min: 0,
+                          // suggestedMax:
+                          //   numLocations > 0
+                          //     ? Math.max(
+                          //         ...slicedData.dataset[0].data,
+                          //         10
+                          //       ) 
+                          //     : undefined,
                         },
                         gridLines: {
                           borderDash: [2],


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)
- At first the scale was determined by the whole dataset provided by the API.
- I have sliced the data such that the scale could be determined by the sliced data.
- I have made the y-axis scale to be determined by the displayed locations on the chart.

#### Status of maturity (all need to be checked before merging):

- [x] I've tested this locally
- [x] I consider this code done
- [x] This change ready to hit production in its current state

#### What are the relevant tickets?

- [AN-490](https://airqoteam.atlassian.net/browse/AN-490)

#### Screenshots (optional)
![exceedance](https://github.com/airqo-platform/AirQo-frontend/assets/103020028/a1d354de-52bf-4551-b093-1f8668d5ff11)


[AN-490]: https://airqoteam.atlassian.net/browse/AN-490?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ