### PR TITLE
refactor:(charts) Add WHO standard reference line

### DIFF
--- a/platform/src/common/components/Charts/Charts.js
+++ b/platform/src/common/components/Charts/Charts.js
@@ -163,6 +163,19 @@ const Charts = ({ chartType = 'line', width = '100%', height = '100%', id }) => 
       ? 60
       : 0;
 
+  const [activeIndex, setActiveIndex] = useState(null);
+  const [activeKey, setActiveKey] = useState(null);
+
+  const handleMouseEnter = (o, index, key) => {
+    setActiveIndex(index);
+    setActiveKey(key);
+  };
+
+  const handleMouseLeave = () => {
+    setActiveIndex(null);
+    setActiveKey(null);
+  };
+
   useEffect(() => {
     let timeoutId;
     if (isLoading && loadingTime > 5000) {
@@ -233,10 +246,16 @@ const Charts = ({ chartType = 'line', width = '100%', height = '100%', id }) => 
                 key={key}
                 dataKey={key}
                 type='monotone'
-                stroke={colors[index % colors.length]}
-                strokeWidth={2}
+                stroke={
+                  index === activeIndex || activeIndex === null
+                    ? colors[index % colors.length]
+                    : '#ccc'
+                }
+                strokeWidth={3}
                 dot={<CustomDot />}
                 activeDot={{ r: 6 }}
+                onMouseEnter={(o) => handleMouseEnter(o, index)}
+                onMouseLeave={handleMouseLeave}
               />
             ))}
           <ReferenceLine y={WHO_STANDARD_VALUE} label={renderCustomizedLabel} stroke='red' />
@@ -276,7 +295,7 @@ const Charts = ({ chartType = 'line', width = '100%', height = '100%', id }) => 
             wrapperStyle={{ bottom: 0, right: 0, position: 'absolute' }}
           />
           <Tooltip
-            content={<CustomTooltipLineGraph />}
+            content={<CustomTooltipLineGraph activeIndex={activeIndex} />}
             cursor={{
               stroke: '#aaa',
               strokeOpacity: 0.3,
@@ -297,15 +316,22 @@ const Charts = ({ chartType = 'line', width = '100%', height = '100%', id }) => 
           }}>
           {Array.from(allKeys)
             .filter((key) => key !== 'time')
-            .map((key, index) => (
-              <Bar
-                key={key}
-                dataKey={key}
-                fill={colors[index % colors.length]}
-                barSize={12}
-                shape={<CustomBar />}
-              />
-            ))}
+            .map(
+              (key, index) => (
+                console.log('key', key),
+                (
+                  <Bar
+                    key={key}
+                    dataKey={key}
+                    fill={colors[index % colors.length]}
+                    barSize={12}
+                    shape={<CustomBar />}
+                    onMouseEnter={(o) => handleMouseEnter(o, index)}
+                    onMouseLeave={handleMouseLeave}
+                  />
+                )
+              ),
+            )}
           <ReferenceLine y={WHO_STANDARD_VALUE} label={renderCustomizedLabel} stroke='red' />
           <CartesianGrid stroke='#ccc' strokeDasharray='5 5' vertical={false} />
           <XAxis dataKey='time' tickLine={true} tick={<CustomizedAxisTick />} axisLine={false} />
@@ -336,7 +362,7 @@ const Charts = ({ chartType = 'line', width = '100%', height = '100%', id }) => 
             wrapperStyle={{ bottom: 0, right: 0, position: 'absolute' }}
           />
           <Tooltip
-            content={<CustomTooltipLineGraph />}
+            content={<CustomTooltipBarGraph activeIndex={activeIndex} />}
             cursor={{ fill: '#eee', fillOpacity: 0.3 }}
           />
         </BarChart>

--- a/platform/src/common/components/Charts/Charts.js
+++ b/platform/src/common/components/Charts/Charts.js
@@ -11,6 +11,7 @@ import {
   ResponsiveContainer,
   Label,
   Legend,
+  ReferenceLine,
 } from 'recharts';
 import { useSelector, useDispatch } from 'react-redux';
 import Spinner from '@/components/Spinner';
@@ -19,9 +20,11 @@ import { fetchAnalyticsData, setAnalyticsData } from '@/lib/store/services/chart
 import {
   renderCustomizedLegend,
   CustomDot,
+  CustomBar,
   CustomizedAxisTick,
   CustomTooltipLineGraph,
   CustomTooltipBarGraph,
+  renderCustomizedLabel,
   colors,
 } from './components';
 
@@ -149,6 +152,16 @@ const Charts = ({ chartType = 'line', width = '100%', height = '100%', id }) => 
   const analyticsData = useSelector((state) => state.analytics.data);
   const [showLoadingMessage, setShowLoadingMessage] = useState(false);
   const [hasLoaded, setHasLoaded] = useState(false);
+  const WHO_STANDARD_VALUE =
+    chartData.pollutionType === 'pm2_5'
+      ? 5 // PM2.5: 5 µg/m³ annual mean
+      : chartData.pollutionType === 'pm10'
+      ? 15 // PM10: 15 µg/m³ annual mean
+      : chartData.pollutionType === 'no2'
+      ? 10
+      : chartData.pollutionType === 'ozone'
+      ? 60
+      : 0;
 
   useEffect(() => {
     let timeoutId;
@@ -226,12 +239,14 @@ const Charts = ({ chartType = 'line', width = '100%', height = '100%', id }) => 
                 activeDot={{ r: 6 }}
               />
             ))}
+          <ReferenceLine y={WHO_STANDARD_VALUE} label={renderCustomizedLabel} stroke='red' />
           <CartesianGrid stroke='#ccc' strokeDasharray='5 5' vertical={false} />
           <XAxis
             dataKey='time'
             tick={<CustomizedAxisTick />}
             tickLine={true}
             axisLine={false}
+            scale='point'
             padding={{ left: 30, right: 30 }}
           />
           <YAxis
@@ -248,12 +263,12 @@ const Charts = ({ chartType = 'line', width = '100%', height = '100%', id }) => 
               }
             }}>
             <Label
-              value={chartData.pollutionType === 'pm2_5' ? 'PM2.5 (µg/m³)' : 'PM10 (µg/m³)'}
+              value={chartData.pollutionType === 'pm2_5' ? 'PM2.5' : 'PM10'}
               position='insideTopRight'
               offset={0}
               fontSize={12}
               dy={-35}
-              dx={60}
+              dx={12}
             />
           </YAxis>
           <Legend
@@ -283,8 +298,15 @@ const Charts = ({ chartType = 'line', width = '100%', height = '100%', id }) => 
           {Array.from(allKeys)
             .filter((key) => key !== 'time')
             .map((key, index) => (
-              <Bar key={key} dataKey={key} fill={colors[index % colors.length]} barSize={15} />
+              <Bar
+                key={key}
+                dataKey={key}
+                fill={colors[index % colors.length]}
+                barSize={12}
+                shape={<CustomBar />}
+              />
             ))}
+          <ReferenceLine y={WHO_STANDARD_VALUE} label={renderCustomizedLabel} stroke='red' />
           <CartesianGrid stroke='#ccc' strokeDasharray='5 5' vertical={false} />
           <XAxis dataKey='time' tickLine={true} tick={<CustomizedAxisTick />} axisLine={false} />
           <YAxis
@@ -301,12 +323,12 @@ const Charts = ({ chartType = 'line', width = '100%', height = '100%', id }) => 
               }
             }}>
             <Label
-              value={chartData.pollutionType === 'pm2_5' ? 'PM2.5 (µg/m³)' : 'PM10 (µg/m³)'}
+              value={chartData.pollutionType === 'pm2_5' ? 'PM2.5' : 'PM10'}
               position='insideTopRight'
               offset={0}
               fontSize={12}
               dy={-35}
-              dx={60}
+              dx={12}
             />
           </YAxis>
           <Legend

--- a/platform/src/common/components/Charts/Charts.js
+++ b/platform/src/common/components/Charts/Charts.js
@@ -154,13 +154,11 @@ const Charts = ({ chartType = 'line', width = '100%', height = '100%', id }) => 
   const [hasLoaded, setHasLoaded] = useState(false);
   const WHO_STANDARD_VALUE =
     chartData.pollutionType === 'pm2_5'
-      ? 5
-      : chartData.pollutionType === 'pm10'
       ? 15
+      : chartData.pollutionType === 'pm10'
+      ? 45
       : chartData.pollutionType === 'no2'
-      ? 10
-      : chartData.pollutionType === 'ozone'
-      ? 60
+      ? 25
       : 0;
 
   const [activeIndex, setActiveIndex] = useState(null);

--- a/platform/src/common/components/Charts/Charts.js
+++ b/platform/src/common/components/Charts/Charts.js
@@ -154,9 +154,9 @@ const Charts = ({ chartType = 'line', width = '100%', height = '100%', id }) => 
   const [hasLoaded, setHasLoaded] = useState(false);
   const WHO_STANDARD_VALUE =
     chartData.pollutionType === 'pm2_5'
-      ? 5 // PM2.5: 5 µg/m³ annual mean
+      ? 5
       : chartData.pollutionType === 'pm10'
-      ? 15 // PM10: 15 µg/m³ annual mean
+      ? 15
       : chartData.pollutionType === 'no2'
       ? 10
       : chartData.pollutionType === 'ozone'

--- a/platform/src/common/components/Charts/components/index.jsx
+++ b/platform/src/common/components/Charts/components/index.jsx
@@ -286,3 +286,45 @@ export const renderCustomizedLegend = (props) => {
     </div>
   );
 };
+
+/**
+ * Customized label component for ReferenceLine
+ * @param {Object} props
+ */
+export const renderCustomizedLabel = (props) => {
+  const { viewBox } = props;
+  const x = viewBox.width + viewBox.x - 10;
+  const y = viewBox.y + 3;
+
+  return (
+    <g>
+      <foreignObject x={x - 20} y={y - 14} width={40} height={20}>
+        <div
+          xmlns='http://www.w3.org/1999/xhtml'
+          style={{ backgroundColor: 'red' }}
+          className='rounded-md py-1 text-center text-white text-[14px] font-semibold leading-[11px]'>
+          WHO
+        </div>
+      </foreignObject>
+    </g>
+  );
+};
+
+/**
+ * Customized bar component for bar chart
+ * @param {Object} props
+ */
+export const CustomBar = (props) => {
+  const { fill, x, y, width, height } = props;
+
+  return (
+    <g>
+      <foreignObject x={x} y={y} width={width} height={height}>
+        <div
+          xmlns='http://www.w3.org/1999/xhtml'
+          style={{ backgroundColor: fill, width: '100%', height: '100%', borderRadius: '5px' }}
+        />
+      </foreignObject>
+    </g>
+  );
+};

--- a/platform/src/common/components/Charts/components/index.jsx
+++ b/platform/src/common/components/Charts/components/index.jsx
@@ -63,7 +63,7 @@ export const getAirQualityLevelText = (value) => {
  * @returns {JSX.Element}
  * @description Custom tooltip component for line graph
  */
-export const CustomTooltipLineGraph = ({ active, payload }) => {
+export const CustomTooltipLineGraph = ({ active, payload, activeIndex }) => {
   const chartData = useSelector((state) => state.chart);
   const { timeFrame } = chartData;
 
@@ -92,7 +92,10 @@ export const CustomTooltipLineGraph = ({ active, payload }) => {
             <span className='text-sm text-gray-300'>{formatDate(hoveredPoint.payload.time)}</span>
             <div className='flex justify-between w-full mb-1 mt-2'>
               <div className='flex items-center text-xs font-medium leading-[14px] text-gray-600'>
-                <div className='w-[10px] h-[10px] bg-blue-700 rounded-xl mr-2'></div>
+                <div
+                  className={`w-[10px] h-[10px] rounded-xl mr-2 ${
+                    activeIndex === 0 ? 'bg-blue-700' : 'bg-gray-400'
+                  }`}></div>
                 {truncate(hoveredPoint.name)}
               </div>
               <div className='text-xs font-medium leading-[14px] text-gray-600'>
@@ -111,12 +114,19 @@ export const CustomTooltipLineGraph = ({ active, payload }) => {
               <div className='w-full h-[2px] bg-transparent my-1 border-t border-dotted border-gray-300' />
               <div className='p-2 space-y-1'>
                 {otherPoints.map((point, index) => (
-                  <div key={index} className='flex justify-between w-full mb-1'>
-                    <div className='flex items-center text-xs font-medium leading-[14px] text-gray-400'>
-                      <div className='w-[10px] h-[10px] bg-gray-400 rounded-xl mr-2'></div>
+                  <div
+                    key={index}
+                    className={`flex justify-between w-full mb-1 ${
+                      activeIndex === index + 1 ? 'text-black' : 'text-gray-400'
+                    }`}>
+                    <div className='flex items-center text-xs font-medium leading-[14px] text-black'>
+                      <div
+                        className={`w-[10px] h-[10px] rounded-xl mr-2 ${
+                          activeIndex === index + 1 ? 'bg-blue-700' : 'bg-gray-400'
+                        }`}></div>
                       {truncate(point.name)}
                     </div>
-                    <div className='text-xs font-medium leading-[14px] text-gray-400'>
+                    <div className='text-xs font-medium leading-[14px]'>
                       {reduceDecimalPlaces(point.value) + ' μg/m3'}
                     </div>
                   </div>
@@ -136,7 +146,7 @@ export const CustomTooltipLineGraph = ({ active, payload }) => {
  * @returns {JSX.Element}
  * @description Custom tooltip component for bar graph
  */
-export const CustomTooltipBarGraph = ({ active, payload }) => {
+export const CustomTooltipBarGraph = ({ active, payload, activeIndex }) => {
   const chartData = useSelector((state) => state.chart);
   const { timeFrame } = chartData;
 
@@ -151,44 +161,63 @@ export const CustomTooltipBarGraph = ({ active, payload }) => {
   };
 
   if (active && payload && payload.length) {
+    const hoveredPoint = payload[0];
+    const otherPoints = payload.slice(1);
+
+    const { airQualityText, AirQualityIcon, airQualityColor } = getAirQualityLevelText(
+      hoveredPoint.value,
+    );
+
     return (
       <div className='bg-white border border-gray-200 rounded-md shadow-lg w-72 outline-none'>
-        <span className='text-sm text-gray-300 px-2'>{formatDate(payload[0].payload.time)}</span>
-        {payload.map((hoveredPoint, index) => {
-          const { airQualityText, AirQualityIcon, airQualityColor } = getAirQualityLevelText(
-            hoveredPoint.value,
-          );
-          const barColor = colors[index % colors.length];
-
-          return (
-            <div className='flex flex-col space-y-1' key={hoveredPoint.dataKey}>
-              <div className='flex flex-col items-start justify-between w-full h-auto p-2'>
-                <div className='flex justify-between w-full mb-1 mt-2'>
-                  <div className='flex items-center text-xs font-medium leading-[14px] text-gray-600'>
-                    <div
-                      style={{
-                        width: '10px',
-                        height: '10px',
-                        backgroundColor: barColor,
-                        borderRadius: '50%',
-                        marginRight: '2px',
-                      }}></div>
-                    {truncate(hoveredPoint.dataKey)}
-                  </div>
-                  <div className='text-xs font-medium leading-[14px] text-gray-600'>
-                    {reduceDecimalPlaces(hoveredPoint.value) + ' μg/m3'}
-                  </div>
-                </div>
-                <div className='flex justify-between items-center w-full'>
-                  <div className={`${airQualityColor} text-xs font-medium leading-[14px] `}>
-                    {airQualityText}
-                  </div>
-                  <AirQualityIcon width={30} height={30} />
-                </div>
+        <div className='flex flex-col space-y-1'>
+          <div className='flex flex-col items-start justify-between w-full h-auto p-2'>
+            <span className='text-sm text-gray-300'>{formatDate(hoveredPoint.payload.time)}</span>
+            <div className='flex justify-between w-full mb-1 mt-2'>
+              <div className='flex items-center text-xs font-medium leading-[14px] text-gray-600'>
+                <div
+                  className={`w-[10px] h-[10px] rounded-xl mr-2 ${
+                    activeIndex === 0 ? 'bg-blue-700' : 'bg-gray-400'
+                  }`}></div>
+                {truncate(hoveredPoint.name)}
+              </div>
+              <div className='text-xs font-medium leading-[14px] text-gray-600'>
+                {reduceDecimalPlaces(hoveredPoint.value) + ' μg/m3'}
               </div>
             </div>
-          );
-        })}
+            <div className='flex justify-between items-center w-full'>
+              <div className={`${airQualityColor} text-xs font-medium leading-[14px] `}>
+                {airQualityText}
+              </div>
+              <AirQualityIcon width={30} height={30} />
+            </div>
+          </div>
+          {otherPoints.length > 0 && (
+            <>
+              <div className='w-full h-[2px] bg-transparent my-1 border-t border-dotted border-gray-300' />
+              <div className='p-2 space-y-1'>
+                {otherPoints.map((point, index) => (
+                  <div
+                    key={index}
+                    className={`flex justify-between w-full mb-1 ${
+                      activeIndex === index + 1 ? 'text-black' : 'text-gray-400'
+                    }`}>
+                    <div className='flex items-center text-xs font-medium leading-[14px] text-black'>
+                      <div
+                        className={`w-[10px] h-[10px] rounded-xl mr-2 ${
+                          activeIndex === index + 1 ? 'bg-blue-700' : 'bg-gray-400'
+                        }`}></div>
+                      {truncate(point.name)}
+                    </div>
+                    <div className='text-xs font-medium leading-[14px]'>
+                      {reduceDecimalPlaces(point.value) + ' μg/m3'}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </>
+          )}
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

- Added the WHO standard (average timing used is the 24hr) for PM2.5 and PM10 accordingly

#### Status of maturity (all need to be checked before merging):

- [x] I've tested this locally
- [x] I consider this code done
- [x] This change ready to hit production in its current state


#### Screenshots (optional)

https://github.com/user-attachments/assets/c61d43b5-bc34-4329-9928-e5e2b4d5ed5e


![image](https://github.com/user-attachments/assets/83e3459c-5c9b-4176-b0fc-f78893e5111c)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a `ReferenceLine` component for better visual reference in charts.
  - Introduced custom bar shapes and sizes in bar charts.
  - Implemented custom labels for enhanced readability on the Y-axis.
  - Included a WHO standard value marker based on pollution type.

- **Enhancements**
  - Improved interactivity with mouse events to highlight data points.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->