### PR TITLE
Added measurements api section for user to copy

### DIFF
--- a/netmanager/src/assets/css/copyable.css
+++ b/netmanager/src/assets/css/copyable.css
@@ -12,3 +12,14 @@
 .copyable-icon:hover {
   fill: #0366d6;
 }
+
+.copyable-scrollable-text {
+  overflow: auto;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+  font-family: monospace;
+}
+
+.copyable-scrollable-text::-webkit-scrollbar {
+  display: none;
+}

--- a/netmanager/src/views/components/Copy/Copyable.js
+++ b/netmanager/src/views/components/Copy/Copyable.js
@@ -1,20 +1,20 @@
-import React, { useState, useRef } from "react";
-import { useDispatch } from "react-redux";
-import CopyIcon, { CopySuccessIcon } from "assets/img/CopyIcon";
-import { updateMainAlert } from "redux/MainAlert/operations";
-import { Button } from "@material-ui/core";
-import clsx from "clsx";
+import React, { useState, useRef } from 'react';
+import { useDispatch } from 'react-redux';
+import CopyIcon, { CopySuccessIcon } from 'assets/img/CopyIcon';
+import { updateMainAlert } from 'redux/MainAlert/operations';
+import { Button } from '@material-ui/core';
+import clsx from 'clsx';
 
-const Copyable = ({ value, className, width, format }) => {
+const Copyable = ({ value, className, width, format, isScrollable = false }) => {
   const copyRef = useRef();
   const [copied, setCopied] = useState(false);
   const dispatch = useDispatch();
-  let isDisabled = value === "-";
+  let isDisabled = value === '-';
 
   const onClick = () => {
     // let comp = document.getElementById(componentID);
     let comp = copyRef.current;
-    let textArea = document.createElement("textarea");
+    let textArea = document.createElement('textarea');
     textArea.value = comp.textContent;
     document.body.appendChild(textArea);
     /* Select the text field */
@@ -22,16 +22,14 @@ const Copyable = ({ value, className, width, format }) => {
     textArea.setSelectionRange(0, 99999); /* For mobile devices */
 
     /* Copy the text inside the text field */
-    document.execCommand("copy");
+    document.execCommand('copy');
     textArea.remove();
     setCopied(true);
     dispatch(
       updateMainAlert({
         show: true,
-        message: `Successfully copied to clipboard. ${
-          format ? "format - " + format : ""
-        }`,
-        severity: "info",
+        message: `Successfully copied to clipboard. ${format ? 'format - ' + format : ''}`,
+        severity: 'info'
       })
     );
     setTimeout(() => setCopied(false), 1000);
@@ -39,29 +37,29 @@ const Copyable = ({ value, className, width, format }) => {
   return (
     <div
       style={{
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "space-between",
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between'
       }}
     >
       <span
         ref={copyRef}
         style={{
-          width: width || "200px",
-          textOverflow: "ellipsis",
-          whiteSpace: "nowrap",
-          overflow: "hidden",
+          width: width || '200px',
+          textOverflow: isScrollable ? 'none' : 'ellipsis',
+          whiteSpace: 'nowrap',
+          overflow: isScrollable ? 'auto' : 'hidden'
         }}
+        className={isScrollable ? 'copyable-scrollable-text' : ''}
+        title={isScrollable ? 'Scroll left to view' : ''}
       >
         {value}
       </span>
       {copied ? (
         <CopySuccessIcon />
       ) : (
-        <Button disabled={value === "-"} onClick={onClick}>
-          <CopyIcon
-            className={clsx(isDisabled && "disabled-copyable-icon", className)}
-          />
+        <Button disabled={value === '-'} onClick={onClick}>
+          <CopyIcon className={clsx(isDisabled && 'disabled-copyable-icon', className)} />
         </Button>
       )}
     </div>

--- a/netmanager/src/views/components/DataDisplay/DeviceView/DeviceOverview/DeviceDetails.js
+++ b/netmanager/src/views/components/DataDisplay/DeviceView/DeviceOverview/DeviceDetails.js
@@ -14,7 +14,6 @@ import { decryptKeyApi } from 'views/apis/deviceRegistry';
 import { isEmpty } from 'underscore';
 import format from 'date-fns/format';
 import { stripTrailingSlash } from '../../../../../config/utils';
-import InfoIcon from '@material-ui/icons/Info';
 import HowToApiModal from '../../../HowToApiModal';
 
 const BASE_ANALYTICS_URL = stripTrailingSlash(process.env.REACT_APP_BASE_URL_V2);

--- a/netmanager/src/views/components/DataDisplay/DeviceView/DeviceOverview/DeviceDetails.js
+++ b/netmanager/src/views/components/DataDisplay/DeviceView/DeviceOverview/DeviceDetails.js
@@ -1,10 +1,22 @@
 import React, { useState, useEffect } from 'react';
-import { Paper, Table, TableBody, TableCell, TableContainer, TableRow } from '@material-ui/core';
+import {
+  Box,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableRow
+} from '@material-ui/core';
 import Copyable from 'views/components/Copy/Copyable';
 import { ChartContainer } from 'views/charts';
 import { decryptKeyApi } from 'views/apis/deviceRegistry';
 import { isEmpty } from 'underscore';
 import format from 'date-fns/format';
+import { stripTrailingSlash } from '../../../../../config/utils';
+import InfoIcon from '@material-ui/icons/Info';
+
+const BASE_ANALYTICS_URL = stripTrailingSlash(process.env.REACT_APP_BASE_URL_V2);
 
 const DeviceDetails = ({ deviceData }) => {
   const BLANK_PLACE_HOLDER = '-';
@@ -157,9 +169,58 @@ const DeviceDetails = ({ deviceData }) => {
                 <Copyable value={writeKey || BLANK_PLACE_HOLDER} />
               </TableCell>
             </TableRow>
+            {deviceData._id && (
+              <TableRow>
+                <TableCell>
+                  <b>Historical measurements API</b>
+                </TableCell>
+                <TableCell>
+                  <Copyable
+                    value={
+                      `${stripTrailingSlash(BASE_ANALYTICS_URL)}/devices/measurements/devices/${
+                        deviceData._id
+                      }/historical` || BLANK_PLACE_HOLDER
+                    }
+                    isScrollable
+                  />
+                </TableCell>
+              </TableRow>
+            )}
+            {deviceData._id && (
+              <TableRow>
+                <TableCell>
+                  <b>Recent measurements API</b>
+                </TableCell>
+                <TableCell>
+                  <Copyable
+                    value={
+                      `${stripTrailingSlash(BASE_ANALYTICS_URL)}/devices/measurements/devices/${
+                        deviceData._id
+                      }` || BLANK_PLACE_HOLDER
+                    }
+                    isScrollable
+                  />
+                </TableCell>
+              </TableRow>
+            )}
           </TableBody>
         </Table>
       </TableContainer>
+
+      <Box
+        style={{
+          display: 'flex',
+          flex: 1,
+          width: '100%',
+          justifyContent: 'flex-end',
+          textDecoration: 'underline',
+          padding: '10px',
+          fontWeight: 'bold',
+          cursor: 'pointer'
+        }}
+      >
+        <p style={{ width: '100%', textAlign: 'right' }}>How to use the API</p>
+      </Box>
     </ChartContainer>
   );
 };

--- a/netmanager/src/views/components/DataDisplay/DeviceView/DeviceOverview/DeviceDetails.js
+++ b/netmanager/src/views/components/DataDisplay/DeviceView/DeviceOverview/DeviceDetails.js
@@ -15,11 +15,13 @@ import { isEmpty } from 'underscore';
 import format from 'date-fns/format';
 import { stripTrailingSlash } from '../../../../../config/utils';
 import InfoIcon from '@material-ui/icons/Info';
+import HowToApiModal from '../../../HowToApiModal';
 
 const BASE_ANALYTICS_URL = stripTrailingSlash(process.env.REACT_APP_BASE_URL_V2);
 
 const DeviceDetails = ({ deviceData }) => {
   const BLANK_PLACE_HOLDER = '-';
+  const [openModal, setOpenModal] = useState(false);
   const [readKey, setReadKey] = useState('');
   const [writeKey, setWriteKey] = useState('');
 
@@ -218,9 +220,11 @@ const DeviceDetails = ({ deviceData }) => {
           fontWeight: 'bold',
           cursor: 'pointer'
         }}
+        onClick={() => setOpenModal(true)}
       >
         <p style={{ width: '100%', textAlign: 'right' }}>How to use the API</p>
       </Box>
+      <HowToApiModal open={openModal} onClose={() => setOpenModal(false)} />
     </ChartContainer>
   );
 };

--- a/netmanager/src/views/components/HowToApiModal/index.js
+++ b/netmanager/src/views/components/HowToApiModal/index.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Dialog, DialogTitle, DialogContent, DialogActions, Button } from '@material-ui/core';
+
+const HowToApiModal = ({ open, onClose }) => {
+  return (
+    <Dialog open={open} onClose={onClose} style={{ padding: '20px' }}>
+      <DialogTitle>How to the API</DialogTitle>
+      <DialogContent>
+        <ol>
+          <li>To use an API, you'll need to add an access token</li>
+          <li>Go to the Settings page.</li>
+          <li>Find the Client section and create a registered client if you don't have one yet.</li>
+          <li>Click on the "Generate Token" button.</li>
+          <li>Copy the generated API token.</li>
+          <li>
+            Paste the API token in your API requests. For example:
+            <br />
+            <span
+              style={{
+                backgroundColor: '#f0f0f0',
+                padding: '5px',
+                borderRadius: '5px',
+                fontFamily: 'monospace'
+              }}
+            >
+              https://example.com/api/v2/devices?token=YOUR_API_TOKEN
+            </span>
+          </li>
+        </ol>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} color="primary">
+          Close
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default HowToApiModal;

--- a/netmanager/src/views/components/HowToApiModal/index.js
+++ b/netmanager/src/views/components/HowToApiModal/index.js
@@ -4,7 +4,7 @@ import { Dialog, DialogTitle, DialogContent, DialogActions, Button } from '@mate
 const HowToApiModal = ({ open, onClose }) => {
   return (
     <Dialog open={open} onClose={onClose} style={{ padding: '20px' }}>
-      <DialogTitle>How to the API</DialogTitle>
+      <DialogTitle>How to the use the API</DialogTitle>
       <DialogContent>
         <ol>
           <li>To use an API, you'll need to add an access token</li>

--- a/netmanager/src/views/pages/CohortsRegistry/CohortDetails.jsx
+++ b/netmanager/src/views/pages/CohortsRegistry/CohortDetails.jsx
@@ -35,6 +35,11 @@ import { updateMainAlert } from 'redux/MainAlert/operations';
 import OutlinedSelect from '../../components/CustomSelects/OutlinedSelect';
 import { createAlertBarExtraContent } from '../../../utils/objectManipulators';
 import { LargeCircularLoader } from '../../components/Loader/CircularLoader';
+import { stripTrailingSlash } from '../../../config/utils';
+import Copyable from '../../components/Copy/Copyable';
+import HowToApiModal from '../../components/HowToApiModal';
+
+const BASE_ANALYTICS_URL = stripTrailingSlash(process.env.REACT_APP_BASE_URL_V2);
 
 const gridItemStyle = {
   padding: '5px',
@@ -185,6 +190,7 @@ const CohortForm = ({ cohort }) => {
   };
   const [form, setState] = useState(initialState);
   const [loading, setLoading] = useState(false);
+  const [openAPIModal, setOpenAPIModal] = useState(false);
   const clearState = () => {
     setState({ ...initialState });
   };
@@ -337,28 +343,90 @@ const CohortForm = ({ cohort }) => {
             <option value={false}>False</option>
           </TextField>
         </Grid>
+        <Grid items xs={12} sm={6} style={gridItemStyle}>
+          <label style={{ textAlign: 'left' }}>Recent Measurements API</label>
+          <Box
+            style={{
+              backgroundColor: '#f0f0f0',
+              padding: '5px',
+              borderRadius: '5px',
+              fontFamily: 'monospace'
+            }}
+          >
+            <Copyable
+              width="100%"
+              value={`${stripTrailingSlash(BASE_ANALYTICS_URL)}/devices/measurements/cohorts/${
+                cohort._id
+              }`}
+              isScrollable
+            />
+          </Box>
+        </Grid>
+        <Grid items xs={12} sm={6} style={gridItemStyle}>
+          <label style={{ textAlign: 'left' }}>Historical Measurements API</label>
+          <Box
+            style={{
+              backgroundColor: '#f0f0f0',
+              padding: '5px',
+              borderRadius: '5px',
+              fontFamily: 'monospace'
+            }}
+          >
+            <Copyable
+              width="100%"
+              value={`${stripTrailingSlash(BASE_ANALYTICS_URL)}/devices/measurements/cohorts/${
+                cohort._id
+              }/historical`}
+              isScrollable
+            />
+          </Box>
+        </Grid>
 
         <Grid
           container
-          alignItems="flex-end"
-          alignContent="flex-end"
-          justify="flex-end"
+          alignItems="center"
+          alignContent="center"
+          justify="space-between"
           xs={12}
           style={{ margin: '10px 0' }}
         >
-          <Button variant="contained" onClick={handleCancel} disabled={loading}>
-            Reset
-          </Button>
-
-          <Button
-            variant="contained"
-            color="primary"
-            onClick={handleSubmit}
-            style={{ marginLeft: '10px' }}
-            disabled={loading}
+          <Grid
+            items
+            xs={12}
+            sm={6}
+            style={{
+              textDecoration: 'underline',
+              padding: '10px',
+              fontWeight: 'bold',
+              cursor: 'pointer'
+            }}
+            onClick={() => setOpenAPIModal(true)}
           >
-            {loading ? 'Laoding...' : 'Save Changes'}
-          </Button>
+            <p style={{ width: '100%', textAlign: 'left' }}>How to use the API</p>
+          </Grid>
+          <Grid
+            items
+            xs={12}
+            sm={6}
+            style={{
+              display: 'flex',
+              justifyContent: 'flex-end'
+            }}
+          >
+            <Button variant="contained" onClick={handleCancel} disabled={loading}>
+              Reset
+            </Button>
+
+            <Button
+              variant="contained"
+              color="primary"
+              onClick={handleSubmit}
+              style={{ marginLeft: '10px' }}
+              disabled={loading}
+            >
+              {loading ? 'Loading...' : 'Save Changes'}
+            </Button>
+          </Grid>
         </Grid>
       </Grid>
 
@@ -368,6 +436,7 @@ const CohortForm = ({ cohort }) => {
         open={openDrawer}
         handleClose={handleCloseDrawer}
       />
+      <HowToApiModal open={openAPIModal} onClose={() => setOpenAPIModal(false)} />
     </Paper>
   );
 };

--- a/netmanager/src/views/pages/GridsRegistry/GridsDetails.js
+++ b/netmanager/src/views/pages/GridsRegistry/GridsDetails.js
@@ -30,6 +30,11 @@ import { updateGridApi } from '../../apis/deviceRegistry';
 import { withPermission } from '../../containers/PageAccess';
 import { LargeCircularLoader } from '../../components/Loader/CircularLoader';
 import { AirQloudView } from '../../components/AirQlouds';
+import HowToApiModal from '../../components/HowToApiModal';
+import { stripTrailingSlash } from '../../../config/utils';
+import Copyable from '../../components/Copy/Copyable';
+
+const BASE_ANALYTICS_URL = stripTrailingSlash(process.env.REACT_APP_BASE_URL_V2);
 
 const gridItemStyle = {
   padding: '5px',
@@ -47,6 +52,8 @@ const GridForm = ({ grid }) => {
     description: ''
   };
   const [form, setState] = useState(initialState);
+  const [openAPIModal, setOpenAPIModal] = useState(false);
+
   const [loading, setLoading] = useState(false);
   const clearState = () => {
     setState({ ...initialState });
@@ -229,6 +236,44 @@ const GridForm = ({ grid }) => {
             onChange={onChangeInputField}
           />
         </Grid>
+        <Grid items xs={12} sm={6} style={gridItemStyle}>
+          <label style={{ textAlign: 'left' }}>Recent Measurements API</label>
+          <Box
+            style={{
+              backgroundColor: '#f0f0f0',
+              padding: '5px',
+              borderRadius: '5px',
+              fontFamily: 'monospace'
+            }}
+          >
+            <Copyable
+              width="100%"
+              value={`${stripTrailingSlash(BASE_ANALYTICS_URL)}/devices/measurements/grids/${
+                grid._id
+              }`}
+              isScrollable
+            />
+          </Box>
+        </Grid>
+        <Grid items xs={12} sm={6} style={gridItemStyle}>
+          <label style={{ textAlign: 'left' }}>Historical Measurements API</label>
+          <Box
+            style={{
+              backgroundColor: '#f0f0f0',
+              padding: '5px',
+              borderRadius: '5px',
+              fontFamily: 'monospace'
+            }}
+          >
+            <Copyable
+              width="100%"
+              value={`${stripTrailingSlash(BASE_ANALYTICS_URL)}/devices/measurements/grids/${
+                grid._id
+              }/historical`}
+              isScrollable
+            />
+          </Box>
+        </Grid>
 
         <Grid
           container
@@ -238,20 +283,46 @@ const GridForm = ({ grid }) => {
           xs={12}
           style={{ margin: '10px 0' }}
         >
-          <Button variant="contained" onClick={handleCancel}>
-            Reset
-          </Button>
-
-          <Button
-            variant="contained"
-            color="primary"
-            onClick={handleSubmit}
-            style={{ marginLeft: '10px' }}
+          <Grid
+            items
+            xs={12}
+            sm={6}
+            style={{
+              textDecoration: 'underline',
+              padding: '10px',
+              fontWeight: 'bold',
+              cursor: 'pointer'
+            }}
+            onClick={() => setOpenAPIModal(true)}
           >
-            Save Changes
-          </Button>
+            <p style={{ width: '100%', textAlign: 'left' }}>How to use the API</p>
+          </Grid>
+
+          <Grid
+            items
+            xs={12}
+            sm={6}
+            style={{
+              display: 'flex',
+              justifyContent: 'flex-end'
+            }}
+          >
+            <Button variant="contained" onClick={handleCancel}>
+              Reset
+            </Button>
+
+            <Button
+              variant="contained"
+              color="primary"
+              onClick={handleSubmit}
+              style={{ marginLeft: '10px' }}
+            >
+              Save Changes
+            </Button>
+          </Grid>
         </Grid>
       </Grid>
+      <HowToApiModal open={openAPIModal} onClose={() => setOpenAPIModal(false)} />
     </Paper>
   );
 };


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

- Added a measurements section under device details section, and grids and cohort details section where a user can copy the historical and recent measurements apis for the corresponding sections.

#### Status of maturity (all need to be checked before merging):

- [x] I've tested this locally
- [x] I consider this code done
- [x] This change ready to hit production in its current state


#### Screenshots (optional)
![image](https://github.com/airqo-platform/AirQo-frontend/assets/46527380/9f1fe6de-88bb-44a2-9d59-4ccfc10b11e3)
![image](https://github.com/airqo-platform/AirQo-frontend/assets/46527380/0581d8a1-bd37-4451-9e18-dcbfd444dfb5)
![image](https://github.com/airqo-platform/AirQo-frontend/assets/46527380/4e0318fb-42b3-4970-8ee3-6c38f982a4dd)
![image](https://github.com/airqo-platform/AirQo-frontend/assets/46527380/1839d035-fe27-4b50-8ef4-8734c5c6808f)
