### PR TITLE
[WEBSITE] Adjust Partners' image onClick Handler

### DIFF
--- a/website/frontend/src/pages/AboutUsPage.js
+++ b/website/frontend/src/pages/AboutUsPage.js
@@ -291,11 +291,10 @@ const AboutUsPage = () => {
                   partnerDataGroup.slice(3, lastGroupArray).map((partnerGroup, key) => (
                     <tr key={key}>
                       {partnerGroup.map((partner) => (
-                        <td key={partner.id}>
+                        <td key={partner.id} onClick={onLogoClick(partner.unique_title)}>
                           <img
                             src={partner.partner_logo}
                             alt={partner.partner_name}
-                            onClick={onLogoClick(partner.unique_title)}
                           />
                         </td>
                       ))}


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

- onClick handler adjust from <img/> to <td/> to trigger routing to Partner description page

#### Status of maturity (all need to be checked before merging):

- [x] I've tested this locally
- [x] I consider this code done
- [x] This change ready to hit production in its current state
- [x] The title of the PR states what changed and the related issues number (used for the release note).

#### How should this be manually tested?

- Click a 4th row partner image on the _About Us_ page to route to its description page.
