### PR TITLE
[Hotfix] Analytics chart loading

### DIFF
--- a/platform/src/common/components/Calendar/CustomCalendar.jsx
+++ b/platform/src/common/components/Calendar/CustomCalendar.jsx
@@ -19,10 +19,6 @@ import {
   format,
   getYear,
 } from 'date-fns';
-import {
-  updateUserPreferences,
-  getIndividualUserPreferences,
-} from '@/lib/store/services/account/UserDefaultsSlice';
 
 /**
  * @param {Object} props
@@ -45,7 +41,6 @@ const CustomCalendar = ({ initialStartDate, initialEndDate, Icon, dropdown, clas
     startDate: initialStartDate,
     endDate: initialEndDate,
   });
-  const userInfo = useSelector((state) => state.login.userInfo);
 
   /**
    * @returns {void}
@@ -60,7 +55,7 @@ const CustomCalendar = ({ initialStartDate, initialEndDate, Icon, dropdown, clas
       return;
     }
 
-    const handleDateChange = async (newValue) => {
+    const handleDateChange = (newValue) => {
       const startDate = new Date(newValue.start);
       const endDate = new Date(newValue.end);
 
@@ -113,18 +108,7 @@ const CustomCalendar = ({ initialStartDate, initialEndDate, Icon, dropdown, clas
         }
       }
 
-      await dispatch(setChartDataRange({ startDate, endDate, label }));
-      const userId = userInfo?._id;
-      const data = {
-        user_id: userId,
-        startDate,
-        endDate,
-        period: { label },
-      };
-      const updatePreferencesresponse = await dispatch(updateUserPreferences(data));
-      if (updatePreferencesresponse?.payload?.success) {
-        await dispatch(getIndividualUserPreferences(userId));
-      }
+      dispatch(setChartDataRange({ startDate, endDate, label }));
       setValue(newValue);
     };
 
@@ -171,8 +155,7 @@ const CustomCalendar = ({ initialStartDate, initialEndDate, Icon, dropdown, clas
       <button
         onClick={handleClick}
         type='button'
-        className='relative border border-grey-750 rounded-xl flex items-center justify-between gap-2 px-4 py-3'
-      >
+        className='relative border border-grey-750 rounded-xl flex items-center justify-between gap-2 px-4 py-3'>
         {Icon ? <Icon /> : <CalendarIcon />}
         <span className='hidden sm:inline-block text-sm font-medium'>
           {chartData.chartDataRange.label}
@@ -184,8 +167,7 @@ const CustomCalendar = ({ initialStartDate, initialEndDate, Icon, dropdown, clas
           openDatePicker
             ? 'opacity-100 translate-y-0 visible'
             : 'opacity-0 -translate-y-2 invisible'
-        } transition-all duration-400 ease-in-out transform`}
-      >
+        } transition-all duration-400 ease-in-out transform`}>
         <DatePickerHiddenInput />
       </div>
     </div>

--- a/platform/src/common/components/Charts/Charts.js
+++ b/platform/src/common/components/Charts/Charts.js
@@ -144,7 +144,8 @@ const Charts = ({ chartType = 'line', width = '100%', height = '100%', id }) => 
   const newAnalyticsData =
     analyticsData?.length > 0
       ? analyticsData.map((data) => {
-          const name = getSiteName(data.site_id) || getExistingSiteName(data.site_id) || '--';
+          const name =
+            getSiteName(data.site_id) || getExistingSiteName(data.site_id) || data.generated_name;
           return { ...data, name };
         })
       : null;

--- a/platform/src/common/components/Layout/index.jsx
+++ b/platform/src/common/components/Layout/index.jsx
@@ -12,6 +12,7 @@ import { toggleSidebar } from '@/lib/store/services/sideBar/SideBarSlice';
 import { useRouter } from 'next/router';
 import CollapsedSidebar from '../SideBar/CollapsedSidebar';
 import SideBarDrawer from '../SideBar/SideBarDrawer';
+import SetChartDetails from '@/core/utils/SetChartDetails';
 import LogoutUser from '@/core/utils/LogoutUser';
 
 const Layout = ({
@@ -26,8 +27,16 @@ const Layout = ({
   const MAX_WIDTH = '(max-width: 1024px)';
   const dispatch = useDispatch();
   const userInfo = useSelector((state) => state.login.userInfo);
+  const preferenceData = useSelector((state) => state.defaults.individual_preferences) || [];
   const cardCheckList = useSelector((state) => state.cardChecklist.cards);
   const [lastActivity, setLastActivity] = useState(Date.now());
+
+  /**
+   * Set chart details
+   */
+  useEffect(() => {
+    SetChartDetails(dispatch, preferenceData);
+  }, []);
 
   /**
    * Fetch user checklists from the database

--- a/platform/src/common/components/Layout/index.jsx
+++ b/platform/src/common/components/Layout/index.jsx
@@ -12,7 +12,6 @@ import { toggleSidebar } from '@/lib/store/services/sideBar/SideBarSlice';
 import { useRouter } from 'next/router';
 import CollapsedSidebar from '../SideBar/CollapsedSidebar';
 import SideBarDrawer from '../SideBar/SideBarDrawer';
-import SetChartDetails from '@/core/utils/SetChartDetails';
 import LogoutUser from '@/core/utils/LogoutUser';
 
 const Layout = ({
@@ -26,20 +25,9 @@ const Layout = ({
   const router = useRouter();
   const MAX_WIDTH = '(max-width: 1024px)';
   const dispatch = useDispatch();
-  const chartData = useSelector((state) => state.chart);
   const userInfo = useSelector((state) => state.login.userInfo);
-  const preferenceData = useSelector((state) => state.defaults.individual_preferences) || [];
   const cardCheckList = useSelector((state) => state.cardChecklist.cards);
   const [lastActivity, setLastActivity] = useState(Date.now());
-  const preferencesLoading = useSelector((state) => state.userDefaults.status === 'loading');
-
-  /**
-   * Set chart details
-   */
-  useEffect(() => {
-    if (preferencesLoading) return;
-    SetChartDetails(dispatch, preferenceData);
-  }, [preferenceData, dispatch]);
 
   /**
    * Fetch user checklists from the database

--- a/platform/src/lib/store/services/charts/ChartData.js
+++ b/platform/src/lib/store/services/charts/ChartData.js
@@ -2,7 +2,6 @@ import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
 import { getAnalyticsData } from '@/core/apis/DeviceRegistry';
 
 export const fetchAnalyticsData = createAsyncThunk('analytics/fetchData', async (body) => {
-  console.log(body);
   const response = await getAnalyticsData(body);
   return response.data;
 });


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

- Added logic to load the analytics data when the user first lands on the home page so that when the user moves to the analytics page, the endpoint can be hit a second time just to refresh the data

#### Status of maturity (all need to be checked before merging):

- [x] I've tested this locally
- [x] I consider this code done
- [x] This change ready to hit production in its current state

#### How should this be manually tested?

- Please include the steps to be done inorder to setup and test this PR.

#### What are the relevant tickets?

- Closes #<enter issue number here>
- [Jira_card_number]() (If exists)

#### Screenshots (optional)
