### PR TITLE
chore: Update with New (AQI) index on AirQo Map for PM2.5 Pollutant

### DIFF
--- a/platform/src/common/components/Map/components/Legend.js
+++ b/platform/src/common/components/Map/components/Legend.js
@@ -43,12 +43,12 @@ export const AirQualityLegend = ({ pollutant }) => {
   const pollutantLevels = {
     pm2_5: [
       {
-        range: '0.0μg/m3 - 12.0μg/m3',
+        range: '0.0μg/m3 - 9.0μg/m3',
         label: 'Air Quality is Good',
         icon: <GoodAir width={size} height={size} />,
       },
       {
-        range: '12.1μg/m3 - 35.4μg/m3',
+        range: '9.1μg/m3 - 35.4μg/m3',
         label: 'Air Quality is Moderate',
         icon: <ModerateAir width={size} height={size} />,
       },
@@ -58,17 +58,17 @@ export const AirQualityLegend = ({ pollutant }) => {
         icon: <UnhealthyForSensitiveGroups width={size} height={size} />,
       },
       {
-        range: '55.5μg/m3 - 150.4μg/m3',
+        range: '55.5μg/m3 - 125.4μg/m3',
         label: 'Air Quality is Unhealthy',
         icon: <Unhealthy width={size} height={size} />,
       },
       {
-        range: '150.5μg/m3 - 250.4μg/m3',
+        range: '125.5μg/m3 - 225.4μg/m3',
         label: 'Air Quality is Very Unhealthy',
         icon: <VeryUnhealthy width={size} height={size} />,
       },
       {
-        range: '250.5μg/m3 - 500.4μg/m3',
+        range: '225.5μg/m3 +',
         label: 'Air Quality is Hazardous',
         icon: <Hazardous width={size} height={size} />,
       },

--- a/platform/src/common/components/Map/components/MapNodes.js
+++ b/platform/src/common/components/Map/components/MapNodes.js
@@ -25,11 +25,11 @@ export const images = {
 const markerDetails = {
   pm2_5: [
     { limit: 500.5, category: 'Invalid' || 'undefined' },
-    { limit: 250.5, category: 'Hazardous' },
-    { limit: 150.5, category: 'VeryUnhealthy' },
+    { limit: 225.5, category: 'Hazardous' },
+    { limit: 125.5, category: 'VeryUnhealthy' },
     { limit: 55.5, category: 'Unhealthy' },
     { limit: 35.5, category: 'UnhealthyForSensitiveGroups' },
-    { limit: 12.1, category: 'ModerateAir' },
+    { limit: 9.1, category: 'ModerateAir' },
     { limit: 0.0, category: 'GoodAir' },
   ],
   pm10: [


### PR DESCRIPTION
#### Summary of Changes

- **Enhanced AirQo Map's AQI**: Updated the Air Quality Index (AQI) for PM2.5 across the labels and legend on the AirQo Map. This update is based on the latest standards shared in the new AQI document.

#### Status of maturity (all need to be checked before merging):

- [x] I've tested this locally
- [x] I consider this code done
- [x] This change ready to hit production in its current state

#### Screenshots (optional)
![image](https://github.com/user-attachments/assets/8caa64cc-983e-4b07-bb01-4bcd8f9b8b0c)
![image](https://github.com/user-attachments/assets/0af7a42a-7dac-4c49-8ce7-6468322e0eec)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated air quality category thresholds for more accurate pollution classification.
	- Enhanced public health awareness through stricter air quality indicators.
  
- **Bug Fixes**
	- Corrected pollutant limit values to ensure accurate representation of air quality levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->