### PR TITLE
[WEBSITE] Redirect Users to Specific app stores

### DIFF
--- a/website/frontend/App.js
+++ b/website/frontend/App.js
@@ -23,6 +23,7 @@ const EventsDetailsPage = React.lazy(() => import('src/pages/Events/Details'));
 const MonitorPage = React.lazy(() => import('src/pages/OurProducts/MonitorPage'));
 const AnalyticsPage = React.lazy(() => import('src/pages/OurProducts/AnalyticsPage'));
 const MobileAppPage = React.lazy(() => import('src/pages/OurProducts/MobileAppPage'));
+const QRCodeRedirectPage = React.lazy(()=>import('src/pages/ExploreData/Redirect'))
 
 import { loadAirQloudSummaryData } from 'reduxStore/AirQlouds/operations';
 import store from './store';
@@ -59,6 +60,7 @@ const App = () => {
             <Route path="/products/monitor" element={<MonitorPage />} />
             <Route path="/products/analytics" element={<AnalyticsPage />} />
             <Route path="/products/mobile-app" element={<MobileAppPage />} />
+            <Route path="/download-apps" element={<QRCodeRedirectPage />} />
             <Route path="*" element={<Error404 />} />
           </Routes>
         </Suspense>

--- a/website/frontend/src/pages/ExploreData/Redirect.js
+++ b/website/frontend/src/pages/ExploreData/Redirect.js
@@ -3,10 +3,8 @@ import { isAndroid, isIOS } from 'react-device-detect';
 
 const QRCodeRedirect = () => {
     const redirectUser = isAndroid ? 'https://play.google.com/store/apps/details?id=com.airqo.app' : isIOS ? 'https://apps.apple.com/ug/app/airqo-monitoring-air-quality/id1337573091' : 'https://www.airqo.net/explore-data/download-apps'
-    console.log('Redirect', redirectUser)
-    return (
-        <a href={redirectUser} rel="noopener noreferrer"></a>
-    )
+    window.location.href = redirectUser
+    return null;
 }
 
 export default QRCodeRedirect;

--- a/website/frontend/src/pages/ExploreData/Redirect.js
+++ b/website/frontend/src/pages/ExploreData/Redirect.js
@@ -1,0 +1,12 @@
+import React from 'react'
+import { isAndroid, isIOS } from 'react-device-detect';
+
+const QRCodeRedirect = () => {
+    const redirectUser = isAndroid ? 'https://play.google.com/store/apps/details?id=com.airqo.app' : isIOS ? 'https://apps.apple.com/ug/app/airqo-monitoring-air-quality/id1337573091' : 'https://www.airqo.net/explore-data/download-apps'
+    console.log('Redirect', redirectUser)
+    return (
+        <a href={redirectUser} rel="noopener noreferrer"></a>
+    )
+}
+
+export default QRCodeRedirect;

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -7349,6 +7349,14 @@
                 "loose-envify": "^1.1.0"
             }
         },
+        "react-device-detect": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/react-device-detect/-/react-device-detect-2.2.3.tgz",
+            "integrity": "sha512-buYY3qrCnQVlIFHrC5UcUoAj7iANs/+srdkwsnNjI7anr3Tt7UY6MqNxtMLlr0tMBied0O49UZVK8XKs3ZIiPw==",
+            "requires": {
+                "ua-parser-js": "^1.0.33"
+            }
+        },
         "react-dom": {
             "version": "18.2.0",
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
@@ -8709,6 +8717,11 @@
                 "for-each": "^0.3.3",
                 "is-typed-array": "^1.1.9"
             }
+        },
+        "ua-parser-js": {
+            "version": "1.0.35",
+            "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.35.tgz",
+            "integrity": "sha512-fKnGuqmTBnIE+/KXSzCn4db8RTigUzw1AN0DmdU6hJovUTbYJKyqj+8Mt1c4VfRDnOVJnENmfYkIPZ946UrSAA=="
         },
         "unbox-primitive": {
             "version": "1.0.2",

--- a/website/package.json
+++ b/website/package.json
@@ -20,6 +20,7 @@
         "axios": "^1.3.2",
         "date-fns": "^2.29.3",
         "react": "^18.2.0",
+        "react-device-detect": "^2.2.3",
         "react-dom": "^18.2.0",
         "react-helmet": "^6.1.0",
         "react-redux": "^8.0.5",


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

- Redirect users to specific store(Play Store or AppStore) when they scan a QR code to download the app.

#### Status of maturity (all need to be checked before merging):

- [x] I've tested this locally
- [x] I consider this code done
- [x] This change ready to hit production in its current state
- [x] The title of the PR states what changed and the related issues number (used for the release note).

#### How should this be manually tested?

- Using the deploy preview: Append URL with _/download-apps_ and you'll be redirected to a store according to the device you have i.e Android user will be redirected to Play Store, iOS user will be redirected to AppStore, all the rest will be redirected to the website.
