### PR TITLE
[Hotfix] Collocation page bug and thresholds error handling

### DIFF
--- a/platform/src/common/components/Collocation/AddMonitor/Calendar/index.jsx
+++ b/platform/src/common/components/Collocation/AddMonitor/Calendar/index.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import {
   addEndDate,
@@ -11,17 +11,56 @@ import {
 } from '@/lib/store/services/collocation/selectedCollocateDevicesSlice';
 import Datepicker from 'react-tailwindcss-datepicker';
 import moment from 'moment';
+import { useSelector } from 'react-redux';
 
 const ScheduleCalendar = () => {
+  const dispatch = useDispatch();
+  const storedStartDate = useSelector((state) => state.selectedCollocateDevices.startDate);
+  const storedEndDate = useSelector((state) => state.selectedCollocateDevices.endDate);
+  const scheduledBatchName = useSelector(
+    (state) => state.selectedCollocateDevices.scheduledBatchName,
+  );
+  const scheduledBatchDataCompletenessThresholdRedux = useSelector(
+    (state) => state.selectedCollocateDevices.scheduledBatchDataCompletenessThreshold,
+  );
+  const scheduledBatchInterCorrelationThresholdRedux = useSelector(
+    (state) => state.selectedCollocateDevices.scheduledBatchInterCorrelationThreshold,
+  );
+  const scheduledBatchIntraCorrelationThresholdRedux = useSelector(
+    (state) => state.selectedCollocateDevices.scheduledBatchIntraCorrelationThreshold,
+  );
+  const scheduledBatchDifferencesThresholdRedux = useSelector(
+    (state) => state.selectedCollocateDevices.scheduledBatchDifferencesThreshold,
+  );
+
+  const [value, setValue] = useState({
+    startDate: storedStartDate,
+    endDate: storedEndDate,
+  });
+
   const collationDurations = [4, 7, 14];
   const [duration, setDuration] = useState(null);
   const [customRange, setCustomRange] = useState(false);
-  const dispatch = useDispatch();
 
-  const [value, setValue] = useState({
-    startDate: null,
-    endDate: null,
-  });
+  const [scheduledBatchDataCompletenessThreshold, setScheduledBatchDataCompletenessThreshold] =
+    useState(scheduledBatchDataCompletenessThresholdRedux);
+  const [scheduledBatchInterCorrelationThreshold, setScheduledBatchInterCorrelationThreshold] =
+    useState(scheduledBatchInterCorrelationThresholdRedux);
+  const [scheduledBatchIntraCorrelationThreshold, setScheduledBatchIntraCorrelationThreshold] =
+    useState(scheduledBatchIntraCorrelationThresholdRedux);
+  const [scheduledBatchDifferencesThreshold, setScheduledBatchDifferencesThreshold] = useState(
+    scheduledBatchDifferencesThresholdRedux,
+  );
+
+  useEffect(() => {
+    // Difference between the start and end date
+    if (value && value.startDate && value.endDate) {
+      const diffDates = moment(value.endDate).diff(moment(value.startDate), 'days');
+      if (diffDates > 0) {
+        setDuration(diffDates + 1);
+      }
+    }
+  }, []);
 
   const handleValueChange = (newValue) => {
     setValue(newValue);
@@ -46,6 +85,34 @@ const ScheduleCalendar = () => {
 
   const handleCustomRangeChange = (event) => {
     setCustomRange(event.target.checked);
+  };
+
+  const validateIntraCorrelationThreshold = (value) => {
+    if (value < 0 || value > 1) {
+      return 'Intra correlation threshold should range from 0 to 1';
+    }
+    return '';
+  };
+
+  const validateInterCorrelationThreshold = (value) => {
+    if (value < 0 || value > 1) {
+      return 'Inter correlation threshold should range from 0 to 1';
+    }
+    return '';
+  };
+
+  const validateDataCompletenessThreshold = (value) => {
+    if (value < 0 || value > 100) {
+      return 'Data completeness threshold should range from 1 to 100';
+    }
+    return '';
+  };
+
+  const validateDifferencesThreshold = (value) => {
+    if (value < 0 || value > 5) {
+      return 'Differences threshold should range from 0 to 5';
+    }
+    return '';
   };
 
   return (
@@ -100,67 +167,101 @@ const ScheduleCalendar = () => {
           <h5 className='text-grey-300 text-sm mb-4'>
             Customise the batch configurations. Can be modified later
           </h5>
-          <div className='form-control w-full max-w-xs'>
+          <div className='form-control w-full'>
             <label className='label'>
               <span className='label-text'>Batch name*</span>
             </label>
             <input
               type='text'
-              className='input input-bordered input-sm w-full max-w-xs rounded-md mb-3 bg-gray-50 border-none'
+              value={scheduledBatchName}
+              className='input input-bordered input-sm w-full rounded-md mb-3 bg-gray-50 border-none'
               onChange={(e) => {
                 dispatch(addScheduledBatchName(e.target.value));
               }}
               required
               aria-required='true'
             />
+            {
+              <p className='text-red-500 text-xs'>
+                {scheduledBatchName.length < 1 && 'Batch name is required'}
+              </p>
+            }
           </div>
-          <div className='form-control w-full max-w-xs'>
+          <div className='form-control w-full'>
             <label className='label'>
               <span className='label-text'>Data completeness threshold</span>
             </label>
             <input
               type='text'
-              className='input input-bordered input-sm w-full max-w-xs rounded-md mb-3 bg-gray-50 border-none'
+              value={scheduledBatchDataCompletenessThreshold}
+              className='input input-bordered input-sm w-full rounded-md mb-3 bg-gray-50 border-none'
               onChange={(e) => {
+                setScheduledBatchDataCompletenessThreshold(e.target.value);
                 dispatch(addScheduledBatchDataCompletenessThreshold(e.target.value));
               }}
             />
+            {
+              <p className='text-red-500 text-xs'>
+                {validateDataCompletenessThreshold(scheduledBatchDataCompletenessThreshold)}
+              </p>
+            }
           </div>
-          <div className='form-control w-full max-w-xs'>
+          <div className='form-control w-full'>
             <label className='label'>
               <span className='label-text'>Intercorrelation threshold</span>
             </label>
             <input
               type='text'
-              className='input input-bordered input-sm w-full max-w-xs rounded-md mb-3 bg-gray-50 border-none'
+              value={scheduledBatchInterCorrelationThreshold}
+              className='input input-bordered input-sm w-full rounded-md mb-3 bg-gray-50 border-none'
               onChange={(e) => {
+                setScheduledBatchInterCorrelationThreshold(e.target.value);
                 dispatch(addScheduledBatchInterCorrelationThreshold(e.target.value));
               }}
             />
+            {
+              <p className='text-red-500 text-xs'>
+                {validateInterCorrelationThreshold(scheduledBatchInterCorrelationThreshold)}
+              </p>
+            }
           </div>
-          <div className='form-control w-full max-w-xs'>
+          <div className='form-control w-full'>
             <label className='label'>
               <span className='label-text'>Intracorrelation threshold</span>
             </label>
             <input
               type='text'
-              className='input input-bordered input-sm w-full max-w-xs rounded-md mb-3 bg-gray-50 border-none'
+              value={scheduledBatchIntraCorrelationThreshold}
+              className='input input-bordered input-sm w-full rounded-md mb-3 bg-gray-50 border-none'
               onChange={(e) => {
+                setScheduledBatchIntraCorrelationThreshold(e.target.value);
                 dispatch(addScheduledBatchIntraCorrelationThreshold(e.target.value));
               }}
             />
+            {
+              <p className='text-red-500 text-xs'>
+                {validateIntraCorrelationThreshold(scheduledBatchIntraCorrelationThreshold)}
+              </p>
+            }
           </div>
-          <div className='form-control w-full max-w-xs'>
+          <div className='form-control w-full'>
             <label className='label'>
               <span className='label-text'>Differences threshold</span>
             </label>
             <input
               type='text'
-              className='input input-bordered input-sm w-full max-w-xs rounded-md mb-3 bg-gray-50 border-none'
+              value={scheduledBatchDifferencesThreshold}
+              className='input input-bordered input-sm w-full rounded-md mb-3 bg-gray-50 border-none'
               onChange={(e) => {
+                setScheduledBatchDifferencesThreshold(e.target.value);
                 dispatch(addScheduledBatchDifferencesThreshold(e.target.value));
               }}
             />
+            {
+              <p className='text-red-500 text-xs'>
+                {validateDifferencesThreshold(scheduledBatchDifferencesThreshold)}
+              </p>
+            }
           </div>
         </div>
       </div>

--- a/platform/src/lib/store/services/collocation/index.js
+++ b/platform/src/lib/store/services/collocation/index.js
@@ -223,7 +223,7 @@ const collocationSlice = createSlice({
       })
       .addCase(collocateDevices.rejected, (state, action) => {
         state.collocateDevices.loading = false;
-        state.collocateDevices.error = action.error.message || '';
+        state.collocateDevices.error = action.error.message;
         state.collocateDevices.rejected = true;
       });
   },

--- a/platform/src/lib/store/services/collocation/selectedCollocateDevicesSlice.js
+++ b/platform/src/lib/store/services/collocation/selectedCollocateDevicesSlice.js
@@ -69,6 +69,15 @@ const selectedCollocateDevicesSlice = createSlice({
         state.scheduledBatchDifferencesThreshold = action.payload;
       }
     },
+    resetBatchData: (state) => {
+      state.startDate = null;
+      state.endDate = null;
+      state.scheduledBatchName = '';
+      state.scheduledBatchDataCompletenessThreshold = 80;
+      state.scheduledBatchInterCorrelationThreshold = 0.98;
+      state.scheduledBatchIntraCorrelationThreshold = 0.98;
+      state.scheduledBatchDifferencesThreshold = 5;
+    },
   },
 });
 
@@ -83,6 +92,7 @@ export const {
   addScheduledBatchDifferencesThreshold,
   addScheduledBatchInterCorrelationThreshold,
   addScheduledBatchIntraCorrelationThreshold,
+  resetBatchData,
 } = selectedCollocateDevicesSlice.actions;
 
 export default selectedCollocateDevicesSlice.reducer;

--- a/platform/src/lib/store/services/deviceRegistry.js
+++ b/platform/src/lib/store/services/deviceRegistry.js
@@ -24,9 +24,8 @@ const deviceRegistrySlice = createSlice({
         state.status = 'loading';
       })
       .addCase(getCollocationDevices.fulfilled, (state, action) => {
-        console.log(action.payload.data);
         state.status = 'succeeded';
-        state.collocationDevices = action.payload.data;
+        state.collocationDevices = action.payload.devices;
       })
       .addCase(getCollocationDevices.rejected, (state, action) => {
         state.status = 'failed';


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

- Add error handling to the threshold input fields. Button for `Schedule devices` will remain disabled if the wrong thresholds are used.
- Fixed application bug caused by wrong api field(was using `data` instead of `devices`)

#### Status of maturity (all need to be checked before merging):

- [x] I've tested this locally
- [x] I consider this code done
- [x] This change ready to hit production in its current state

#### How should this be manually tested?

- On collocate page, click `Add monitor` button

#### Screenshots (optional)
![image](https://github.com/airqo-platform/AirQo-frontend/assets/46527380/08b53640-4ecc-447e-80a4-0704962d225e)
