### PR TITLE
(Website) chore: Update event views and frontend API to retrieve event details

### DIFF
--- a/website/backend/event/views.py
+++ b/website/backend/event/views.py
@@ -2,6 +2,7 @@ from django.db.models import Prefetch
 from django.utils import translation
 from rest_framework import viewsets
 from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
 from .models import Event, Inquiry, Program, Session, PartnerLogo, Resource
 from .serializers import EventSerializer
 
@@ -23,3 +24,8 @@ class EventViewSet(viewsets.ReadOnlyModelViewSet):
         if language is not None:
             translation.activate(language)
         return super().list(request, *args, **kwargs)
+
+    def retrieve(self, request, *args, **kwargs):
+        instance = self.get_object()
+        serializer = self.get_serializer(instance)
+        return Response(serializer.data)

--- a/website/backend/event/views.py
+++ b/website/backend/event/views.py
@@ -3,7 +3,7 @@ from django.utils import translation
 from rest_framework import viewsets
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
-from .models import Event, Inquiry, Program, Session, PartnerLogo, Resource
+from .models import Event
 from .serializers import EventSerializer
 
 

--- a/website/frontend/apis/index.js
+++ b/website/frontend/apis/index.js
@@ -85,6 +85,8 @@ export const getAllPressApi = async (lang) => fetchData(PRESS_URL, lang);
 // Events endpoint
 export const getAllEventsApi = async (lang) => fetchData(EVENTS_URL, lang);
 
+export const getEventApi = async (id, lang) => fetchData(`${EVENTS_URL}/${id}`, lang);
+
 // Cities endpoint
 export const getAllCitiesApi = async (lang) => fetchData(CITIES_URL, lang);
 

--- a/website/frontend/src/pages/CleanAir/EventDetails.js
+++ b/website/frontend/src/pages/CleanAir/EventDetails.js
@@ -1,8 +1,8 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { AccessTimeOutlined, CalendarMonth, PlaceOutlined } from '@mui/icons-material';
 import { useInitScrollTop } from 'utilities/customHooks';
 import { useParams } from 'react-router-dom';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import { isEmpty } from 'underscore';
 import { format } from 'date-fns';
 import Loadspinner from '../../components/LoadSpinner';
@@ -11,9 +11,12 @@ import { useTranslation } from 'react-i18next';
 import LanguageSwitcher from 'src/components/LanguageSwitcher';
 import { Link } from 'react-router-dom';
 import { useNavigate } from 'react-router-dom';
+import { getEventApi } from '../../../apis';
+import { getAllEvents } from 'reduxStore/Events/EventSlice';
 
 const EventDetails = () => {
   useInitScrollTop();
+  const dispatch = useDispatch();
   const navigate = useNavigate();
   const { t } = useTranslation();
   const { uniqueTitle } = useParams();
@@ -22,6 +25,13 @@ const EventDetails = () => {
   const eventData = allEventsData.filter((event) => event.website_category === 'cleanair');
   const eventDetails = eventData.filter((event) => event.unique_title === uniqueTitle) || {};
   const loading = useSelector((state) => state.eventsData.loading);
+  const language = useSelector((state) => state.eventsNavTab.languageTab);
+
+  useEffect(() => {
+    if (isEmpty(allEventsData)) {
+      dispatch(getAllEvents(language));
+    }
+  }, [dispatch, language]);
 
   return (
     <>

--- a/website/frontend/src/pages/Events/Details.js
+++ b/website/frontend/src/pages/Events/Details.js
@@ -1,17 +1,19 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { AccessTimeOutlined, CalendarMonth, PlaceOutlined } from '@mui/icons-material';
 import { useInitScrollTop } from 'utilities/customHooks';
 import { useParams } from 'react-router-dom';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import { isEmpty } from 'underscore';
 import { format } from 'date-fns';
 import Loadspinner from '../../components/LoadSpinner';
 import PageMini from '../PageMini';
 import { useTranslation } from 'react-i18next';
+import { getAllEvents } from 'reduxStore/Events/EventSlice';
 
 const EventDetails = () => {
   useInitScrollTop();
+  const dispatch = useDispatch();
   const { t } = useTranslation();
   const { uniqueTitle } = useParams();
 
@@ -19,6 +21,14 @@ const EventDetails = () => {
   const eventData = allEventsData.filter((event) => event.website_category === 'airqo');
   const eventDetails = eventData.filter((event) => event.unique_title === uniqueTitle) || {};
   const loading = useSelector((state) => state.eventsData.loading);
+
+  const language = useSelector((state) => state.eventsNavTab.languageTab);
+
+  useEffect(() => {
+    if (isEmpty(allEventsData)) {
+      dispatch(getAllEvents(language));
+    }
+  }, [dispatch, language]);
 
   return (
     <PageMini>


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

- The models view has been updated to include the retrieval of a single event for future use.
- An issue with event loading on link sharing has been fixed.

#### Status of maturity (all need to be checked before merging):

- [x] I've tested this locally
- [x] I consider this code done
- [x] This change ready to hit production in its current state


#### Screenshots (optional)
![image](https://github.com/airqo-platform/AirQo-frontend/assets/97807374/6d23f33a-a974-4059-9732-895bf4ae9753)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added retrieval functionality to fetch and display specific events in the backend.
  - Introduced `getEventApi` to fetch event details by ID in the frontend.

- **Enhancements**
  - Updated `EventDetails` component to fetch and display event details using hooks and dispatch actions.

- **Refactor**
  - Improved event data fetching logic in `EventDetails.js` and `Details.js`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->