### PR TITLE
[Netmanager] Improved error handling for network selection in sidebar dropdown

### DIFF
--- a/netmanager/src/views/containers/PageAccess.js
+++ b/netmanager/src/views/containers/PageAccess.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import { Redirect } from 'react-router-dom';
+import { useSelector } from 'react-redux';
 
 export const withPermission = (Component, requiredPermission) => {
   const WithPermission = (props) => {
-    const currentRole = JSON.parse(localStorage.getItem('currentUserRole'));
+    const currentRole = useSelector((state) => state.accessControl.currentRole);
 
     let hasPermission = false;
     if (currentRole && currentRole.role_permissions) {

--- a/netmanager/src/views/layouts/common/Sidebar/Sidebar.js
+++ b/netmanager/src/views/layouts/common/Sidebar/Sidebar.js
@@ -271,11 +271,17 @@ const Sidebar = (props) => {
             (network) => network.net_name === 'airqo'
           );
 
-          if (!activeNetwork) {
+          if (!activeNetwork && airqoNetwork) {
             localStorage.setItem('activeNetwork', JSON.stringify(airqoNetwork));
             dispatch(addActiveNetwork(airqoNetwork));
             dispatch(addCurrentUserRole(airqoNetwork.role));
             localStorage.setItem('currentUserRole', JSON.stringify(airqoNetwork.role));
+          } else {
+            const selectedNetwork = res.users[0].networks[0];
+            localStorage.setItem('activeNetwork', JSON.stringify(selectedNetwork));
+            dispatch(addActiveNetwork(selectedNetwork));
+            dispatch(addCurrentUserRole(selectedNetwork.role));
+            localStorage.setItem('currentUserRole', JSON.stringify(selectedNetwork.role));
           }
         }
       } catch (err) {


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)
This pull request introduces several changes to the `netmanager` project to enhance the handling of user roles and network data. The most important changes include switching from local storage to Redux for managing user roles, improving the logic for setting the active network, and refactoring the `NetworkDropdown` component for better data handling and user experience.

### User Role Management:
* [`netmanager/src/views/containers/PageAccess.js`](diffhunk://#diff-df54caa9e505ade5d25f41f29931ec2394657c1639afda5d352ba3025f6b3ea6R3-R7): Replaced local storage with Redux to manage `currentRole` using `useSelector` for better state management.

### Active Network Logic:
* [`netmanager/src/views/layouts/common/Sidebar/Sidebar.js`](diffhunk://#diff-49a7bdd9838d73ee87f51d641a95c3881d14867b4914970e804ed387e5cf5b9dL274-R284): Improved the logic for setting the active network and user role, ensuring that the correct network and role are stored and dispatched.

### NetworkDropdown Component Refactoring:
* [`netmanager/src/views/layouts/common/Sidebar/components/NetworkDropdown.js`](diffhunk://#diff-11da413ed68d36e52ed175b1f6ccbdd63985250d1b79ada21fd0f90be675ca0fR74-R102): Added a check to return early if `userNetworks` is empty, refactored the logic to set the active network, and created a `loadNetworkData` function to handle data loading. [[1]](diffhunk://#diff-11da413ed68d36e52ed175b1f6ccbdd63985250d1b79ada21fd0f90be675ca0fR74-R102) [[2]](diffhunk://#diff-11da413ed68d36e52ed175b1f6ccbdd63985250d1b79ada21fd0f90be675ca0fL98-R125)
* [`netmanager/src/views/layouts/common/Sidebar/components/NetworkDropdown.js`](diffhunk://#diff-11da413ed68d36e52ed175b1f6ccbdd63985250d1b79ada21fd0f90be675ca0fL125-R143): Updated the `handleSelect` method to use the new `loadNetworkData` function and dispatch a custom event when the network changes.
* [`netmanager/src/views/layouts/common/Sidebar/components/NetworkDropdown.js`](diffhunk://#diff-11da413ed68d36e52ed175b1f6ccbdd63985250d1b79ada21fd0f90be675ca0fL136-R155): Made minor formatting adjustments to improve code readability. [[1]](diffhunk://#diff-11da413ed68d36e52ed175b1f6ccbdd63985250d1b79ada21fd0f90be675ca0fL136-R155) [[2]](diffhunk://#diff-11da413ed68d36e52ed175b1f6ccbdd63985250d1b79ada21fd0f90be675ca0fL146-R166) [[3]](diffhunk://#diff-11da413ed68d36e52ed175b1f6ccbdd63985250d1b79ada21fd0f90be675ca0fL158-R179) [[4]](diffhunk://#diff-11da413ed68d36e52ed175b1f6ccbdd63985250d1b79ada21fd0f90be675ca0fL169-R198) [[5]](diffhunk://#diff-11da413ed68d36e52ed175b1f6ccbdd63985250d1b79ada21fd0f90be675ca0fL184-R213)

#### Status of maturity (all need to be checked before merging):

- [x] I've tested this locally
- [x] I consider this code done
- [x] This change ready to hit production in its current state
- [x] The title of the PR states what changed and the related issues number (used for the release note).
- [ ] I've included issue number in the "Closes #ISSUE-NUMBER" part of the "[What are the relevant tickets?](#what-are-the-relevant-tickets)" section to [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [ ] I've updated corresponding documentation for the changes in this PR.
- [ ] I have written unit and/or e2e tests for my change(s).

#### How should this be manually tested?

- Please include the steps to be done inorder to setup and test this PR.

#### What are the relevant tickets?

- Closes #<enter issue number here>
- [AN-677](https://airqoteam.atlassian.net/browse/AN-677?atlOrigin=eyJpIjoiNWNlMTk0Zjc5NDJiNDk2YjhmMTc2OTQ0OTUzMjE4YjgiLCJwIjoiaiJ9) (If exists)

#### Screenshots (optional)
![image](https://github.com/user-attachments/assets/6185631b-611a-429c-8d88-8ddfcc511fe3)
![image](https://github.com/user-attachments/assets/aaf98f71-385d-4c96-9171-e62772978a93)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved user role management by integrating Redux for retrieving the current user's role.
	- Enhanced logic in the Sidebar component for determining the active network based on user data.
	- Added asynchronous data loading for network-related information in the NetworkDropdown component.

- **Bug Fixes**
	- Streamlined the handling of user roles and active networks to ensure accurate permissions and access.

- **Documentation**
	- Updated component imports and structure to reflect changes in state management and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[AN-677]: https://airqoteam.atlassian.net/browse/AN-677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ