### PR TITLE
[Analytics] Group realtime switch in settings page

### DIFF
--- a/platform/src/pages/settings/index.jsx
+++ b/platform/src/pages/settings/index.jsx
@@ -4,12 +4,13 @@ import Tab from '@/components/Tabs/Tab';
 import Password from './Tabs/Password';
 import withAuth from '@/core/utils/protectedRoute';
 import Team from './Tabs/Team';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import { useEffect, useState } from 'react';
 import { getAssignedGroupMembers } from '@/core/apis/Account';
 import Profile from './Tabs/Profile';
 import OrganizationProfile from './Tabs/OrganizationProfile';
 import { isEmpty } from 'underscore';
+import { setChartTab } from '@/lib/store/services/charts/ChartSlice';
 
 const checkAccess = (requiredPermission, rolePermissions) => {
   const permissions = rolePermissions && rolePermissions.map((item) => item.permission);
@@ -18,6 +19,7 @@ const checkAccess = (requiredPermission, rolePermissions) => {
 };
 
 const Settings = () => {
+  const dispatch = useDispatch();
   const [teamMembers, setTeamMembers] = useState([]);
   const [loading, setLoading] = useState(false);
   const [userPermissions, setUserPermissions] = useState([]);
@@ -39,6 +41,7 @@ const Settings = () => {
       setUserPermissions(storedUserPermissions);
     } else {
       setUserPermissions([]);
+      dispatch(setChartTab(0));
     }
 
     try {

--- a/platform/src/pages/settings/index.jsx
+++ b/platform/src/pages/settings/index.jsx
@@ -4,6 +4,7 @@ import Tab from '@/components/Tabs/Tab';
 import Password from './Tabs/Password';
 import withAuth from '@/core/utils/protectedRoute';
 import Team from './Tabs/Team';
+import { useSelector } from 'react-redux';
 import { useEffect, useState } from 'react';
 import { getAssignedGroupMembers } from '@/core/apis/Account';
 import Profile from './Tabs/Profile';
@@ -21,6 +22,8 @@ const Settings = () => {
   const [loading, setLoading] = useState(false);
   const [userPermissions, setUserPermissions] = useState([]);
   const [userGroup, setUserGroup] = useState({});
+  const preferences = useSelector((state) => state.defaults.individual_preferences);
+  const userInfo = useSelector((state) => state.login.userInfo);
 
   useEffect(() => {
     setLoading(true);
@@ -34,6 +37,8 @@ const Settings = () => {
 
     if (storedUserPermissions && storedUserPermissions.length > 0) {
       setUserPermissions(storedUserPermissions);
+    } else {
+      setUserPermissions([]);
     }
 
     try {
@@ -49,7 +54,7 @@ const Settings = () => {
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [userInfo, preferences]);
 
   return (
     <Layout topbarTitle={'Settings'} noBorderBottom pageTitle='Settings'>


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)
- Enhance the user interface by dynamically updating tabs based on user permissions in the newly selected group.
- This update ensures that users only see the tabs they have access to when they switch groups, enhancing security and user experience.

#### Status of maturity (all need to be checked before merging):

- [x] I've tested this locally
- [x] I consider this code done
- [x] This change ready to hit production in its current state

#### Screenshots (optional)
![image](https://github.com/airqo-platform/AirQo-frontend/assets/97807374/12e86fd7-329a-4db7-83ee-90f99fe61ee2)
