### PR TITLE
[Netmanager] Responsiveness of the Average Chart Modal header

### DIFF
--- a/netmanager/src/views/pages/Dashboard/components/AveragesChart.js
+++ b/netmanager/src/views/pages/Dashboard/components/AveragesChart.js
@@ -665,22 +665,14 @@ const AveragesChart = ({ classes }) => {
           },
         }}
       >
-        {/* <DialogTitle
-          style={{
-            alignItems: "center",
-            justifyContent: "center",
-            fontWeight: "600",
-            paddingLeft: "500px",
-            fontSize: "100"
-          }}
-        >{customChartTitle}</DialogTitle> */}
         <h5
           style={{
+            display: "flex",
             alignItems: "center",
             justifyContent: "center",
+            textAlign: "center",
             fontWeight: "bold",
-            paddingLeft: "450px",
-            fontSize: "100"
+            fontSize: "20px",
           }}
         >{customChartTitle}</h5>
         <DialogContent>

--- a/netmanager/src/views/pages/Dashboard/components/AveragesChart.js
+++ b/netmanager/src/views/pages/Dashboard/components/AveragesChart.js
@@ -672,6 +672,7 @@ const AveragesChart = ({ classes }) => {
             justifyContent: "center",
             textAlign: "center",
             fontWeight: "bold",
+            padding: "20px",
             fontSize: "20px",
           }}
         >{customChartTitle}</h5>


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

- I have made the Average Chart Modal header to be responsive on all devices
- Before it was conflicting on small devices.

#### Status of maturity (all need to be checked before merging):

- [x] I've tested this locally
- [x] I consider this code done
- [x] This change ready to hit production in its current state
#### What are the relevant tickets?

- [AN-498](https://airqoteam.atlassian.net/browse/AN-498)

#### Screenshots (optional)
#### Before
![prob](https://github.com/airqo-platform/AirQo-frontend/assets/103020028/68ff3a8d-cdec-4b16-914b-a4262da79a57)

#### After
![prob1](https://github.com/airqo-platform/AirQo-frontend/assets/103020028/c5d80e07-0d55-483f-9739-7e86401c3a7c)


[AN-498]: https://airqoteam.atlassian.net/browse/AN-498?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ