### PR TITLE
[netmanager] just adding the GAS option for device type during creation

### DIFF
--- a/netmanager/src/views/components/DataDisplay/DeviceView/DeviceEdit.js
+++ b/netmanager/src/views/components/DataDisplay/DeviceView/DeviceEdit.js
@@ -417,6 +417,7 @@ const EditDeviceForm = ({ deviceData, siteOptions }) => {
               required>
               <option value={'lowcost'}>Lowcost</option>
               <option value={'bam'}>BAM</option>
+              <option value={'gas'}>GAS</option>
             </TextField>
           </Grid>
 

--- a/netmanager/src/views/components/DataDisplay/Devices.js
+++ b/netmanager/src/views/components/DataDisplay/Devices.js
@@ -245,7 +245,8 @@ const createDeviceColumns = (history, setDelState) => [
 
 const CATEGORIES = [
   { value: 'lowcost', name: 'Lowcost' },
-  { value: 'bam', name: 'BAM' }
+  { value: 'bam', name: 'BAM' },
+  { value: 'gas', name: 'GAS' }
 ];
 
 // categories options


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)
just adding the GAS option for device type during creation

#### Status of maturity (all need to be checked before merging):

- [ ] I've tested this locally
- [ ] I consider this code done
- [ ] This change ready to hit production in its current state
- [ ] The title of the PR states what changed and the related issues number (used for the release note).
- [ ] I've included issue number in the "Closes #ISSUE-NUMBER" part of the "[What are the relevant tickets?](#what-are-the-relevant-tickets)" section to [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [ ] I've updated corresponding documentation for the changes in this PR.
- [ ] I have written unit and/or e2e tests for my change(s).

#### How should this be manually tested?

Navigate to the `netmanager` folder and check the README for run instructions

#### What are the relevant tickets?

- [OPS-263]




[OPS-263]: https://airqoteam.atlassian.net/browse/OPS-263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new option "GAS" to the dropdown menu in the Edit Device form, providing users with more selection options.
	- Introduced a new category "GAS" in the devices display, enhancing the categorization of devices available for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->