### PR TITLE
[Netmanager] Added serial number field to create device and soft create device, fix network bug

### DIFF
--- a/netmanager/src/views/components/DataDisplay/Devices.js
+++ b/netmanager/src/views/components/DataDisplay/Devices.js
@@ -277,15 +277,17 @@ const CreateDevice = ({ open, setOpen, network }) => {
   const newDeviceInitState = {
     long_name: '',
     category: CATEGORIES[0].value,
-    network: network,
-    description: ''
+    network: network.net_name,
+    description: '',
+    serial_number: ''
   };
 
   const initialErrors = {
     long_name: '',
     category: '',
     network: '',
-    description: ''
+    description: '',
+    serial_number: ''
   };
 
   const [newDevice, setNewDevice] = useState(newDeviceInitState);
@@ -301,6 +303,13 @@ const CreateDevice = ({ open, setOpen, network }) => {
       setErrors({
         ...errors,
         long_name: newValue.trim() === '' ? 'Device name is required' : ''
+      });
+    }
+
+    if (key === 'serial_number') {
+      setErrors({
+        ...errors,
+        serial_number: newValue.trim() === '' ? 'Serial number is required' : ''
       });
     }
   };
@@ -322,14 +331,19 @@ const CreateDevice = ({ open, setOpen, network }) => {
     setNewDevice({
       long_name: '',
       category: CATEGORIES[0].value,
-      network: network,
-      description: ''
+      network: network.net_name,
+      description: '',
+      serial_number: ''
     });
-    setErrors({ long_name: '', category: '', network: '', description: '' });
+    setErrors({ long_name: '', category: '', network: '', description: '', serial_number: '' });
   };
 
   const isFormValid = () => {
-    return newDevice.long_name.trim() !== '' && newDevice.category !== '';
+    return (
+      newDevice.long_name.trim() !== '' &&
+      newDevice.category !== '' &&
+      newDevice.serial_number.trim() !== ''
+    );
   };
 
   const handleRegisterSubmit = (e) => {
@@ -350,16 +364,26 @@ const CreateDevice = ({ open, setOpen, network }) => {
         return;
       }
 
+      // Create a copy of newDevice
+      const deviceDataToSend = { ...newDevice };
+
+      // Remove fields with empty values
+      Object.keys(deviceDataToSend).forEach((key) => {
+        if (!deviceDataToSend[key]) {
+          delete deviceDataToSend[key];
+        }
+      });
+
       createAxiosInstance()
-        .post(REGISTER_DEVICE_URI, newDevice, {
+        .post(REGISTER_DEVICE_URI, deviceDataToSend, {
           headers: { 'Content-Type': 'application/json' }
         })
         .then((res) => res.data)
         .then((resData) => {
           handleRegisterClose();
           dispatch(loadStatus(false));
-          if (!isEmpty(network)) {
-            dispatch(loadDevicesData(network));
+          if (!isEmpty(network.net_name)) {
+            dispatch(loadDevicesData(network.net_name));
           }
           dispatch(
             updateMainAlert({
@@ -441,6 +465,18 @@ const CreateDevice = ({ open, setOpen, network }) => {
           />
 
           <TextField
+            margin="dense"
+            label="Serial Number"
+            variant="outlined"
+            value={newDevice.serial_number}
+            onChange={handleDeviceDataChange('serial_number')}
+            fullWidth
+            required
+            error={!!errors.serial_number}
+            helperText={errors.serial_number}
+          />
+
+          <TextField
             fullWidth
             margin="dense"
             label="Network"
@@ -500,7 +536,8 @@ const SoftCreateDevice = ({ open, setOpen, network }) => {
     device_number: '',
     writeKey: '',
     readKey: '',
-    description: ''
+    description: '',
+    serial_number: ''
   };
 
   const initialErrors = {
@@ -510,7 +547,8 @@ const SoftCreateDevice = ({ open, setOpen, network }) => {
     device_number: '',
     writeKey: '',
     readKey: '',
-    description: ''
+    description: '',
+    serial_number: ''
   };
 
   const [newDevice, setNewDevice] = useState(newDeviceInitState);
@@ -527,6 +565,13 @@ const SoftCreateDevice = ({ open, setOpen, network }) => {
       setErrors({
         ...errors,
         long_name: newValue.trim() === '' ? 'Device name is required' : ''
+      });
+    }
+
+    if (key === 'serial_number') {
+      setErrors({
+        ...errors,
+        serial_number: newValue.trim() === '' ? 'Serial number is required' : ''
       });
     }
   };
@@ -553,7 +598,8 @@ const SoftCreateDevice = ({ open, setOpen, network }) => {
       device_number: '',
       writeKey: '',
       readKey: '',
-      description: ''
+      description: '',
+      serial_number: ''
     });
     setErrors({
       long_name: '',
@@ -562,12 +608,17 @@ const SoftCreateDevice = ({ open, setOpen, network }) => {
       device_number: '',
       writeKey: '',
       readKey: '',
-      description: ''
+      description: '',
+      serial_number: ''
     });
   };
 
   const isFormValid = () => {
-    return newDevice.long_name.trim() !== '' && newDevice.category !== '';
+    return (
+      newDevice.long_name.trim() !== '' &&
+      newDevice.category !== '' &&
+      newDevice.serial_number.trim() !== ''
+    );
   };
 
   const handleRegisterSubmit = async (e) => {
@@ -590,16 +641,12 @@ const SoftCreateDevice = ({ open, setOpen, network }) => {
           // Create a copy of newDevice
           const deviceDataToSend = { ...newDevice };
 
-          // Remove device_number, writeKey, and readKey if they're empty
-          if (!deviceDataToSend.device_number) {
-            delete deviceDataToSend.device_number;
-          }
-          if (!deviceDataToSend.writeKey) {
-            delete deviceDataToSend.writeKey;
-          }
-          if (!deviceDataToSend.readKey) {
-            delete deviceDataToSend.readKey;
-          }
+          // Remove fields with empty values
+          Object.keys(deviceDataToSend).forEach((key) => {
+            if (!deviceDataToSend[key]) {
+              delete deviceDataToSend[key];
+            }
+          });
 
           const resData = await softCreateDeviceApi(deviceDataToSend, {
             headers: { 'Content-Type': 'application/json' }
@@ -612,7 +659,7 @@ const SoftCreateDevice = ({ open, setOpen, network }) => {
           dispatch(
             updateMainAlert({
               message: `${resData.message}. ${
-                newDevice.network !== network
+                newDevice.network !== network.net_name
                   ? `Switch to the ${newDevice.network} organisation to see the new device.`
                   : ''
               }`,
@@ -671,6 +718,7 @@ const SoftCreateDevice = ({ open, setOpen, network }) => {
             error={!!errors.long_name}
             helperText={errors.long_name}
           />
+
           <Select
             fullWidth
             label="Category"
@@ -687,6 +735,19 @@ const SoftCreateDevice = ({ open, setOpen, network }) => {
             }}
             required
           />
+
+          <TextField
+            margin="dense"
+            label="Serial Number"
+            variant="outlined"
+            value={newDevice.serial_number}
+            onChange={handleDeviceDataChange('serial_number')}
+            fullWidth
+            required
+            error={!!errors.serial_number}
+            helperText={errors.serial_number}
+          />
+
           <TextField
             fullWidth
             margin="dense"

--- a/netmanager/src/views/layouts/Main.js
+++ b/netmanager/src/views/layouts/Main.js
@@ -136,7 +136,12 @@ const Main = (props) => {
   }, []);
 
   useEffect(() => {
-    if (!isEmpty(activeNetwork)) {
+    if (isEmpty(activeNetwork)) {
+      const activeNetworkStorage = localStorage.getItem('activeNetwork');
+      if (activeNetworkStorage) {
+        dispatch(addActiveNetwork(JSON.parse(activeNetworkStorage)));
+      }
+    } else {
       dispatch(addCurrentUserRole(activeNetwork.role));
       localStorage.setItem('currentUserRole', JSON.stringify(activeNetwork.role));
     }


### PR DESCRIPTION
This pull request introduces several changes to the `CreateDevice` and `SoftCreateDevice` components in the `netmanager` project to include a new "serial number" field and improve the handling of device data. Additionally, it modifies the `Main` layout to handle the active network more robustly. The most important changes are detailed below:

### Enhancements to Device Creation Forms:

* Added a new `serial_number` field to the `newDeviceInitState` and `initialErrors` objects in both `CreateDevice` and `SoftCreateDevice` components. (`netmanager/src/views/components/DataDisplay/Devices.js`) [[1]](diffhunk://#diff-1a133264655ec75bf6f61e51ebd154c128b8ba14f4c6801bbc981f9e8733e3cfL280-R290) [[2]](diffhunk://#diff-1a133264655ec75bf6f61e51ebd154c128b8ba14f4c6801bbc981f9e8733e3cfL503-R540)
* Updated the `handleDeviceDataChange` function to include validation for the `serial_number` field. (`netmanager/src/views/components/DataDisplay/Devices.js`) [[1]](diffhunk://#diff-1a133264655ec75bf6f61e51ebd154c128b8ba14f4c6801bbc981f9e8733e3cfR308-R314) [[2]](diffhunk://#diff-1a133264655ec75bf6f61e51ebd154c128b8ba14f4c6801bbc981f9e8733e3cfR570-R576)
* Modified the form reset logic to include the `serial_number` field. (`netmanager/src/views/components/DataDisplay/Devices.js`) [[1]](diffhunk://#diff-1a133264655ec75bf6f61e51ebd154c128b8ba14f4c6801bbc981f9e8733e3cfL325-R346) [[2]](diffhunk://#diff-1a133264655ec75bf6f61e51ebd154c128b8ba14f4c6801bbc981f9e8733e3cfL556-R602)
* Enhanced the form validation logic to check for non-empty `serial_number`. (`netmanager/src/views/components/DataDisplay/Devices.js`) [[1]](diffhunk://#diff-1a133264655ec75bf6f61e51ebd154c128b8ba14f4c6801bbc981f9e8733e3cfL325-R346) [[2]](diffhunk://#diff-1a133264655ec75bf6f61e51ebd154c128b8ba14f4c6801bbc981f9e8733e3cfL565-R621)
* Added the `serial_number` field to the form UI in both `CreateDevice` and `SoftCreateDevice` components. (`netmanager/src/views/components/DataDisplay/Devices.js`) [[1]](diffhunk://#diff-1a133264655ec75bf6f61e51ebd154c128b8ba14f4c6801bbc981f9e8733e3cfR467-R478) [[2]](diffhunk://#diff-1a133264655ec75bf6f61e51ebd154c128b8ba14f4c6801bbc981f9e8733e3cfR738-R750)

### Improvements to Device Data Handling:

* Created a copy of `newDevice` and removed fields with empty values before sending the data to the server in both `CreateDevice` and `SoftCreateDevice` components. (`netmanager/src/views/components/DataDisplay/Devices.js`) [[1]](diffhunk://#diff-1a133264655ec75bf6f61e51ebd154c128b8ba14f4c6801bbc981f9e8733e3cfR367-R386) [[2]](diffhunk://#diff-1a133264655ec75bf6f61e51ebd154c128b8ba14f4c6801bbc981f9e8733e3cfL593-R649)
* Updated the network handling logic to use `network.net_name` instead of `network`. (`netmanager/src/views/components/DataDisplay/Devices.js`) [[1]](diffhunk://#diff-1a133264655ec75bf6f61e51ebd154c128b8ba14f4c6801bbc981f9e8733e3cfR367-R386) [[2]](diffhunk://#diff-1a133264655ec75bf6f61e51ebd154c128b8ba14f4c6801bbc981f9e8733e3cfL615-R662)

### Enhancements to Active Network Handling:

* Modified the `Main` layout to retrieve the active network from local storage if it is not already set, ensuring the user's role is correctly assigned. (`netmanager/src/views/layouts/Main.js`)

![image](https://github.com/user-attachments/assets/2a9422b8-41b9-4672-910d-7fa02ae60014)
![image](https://github.com/user-attachments/assets/b901f1f0-6c63-4371-b80a-f94e20e25bda)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a required "Serial Number" field on device registration forms, complete with validation and error feedback to ensure proper input.

- **Refactor**
  - Enhanced the application's initialization flow to correctly manage active network settings and user roles, improving overall configuration accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->