### PR TITLE
Language switch fix

### DIFF
--- a/mobile/lib/screens/settings/language_switch.dart
+++ b/mobile/lib/screens/settings/language_switch.dart
@@ -66,22 +66,22 @@ class LanguageListState extends State<LanguageList> {
               Locale locale = await setLocale(language.languageCode);
               await AirQoApp.setLocale(context, locale);
               Navigator.pop(context, true);
-              await Restart.restartApp();
+              //await Restart.restartApp();
             },
           ),
-          CupertinoDialogAction(
-            child: Text(
-              style: TextStyle(
-                color: CustomColors.appColorBlue,
-                fontSize: 16,
-                fontWeight: FontWeight.w600,
-              ),
-              AppLocalizations.of(context)!.cancel,
-            ),
-            onPressed: () {
-              Navigator.pop(context, false);
-            },
-          ),
+          // CupertinoDialogAction(
+          //   child: Text(
+          //     style: TextStyle(
+          //       color: CustomColors.appColorBlue,
+          //       fontSize: 16,
+          //       fontWeight: FontWeight.w600,
+          //     ),
+          //     AppLocalizations.of(context)!.cancel,
+          //   ),
+          //   onPressed: () {
+          //     Navigator.pop(context, false);
+          //   },
+          // ),
         ],
       ),
       barrierDismissible: true,

--- a/mobile/lib/screens/settings/language_switch.dart
+++ b/mobile/lib/screens/settings/language_switch.dart
@@ -2,6 +2,7 @@ import 'package:app/constants/constants.dart';
 import 'package:app/main_common.dart';
 import 'package:app/screens/offline_banner.dart';
 import 'package:app/themes/theme.dart';
+import 'package:app/utils/utils.dart';
 import 'package:app/widgets/widgets.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
@@ -10,7 +11,7 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import '../../constants/language_contants.dart';
 import '../../themes/colors.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:restart_app/restart_app.dart';
+// import 'package:restart_app/restart_app.dart';
 
 class LanguageList extends StatefulWidget {
   const LanguageList({Key? key}) : super(key: key);
@@ -69,19 +70,19 @@ class LanguageListState extends State<LanguageList> {
               //await Restart.restartApp();
             },
           ),
-          // CupertinoDialogAction(
-          //   child: Text(
-          //     style: TextStyle(
-          //       color: CustomColors.appColorBlue,
-          //       fontSize: 16,
-          //       fontWeight: FontWeight.w600,
-          //     ),
-          //     AppLocalizations.of(context)!.cancel,
-          //   ),
-          //   onPressed: () {
-          //     Navigator.pop(context, false);
-          //   },
-          // ),
+          CupertinoDialogAction(
+            child: Text(
+              style: TextStyle(
+                color: CustomColors.appColorBlue,
+                fontSize: 16,
+                fontWeight: FontWeight.w600,
+              ),
+              AppLocalizations.of(context)!.cancel,
+            ),
+            onPressed: () {
+              Navigator.pop(context, false);
+            },
+          ),
         ],
       ),
       barrierDismissible: true,
@@ -137,15 +138,35 @@ class LanguageListState extends State<LanguageList> {
                             ),
                             title: Text(language.name),
                             onTap: () async {
-                              final shouldChangeLanguage =
-                                  await languageDialog(context, language);
-                              if (shouldChangeLanguage) {
-                                await _saveSelectedLanguage(
-                                    language.languageCode);
-                                setState(() {
-                                  selectedLanguageCode = language.languageCode;
-                                });
-                              }
+                              // final shouldChangeLanguage =
+                              //     await languageDialog(context, language);
+                              // if (shouldChangeLanguage) {
+                              //   await _saveSelectedLanguage(
+                              //       language.languageCode);
+                              //   setState(() {
+                              //     selectedLanguageCode = language.languageCode;
+                              //   });
+                              // }
+
+                              await _saveSelectedLanguage(
+                                  language.languageCode);
+                              Locale locale =
+                                  await setLocale(language.languageCode);
+                              setState(() {
+                                selectedLanguageCode = language.languageCode;
+                              });
+                              ScaffoldMessenger.of(context).showSnackBar(
+                                SnackBar(
+                                  elevation: 1,
+                                  content: Text(
+                                    AppLocalizations.of(context)!
+                                        .languageChangedSuccessfully(
+                                            language.name.toCapitalized()),
+                                  ),
+                                ),
+                              );
+                              await AirQoApp.setLocale(context, locale);
+                              //Navigator.pop(context, true);
                             },
                           ),
                         ),


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

- Disabled The auto-restart functionality when the languages are switched and a snackbar inform user that the preferred language is successfully switched 

#### Status of maturity (all need to be checked before merging):

- [x] I've tested this locally
- [x] I consider this code done
- [ ] This change ready to hit production in its current state
- [ ] The title of the PR states what changed and the related issues number (used for the release note).
- [ ] I've included issue number in the "Closes #ISSUE-NUMBER" part of the "[What are the relevant tickets?](#what-are-the-relevant-tickets)" section to [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [ ] I've updated corresponding documentation for the changes in this PR.
- [ ] I have written unit and/or e2e tests for my change(s).

#### How should this be manually tested?

- Please include the steps to be done inorder to setup and test this PR.

#### What are the relevant tickets?

- Closes #<enter issue number here>
- [Jira_card_number]() (If exists)

#### Screenshots (optional)
