### PR TITLE
[Analytics] Format organisation dropdown text to uppercase

### DIFF
--- a/platform/src/common/components/Dropdowns/OrganizationDropdown.jsx
+++ b/platform/src/common/components/Dropdowns/OrganizationDropdown.jsx
@@ -14,15 +14,8 @@ const formatGroupName = (name) => {
   const trimmedName = name.trim();
   if (!trimmedName) return 'Unknown';
 
-  return trimmedName.toLowerCase() === 'airqo'
-    ? 'AirQo'
-    : trimmedName
-        .replace(/_/g, ' ')
-        .split(' ')
-        .map(
-          (word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase(),
-        )
-        .join(' ');
+  // make name upper case and replace _ or - with space
+  return trimmedName.toUpperCase().replace(/_/g, ' ').replace(/-/g, ' ');
 };
 
 const getAbbreviation = (name) => {

--- a/platform/src/common/components/Modal/dataDownload/components/CustomFields.jsx
+++ b/platform/src/common/components/Modal/dataDownload/components/CustomFields.jsx
@@ -4,11 +4,17 @@ import CheckIcon from '@/icons/tickIcon';
 import CustomDropdown from '../../../Dropdowns/CustomDropdown';
 import DatePicker from '../../../Calendar/DatePicker';
 
-const formatName = (name) => {
-  if (typeof name === 'string' && name.toLowerCase() === 'airqo') {
-    return 'AirQo';
-  }
-  return name;
+const capitalize = (name) => {
+  return name.charAt(0).toUpperCase() + name.slice(1);
+};
+
+const formatName = (name, textFormat = 'lowercase') => {
+  if (!name) return '';
+  return typeof name === 'string'
+    ? textFormat === 'uppercase'
+      ? name.toUpperCase().replace(/_/g, ' ').replace(/-/g, ' ')
+      : name.replace(/_/g, ' ').replace(/-/g, ' ')
+    : capitalize(name);
 };
 
 const CustomFields = ({
@@ -22,6 +28,7 @@ const CustomFields = ({
   useCalendar = false,
   handleOptionSelect,
   defaultOption,
+  textFormat = 'lowercase',
 }) => {
   const [selectedOption, setSelectedOption] = useState(
     defaultOption || options[0],
@@ -65,9 +72,13 @@ const CustomFields = ({
           tabStyle="w-full bg-white px-3 py-2"
           dropdown
           tabIcon={icon}
-          btnText={btnText || formatName(selectedOption.name)}
+          btnText={
+            formatName(btnText, textFormat) ||
+            formatName(selectedOption.name, textFormat)
+          }
           customPopperStyle={{ left: '-7px' }}
           dropDownClass="w-full"
+          textFormat={textFormat}
         >
           {options.map((option) => (
             <span
@@ -77,8 +88,8 @@ const CustomFields = ({
                 selectedOption.id === option.id ? 'bg-[#EBF5FF] rounded-md' : ''
               }`}
             >
-              <span className="flex items-center capitalize space-x-2">
-                <span>{formatName(option.name)}</span>
+              <span className="flex items-center space-x-2">
+                <span>{formatName(option.name, textFormat)}</span>
               </span>
               {selectedOption.id === option.id && (
                 <CheckIcon fill={'#145FFF'} />

--- a/platform/src/common/components/Modal/dataDownload/components/CustomFields.jsx
+++ b/platform/src/common/components/Modal/dataDownload/components/CustomFields.jsx
@@ -5,11 +5,12 @@ import CustomDropdown from '../../../Dropdowns/CustomDropdown';
 import DatePicker from '../../../Calendar/DatePicker';
 
 const capitalize = (name) => {
+  if (typeof name !== 'string' || !name) return name;
   return name.charAt(0).toUpperCase() + name.slice(1);
 };
 
 const formatName = (name, textFormat = 'lowercase') => {
-  if (!name) return '';
+  if (typeof name !== 'string' || !name) return name;
   return typeof name === 'string'
     ? textFormat === 'uppercase'
       ? name.toUpperCase().replace(/_/g, ' ').replace(/-/g, ' ')

--- a/platform/src/common/components/Modal/dataDownload/components/CustomFields.jsx
+++ b/platform/src/common/components/Modal/dataDownload/components/CustomFields.jsx
@@ -114,6 +114,7 @@ CustomFields.propTypes = {
   useCalendar: PropTypes.bool,
   handleOptionSelect: PropTypes.func,
   defaultOption: PropTypes.object,
+  textFormat: PropTypes.oneOf(['uppercase', 'lowercase']),
 };
 
 export default CustomFields;

--- a/platform/src/common/components/Modal/dataDownload/modules/DataDownload.jsx
+++ b/platform/src/common/components/Modal/dataDownload/modules/DataDownload.jsx
@@ -301,6 +301,7 @@ const DataDownload = ({ onClose }) => {
           icon={<WorldIcon width={16} height={16} fill="#000" />}
           defaultOption={formData.network}
           handleOptionSelect={handleOptionSelect}
+          textFormat="uppercase"
         />
         <CustomFields
           title="Data type"


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

This pull request includes changes to the `platform/src/common/components/Modal/dataDownload/components/CustomFields.jsx` and `platform/src/common/components/Dropdowns/OrganizationDropdown.jsx` files to improve the formatting of names and provide more flexibility in text formatting. The most important changes include modifying the `formatName` function to support different text formats, updating the `CustomFields` component to accept a `textFormat` prop, and simplifying the `formatGroupName` function.

Improvements to name formatting:

* [`platform/src/common/components/Dropdowns/OrganizationDropdown.jsx`](diffhunk://#diff-bbab9adcc9ceaa8fd9affa5a4994dfb12008f3867fa761fb7e4ec8b514dafb1eL17-R18): Simplified the `formatGroupName` function to make the name uppercase and replace underscores or hyphens with spaces.

* [`platform/src/common/components/Modal/dataDownload/components/CustomFields.jsx`](diffhunk://#diff-67e65fef165ab500f5a20582d9e3d608f68f22ff2f6367389c3eeb3062c08b24L7-R17): Modified the `formatName` function to support different text formats (uppercase and lowercase) and added a `capitalize` helper function.

Enhancements to `CustomFields` component:

* [`platform/src/common/components/Modal/dataDownload/components/CustomFields.jsx`](diffhunk://#diff-67e65fef165ab500f5a20582d9e3d608f68f22ff2f6367389c3eeb3062c08b24R31): Updated the `CustomFields` component to accept a `textFormat` prop, allowing for dynamic text formatting based on the provided format. [[1]](diffhunk://#diff-67e65fef165ab500f5a20582d9e3d608f68f22ff2f6367389c3eeb3062c08b24R31) [[2]](diffhunk://#diff-67e65fef165ab500f5a20582d9e3d608f68f22ff2f6367389c3eeb3062c08b24L68-R81) [[3]](diffhunk://#diff-67e65fef165ab500f5a20582d9e3d608f68f22ff2f6367389c3eeb3062c08b24L80-R92)

* [`platform/src/common/components/Modal/dataDownload/modules/DataDownload.jsx`](diffhunk://#diff-ba10d4a60d7b802977d7b5219f9be096c52062140b9a458c79de70b6a9502bdcR304): Set the `textFormat` prop to "uppercase" for the `CustomFields` component in the `DataDownload` module.

#### Status of maturity (all need to be checked before merging):

- [x] I've tested this locally
- [x] I consider this code done
- [x] This change ready to hit production in its current state

#### How should this be manually tested?

- Please include the steps to be done inorder to setup and test this PR.

#### What are the relevant tickets?

- Closes #<enter issue number here>
- [Jira_card_number]() (If exists)

#### Screenshots (optional)
![image](https://github.com/user-attachments/assets/32939897-8383-4fd0-9a71-d7cb3a6b9fd1)
![image](https://github.com/user-attachments/assets/109fcca8-9080-4e0e-929c-dcd6a44f48bf)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced customizable text formatting options for the `CustomFields` component, allowing names to be displayed in uppercase or lowercase.
	- Added a new `textFormat` property for the "Network" field in the `DataDownload` component.

- **Bug Fixes**
	- Improved handling of falsy values in the `formatName` function to prevent errors.

- **Documentation**
	- Updated component props to reflect the new `textFormat` parameter in `CustomFields`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->