### PR TITLE
[Hotfix] Fix tabs vertical scroll issue

### DIFF
--- a/platform/src/common/components/Tabs/index.jsx
+++ b/platform/src/common/components/Tabs/index.jsx
@@ -69,7 +69,7 @@ const Tabs = ({ children, childrenRight, positionFixed }) => {
   return (
     <div
       data-testid="tabs"
-      className="relative w-full h-dvh transition-all duration-300 ease-in-out"
+      className="relative w-full transition-all duration-300 ease-in-out"
     >
       <div
         className={`${


### PR DESCRIPTION
This pull request includes a small change to the `Tabs` component in the `platform/src/common/components/Tabs/index.jsx` file. The change removes the `h-dvh` class from the `div` element's className attribute.

* [`platform/src/common/components/Tabs/index.jsx`](diffhunk://#diff-43ee52324cdf77cf36b276a3698f35f85dbcc73323bd1f3c4a06cef3c7ff9a24L72-R72): Removed the `h-dvh` class from the `div` element's className attribute to potentially fix or improve layout behavior.

![image](https://github.com/user-attachments/assets/ede10c33-eb01-450f-a518-fb552b132d0d)
![image](https://github.com/user-attachments/assets/8942397d-db89-4683-9436-7b9ab7423fc4)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated styling for the Tabs component by removing a height-related class.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->