### PR TITLE
[Hotfix] Locations search fix

### DIFF
--- a/platform/src/common/components/Customise/LocationsContentComponent.jsx
+++ b/platform/src/common/components/Customise/LocationsContentComponent.jsx
@@ -138,7 +138,7 @@ const LocationsContentComponent = ({ selectedLocations, resetSearchData = false 
 
   useEffect(() => {
     const fetchGridsData = async () => {
-      if (!gridsSummaryData) {
+      if (gridsSummaryData && gridsSummaryData.length === 0) {
         try {
           const response = await getGridsSummaryApi();
           if (response && response.success) {

--- a/platform/src/common/components/Customise/LocationsContentComponent.jsx
+++ b/platform/src/common/components/Customise/LocationsContentComponent.jsx
@@ -150,7 +150,7 @@ const LocationsContentComponent = ({ selectedLocations, resetSearchData = false 
       }
     };
     fetchGridsData();
-  }, []);
+  }, [gridsSummaryData]);
 
   useEffect(() => {
     if (gridsSummaryData && gridsSummaryData.length > 0) {

--- a/platform/src/common/components/Customise/LocationsContentComponent.jsx
+++ b/platform/src/common/components/Customise/LocationsContentComponent.jsx
@@ -150,7 +150,7 @@ const LocationsContentComponent = ({ selectedLocations, resetSearchData = false 
       }
     };
     fetchGridsData();
-  }, [gridsSummaryData]);
+  }, []);
 
   useEffect(() => {
     if (gridsSummaryData && gridsSummaryData.length > 0) {


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

- To be able to able to keep the scope of the searched locations within the countries where we have monitors, we use the grids summary api. This fix ensures that the grids summary api is called when the grids summary data is empty.

#### Status of maturity (all need to be checked before merging):

- [x] I've tested this locally
- [x] I consider this code done
- [x] This change ready to hit production in its current state

#### How should this be manually tested?

- Please include the steps to be done inorder to setup and test this PR.

#### What are the relevant tickets?

- Closes #<enter issue number here>
- [Jira_card_number]() (If exists)

#### Screenshots (optional)
