### PR TITLE
Fix timeout interval: App Engine Deployment and add App start timeout in staging 

### DIFF
--- a/.github/workflows/deploy-frontends-to-production.yml
+++ b/.github/workflows/deploy-frontends-to-production.yml
@@ -287,8 +287,8 @@ jobs:
           echo "  operating_system: \"ubuntu22\"" >> app.yaml
           echo "  runtime_version: \"3.12\"" >> app.yaml
           echo "readiness_check:" >> app.yaml
-          echo "  check_interval_sec: 10" >> app.yaml
-          echo "  timeout_sec: 15" >> app.yaml
+          echo "  check_interval_sec: 5" >> app.yaml
+          echo "  timeout_sec: 4" >> app.yaml
           echo "  failure_threshold: 2" >> app.yaml
           echo "  success_threshold: 2" >> app.yaml
           echo "  app_start_timeout_sec: 1800" >> app.yaml

--- a/.github/workflows/deploy-frontends-to-staging.yml
+++ b/.github/workflows/deploy-frontends-to-staging.yml
@@ -335,6 +335,12 @@ jobs:
           echo "  max_num_instances: 5" >> app.yaml
           echo "  cpu_utilization:" >> app.yaml
           echo "    target_utilization: 0.8" >> app.yaml
+          echo "readiness_check:" >> app.yaml
+          echo "  check_interval_sec: 5" >> app.yaml
+          echo "  timeout_sec: 4" >> app.yaml
+          echo "  failure_threshold: 2" >> app.yaml
+          echo "  success_threshold: 2" >> app.yaml
+          echo "  app_start_timeout_sec: 1800" >> app.yaml
           echo "========== Creating .env.yaml file =========="  
           echo "env_variables:" > .env.yaml
           echo "runtime_config:" >> app.yaml


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

- Fix timeout interval: App Engine Deployment.
-  Add App start timeout in staging to mimic production runtime

#### Status of maturity (all need to be checked before merging):

- [ ] I've tested this locally
- [ ] I consider this code done
- [ ] This change ready to hit production in its current state
- [ ] The title of the PR states what changed and the related issues number (used for the release note).
- [ ] I've included issue number in the "Closes #ISSUE-NUMBER" part of the "[What are the relevant tickets?](#what-are-the-relevant-tickets)" section to [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [ ] I've updated corresponding documentation for the changes in this PR.
- [ ] I have written unit and/or e2e tests for my change(s).

#### How should this be manually tested?

- Please include the steps to be done inorder to setup and test this PR.

#### What are the relevant tickets?

- Closes #<enter issue number here>
- [Jira_card_number]() (If exists)

#### Screenshots (optional)
