### PR TITLE
[Hotfix] fix download calibrated file functionality for calibrate tool

### DIFF
--- a/calibrate/package-lock.json
+++ b/calibrate/package-lock.json
@@ -8954,6 +8954,11 @@
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
     },
+    "papaparse": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.4.1.tgz",
+      "integrity": "sha512-HipMsgJkZu8br23pW15uvo6sib6wne/4woLZPlFf3rpDyMe9ywEXUsuD7+6K9PRkJlVT51j/sCOYDKGGS3ZJrw=="
+    },
     "param-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",

--- a/calibrate/package.json
+++ b/calibrate/package.json
@@ -18,6 +18,7 @@
     "cross-env": "^7.0.3",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-prettier": "^4.0.0",
+    "papaparse": "^5.4.1",
     "prettier": "^2.6.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/calibrate/src/views/apis/calibrateTool.js
+++ b/calibrate/src/views/apis/calibrateTool.js
@@ -4,7 +4,7 @@ import {
   TRAIN_CALIBRATE_TOOL_URL,
 } from "../../configs/urls";
 
-const BASE_AUTH_TOKEN = process.env.REACT_APP_AUTH_TOKEN;
+axios.defaults.headers.common.Authorization = `JWT ${process.env.REACT_APP_AUTHORIZATION_TOKEN}`;
 
 export const calibrateDataApi = async (data) => {
   return await axios
@@ -13,9 +13,6 @@ export const calibrateDataApi = async (data) => {
       method: "POST",
       data: data,
       headers: { "Content-Type": "multipart/form-data" },
-      params: {
-        token: BASE_AUTH_TOKEN,
-      },
       responseType: "blob", //important
     })
 
@@ -30,9 +27,6 @@ export const trainAndCalibrateDataApi = async (data) => {
       method: "POST",
       data: data,
       headers: { "Content-Type": "multipart/form-data" },
-      params: {
-        token: BASE_AUTH_TOKEN,
-      },
       responseType: "blob", //important
     })
     .then((response) => response.data)

--- a/calibrate/src/views/apis/calibrateTool.js
+++ b/calibrate/src/views/apis/calibrateTool.js
@@ -4,7 +4,7 @@ import {
   TRAIN_CALIBRATE_TOOL_URL,
 } from "../../configs/urls";
 
-axios.defaults.headers.common.Authorization = `JWT ${process.env.REACT_APP_AUTHORIZATION_TOKEN}`;
+const BASE_AUTH_TOKEN = process.env.REACT_APP_AUTH_TOKEN;
 
 export const calibrateDataApi = async (data) => {
   return await axios
@@ -13,6 +13,9 @@ export const calibrateDataApi = async (data) => {
       method: "POST",
       data: data,
       headers: { "Content-Type": "multipart/form-data" },
+      params: {
+        token: BASE_AUTH_TOKEN,
+      },
       responseType: "blob", //important
     })
 
@@ -27,6 +30,9 @@ export const trainAndCalibrateDataApi = async (data) => {
       method: "POST",
       data: data,
       headers: { "Content-Type": "multipart/form-data" },
+      params: {
+        token: BASE_AUTH_TOKEN,
+      },
       responseType: "blob", //important
     })
     .then((response) => response.data)

--- a/calibrate/src/views/components/Calibrate.js
+++ b/calibrate/src/views/components/Calibrate.js
@@ -11,6 +11,7 @@ import {
   trainAndCalibrateDataApi,
 } from "../apis/calibrateTool";
 import PropTypes from "prop-types";
+import Papa from "papaparse";
 
 // styles
 import "../../styles/calibrate.css";
@@ -183,16 +184,14 @@ const Calibrate = () => {
   }, [selectedFile]);
 
   const downloadCSVData = (filename, data) => {
-    const downloadUrl = window.URL.createObjectURL(data);
-    const link = document.createElement("a");
-
-    link.href = downloadUrl;
-    link.setAttribute("download", filename); //any other extension
-
-    document.body.appendChild(link);
-
-    link.click();
-    link.remove();
+    const csvData = Papa.unparse(data);
+    const blob = new Blob([csvData], { type: "text/csv;charset=utf-8;" });
+    const url = window.URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = filename;
+    a.click();
+    window.URL.revokeObjectURL(url);
   };
 
   const onSubmit = async (event) => {


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

- fix download calibrated file functionality for calibrate tool
- Unable to test with staging but works with production api

#### Status of maturity (all need to be checked before merging):

- [x] I've tested this in production(staging api is returning 504 error)
- [x] I consider this code done
- [x] This change ready to hit production in its current state

#### How should this be manually tested?

- Please include the steps to be done inorder to setup and test this PR.

#### What are the relevant tickets?

- Closes #<enter issue number here>
- [AN-535](https://airqoteam.atlassian.net/browse/AN-535) 

#### Screenshots (optional)
![Screenshot from 2023-09-13 13-36-15](https://github.com/airqo-platform/AirQo-frontend/assets/46527380/23bd7a43-f0f7-4f4d-8a56-df1607682b64)


[AN-535]: https://airqoteam.atlassian.net/browse/AN-535?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ