### PR TITLE
[NetManager] Renaming of the title from NetManager to AirQo Analytics

### DIFF
--- a/netmanager/public/index.html
+++ b/netmanager/public/index.html
@@ -103,7 +103,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>NetManager</title>
+    <title>AirQo Analytics</title>
   </head>
 
   <body style="position: relative">


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

- I have changed the title of NetManager to AirQo Analytics
#### Status of maturity (all need to be checked before merging):

- [x] I've tested this locally
- [x] I consider this code done
- [x] This change ready to hit production in its current state

#### What are the relevant tickets?

- [AN-491](https://airqoteam.atlassian.net/browse/AN-491)

#### Screenshots (optional)
![airqo](https://github.com/airqo-platform/AirQo-frontend/assets/103020028/1320a431-56e9-4928-ad9e-d887d3a36fa5)


[AN-491]: https://airqoteam.atlassian.net/browse/AN-491?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ