### PR TITLE
REMOVE DULICATE FEEDBACK CARD

### DIFF
--- a/mobile/lib/screens/settings/settings_page.dart
+++ b/mobile/lib/screens/settings/settings_page.dart
@@ -18,7 +18,6 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:showcaseview/showcaseview.dart';
 
-import '../feedback/feedback_page.dart';
 import 'about_page.dart';
 import 'delete_account_screen.dart';
 
@@ -123,28 +122,6 @@ class _SettingsPageState extends State<SettingsPage>
                                 );
                               },
                               value: state.notifications,
-                            ),
-                          ),
-                        ),
-                        divider,
-                        Card(
-                          margin: EdgeInsets.zero,
-                          elevation: 0,
-                          child: ListTile(
-                            tileColor: Colors.white,
-                            onTap: () async {
-                              await Navigator.push(
-                                context,
-                                MaterialPageRoute(
-                                  builder: (context) {
-                                    return const FeedbackPage();
-                                  },
-                                ),
-                              );
-                            },
-                            title: Text(
-                              AppLocalizations.of(context)!.sendFeedback,
-                              style: Theme.of(context).textTheme.bodyLarge,
                             ),
                           ),
                         ),


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

- Removes the duplicate feedback page from the settings page, there was already one in the profile page 

#### Status of maturity (all need to be checked before merging):

- [ ] I've tested this locally
- [ ] I consider this code done
- [ ] This change ready to hit production in its current state
- [ ] The title of the PR states what changed and the related issues number (used for the release note).
- [ ] I've included issue number in the "Closes #ISSUE-NUMBER" part of the "[What are the relevant tickets?](#what-are-the-relevant-tickets)" section to [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [ ] I've updated corresponding documentation for the changes in this PR.
- [ ] I have written unit and/or e2e tests for my change(s).

#### How should this be manually tested?

- Please include the steps to be done inorder to setup and test this PR.

#### What are the relevant tickets?

- Closes #<enter issue number here>
- [Jira_card_number]() (If exists)

#### Screenshots (optional)
