### PR TITLE
Remove serial number field from create device

### DIFF
--- a/netmanager/src/views/components/DataDisplay/Devices.js
+++ b/netmanager/src/views/components/DataDisplay/Devices.js
@@ -278,16 +278,14 @@ const CreateDevice = ({ open, setOpen, network }) => {
     long_name: '',
     category: CATEGORIES[0].value,
     network: network.net_name,
-    description: '',
-    serial_number: ''
+    description: ''
   };
 
   const initialErrors = {
     long_name: '',
     category: '',
     network: '',
-    description: '',
-    serial_number: ''
+    description: ''
   };
 
   const [newDevice, setNewDevice] = useState(newDeviceInitState);
@@ -303,13 +301,6 @@ const CreateDevice = ({ open, setOpen, network }) => {
       setErrors({
         ...errors,
         long_name: newValue.trim() === '' ? 'Device name is required' : ''
-      });
-    }
-
-    if (key === 'serial_number') {
-      setErrors({
-        ...errors,
-        serial_number: newValue.trim() === '' ? 'Serial number is required' : ''
       });
     }
   };
@@ -332,18 +323,13 @@ const CreateDevice = ({ open, setOpen, network }) => {
       long_name: '',
       category: CATEGORIES[0].value,
       network: network.net_name,
-      description: '',
-      serial_number: ''
+      description: ''
     });
-    setErrors({ long_name: '', category: '', network: '', description: '', serial_number: '' });
+    setErrors({ long_name: '', category: '', network: '', description: '' });
   };
 
   const isFormValid = () => {
-    return (
-      newDevice.long_name.trim() !== '' &&
-      newDevice.category !== '' &&
-      newDevice.serial_number.trim() !== ''
-    );
+    return newDevice.long_name.trim() !== '' && newDevice.category !== '';
   };
 
   const handleRegisterSubmit = (e) => {
@@ -462,18 +448,6 @@ const CreateDevice = ({ open, setOpen, network }) => {
               style: { width: '100%', height: '40px' }
             }}
             required
-          />
-
-          <TextField
-            margin="dense"
-            label="Serial Number"
-            variant="outlined"
-            value={newDevice.serial_number}
-            onChange={handleDeviceDataChange('serial_number')}
-            fullWidth
-            required
-            error={!!errors.serial_number}
-            helperText={errors.serial_number}
           />
 
           <TextField


### PR DESCRIPTION
This pull request includes changes to the `CreateDevice` component in the `Devices.js` file to remove the `serial_number` field from the device creation form. The most important changes involve updating the initial state, validation logic, and form rendering to exclude the `serial_number` field.

Changes to `CreateDevice` component:

* Removed `serial_number` from the initial state and error state (`netmanager/src/views/components/DataDisplay/Devices.js`).
* Removed validation logic for `serial_number` (`netmanager/src/views/components/DataDisplay/Devices.js`).
* Updated form reset logic to exclude `serial_number` and modified form validation to no longer check for `serial_number` (`netmanager/src/views/components/DataDisplay/Devices.js`).
* Removed `serial_number` input field from the form rendering (`netmanager/src/views/components/DataDisplay/Devices.js`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined the device creation form by removing the serial number input.
	- Updated validation and error handling to focus solely on essential fields (long name and category).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->