### PR TITLE
(Analytics) chore: Add disabled state to account creation roles

### DIFF
--- a/platform/src/common/components/Account/CheckComponent.jsx
+++ b/platform/src/common/components/Account/CheckComponent.jsx
@@ -12,14 +12,20 @@ const CheckComponent = ({
   titleFont,
   checked,
   onChangeFunc,
+  disabled,
 }) => {
   return (
     <div
-      className={`${bgColor || 'bg-white'} ${padding || 'p-7'} ${
+      className={`relative ${bgColor || 'bg-white'} ${padding || 'p-7'} ${
         width || 'lg:w-fit w-11/12'
       } border ${border || 'border-radio-border'} rounded-lg ${
         checked && 'ring-1 ring-blue-600 focus:shadow-lg focus:outline-blue-600'
-      }`}>
+      } ${disabled ? 'opacity-50 pointer-events-none' : ''}`}>
+      {disabled && (
+        <div className='absolute top-0 right-0 bg-yellow-500 text-white text-xs font-bold py-1 px-2 rounded-bl-md rounded-tr-md'>
+          Coming Soon
+        </div>
+      )}
       <div className='flex flex-col justify-start'>
         {checked ? (
           <div className='w-8 h-8 mb-3 flex justify-center items-center rounded-full bg-blue-900'>

--- a/platform/src/common/components/Account/CheckComponent.jsx
+++ b/platform/src/common/components/Account/CheckComponent.jsx
@@ -50,6 +50,7 @@ CheckComponent.propTypes = {
   titleFont: PropTypes.string,
   checked: PropTypes.bool,
   onChangeFunc: PropTypes.func,
+  disabled: PropTypes.bool,
 };
 
 export default CheckComponent;

--- a/platform/src/pages/account/creation/index.jsx
+++ b/platform/src/pages/account/creation/index.jsx
@@ -9,11 +9,13 @@ const userRoles = [
     title: 'Individual',
     subText:
       'Empower yourself with real-time Air Pollution Location Data for research and personal use. Stay informed, stay healthy. Join the clean air revolution today.',
+    disabled: false,
   },
   {
     title: 'Organisation',
     subText:
       'Beyond data, gain access to network management tools. Drive meaningful change, one location at a time. Shape a cleaner future for all.',
+    disabled: true,
   },
 ];
 
@@ -46,12 +48,18 @@ const UserDesignation = () => {
               <div
                 key={index}
                 className='w-full cursor-pointer mb-8 lg:w-10/12 lg:mb-0 flex flex-col'
-                onClick={() => handleRoleClick(role.title)}>
+                onClick={() => {
+                  if (role.disabled) {
+                    return;
+                  }
+                  handleRoleClick(role.title);
+                }}>
                 <CheckComponent
                   text={role.title}
                   width={'w-full lg:w-10/12'}
                   subText={role.subText}
                   checked={clickedRole === role.title}
+                  disabled={role.disabled}
                 />
               </div>
             ))}

--- a/platform/src/pages/account/creation/index.jsx
+++ b/platform/src/pages/account/creation/index.jsx
@@ -53,7 +53,16 @@ const UserDesignation = () => {
                     return;
                   }
                   handleRoleClick(role.title);
-                }}>
+                }}
+                onKeyUp={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    if (role.disabled) {
+                      return;
+                    }
+                    handleRoleClick(role.title);
+                  }
+                }}
+                tabIndex={0}>
                 <CheckComponent
                   text={role.title}
                   width={'w-full lg:w-10/12'}

--- a/platform/src/pages/account/creation/index.jsx
+++ b/platform/src/pages/account/creation/index.jsx
@@ -61,8 +61,7 @@ const UserDesignation = () => {
                     }
                     handleRoleClick(role.title);
                   }
-                }}
-                tabIndex={0}>
+                }}>
                 <CheckComponent
                   text={role.title}
                   width={'w-full lg:w-10/12'}


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

- Disabled Account creation Flow with coming soon message.

#### Status of maturity (all need to be checked before merging):

- [x] I've tested this locally
- [x] I consider this code done
- [x] This change ready to hit production in its current state

#### Screenshots (optional)
![image](https://github.com/airqo-platform/AirQo-frontend/assets/97807374/99d1155f-9e38-46bd-8840-b1765313001e)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a `disabled` prop to the `CheckComponent` which conditionally shows a "Coming Soon" message.
  - Introduced a new `disabled` property to user roles in the account creation process, rendering roles as clickable or non-clickable based on their status.

- **Enhancements**
  - Updated the `UserDesignation` component to render the `CheckComponent` based on the disabled status of roles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->