### PR TITLE
Add warning dialog for removing the last location in My Places

### DIFF
--- a/src/mobile-v3/lib/src/app/dashboard/widgets/my_places_view.dart
+++ b/src/mobile-v3/lib/src/app/dashboard/widgets/my_places_view.dart
@@ -298,7 +298,6 @@ class _MyPlacesViewState extends State<MyPlacesView> with UiLoggy {
     context.read<DashboardBloc>().add(LoadDashboard());
   }
 
-
   void _removeLocation(String id) {
     // Check if this is the last location
     if ((selectedMeasurements.length + unmatchedSites.length) <= 1) {
@@ -336,6 +335,13 @@ class _MyPlacesViewState extends State<MyPlacesView> with UiLoggy {
           ),
           backgroundColor: Theme.of(context).cardColor,
         ),
+      );
+      // Show a notification explaining why the action was prevented
+      NotificationManager().showNotification(
+        context,
+        message:
+            'Cannot remove the last location. Please add another location first.',
+        isSuccess: false,
       );
       return;
     }

--- a/src/mobile-v3/lib/src/app/dashboard/widgets/my_places_view.dart
+++ b/src/mobile-v3/lib/src/app/dashboard/widgets/my_places_view.dart
@@ -298,7 +298,48 @@ class _MyPlacesViewState extends State<MyPlacesView> with UiLoggy {
     context.read<DashboardBloc>().add(LoadDashboard());
   }
 
+
   void _removeLocation(String id) {
+    // Check if this is the last location
+    if ((selectedMeasurements.length + unmatchedSites.length) <= 1) {
+      // Show warning dialog
+      showDialog(
+        context: context,
+        builder: (context) => AlertDialog(
+          title: Text(
+            "Cannot Remove Default Location",
+            style: TextStyle(
+              fontWeight: FontWeight.bold,
+              color: Theme.of(context).textTheme.headlineSmall?.color,
+            ),
+          ),
+          content: Text(
+            "You need to have at least one location in My Places. Add another location before removing this one.",
+            style: TextStyle(
+              color: Theme.of(context).textTheme.bodyMedium?.color,
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: Text(
+                "OK",
+                style: TextStyle(
+                  color: AppColors.primaryColor,
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+            ),
+          ],
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(12),
+          ),
+          backgroundColor: Theme.of(context).cardColor,
+        ),
+      );
+      return;
+    }
+
     // Find the name of the location being removed
     String locationName = "Location";
     for (var m in selectedMeasurements) {
@@ -347,6 +388,7 @@ class _MyPlacesViewState extends State<MyPlacesView> with UiLoggy {
         }
       });
     }
+
     NotificationManager().showNotification(
       context,
       message: '"$locationName" has been removed from your places',


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

#### Status of maturity (all need to be checked before merging):

- [ ] I've tested this locally
- [ ] I consider this code done
- [ ] This change ready to hit production in its current state
- [ ] The title of the PR states what changed and the related issues number (used for the release note).
- [ ] I've included issue number in the "Closes #ISSUE-NUMBER" part of the "[What are the relevant tickets?](#what-are-the-relevant-tickets)" section to [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [ ] I've updated corresponding documentation for the changes in this PR.
- [ ] I have written unit and/or e2e tests for my change(s).

#### How should this be manually tested?

- Please include the steps to be done inorder to setup and test this PR.

#### What are the relevant tickets?

- Closes #<enter issue number here>
- [Jira_card_number]() (If exists)

#### Screenshots (optional)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a warning dialog to prevent users from removing the last remaining location in "My Places." Users must have at least one location saved and will be prompted to add another before removing the final location.

- **Bug Fixes**
  - Improved safeguards to ensure at least one location always remains in "My Places."
<!-- end of auto-generated comment: release notes by coderabbit.ai -->