### PR TITLE
[NET] Removed the distance and bearing to kampala fields (site Registry)

### DIFF
--- a/netmanager/src/__tests__/DataDisplay/sitesView.test.js
+++ b/netmanager/src/__tests__/DataDisplay/sitesView.test.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { createStore } from 'redux';
+import { BrowserRouter as Router } from 'react-router-dom';
+import SiteView from '../../views/components/Sites/SiteView';
+import RootReducer from '../../redux/SiteRegistry/reducers';
+import { ThemeProvider, createMuiTheme } from '@material-ui/core/styles';
+
+const theme = createMuiTheme();
+const store = createStore(RootReducer);
+
+Storage.prototype.getItem = jest.fn(() => JSON.stringify({ net_name: 'test' }));
+
+describe('SiteView', () => {
+  it('renders without crashing', () => {
+    const currentRole = {
+      role_permissions: [{ permission: 'requiredPermission' }]
+    };
+
+    render(
+      <Provider store={store}>
+        <ThemeProvider theme={theme}>
+          <Router>
+            <SiteView currentRole={currentRole} />
+          </Router>
+        </ThemeProvider>
+      </Provider>
+    );
+  });
+});

--- a/netmanager/src/views/components/Sites/SiteView.js
+++ b/netmanager/src/views/components/Sites/SiteView.js
@@ -358,6 +358,30 @@ const SiteForm = ({ site }) => {
             fullWidth
           />
         </Grid>
+        <Grid items xs={12} sm={6} style={gridItemStyle}>
+          <TextField
+            id="bearing_to_capital_city_center"
+            label="Bearing to Capital City center"
+            variant="outlined"
+            defaultValue={site?.bearing_to_capital_city_center}
+            onChange={handleSiteInfoChange}
+            error={!!errors.bearing_to_capital_city_center}
+            helperText={errors.bearing_to_capital_city_center}
+            fullWidth
+          />
+        </Grid>
+        <Grid items xs={12} sm={6} style={gridItemStyle}>
+          <TextField
+            id="distance_to_capital_city_center"
+            variant="outlined"
+            label="Distance to Capital City center (km)"
+            defaultValue={site?.distance_to_capital_city_center}
+            onChange={handleSiteInfoChange}
+            error={!!errors.distance_to_capital_city_center}
+            helperText={errors.distance_to_capital_city_center}
+            fullWidth
+          />
+        </Grid>
 
         <Grid xs={12} sm={12} style={gridItemStyle}>
           <Typography variant="h3">Mobile app site details</Typography>

--- a/netmanager/src/views/components/Sites/SiteView.js
+++ b/netmanager/src/views/components/Sites/SiteView.js
@@ -111,8 +111,7 @@ const SiteForm = ({ site }) => {
         minHeight: '400px',
         padding: '20px 20px',
         maxWidth: '1500px'
-      }}
-    >
+      }}>
       {/* custome Horizontal loader indicator */}
       <HorizontalLoader loading={loading} />
       <div
@@ -122,15 +121,13 @@ const SiteForm = ({ site }) => {
           fontSize: '1.2rem',
           fontWeight: 'bold',
           margin: '20px 0'
-        }}
-      >
+        }}>
         <div
           style={{
             display: 'flex',
             alignItems: 'center',
             padding: '5px'
-          }}
-        >
+          }}>
           <ArrowBackIosRounded
             style={{ color: '#3f51b5', cursor: 'pointer' }}
             onClick={() => history.push(goBackUrl)}
@@ -361,30 +358,6 @@ const SiteForm = ({ site }) => {
             fullWidth
           />
         </Grid>
-        <Grid items xs={12} sm={6} style={gridItemStyle}>
-          <TextField
-            id="bearing_to_kampala_center"
-            label="Bearing to Kampala center"
-            variant="outlined"
-            defaultValue={site.bearing_to_kampala_center}
-            onChange={handleSiteInfoChange}
-            error={!!errors.bearing_to_kampala_center}
-            helperText={errors.bearing_to_kampala_center}
-            fullWidth
-          />
-        </Grid>
-        <Grid items xs={12} sm={6} style={gridItemStyle}>
-          <TextField
-            id="distance_to_kampala_center"
-            variant="outlined"
-            label="Distance to Kampala center (km)"
-            defaultValue={site.distance_to_kampala_center}
-            onChange={handleSiteInfoChange}
-            error={!!errors.distance_to_kampala_center}
-            helperText={errors.distance_to_kampala_center}
-            fullWidth
-          />
-        </Grid>
 
         <Grid xs={12} sm={12} style={gridItemStyle}>
           <Typography variant="h3">Mobile app site details</Typography>
@@ -422,8 +395,7 @@ const SiteForm = ({ site }) => {
           alignContent="flex-end"
           justify="flex-end"
           xs={12}
-          style={{ margin: '10px 0' }}
-        >
+          style={{ margin: '10px 0' }}>
           <Button variant="contained" onClick={handleCancel}>
             Cancel
           </Button>
@@ -433,8 +405,7 @@ const SiteForm = ({ site }) => {
             color="primary"
             disabled={weightedBool(loading, isEmpty(siteInfo))}
             onClick={handleSubmit}
-            style={{ marginLeft: '10px' }}
-          >
+            style={{ marginLeft: '10px' }}>
             Save Changes
           </Button>
         </Grid>
@@ -463,8 +434,7 @@ const SiteView = (props) => {
       style={{
         width: '96%',
         margin: ' 20px auto'
-      }}
-    >
+      }}>
       <SiteForm site={site} key={`${site._id}`} />
 
       <div>
@@ -473,8 +443,7 @@ const SiteView = (props) => {
             margin: '50px auto',
             // minHeight: "400px",
             maxWidth: '1500px'
-          }}
-        >
+          }}>
           <CustomMaterialTable
             title="Site Devices details"
             userPreferencePaginationKey={'siteDevices'}

--- a/netmanager/src/views/components/Sites/SiteView.js
+++ b/netmanager/src/views/components/Sites/SiteView.js
@@ -363,7 +363,9 @@ const SiteForm = ({ site }) => {
             id="bearing_to_capital_city_center"
             label="Bearing to Capital City center"
             variant="outlined"
-            defaultValue={site?.bearing_to_capital_city_center}
+            defaultValue={
+              site && site.bearing_to_capital_city_center ? site.bearing_to_capital_city_center : ''
+            }
             onChange={handleSiteInfoChange}
             error={!!errors.bearing_to_capital_city_center}
             helperText={errors.bearing_to_capital_city_center}
@@ -375,7 +377,11 @@ const SiteForm = ({ site }) => {
             id="distance_to_capital_city_center"
             variant="outlined"
             label="Distance to Capital City center (km)"
-            defaultValue={site?.distance_to_capital_city_center}
+            defaultValue={
+              site && site.distance_to_capital_city_center
+                ? site.distance_to_capital_city_center
+                : ''
+            }
             onChange={handleSiteInfoChange}
             error={!!errors.distance_to_capital_city_center}
             helperText={errors.distance_to_capital_city_center}

--- a/netmanager/src/views/containers/PageAccess.js
+++ b/netmanager/src/views/containers/PageAccess.js
@@ -8,7 +8,7 @@ export const withPermission = (Component, requiredPermission) => {
     // Check if the user has the required permission
     const hasPermission =
       currentRole &&
-      currentRole.role_permissions.some(
+      currentRole?.role_permissions?.some(
         (permission) => permission.permission === requiredPermission
       );
 


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

- This PR updates the site registry view to reflect recent modifications in the metadata microservice. The introduction of new fields to the site Registry form i.e. distance to capital city center and bearing to capital city center.
- Additionally, modifications have been made to the PageAccess.js file to address issues identified during testing.

#### Status of maturity (all need to be checked before merging):

- [x] I've tested this locally
- [x] I consider this code done
- [x] This change ready to hit production in its current state

#### How should this be manually tested?
-  To view the change navigate to the site Registry View

#### Screenshots (optional)
![image](https://github.com/airqo-platform/AirQo-frontend/assets/97807374/4f9151da-a51d-47d7-aaed-f040ac1ac1b6)
![image](https://github.com/airqo-platform/AirQo-frontend/assets/97807374/f06c8871-925e-4f10-8df6-d4029750096a)
