### PR TITLE
[Netmanager] hides network monitoring sidebar item for other orgs

### DIFF
--- a/netmanager/src/views/layouts/common/Sidebar/components/SidebarNav/SidebarNav.js
+++ b/netmanager/src/views/layouts/common/Sidebar/components/SidebarNav/SidebarNav.js
@@ -126,37 +126,41 @@ const SidebarNav = (props) => {
       {pages &&
         pages.map((page) => {
           if (page.nested) {
-            return (
-              <NestedMenuItem
-                label={
-                  <Button
-                    className={
-                      (location.pathname.includes(page.href) && classes.buttonActive) ||
-                      classes.button
-                    }
-                  >
-                    <div className={classes.icon}>{page.icon}</div>
-                    {page.title}
-                  </Button>
-                }
-                parentMenuOpen={true}
-                style={{ padding: '0px' }}
-              >
-                {page.nestItems.map((nestPage, key) => (
-                  <MenuItem>
+            if (activeNetwork.net_name !== 'airqo' && page.title === 'Network Monitoring') {
+              return;
+            } else {
+              return (
+                <NestedMenuItem
+                  label={
                     <Button
-                      activeClassName={classes.active}
-                      className={classes.nestButton}
-                      component={CustomRouterLink}
-                      to={nestPage.href}
-                      key={key}
+                      className={
+                        (location.pathname.includes(page.href) && classes.buttonActive) ||
+                        classes.button
+                      }
                     >
-                      {nestPage.title}
+                      <div className={classes.icon}>{page.icon}</div>
+                      {page.title}
                     </Button>
-                  </MenuItem>
-                ))}
-              </NestedMenuItem>
-            );
+                  }
+                  parentMenuOpen={true}
+                  style={{ padding: '0px' }}
+                >
+                  {page.nestItems.map((nestPage, key) => (
+                    <MenuItem>
+                      <Button
+                        activeClassName={classes.active}
+                        className={classes.nestButton}
+                        component={CustomRouterLink}
+                        to={nestPage.href}
+                        key={key}
+                      >
+                        {nestPage.title}
+                      </Button>
+                    </MenuItem>
+                  ))}
+                </NestedMenuItem>
+              );
+            }
           }
           if (
             activeNetwork.net_name !== 'airqo' &&


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

- hides network monitoring sidebar item for other orgs

#### Status of maturity (all need to be checked before merging):

- [x] I've tested this locally
- [x] I consider this code done
- [x] This change ready to hit production in its current state

#### How should this be manually tested?

- Please include the steps to be done inorder to setup and test this PR.

#### What are the relevant tickets?

- Closes #<enter issue number here>
- [Jira_card_number]() (If exists)

#### Screenshots (optional)
![image](https://github.com/airqo-platform/AirQo-frontend/assets/46527380/20751083-3310-4198-b426-3e3091dd6517)
