### PR TITLE
[Netmanager] Hide Sim Registry and included JWT to heatmap and sites API headers

### DIFF
--- a/netmanager/src/views/apis/analytics.js
+++ b/netmanager/src/views/apis/analytics.js
@@ -21,6 +21,7 @@ export const getMonitoringSitesInfoApi = async (pm25Category) => {
 };
 
 export const getSitesApi = async () => {
+  axios.defaults.headers.common.Authorization = jwtToken;
   return await axios.get(GET_SITES).then((response) => response.data);
 };
 

--- a/netmanager/src/views/apis/deviceRegistry.js
+++ b/netmanager/src/views/apis/deviceRegistry.js
@@ -136,26 +136,31 @@ export const getEventsApi = async (params) => {
 };
 
 export const getSitesApi = async (params) => {
+  axios.defaults.headers.common.Authorization = jwtToken;
   return await axios.get(SITES, { params: { ...params } }).then((response) => response.data);
 };
 
 export const getSitesSummaryApi = async (params) => {
+  axios.defaults.headers.common.Authorization = jwtToken;
   return await axios
     .get(`${SITES}/summary`, { params: { ...params } })
     .then((response) => response.data);
 };
 
 export const getSiteDetailsApi = async (site_id) => {
+  axios.defaults.headers.common.Authorization = jwtToken;
   return await axios.get(SITES, { params: { id: site_id } }).then((response) => response.data);
 };
 
 export const updateSiteApi = async (site_id, siteData) => {
+  axios.defaults.headers.common.Authorization = jwtToken;
   return await axios
     .put(SITES, siteData, { params: { id: site_id } })
     .then((response) => response.data);
 };
 
 export const createSiteApi = async (siteData) => {
+  axios.defaults.headers.common.Authorization = jwtToken;
   return await axios.post(SITES, siteData).then((response) => response.data);
 };
 

--- a/netmanager/src/views/apis/location.js
+++ b/netmanager/src/views/apis/location.js
@@ -1,15 +1,15 @@
 import axios from 'axios';
 import { GET_MONITORING_SITES_LOCATIONS_URI } from 'config/urls/analytics';
 import { ALL_LOCATIONS_URI } from 'config/urls/locationRegistry';
-import { isEmpty } from 'validate.js';
 
 const jwtToken = localStorage.getItem('jwtToken');
-axios.defaults.headers.common.Authorization = jwtToken;
 
 export const getMonitoringSitesLocationsApi = async () => {
+  axios.defaults.headers.common.Authorization = jwtToken;
   return await axios.get(GET_MONITORING_SITES_LOCATIONS_URI).then((response) => response.data);
 };
 
 export const getAllLocationsApi = async () => {
+  axios.defaults.headers.common.Authorization = jwtToken;
   return await axios.get(ALL_LOCATIONS_URI).then((response) => response.data);
 };

--- a/netmanager/src/views/apis/predict.js
+++ b/netmanager/src/views/apis/predict.js
@@ -1,11 +1,7 @@
 import axios from 'axios';
 import { GET_HEATMAP_DATA, GET_GEOCOORDINATES_DATA } from 'config/urls/predict';
-import { isEmpty } from 'validate.js';
 
 const jwtToken = localStorage.getItem('jwtToken');
-axios.defaults.headers.common.Authorization = jwtToken;
-
-const API_TOKEN = process.env.REACT_APP_API_TOKEN;
 
 export const heatmapPredictApi = async () => {
   let allHeatMapData = [];
@@ -14,6 +10,7 @@ export const heatmapPredictApi = async () => {
   let MAX_PAGES;
   do {
     try {
+      axios.defaults.headers.common.Authorization = jwtToken;
       response = await axios.get(GET_HEATMAP_DATA);
       MAX_PAGES = response.data.pages;
       allHeatMapData.push(axios.get(`${GET_HEATMAP_DATA}?page=${page}`));
@@ -30,5 +27,6 @@ export const heatmapPredictApi = async () => {
 };
 
 export const geocoordinatesPredictApi = async (params) => {
+  axios.defaults.headers.common.Authorization = jwtToken;
   return await axios.get(GET_GEOCOORDINATES_DATA, { params }).then((response) => response.data);
 };

--- a/netmanager/src/views/layouts/common/Sidebar/Sidebar.js
+++ b/netmanager/src/views/layouts/common/Sidebar/Sidebar.js
@@ -328,6 +328,7 @@ const Sidebar = (props) => {
         'Location Registry',
         'Device Registry',
         'Host Registry',
+        'SIM Registry',
         'Site Registry',
         'AirQloud Registry',
         'Cohorts Registry',


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

-Removed the Sim Registry from the sidebar; it will now only appear when the user signs in.
- Integrated JWT token directly into the Heatmap and Sites API to address the issue of unauthorized errors appearing in the networks section.

#### Status of maturity (all need to be checked before merging):

- [x] I've tested this locally
- [x] I consider this code done
- [x] This change ready to hit production in its current state

#### Screenshots (optional)
![image](https://github.com/airqo-platform/AirQo-frontend/assets/97807374/43f4dc1a-1ac9-4c47-9922-63af4168f75f)
![image](https://github.com/airqo-platform/AirQo-frontend/assets/97807374/76398606-79be-4276-9482-65e1eb7e0964)
