### PR TITLE
[Netmanager] Team Creation Error

### DIFF
--- a/netmanager/src/views/pages/Teams/Teams.js
+++ b/netmanager/src/views/pages/Teams/Teams.js
@@ -98,6 +98,7 @@ const CreateTeam = ({
 
     if (team.name && team.description) {
       let teamData = {
+        user_id: JSON.parse(localStorage.getItem('currentUser'))?._id,
         grp_title: team.name,
         grp_description: team.description
       };


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

- Improved Team Creation Functionality, Now Supports Mission User ID to solve the error of "creator's account is not provided"

#### Status of maturity (all need to be checked before merging):

- [x] I've tested this locally
- [x] I consider this code done
- [x] This change ready to hit production in its current state

#### Screenshots (optional)
![image](https://github.com/airqo-platform/AirQo-frontend/assets/97807374/3559e4b9-764c-471f-89a1-6a40a6f66c1a)
