### PR TITLE
[Hotfix] Makes airqo deafult request access org

### DIFF
--- a/netmanager/src/views/components/DataDisplay/DeviceView/DeviceEdit.js
+++ b/netmanager/src/views/components/DataDisplay/DeviceView/DeviceEdit.js
@@ -370,7 +370,7 @@ const EditDeviceForm = ({ deviceData, siteOptions }) => {
             />
           </Grid>
           <Grid items xs={12} sm={4} style={gridItemStyle}>
-            {/* <Box height="10px" />
+            <Box height="10px" />
             <OutlinedSelect
               label="Network"
               value={networkList.find((option) => option.value === editData.network)}
@@ -388,18 +388,7 @@ const EditDeviceForm = ({ deviceData, siteOptions }) => {
               error={!!errors.network}
               helperText={errors.network}
               required
-              disabled={true}
-            /> */}
-            <TextField
-              style={{ margin: '10px 0' }}
-              label="Network"
-              variant="outlined"
-              value={deviceData.network}
-              error={!!errors.network}
-              helperText={errors.network}
-              disabled
-              fullWidth
-              required
+              isDisabled={true}
             />
           </Grid>
           <Grid items xs={12} sm={4} style={gridItemStyle}>

--- a/netmanager/src/views/components/DataDisplay/DeviceView/DeviceEdit.js
+++ b/netmanager/src/views/components/DataDisplay/DeviceView/DeviceEdit.js
@@ -370,7 +370,7 @@ const EditDeviceForm = ({ deviceData, siteOptions }) => {
             />
           </Grid>
           <Grid items xs={12} sm={4} style={gridItemStyle}>
-            <Box height="10px" />
+            {/* <Box height="10px" />
             <OutlinedSelect
               label="Network"
               value={networkList.find((option) => option.value === editData.network)}
@@ -387,6 +387,18 @@ const EditDeviceForm = ({ deviceData, siteOptions }) => {
               name="network"
               error={!!errors.network}
               helperText={errors.network}
+              required
+              disabled={true}
+            /> */}
+            <TextField
+              style={{ margin: '10px 0' }}
+              label="Network"
+              variant="outlined"
+              value={deviceData.network}
+              error={!!errors.network}
+              helperText={errors.network}
+              disabled
+              fullWidth
               required
             />
           </Grid>

--- a/netmanager/src/views/pages/SignUp/Register.js
+++ b/netmanager/src/views/pages/SignUp/Register.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { Link, withRouter } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
@@ -15,7 +15,6 @@ import countries from 'i18n-iso-countries';
 import enLocale from 'i18n-iso-countries/langs/en.json';
 import Select from 'react-select';
 import { getNetworkListSummaryApi } from '../../apis/accessControl';
-import OutlinedSelect from '../../components/CustomSelects/OutlinedSelect';
 
 countries.registerLocale(enLocale);
 
@@ -111,6 +110,7 @@ const Register = ({
 }) => {
   const query = new URLSearchParams(location.search);
   const tenant = match.params.tenant || 'airqo';
+  const selectRef = useRef(null);
 
   const [state, setState] = useState({
     firstName: '',
@@ -457,8 +457,12 @@ const Register = ({
                   InputLabelProps={{ style: { fontSize: '0.8rem' } }}
                 />
 
-                <div style={{ marginTop: '15px', marginBottom: '15px' }}>
-                  <OutlinedSelect
+                <div style={{ marginTop: '8px', marginBottom: '15px' }}>
+                  <label style={{ textAlign: 'left', color: '#000' }}>
+                    Choose the organisation you want to request access to
+                  </label>
+                  <Select
+                    ref={selectRef}
                     value={
                       showAllNetworks
                         ? networkList.find((option) => option.value === state.network_id)
@@ -467,14 +471,19 @@ const Register = ({
                     onChange={onChangeDropdown}
                     options={showAllNetworks ? networkList : [defaultNetwork]}
                     isSearchable
-                    label="Choose the organisation you want to request access to"
                     name="network_id"
                     placeholder="Network"
                     error={!!formErrors.network_id}
                     styles={customStyles}
                   />
                   <small>
-                    <a onClick={() => setShowAllNetworks(true)} style={{ cursor: 'pointer' }}>
+                    <a
+                      onClick={() => {
+                        setShowAllNetworks(true);
+                        selectRef.current.focus();
+                      }}
+                      style={{ cursor: 'pointer' }}
+                    >
                       Looking for other organizations? Click to view more in the list
                     </a>
                   </small>


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

- Disables editing device network field
- User needs to click link for more organisations to appear under request access form

#### Status of maturity (all need to be checked before merging):

- [x] I've tested this locally
- [x] I consider this code done
- [x] This change ready to hit production in its current state

#### How should this be manually tested?

- Please include the steps to be done inorder to setup and test this PR.

#### What are the relevant tickets?

- Closes #<enter issue number here>
- [Jira_card_number]() (If exists)

#### Screenshots (optional)
![image](https://github.com/airqo-platform/AirQo-frontend/assets/46527380/1149cd46-e1f7-4fa8-9a22-60242a970234)
![image](https://github.com/airqo-platform/AirQo-frontend/assets/46527380/b27626d9-1d26-447d-919e-4e3ea712c4a9)
![image](https://github.com/airqo-platform/AirQo-frontend/assets/46527380/e88bbdd2-90aa-45c7-a50e-e125462d14fa)

![image](https://github.com/airqo-platform/AirQo-frontend/assets/46527380/bf4d3203-2030-4a29-9d21-8a892af0a528)
