### PR TITLE
[Netmanager]  Offline Mode for Map Nodes and User Stats UI

### DIFF
--- a/netmanager/src/AppRoutes.js
+++ b/netmanager/src/AppRoutes.js
@@ -55,6 +55,7 @@ const GridsDetails = lazy(() => import('./views/pages/GridsRegistry/GridsDetails
 const Teams = lazy(() => import('./views/pages/Teams/Teams'));
 const TeamsView = lazy(() => import('./views/pages/Teams/TeamsView'));
 const SimRegistry = lazy(() => import('./views/components/SIM/SimRegistry'));
+const UserStats = lazy(() => import('./views/pages/UserStats/UserStats'));
 
 const AppRoutes = ({ auth, logoutUser }) => {
   useJiraHelpDesk();
@@ -112,6 +113,12 @@ const AppRoutes = ({ auth, logoutUser }) => {
               exact
               path="/admin/users/available-users"
               component={AvailableUserList}
+              layout={MainLayout}
+            />
+            <PrivateRoute
+              exact
+              path="/admin/users/users-statistics"
+              component={UserStats}
               layout={MainLayout}
             />
             <PrivateRoute component={CandidateList} exact layout={MainLayout} path="/candidates" />
@@ -197,8 +204,7 @@ const AppRoutes = ({ auth, logoutUser }) => {
             right: 0,
             marginRight: '10px',
             marginBottom: '20px'
-          }}
-        >
+          }}>
           <div id="jira-help-desk" />
         </div>
 

--- a/netmanager/src/config/urls/analytics.js
+++ b/netmanager/src/config/urls/analytics.js
@@ -52,3 +52,6 @@ export const CREATE_TEAM_URI = `${BASE_ANALYTICS_URL_V2}/users/groups`;
 
 // SIM
 export const GET_SIM_URI = `${BASE_ANALYTICS_URL_V2}/incentives/sims`;
+
+// USER STATS
+export const GET_USER_STATS_URI = `${BASE_ANALYTICS_URL_V2}/users/stats`;

--- a/netmanager/src/views/apis/analytics.js
+++ b/netmanager/src/views/apis/analytics.js
@@ -7,7 +7,8 @@ import {
   SCHEDULE_EXPORT_DATA,
   CREATE_CLIENT_URI,
   GET_CLIENTS_URI,
-  GENERATE_TOKEN_URI
+  GENERATE_TOKEN_URI,
+  GET_USER_STATS_URI
 } from 'config/urls/analytics';
 import createAxiosInstance from './axiosConfig';
 
@@ -77,5 +78,10 @@ export const getClientsApi = async () => {
 
 export const generateTokenApi = async (data) => {
   const response = await createAxiosInstance().post(GENERATE_TOKEN_URI, data);
+  return response.data;
+};
+
+export const getUserStatsApi = async () => {
+  const response = await createAxiosInstance().get(GET_USER_STATS_URI);
   return response.data;
 };

--- a/netmanager/src/views/layouts/common/Sidebar/Sidebar.js
+++ b/netmanager/src/views/layouts/common/Sidebar/Sidebar.js
@@ -43,6 +43,7 @@ import SimCardIcon from '@material-ui/icons/SimCard';
 import GridOnIcon from '@material-ui/icons/GridOn';
 import GrainIcon from '@material-ui/icons/Grain';
 import GroupAddIcon from '@material-ui/icons/GroupAdd';
+import AssignmentIndIcon from '@material-ui/icons/AssignmentInd';
 
 const useStyles = makeStyles((theme) => ({
   drawer: {
@@ -211,7 +212,7 @@ const allUserManagementPages = [
   {
     title: 'Roles',
     href: '/roles',
-    icon: <SupervisorAccountIcon />,
+    icon: <AssignmentIndIcon />,
     permission: 'CREATE_UPDATE_AND_DELETE_NETWORK_ROLES'
   },
   {

--- a/netmanager/src/views/layouts/common/Sidebar/Sidebar.js
+++ b/netmanager/src/views/layouts/common/Sidebar/Sidebar.js
@@ -204,7 +204,8 @@ const allUserManagementPages = [
     nested: true,
     nestItems: [
       { title: 'Assigned Users', href: '/admin/users/assigned-users' },
-      { title: 'Available Users', href: '/admin/users/available-users' }
+      { title: 'Available Users', href: '/admin/users/available-users' },
+      { title: 'User Statistics', href: '/admin/users/users-statistics' }
     ]
   },
   {

--- a/netmanager/src/views/pages/Heatmap/HeatMapOverlay.js
+++ b/netmanager/src/views/pages/Heatmap/HeatMapOverlay.js
@@ -524,8 +524,7 @@ export const OverlayMap = ({ center, zoom, heatMapData, monitoringSiteData }) =>
           const [markerClass, desc] = getMarkerDetail(pollutantValue, markerKey);
 
           const el = document.createElement('div');
-          // el.className = `marker ${seconds >= MAX_OFFLINE_DURATION ? 'marker-grey' : markerClass}`;
-          el.className = `marker ${markerClass}`;
+          el.className = `marker ${seconds >= MAX_OFFLINE_DURATION ? 'marker-grey' : markerClass}`;
           el.style.borderRadius = '50%';
           el.style.display = 'flex';
           el.style.justifyContent = 'center';

--- a/netmanager/src/views/pages/Map/OverlayMap.js
+++ b/netmanager/src/views/pages/Map/OverlayMap.js
@@ -446,8 +446,7 @@ export const OverlayMap = ({ center, zoom, monitoringSiteData }) => {
           const [markerClass, desc] = getMarkerDetail(pollutantValue, markerKey);
 
           const el = document.createElement('div');
-          // el.className = `marker ${seconds >= MAX_OFFLINE_DURATION ? 'marker-grey' : markerClass}`;
-          el.className = `marker ${markerClass}`;
+          el.className = `marker ${seconds >= MAX_OFFLINE_DURATION ? 'marker-grey' : markerClass}`;
           el.style.borderRadius = '50%';
           el.style.display = 'flex';
           el.style.justifyContent = 'center';

--- a/netmanager/src/views/pages/UserStats/UserStats.js
+++ b/netmanager/src/views/pages/UserStats/UserStats.js
@@ -74,25 +74,26 @@ const UserStats = () => {
     // Prepare table rows from data
     const tableRows = data.map((record) => [record.email]);
 
-    // Add title to PDF
     doc.setFontSize(18);
-    doc.text(tableTitle, 14, 15); // Adjust the position as needed
+    doc.text(tableTitle, 14, 15);
+
+    doc.setFontSize(14);
+    doc.text(`Total: ${tableRows.length}`, 14, 22);
 
     setButtonLabel('Preparing...');
-    // Add table to PDF
+
     autoTable(doc, {
-      startY: 20,
+      startY: 25,
       head: [tableColumn],
       body: tableRows
     });
 
     setButtonLabel('Exporting...');
-    // Wait for 2 seconds before saving the PDF
+
     setTimeout(() => {
       doc.save(`AirQo_${selectedUserType}.pdf`);
       setButtonLabel('Exported');
 
-      // Reset the button label after 3 seconds
       setTimeout(() => {
         setButtonLabel('Export as PDF');
       }, 3000);

--- a/netmanager/src/views/pages/UserStats/UserStats.js
+++ b/netmanager/src/views/pages/UserStats/UserStats.js
@@ -1,0 +1,242 @@
+import React, { useEffect, useState } from 'react';
+import { getUserStatsApi } from 'views/apis/analytics';
+import CustomMaterialTable from '../../components/Table/CustomMaterialTable';
+import {
+  Card,
+  CardContent,
+  Typography,
+  Button,
+  Grid,
+  Box,
+  ButtonGroup,
+  Tooltip
+} from '@material-ui/core';
+import ErrorBoundary from '../../ErrorBoundary/ErrorBoundary';
+import { makeStyles } from '@material-ui/styles';
+import jsPDF from 'jspdf';
+import autoTable from 'jspdf-autotable';
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    padding: theme.spacing(2),
+    [theme.breakpoints.down('sm')]: {
+      padding: theme.spacing(1)
+    }
+  },
+  title: {
+    margin: theme.spacing(2, 0)
+  },
+  category_btn_con: {
+    display: 'flex',
+    justifyContent: 'right',
+    alignItems: 'center',
+    margin: theme.spacing(2, 0)
+  }
+}));
+
+const UserStats = () => {
+  const classes = useStyles();
+  const [loading, setLoading] = useState(false);
+  const [userStats, setUserStats] = useState([]);
+  const [selectedUserType, setSelectedUserType] = useState('users');
+
+  useEffect(() => {
+    setLoading(true);
+    getUserStatsApi().then((res) => {
+      setUserStats(res.users_stats);
+      setLoading(false);
+    });
+  }, []);
+
+  const allUsers = userStats.users ? userStats.users : { number: 0, details: [] };
+  const activeUsers = userStats.active_users ? userStats.active_users : { number: 0, details: [] };
+  const apiUsers = userStats.api_users ? userStats.api_users : { number: 0, details: [] };
+
+  const handleUserTypeChange = (userType) => {
+    setSelectedUserType(userType);
+  };
+
+  const selectedUserStats = userStats[selectedUserType] ? userStats[selectedUserType].details : [];
+
+  const [buttonLabel, setButtonLabel] = useState('Export as PDF');
+
+  const handleExport = async (data) => {
+    setButtonLabel('Initializing...');
+    const doc = new jsPDF();
+    const tableColumn = ['User Email'];
+    const tableTitle =
+      selectedUserType === 'users'
+        ? 'ALL USERS'
+        : selectedUserType === 'active_users'
+        ? 'ACTIVE USERS'
+        : 'API USERS';
+
+    // Prepare table rows from data
+    const tableRows = data.map((record) => [record.email]);
+
+    // Add title to PDF
+    doc.setFontSize(18);
+    doc.text(tableTitle, 14, 15); // Adjust the position as needed
+
+    setButtonLabel('Preparing...');
+    // Add table to PDF
+    autoTable(doc, {
+      startY: 20,
+      head: [tableColumn],
+      body: tableRows
+    });
+
+    setButtonLabel('Exporting...');
+    // Wait for 2 seconds before saving the PDF
+    setTimeout(() => {
+      doc.save(`AirQo_${selectedUserType}.pdf`);
+      setButtonLabel('Exported');
+
+      // Reset the button label after 3 seconds
+      setTimeout(() => {
+        setButtonLabel('Export as PDF');
+      }, 3000);
+    }, 2000);
+  };
+
+  return (
+    <ErrorBoundary>
+      <div className={classes.root}>
+        {/* Page title */}
+        <div className={classes.title}>
+          <Typography variant="h2" gutterBottom align="left">
+            AirQo User Statistics
+          </Typography>
+        </div>
+        <Grid container spacing={3}>
+          <Grid item xs={12} sm={6} md={4}>
+            <Card>
+              <CardContent>
+                <Box
+                  display="flex"
+                  flexDirection="column"
+                  justifyContent="space-between"
+                  height="100%">
+                  <Typography variant="h5" component="h2" align="left">
+                    All Users
+                  </Typography>
+                  <Typography variant="h2" component="p" align="right">
+                    {allUsers.number}
+                  </Typography>
+                </Box>
+              </CardContent>
+            </Card>
+          </Grid>
+          <Grid item xs={12} sm={6} md={4}>
+            <Card>
+              <CardContent>
+                <Box
+                  display="flex"
+                  flexDirection="column"
+                  justifyContent="space-between"
+                  height="100%">
+                  <Typography variant="h5" component="h2" align="left">
+                    Active Users
+                  </Typography>
+                  <Typography variant="h2" component="p" align="right">
+                    {activeUsers.number}
+                  </Typography>
+                </Box>
+              </CardContent>
+            </Card>
+          </Grid>
+          <Grid item xs={12} sm={6} md={4}>
+            <Card>
+              <CardContent>
+                <Box
+                  display="flex"
+                  flexDirection="column"
+                  justifyContent="space-between"
+                  height="100%">
+                  <Typography variant="h5" component="h2" align="left">
+                    API Users
+                  </Typography>
+                  <Typography variant="h2" component="p" align="right">
+                    {apiUsers.number}
+                  </Typography>
+                </Box>
+              </CardContent>
+            </Card>
+          </Grid>
+        </Grid>
+        <div className={classes.category_btn_con}>
+          <Box display="flex" justifyContent="space-between" width="100%">
+            <Tooltip title="Your Exporting the selected table data." placement="right">
+              <Button
+                variant="contained"
+                color="primary"
+                onClick={() => handleExport(selectedUserStats)}>
+                {buttonLabel}
+              </Button>
+            </Tooltip>
+
+            <ButtonGroup
+              variant="contained"
+              color="primary"
+              aria-label="contained primary button group">
+              <Button
+                onClick={() => handleUserTypeChange('users')}
+                color={selectedUserType === 'users' ? 'secondary' : 'primary'}>
+                All Users
+              </Button>
+              <Button
+                onClick={() => handleUserTypeChange('active_users')}
+                color={selectedUserType === 'active_users' ? 'secondary' : 'primary'}>
+                Active Users
+              </Button>
+              <Button
+                onClick={() => handleUserTypeChange('api_users')}
+                color={selectedUserType === 'api_users' ? 'secondary' : 'primary'}>
+                API Users
+              </Button>
+            </ButtonGroup>
+          </Box>
+        </div>
+        <CustomMaterialTable
+          pointerCursor
+          userPreferencePaginationKey={'user_stats'}
+          title={
+            selectedUserType === 'users'
+              ? 'ALL USERS'
+              : selectedUserType === 'active_users'
+              ? 'ACTIVE USERS'
+              : 'API USERS'
+          }
+          columns={[
+            {
+              field: 'email',
+              title: 'User Email'
+            }
+          ]}
+          onRowClick={(event, row) => {
+            event.preventDefault();
+            return null;
+          }}
+          isLoading={loading}
+          data={selectedUserStats}
+          options={{
+            search: true,
+            exportButton: false,
+            searchFieldAlignment: 'right',
+            showTitle: true,
+            searchFieldStyle: {
+              fontFamily: 'Open Sans'
+            },
+            headerStyle: {
+              fontFamily: 'Open Sans',
+              fontSize: 16,
+              fontWeight: 600
+            }
+          }}
+        />
+      </div>
+    </ErrorBoundary>
+  );
+};
+
+export default UserStats;


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

- Reactivated the offline mode for the map Nodes
- Implemented the user stats UI page Under the User view
- Users can now export the user List as a PDF only in the Users section.
- Updated the ‘Roles’ icon for distinct visual representation across different tabs

#### Status of maturity (all need to be checked before merging):

- [x] I've tested this locally
- [x] I consider this code done
- [x] This change is ready to hit production in its current state

#### Screenshots (optional)
![image](https://github.com/airqo-platform/AirQo-frontend/assets/97807374/df1cb698-740b-463a-b250-ce8fb20a7405)
![image](https://github.com/airqo-platform/AirQo-frontend/assets/97807374/ae52d1da-03ed-47f9-b5ac-d989513fbaa8)
![image](https://github.com/airqo-platform/AirQo-frontend/assets/97807374/4d0496a8-c29c-49ef-9e96-c4a13cd8ae3c)
![image](https://github.com/airqo-platform/AirQo-frontend/assets/97807374/774fa513-2ac9-4175-8b2f-c3127f09b0cb)
