### PR TITLE
[Hotfix] Usage of one name for location names

### DIFF
--- a/platform/src/common/components/AQNumberCard/index.jsx
+++ b/platform/src/common/components/AQNumberCard/index.jsx
@@ -7,7 +7,7 @@ import VeryUnhealthy from '@/icons/Charts/VeryUnhealthy';
 import WindIcon from '@/icons/Common/wind.svg';
 import CustomTooltip from '../Tooltip';
 import { useWindowSize } from '@/lib/windowSize';
-import { capitalizeText } from '@/core/utils/strings';
+import { capitalizeAllText } from '@/core/utils/strings';
 
 const AQNumberCard = ({ reading, location, pollutant, count, locationFullName }) => {
   let airQualityText = '';
@@ -54,13 +54,17 @@ const AQNumberCard = ({ reading, location, pollutant, count, locationFullName })
               {location !== '--' ? (
                 <div
                   className='text-gray-700 text-base font-medium leading-normal whitespace-nowrap overflow-ellipsis'
-                  title={capitalizeText(locationFullName)}
+                  title={capitalizeAllText(locationFullName)}
                 >
-                  {capitalizeText(location.length > 17 ? location.slice(0, 17) + '...' : location)}
+                  {capitalizeAllText(
+                    location.length > 17 ? location.slice(0, 17) + '...' : location,
+                  )}
                 </div>
               ) : (
                 <div className='text-gray-700 text-base font-medium leading-normal whitespace-nowrap overflow-ellipsis'>
-                  {capitalizeText(location.length > 17 ? location.slice(0, 17) + '...' : location)}
+                  {capitalizeAllText(
+                    location.length > 17 ? location.slice(0, 17) + '...' : location,
+                  )}
                 </div>
               )}
               <div className='text-slate-400 text-sm font-medium leading-tight'>Daily Avg.</div>

--- a/platform/src/common/components/Customise/LocationsContentComponent.jsx
+++ b/platform/src/common/components/Customise/LocationsContentComponent.jsx
@@ -5,7 +5,6 @@ import {
   getSitesSummary,
   setGridsSummary,
 } from '@/lib/store/services/deviceRegistry/GridsSlice';
-import SearchIcon from '@/icons/Common/search_md.svg';
 import LocationIcon from '@/icons/SideBar/Sites.svg';
 import TrashIcon from '@/icons/Actions/bin_icon.svg';
 import StarIcon from '@/icons/Actions/star_icon.svg';
@@ -17,10 +16,9 @@ import Spinner from '@/components/Spinner';
 import AlertBox from '@/components/AlertBox';
 import useOutsideClick from '@/core/utils/useOutsideClick';
 import SearchField from '@/components/search/SearchField';
-import axios from 'axios';
 import { getNearestSite, getGridsSummaryApi } from '@/core/apis/DeviceRegistry';
 import { addSearchTerm } from '@/lib/store/services/search/LocationSearchSlice';
-import allCountries from '../Map/components/countries.json';
+import { capitalizeAllText } from '@/core/utils/strings';
 
 const SearchResultsSkeleton = () => (
   <div className='flex flex-col gap-1 animate-pulse'>
@@ -48,42 +46,58 @@ const LocationItemCards = ({
   innerRef,
   showTrashIcon = false,
   showActiveStarIcon = true,
-}) => (
-  <div
-    className='border rounded-lg bg-secondary-neutral-light-25 border-input-light-outline flex flex-row justify-between items-center p-3 w-full mb-2'
-    key={location.name}
-    ref={innerRef}
-    {...draggableProps}
-    {...dragHandleProps}
-  >
-    <div className='flex flex-row items-center overflow-x-clip'>
-      <div>{showActiveStarIcon ? <DragIcon /> : <DragIconLight />}</div>
-      <span className='text-sm text-secondary-neutral-light-800 font-medium'>{location.name}</span>
+}) => {
+  let locationName = location?.search_name || location?.name;
+  let locationDescripton =
+    location.location_name || location?.search_name || location?.name || location?.long_name;
+
+  return (
+    <div
+      className='border rounded-lg bg-secondary-neutral-light-25 border-input-light-outline flex flex-row justify-between items-center p-3 w-full mb-2'
+      key={locationName}
+      ref={innerRef}
+      {...draggableProps}
+      {...dragHandleProps}
+    >
+      <div
+        className='flex flex-row items-center overflow-x-clip'
+        title={capitalizeAllText(locationName)}
+      >
+        <div>{showActiveStarIcon ? <DragIcon /> : <DragIconLight />}</div>
+        <span className='text-sm text-secondary-neutral-light-800 font-medium'>
+          {locationName?.split(',')[0].length > 20
+            ? capitalizeAllText(locationName?.split(',')[0].substring(0, 15)) + '...'
+            : capitalizeAllText(locationName?.split(',')[0])}
+          {locationDescripton?.split(',').length > 1 && (
+            <span className='text-grey-400'>{locationDescripton?.split(',').pop()}</span>
+          )}
+        </span>
+      </div>
+      <div className='flex flex-row'>
+        {showTrashIcon && (
+          <div className='mr-1 hover:cursor-pointer' onClick={() => handleRemoveLocation(location)}>
+            <TrashIcon />
+          </div>
+        )}
+        {showActiveStarIcon ? (
+          <div
+            className='bg-primary-600 rounded-md p-2 flex items-center justify-center hover:cursor-pointer'
+            onClick={() => handleLocationSelect(location)}
+          >
+            <StarIcon />
+          </div>
+        ) : (
+          <div
+            className='border border-input-light-outline rounded-md p-2 flex items-center justify-center hover:cursor-pointer'
+            onClick={() => handleLocationSelect(location)}
+          >
+            <StarIconLight />
+          </div>
+        )}
+      </div>
     </div>
-    <div className='flex flex-row'>
-      {showTrashIcon && (
-        <div className='mr-1 hover:cursor-pointer' onClick={() => handleRemoveLocation(location)}>
-          <TrashIcon />
-        </div>
-      )}
-      {showActiveStarIcon ? (
-        <div
-          className='bg-primary-600 rounded-md p-2 flex items-center justify-center hover:cursor-pointer'
-          onClick={() => handleLocationSelect(location)}
-        >
-          <StarIcon />
-        </div>
-      ) : (
-        <div
-          className='border border-input-light-outline rounded-md p-2 flex items-center justify-center hover:cursor-pointer'
-          onClick={() => handleLocationSelect(location)}
-        >
-          <StarIconLight />
-        </div>
-      )}
-    </div>
-  </div>
-);
+  );
+};
 
 /**
  * @param {Object} props
@@ -302,6 +316,8 @@ const LocationsContentComponent = ({ selectedLocations, resetSearchData = false 
             ...response.sites[Math.floor(Math.random() * response.sites.length)],
             name: item?.description,
             long_name: item?.description,
+            search_name: item?.description,
+            location_name: item?.description,
           };
         } else {
           setIsError({
@@ -314,7 +330,7 @@ const LocationsContentComponent = ({ selectedLocations, resetSearchData = false 
           return;
         }
       } else {
-        newLocationValue = item;
+        newLocationValue = { ...item, name: item?.search_name };
       }
 
       const newLocationArray = [...locationArray];
@@ -520,7 +536,7 @@ const LocationsContentComponent = ({ selectedLocations, resetSearchData = false 
                       .slice(0, 15)
                       .map((location) => (
                         <LocationItemCards
-                          key={location.location_name}
+                          key={location.search_name}
                           location={location}
                           handleLocationSelect={handleLocationSelect}
                           showActiveStarIcon={false}

--- a/platform/src/common/components/Map/AirQoMap.jsx
+++ b/platform/src/common/components/Map/AirQoMap.jsx
@@ -356,7 +356,7 @@ const AirQoMap = ({ customStyle, mapboxApiAccessToken, pollutant }) => {
     const leaves = indexRef.current.getLeaves(cluster.properties.cluster_id, Infinity);
 
     // Create an object to count the occurrences of each AQI
-    const aqiCounts = leaves.reduce((acc, leaf) => {
+    const aqiCounts = leaves?.reduce((acc, leaf) => {
       const aqi = leaf.properties.airQuality;
       acc[aqi] = (acc[aqi] || 0) + 1;
       return acc;
@@ -371,7 +371,7 @@ const AirQoMap = ({ customStyle, mapboxApiAccessToken, pollutant }) => {
     mostCommonAQIs = mostCommonAQIs.map((aqi) => aqi[0]);
 
     // Find the leaves with the most common AQIs
-    const leavesWithMostCommonAQIs = leaves.filter((leaf) =>
+    const leavesWithMostCommonAQIs = leaves?.filter((leaf) =>
       mostCommonAQIs.includes(leaf.properties.airQuality),
     );
 
@@ -648,7 +648,8 @@ const AirQoMap = ({ customStyle, mapboxApiAccessToken, pollutant }) => {
               <button
                 onClick={() => setIsOpen(true)}
                 title='Map Layers'
-                className='inline-flex items-center justify-center p-2 md:p-3 mr-2 text-white rounded-full bg-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 shadow-md'>
+                className='inline-flex items-center justify-center p-2 md:p-3 mr-2 text-white rounded-full bg-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 shadow-md'
+              >
                 <LayerIcon />
               </button>
             </div>
@@ -656,13 +657,15 @@ const AirQoMap = ({ customStyle, mapboxApiAccessToken, pollutant }) => {
           <button
             onClick={refreshMap}
             title='Refresh Map'
-            className='inline-flex items-center justify-center p-2 md:p-3 mr-2 text-white rounded-full bg-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 shadow-md'>
+            className='inline-flex items-center justify-center p-2 md:p-3 mr-2 text-white rounded-full bg-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 shadow-md'
+          >
             <RefreshIcon />
           </button>
           <button
             onClick={shareLocation}
             title='Share Location'
-            className='inline-flex items-center justify-center w-10 h-10 md:w-12 md:h-12 text-white rounded-full bg-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 shadow-md'>
+            className='inline-flex items-center justify-center w-10 h-10 md:w-12 md:h-12 text-white rounded-full bg-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 shadow-md'
+          >
             <ShareIcon />
           </button>
         </div>

--- a/platform/src/common/components/Map/components/Sidebar.js
+++ b/platform/src/common/components/Map/components/Sidebar.js
@@ -786,12 +786,14 @@ const Sidebar = ({ siteDetails, isAdmin }) => {
                   <ArrowLeftIcon />
                 </Button>
                 <h3 className='text-xl font-medium leading-7'>
-                  {capitalizeAllText(
-                    selectedSite?.description ||
-                      (selectedSite?.name && selectedSite.name) ||
-                      selectedSite?.search_name ||
-                      selectedSite?.location,
-                  )}
+                  {
+                    capitalizeAllText(
+                      selectedSite?.description ||
+                        (selectedSite?.name && selectedSite.name) ||
+                        selectedSite?.search_name ||
+                        selectedSite?.location,
+                    )?.split(',')[0]
+                  }
                 </h3>
               </div>
 
@@ -845,7 +847,7 @@ const Sidebar = ({ siteDetails, isAdmin }) => {
                     <p className='text-xl font-bold leading-7 text-secondary-neutral-dark-950'>
                       <span className='text-blue-500'>
                         {capitalizeAllText(
-                          selectedSite?.description ||
+                          selectedSite?.description?.split(',')[0] ||
                             selectedSite?.name?.split(',')[0] ||
                             selectedSite?.search_name ||
                             selectedSite?.location,

--- a/platform/src/common/components/Map/components/Sidebar.js
+++ b/platform/src/common/components/Map/components/Sidebar.js
@@ -24,7 +24,7 @@ import Toast from '../../Toast';
 import { addSearchTerm } from '@/lib/store/services/search/LocationSearchSlice';
 import { dailyPredictionsApi } from '@/core/apis/predict';
 import Spinner from '@/components/Spinner';
-import { capitalizeText } from '@/core/utils/strings';
+import { capitalizeAllText } from '@/core/utils/strings';
 
 const MAPBOX_URL = 'https://api.mapbox.com/geocoding/v5/mapbox.places';
 const MAPBOX_TOKEN = process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN;
@@ -165,14 +165,14 @@ const SectionCards = ({ searchResults, handleLocationSelect }) => {
           >
             <div className='flex flex-col item-start w-full'>
               <span className='text-base font-medium text-black'>
-                {capitalizeText(
+                {capitalizeAllText(
                   grid && grid.description
                     ? grid.description.split(',')[0]
                     : grid.name && grid.name.split(',')[0],
                 )}
               </span>
               <span className='font-medium text-secondary-neutral-light-300 text-sm leading-tight'>
-                {capitalizeText(
+                {capitalizeAllText(
                   grid && grid.description
                     ? grid.description.split(',').slice(1).join(',')
                     : (grid.name && grid.name.split(',').slice(1).join(',')) || grid.search_name,
@@ -786,7 +786,7 @@ const Sidebar = ({ siteDetails, isAdmin }) => {
                   <ArrowLeftIcon />
                 </Button>
                 <h3 className='text-xl font-medium leading-7'>
-                  {capitalizeText(
+                  {capitalizeAllText(
                     selectedSite?.description ||
                       (selectedSite?.name && selectedSite.name) ||
                       selectedSite?.search_name ||
@@ -844,7 +844,7 @@ const Sidebar = ({ siteDetails, isAdmin }) => {
                   selectedSite?.airQuality ? (
                     <p className='text-xl font-bold leading-7 text-secondary-neutral-dark-950'>
                       <span className='text-blue-500'>
-                        {capitalizeText(
+                        {capitalizeAllText(
                           selectedSite?.description ||
                             selectedSite?.name?.split(',')[0] ||
                             selectedSite?.search_name ||

--- a/platform/src/core/utils/strings.js
+++ b/platform/src/core/utils/strings.js
@@ -4,18 +4,18 @@ export const capitalizeAllText = (text) => {
   if (!text) {
     return '';
   }
-  const words = text.split(' ');
-  const capitalizedWords = words.map((word) => {
-    const firstLetter = word.charAt(0)?.toUpperCase();
-    const restOfWord = word.slice(1)?.toLowerCase();
+  const words = text?.split(' ');
+  const capitalizedWords = words?.map((word) => {
+    const firstLetter = word?.charAt(0)?.toUpperCase();
+    const restOfWord = word?.slice(1)?.toLowerCase();
     return firstLetter + restOfWord;
   });
-  return capitalizedWords.join(' ');
+  return capitalizedWords?.join(' ');
 };
 
 export const capitalizeFirstLetter = (text) => {
   if (!text) {
     return '';
   }
-  return text.charAt(0)?.toUpperCase() + text.slice(1)?.toLowerCase();
+  return text?.charAt(0)?.toUpperCase() + text?.slice(1)?.toLowerCase();
 };

--- a/platform/src/core/utils/strings.js
+++ b/platform/src/core/utils/strings.js
@@ -1,6 +1,6 @@
 export const stripTrailingSlash = (url) => url.trim().replace(/\/$/, '');
 
-export const capitalizeText = (text) => {
+export const capitalizeAllText = (text) => {
   if (!text) {
     return '';
   }
@@ -11,4 +11,11 @@ export const capitalizeText = (text) => {
     return firstLetter + restOfWord;
   });
   return capitalizedWords.join(' ');
+};
+
+export const capitalizeFirstLetter = (text) => {
+  if (!text) {
+    return '';
+  }
+  return text.charAt(0)?.toUpperCase() + text.slice(1)?.toLowerCase();
 };

--- a/platform/src/pages/analytics/index.jsx
+++ b/platform/src/pages/analytics/index.jsx
@@ -42,7 +42,7 @@ const AuthenticatedHomePage = () => {
   const toggleCustomise = () => setCustomise(!customise);
 
   useEffect(() => {
-    const userId = JSON.parse(localStorage.getItem('loggedUser'))._id;
+    const userId = JSON.parse(localStorage.getItem('loggedUser'))?._id;
     if (userId) {
       dispatch(fetchUserPreferences(userId));
     }
@@ -151,14 +151,16 @@ const AuthenticatedHomePage = () => {
             <Button
               className='text-sm font-medium capitalize'
               variant='outlined'
-              onClick={handlePrint}>
+              onClick={handlePrint}
+            >
               Print
             </Button>
             <Button
               className='text-sm font-medium capitalize'
               variant='filled'
               Icon={DownloadIcon}
-              onClick={handleExport}>
+              onClick={handleExport}
+            >
               Export
             </Button>
           </div>

--- a/platform/src/pages/settings/Tabs/Profile.jsx
+++ b/platform/src/pages/settings/Tabs/Profile.jsx
@@ -260,7 +260,7 @@ const Profile = () => {
       await cloudinaryImageUpload(formData)
         .then(async (responseData) => {
           setUserData({ ...userData, profilePicture: responseData.secure_url });
-          const userID = JSON.parse(localStorage.getItem('loggedUser'))._id;
+          const userID = JSON.parse(localStorage.getItem('loggedUser'))?._id;
           return await updateUserCreationDetails(
             { profilePicture: responseData.secure_url },
             userID,
@@ -305,7 +305,7 @@ const Profile = () => {
     setUpdatedProfilePicture('');
     setUserData({ ...userData, profilePicture: '' });
 
-    const userID = JSON.parse(localStorage.getItem('loggedUser'))._id;
+    const userID = JSON.parse(localStorage.getItem('loggedUser'))?._id;
     updateUserCreationDetails({ profilePicture: '' }, userID)
       .then((response) => {
         localStorage.setItem(
@@ -362,7 +362,8 @@ const Profile = () => {
                   <div
                     className='w-16 h-16 bg-secondary-neutral-light-25 rounded-full flex justify-center items-center cursor-pointer'
                     onClick={handleAvatarClick}
-                    title='Tap to change profile image'>
+                    title='Tap to change profile image'
+                  >
                     {userData.profilePicture ? (
                       <img
                         src={userData.profilePicture}
@@ -378,7 +379,8 @@ const Profile = () => {
                   <div className='flex items-center'>
                     <Button
                       className='text-sm font-medium text-secondary-neutral-light-500'
-                      onClick={confirmDeleteProfileImage}>
+                      onClick={confirmDeleteProfileImage}
+                    >
                       Delete
                     </Button>
                     <Button
@@ -388,7 +390,8 @@ const Profile = () => {
                           : 'text-blue-600 bg-blue-50 rounded'
                       }`}
                       onClick={handleProfileImageUpdate}
-                      disabled={!updatedProfilePicture}>
+                      disabled={!updatedProfilePicture}
+                    >
                       {updatedProfilePicture && !profileUploading
                         ? 'Save photo'
                         : profileUploading
@@ -447,7 +450,8 @@ const Profile = () => {
                         value={userData.country}
                         onChange={handleChange}
                         className='bg-white border border-gray-200 text-secondary-neutral-light-400 focus:border-gray-200 focus:bg-gray-100 text-sm w-full rounded p-3 dark:placeholder-white-400 dark:text-white'
-                        required>
+                        required
+                      >
                         <option value='' disabled></option>
                         {countryOptions.map((country) => (
                           <option value={country.value} key={country.value}>
@@ -471,7 +475,8 @@ const Profile = () => {
                       value={userData.timezone}
                       onChange={handleChange}
                       className='bg-white border border-gray-200 text-secondary-neutral-light-400 focus:border-gray-200 focus:bg-gray-100 text-sm rounded block w-full pl-10 pr-3 py-3 dark:placeholder-white-400 dark:text-white'
-                      required>
+                      required
+                    >
                       <option value='' disabled></option>
                       {timeZonesArr.map((timeZone) => (
                         <option value={timeZone.value} key={timeZone.value}>
@@ -500,13 +505,15 @@ const Profile = () => {
                 <Button
                   onClick={handleCancel}
                   className='text-sm font-medium leading-5 text-secondary-neutral-light-600 py-3 px-4 rounded border border-secondary-neutral-light-100 bg-white'
-                  disabled={isLoading}>
+                  disabled={isLoading}
+                >
                   Cancel
                 </Button>
                 <Button
                   onClick={handleSubmit}
                   className='text-sm font-medium leading-5 text-white py-3 px-4 rounded bg-blue-600'
-                  disabled={isLoading}>
+                  disabled={isLoading}
+                >
                   {isLoading ? 'Loading...' : 'Save'}
                 </Button>
               </div>


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

- Highlight one name of the selected location, while the country of the location is in dull text on the customise feature
- Show only one name on the location cards and the charts(rest of the location details are visible when one hovers over the location name)

#### Status of maturity (all need to be checked before merging):

- [x] I've tested this locally
- [x] I consider this code done
- [x] This change ready to hit production in its current state

#### How should this be manually tested?

- Please include the steps to be done inorder to setup and test this PR.

#### What are the relevant tickets?

- Closes #<enter issue number here>
- [Jira_card_number]() (If exists)

#### Screenshots (optional)
![image](https://github.com/airqo-platform/AirQo-frontend/assets/46527380/21fecc19-e258-4399-95b1-ccc4693ca5e0)
![image](https://github.com/airqo-platform/AirQo-frontend/assets/46527380/d3e00e1b-d9d5-4745-af99-901764cabaf2)
![image](https://github.com/airqo-platform/AirQo-frontend/assets/46527380/eeb10f2a-30a9-455b-a9d3-71972a1def55)
