### PR TITLE
[Netmanager] Added editable site name and site description

### DIFF
--- a/netmanager/src/views/components/Sites/SiteView.js
+++ b/netmanager/src/views/components/Sites/SiteView.js
@@ -111,7 +111,8 @@ const SiteForm = ({ site }) => {
         minHeight: '400px',
         padding: '20px 20px',
         maxWidth: '1500px'
-      }}>
+      }}
+    >
       {/* custome Horizontal loader indicator */}
       <HorizontalLoader loading={loading} />
       <div
@@ -121,13 +122,15 @@ const SiteForm = ({ site }) => {
           fontSize: '1.2rem',
           fontWeight: 'bold',
           margin: '20px 0'
-        }}>
+        }}
+      >
         <div
           style={{
             display: 'flex',
             alignItems: 'center',
             padding: '5px'
-          }}>
+          }}
+        >
           <ArrowBackIosRounded
             style={{ color: '#3f51b5', cursor: 'pointer' }}
             onClick={() => history.push(goBackUrl)}
@@ -263,6 +266,32 @@ const SiteForm = ({ site }) => {
         </Grid>
         <Grid items xs={12} sm={6} style={gridItemStyle}>
           <TextField
+            id="search_name"
+            label="Editable Name"
+            defaultValue={site.search_name}
+            variant="outlined"
+            onChange={handleSiteInfoChange}
+            error={!!errors.search_name}
+            helperText={errors.search_name}
+            fullWidth
+            required
+          />
+        </Grid>
+        <Grid items xs={12} sm={6} style={gridItemStyle}>
+          <TextField
+            id="location_name"
+            label="Editable Description"
+            defaultValue={site.location_name}
+            variant="outlined"
+            onChange={handleSiteInfoChange}
+            error={!!errors.location_name}
+            helperText={errors.location_name}
+            fullWidth
+            required
+          />
+        </Grid>
+        <Grid items xs={12} sm={6} style={gridItemStyle}>
+          <TextField
             id="region"
             label="Region"
             variant="outlined"
@@ -389,7 +418,8 @@ const SiteForm = ({ site }) => {
           alignContent="flex-end"
           justify="flex-end"
           xs={12}
-          style={{ margin: '10px 0' }}>
+          style={{ margin: '10px 0' }}
+        >
           <Button variant="contained" onClick={handleCancel}>
             Cancel
           </Button>
@@ -399,7 +429,8 @@ const SiteForm = ({ site }) => {
             color="primary"
             disabled={weightedBool(loading, isEmpty(siteInfo))}
             onClick={handleSubmit}
-            style={{ marginLeft: '10px' }}>
+            style={{ marginLeft: '10px' }}
+          >
             Save Changes
           </Button>
         </Grid>
@@ -428,7 +459,8 @@ const SiteView = (props) => {
       style={{
         width: '96%',
         margin: ' 20px auto'
-      }}>
+      }}
+    >
       <SiteForm site={site} key={`${site._id}`} />
 
       <div>
@@ -437,7 +469,8 @@ const SiteView = (props) => {
             margin: '50px auto',
             // minHeight: "400px",
             maxWidth: '1500px'
-          }}>
+          }}
+        >
           <CustomMaterialTable
             title="Site Devices details"
             userPreferencePaginationKey={'siteDevices'}

--- a/netmanager/src/views/components/Sites/SiteView.js
+++ b/netmanager/src/views/components/Sites/SiteView.js
@@ -4,7 +4,7 @@ import { isEmpty } from 'underscore';
 import PropTypes from 'prop-types';
 import { useHistory, useParams } from 'react-router-dom';
 import { ArrowBackIosRounded } from '@material-ui/icons';
-import { Button, Grid, Paper, TextField } from '@material-ui/core';
+import { Button, Grid, Paper, TextField, Typography } from '@material-ui/core';
 
 import { useSiteDetailsData } from 'redux/SiteRegistry/selectors';
 import { loadSiteDetails } from 'redux/SiteRegistry/operations';
@@ -266,32 +266,6 @@ const SiteForm = ({ site }) => {
         </Grid>
         <Grid items xs={12} sm={6} style={gridItemStyle}>
           <TextField
-            id="search_name"
-            label="Editable Name"
-            defaultValue={site.search_name}
-            variant="outlined"
-            onChange={handleSiteInfoChange}
-            error={!!errors.search_name}
-            helperText={errors.search_name}
-            fullWidth
-            required
-          />
-        </Grid>
-        <Grid items xs={12} sm={6} style={gridItemStyle}>
-          <TextField
-            id="location_name"
-            label="Editable Description"
-            defaultValue={site.location_name}
-            variant="outlined"
-            onChange={handleSiteInfoChange}
-            error={!!errors.location_name}
-            helperText={errors.location_name}
-            fullWidth
-            required
-          />
-        </Grid>
-        <Grid items xs={12} sm={6} style={gridItemStyle}>
-          <TextField
             id="region"
             label="Region"
             variant="outlined"
@@ -409,6 +383,36 @@ const SiteForm = ({ site }) => {
             error={!!errors.distance_to_kampala_center}
             helperText={errors.distance_to_kampala_center}
             fullWidth
+          />
+        </Grid>
+
+        <Grid xs={12} sm={12} style={gridItemStyle}>
+          <Typography variant="h3">Mobile app site details</Typography>
+        </Grid>
+        <Grid items xs={12} sm={6} style={gridItemStyle}>
+          <TextField
+            id="search_name"
+            label="Editable Name"
+            defaultValue={site.search_name}
+            variant="outlined"
+            onChange={handleSiteInfoChange}
+            error={!!errors.search_name}
+            helperText={errors.search_name}
+            fullWidth
+            required
+          />
+        </Grid>
+        <Grid items xs={12} sm={6} style={gridItemStyle}>
+          <TextField
+            id="location_name"
+            label="Editable Description"
+            defaultValue={site.location_name}
+            variant="outlined"
+            onChange={handleSiteInfoChange}
+            error={!!errors.location_name}
+            helperText={errors.location_name}
+            fullWidth
+            required
           />
         </Grid>
 


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

- Added editable site name and description fields in the site details form which can be utilised by mobile app and website to display clear site information

#### Status of maturity (all need to be checked before merging):

- [x] I've tested this locally
- [x] I consider this code done
- [x] This change ready to hit production in its current state

#### How should this be manually tested?

- Please include the steps to be done inorder to setup and test this PR.

#### What are the relevant tickets?

- Closes #<enter issue number here>
- [Jira_card_number]() (If exists)

#### Screenshots (optional)
![image](https://github.com/airqo-platform/AirQo-frontend/assets/46527380/a451f0d5-637c-4cc8-9336-302dc52aa84a)
