### PR TITLE
[Netmanager]  Added description field to device creation form

### DIFF
--- a/netmanager/src/views/components/DataDisplay/DeviceView/DeviceView.js
+++ b/netmanager/src/views/components/DataDisplay/DeviceView/DeviceView.js
@@ -33,10 +33,8 @@ const DeviceView = () => {
   });
 
   useEffect(() => {
-    if (isEmpty(devices)) {
-      dispatch(getOrgDevices(activeNetwork.net_name));
-      dispatch(updateDeviceDetails(deviceData));
-    }
+    dispatch(getOrgDevices(activeNetwork.net_name));
+    dispatch(updateDeviceDetails(deviceData));
   }, []);
 
   return (
@@ -46,7 +44,8 @@ const DeviceView = () => {
         alignItems: 'center',
         justifyContent: 'center',
         flexWrap: 'wrap'
-      }}>
+      }}
+    >
       <DeviceToolBar deviceName={deviceData.name} />
       <DeviceToolBarContainer>
         <Switch>

--- a/netmanager/src/views/components/DataDisplay/Devices.js
+++ b/netmanager/src/views/components/DataDisplay/Devices.js
@@ -277,13 +277,15 @@ const CreateDevice = ({ open, setOpen }) => {
   const newDeviceInitState = {
     long_name: '',
     category: CATEGORIES[0].value,
-    network: selectedNetwork
+    network: selectedNetwork,
+    description: ''
   };
 
   const initialErrors = {
     long_name: '',
     category: '',
-    network: ''
+    network: '',
+    description: ''
   };
 
   const [newDevice, setNewDevice] = useState(newDeviceInitState);
@@ -321,9 +323,10 @@ const CreateDevice = ({ open, setOpen }) => {
     setNewDevice({
       long_name: '',
       category: CATEGORIES[0].value,
-      network: selectedNetwork
+      network: selectedNetwork,
+      description: ''
     });
-    setErrors({ long_name: '', category: '', network: '' });
+    setErrors({ long_name: '', category: '', network: '', description: '' });
   };
 
   const isFormValid = () => {
@@ -448,6 +451,19 @@ const CreateDevice = ({ open, setOpen }) => {
             helperText={errors.network}
             disabled
           />
+
+          <TextField
+            margin="dense"
+            label="Description (Optional)"
+            variant="outlined"
+            value={newDevice.description}
+            onChange={handleDeviceDataChange('description')}
+            fullWidth
+            multiline
+            rows={3}
+            error={!!errors.description}
+            helperText={errors.description}
+          />
         </form>
       </DialogContent>
 
@@ -482,8 +498,9 @@ const SoftCreateDevice = ({ open, setOpen, network }) => {
     category: CATEGORIES[0].value,
     network: selectedNetwork,
     device_number: '',
-    write_key: '',
-    read_key: ''
+    writeKey: '',
+    readKey: '',
+    description: ''
   };
 
   const initialErrors = {
@@ -491,8 +508,9 @@ const SoftCreateDevice = ({ open, setOpen, network }) => {
     category: '',
     network: '',
     device_number: '',
-    write_key: '',
-    read_key: ''
+    writeKey: '',
+    readKey: '',
+    description: ''
   };
 
   const [newDevice, setNewDevice] = useState(newDeviceInitState);
@@ -534,16 +552,18 @@ const SoftCreateDevice = ({ open, setOpen, network }) => {
       category: CATEGORIES[0].value,
       network: selectedNetwork,
       device_number: '',
-      write_key: '',
-      read_key: ''
+      writeKey: '',
+      readKey: '',
+      description: ''
     });
     setErrors({
       long_name: '',
       category: '',
       network: '',
       device_number: '',
-      write_key: '',
-      read_key: ''
+      writeKey: '',
+      readKey: '',
+      description: ''
     });
   };
 
@@ -565,20 +585,21 @@ const SoftCreateDevice = ({ open, setOpen, network }) => {
               severity: 'error'
             })
           );
+          dispatch(loadStatus(false));
           return;
         } else {
           // Create a copy of newDevice
           const deviceDataToSend = { ...newDevice };
 
-          // Remove device_number, write_key, and read_key if they're empty
+          // Remove device_number, writeKey, and readKey if they're empty
           if (!deviceDataToSend.device_number) {
             delete deviceDataToSend.device_number;
           }
-          if (!deviceDataToSend.write_key) {
-            delete deviceDataToSend.write_key;
+          if (!deviceDataToSend.writeKey) {
+            delete deviceDataToSend.writeKey;
           }
-          if (!deviceDataToSend.read_key) {
-            delete deviceDataToSend.read_key;
+          if (!deviceDataToSend.readKey) {
+            delete deviceDataToSend.readKey;
           }
 
           const resData = await softCreateDeviceApi(deviceDataToSend, {
@@ -678,6 +699,19 @@ const SoftCreateDevice = ({ open, setOpen, network }) => {
             disabled
           ></TextField>
 
+          <TextField
+            margin="dense"
+            label="Description (Optional)"
+            variant="outlined"
+            value={newDevice.description}
+            onChange={handleDeviceDataChange('description')}
+            fullWidth
+            multiline
+            rows={3}
+            error={!!errors.description}
+            helperText={errors.description}
+          />
+
           <Button onClick={toggleMoreOptions} color="primary" style={{ marginTop: '10px' }}>
             {showMoreOptions ? 'Show less options' : 'Show more options'}
           </Button>
@@ -699,22 +733,22 @@ const SoftCreateDevice = ({ open, setOpen, network }) => {
                 margin="dense"
                 label="Write Key (Optional)"
                 variant="outlined"
-                value={newDevice.write_key}
-                onChange={handleDeviceDataChange('write_key')}
+                value={newDevice.writeKey}
+                onChange={handleDeviceDataChange('writeKey')}
                 fullWidth
-                error={!!errors.write_key}
-                helperText={errors.write_key}
+                error={!!errors.writeKey}
+                helperText={errors.writeKey}
               />
 
               <TextField
                 margin="dense"
                 label="Read Key (Optional)"
                 variant="outlined"
-                value={newDevice.read_key}
-                onChange={handleDeviceDataChange('read_key')}
+                value={newDevice.readKey}
+                onChange={handleDeviceDataChange('readKey')}
                 fullWidth
-                error={!!errors.read_key}
-                helperText={errors.read_key}
+                error={!!errors.readKey}
+                helperText={errors.readKey}
               />
             </>
           )}


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

- Introduced a new description field for device creation, allowing users to provide optional context.
- Corrected read and write key fields naming as needed by the device creation APIs.

#### Status of maturity (all need to be checked before merging):

- [x] I've tested this locally
- [x] I consider this code done
- [x] This change ready to hit production in its current state

#### How should this be manually tested?

- Please include the steps to be done inorder to setup and test this PR.

#### What are the relevant tickets?

- Closes #<enter issue number here>
- [Jira_card_number]() (If exists)

#### Screenshots (optional)
![image](https://github.com/user-attachments/assets/c0d15a45-0de7-4041-9794-c04ee1467d6c)
![image](https://github.com/user-attachments/assets/0a091c1e-4da6-4b24-a47e-eb43172a8791)
![image](https://github.com/user-attachments/assets/cf73646d-0641-498d-ba15-0c3fe4922f76)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `description` field for device creation, allowing users to provide optional context.
	- Enhanced form functionality with improved error handling and validation for the new field.

- **Improvements**
	- Streamlined data fetching logic in the device view for more consistent behavior upon component mount.
	- Updated naming conventions for clarity and consistency in the device creation components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->