### PR TITLE
Change time displayed on widget

### DIFF
--- a/mobile/lib/models/widget_data.dart
+++ b/mobile/lib/models/widget_data.dart
@@ -43,8 +43,8 @@ class WidgetData {
       location: airQualityReading.name,
       circularLocation: airQualityReading.name,
       airQuality: Pollutant.pm2_5.airQuality(airQualityReading.pm2_5),
-      date: DateFormat('dd/MM, h:mm a').format(DateTime.now().toLocal()),
-      circularDate: DateFormat('h:mm a').format(DateTime.now().toLocal()),
+      date: DateFormat('dd/MM, h:mm a').format(airQualityReading.dateTime.toLocal()),
+      circularDate: DateFormat('h:mm a').format(airQualityReading.dateTime.toLocal()),
       pmValue: airQualityReading.pm2_5,
       circularPmValue: airQualityReading.pm2_5,
 


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

- This changes the time displayed on the widget from current time to time of last air quality update for the location

#### Status of maturity (all need to be checked before merging):

- [x] I've tested this locally
- [x] I consider this code done
- [x] This change ready to hit production in its current state
- [x] The title of the PR states what changed and the related issues number (used for the release note).
- [ ] I've included issue number in the "Closes #ISSUE-NUMBER" part of the "[What are the relevant tickets?](#what-are-the-relevant-tickets)" section to [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [ ] I've updated corresponding documentation for the changes in this PR.
- [ ] I have written unit and/or e2e tests for my change(s).

#### How should this be manually tested?

- checkout the branch
- `flutter run`
- add widget to screen

#### Screenshots (optional)
![Screenshot_20230918_140549](https://github.com/airqo-platform/AirQo-frontend/assets/60974514/68c633be-92c1-406d-a8dc-881ace9008e3)

