### PR TITLE
Refactor logging setup to integrate Slack logging and improve error h…

### DIFF
--- a/src/mobile-v3/lib/core/utils/app_loggy_setup.dart
+++ b/src/mobile-v3/lib/core/utils/app_loggy_setup.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/foundation.dart';
+import 'package:airqo/core/utils/slack_loggy_printer.dart';
 import 'package:loggy/loggy.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:airqo/core/utils/slack_logger.dart';
@@ -11,11 +11,11 @@ class AppLoggySetup {
   static Future<void> init({bool isDevelopment = true}) async {
     if (_initialized) return;
 
+    final defaultPrinter = PrettyPrinter(showColors: true);
+
     // Set up Loggy
     Loggy.initLoggy(
-      logPrinter: const PrettyPrinter(
-        showColors: true,
-      ),
+      logPrinter: SlackLoggyPrinter(defaultPrinter),
       logOptions: LogOptions(
         LogLevel.all,
         stackTraceLevel: LogLevel.error,
@@ -54,23 +54,13 @@ class AppLoggySetup {
 extension LoggyExtension on Object {
   void logInfo(String message) {
     Loggy('Global').info(message);
-    // Only send important info logs to Slack
-    if (message.contains('CRITICAL') || message.contains('IMPORTANT')) {
-      SlackLogger().logInfo(message);
-    }
   }
 
   void logWarning(String message) {
     Loggy('Global').warning(message);
-    // Send all warnings to Slack in production
-    if (!kDebugMode) {
-      SlackLogger().logWarning(message);
-    }
   }
 
   void logError(String message, [dynamic error, StackTrace? stackTrace]) {
     Loggy('Global').error(message);
-    // Always send errors to Slack
-    SlackLogger().logError(message, error: error, stackTrace: stackTrace);
   }
 }

--- a/src/mobile-v3/lib/core/utils/logging_bloc_observer.dart
+++ b/src/mobile-v3/lib/core/utils/logging_bloc_observer.dart
@@ -1,0 +1,10 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:airqo/core/utils/app_loggy_setup.dart';
+
+class LoggingBlocObserver extends BlocObserver {
+  @override
+  void onError(BlocBase bloc, Object error, StackTrace stackTrace) {
+    super.onError(bloc, error, stackTrace);
+    Object().logError('Bloc error in ${bloc.runtimeType}', error, stackTrace);
+  }
+}

--- a/src/mobile-v3/lib/core/utils/slack_loggy_printer.dart
+++ b/src/mobile-v3/lib/core/utils/slack_loggy_printer.dart
@@ -1,0 +1,45 @@
+import 'package:loggy/loggy.dart';
+import 'package:airqo/core/utils/slack_logger.dart';
+import 'package:flutter/foundation.dart';
+
+class SlackLoggyPrinter extends LoggyPrinter {
+  final LoggyPrinter _defaultPrinter;
+  
+  SlackLoggyPrinter(this._defaultPrinter);
+  
+  @override
+  void onLog(LogRecord record) {
+    // Always use the default printer for local logging
+    _defaultPrinter.onLog(record);
+    
+    // Then forward appropriate logs to Slack based on level
+    final message = '${record.loggerName}: ${record.message}';
+    
+    switch (record.level) {
+      case LogLevel.error:
+        SlackLogger().logError(
+          message,
+          error: record.error,
+          stackTrace: record.stackTrace,
+        );
+        break;
+        
+      case LogLevel.warning:
+        // Only send warnings to Slack in production, matching your current logic
+        if (!kDebugMode) {
+          SlackLogger().logWarning(message);
+        }
+        break;
+        
+      case LogLevel.info:
+        // Only send critical info logs to Slack
+        if (message.contains('CRITICAL') || message.contains('IMPORTANT')) {
+          SlackLogger().logInfo(message);
+        }
+        break;
+        
+      default:
+        break;
+    }
+  }
+}


### PR DESCRIPTION
…andling

#### Summary of Changes (What does this PR do?)

- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

#### Status of maturity (all need to be checked before merging):

- [ ] I've tested this locally
- [ ] I consider this code done
- [ ] This change ready to hit production in its current state
- [ ] The title of the PR states what changed and the related issues number (used for the release note).
- [ ] I've included issue number in the "Closes #ISSUE-NUMBER" part of the "[What are the relevant tickets?](#what-are-the-relevant-tickets)" section to [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [ ] I've updated corresponding documentation for the changes in this PR.
- [ ] I have written unit and/or e2e tests for my change(s).

#### How should this be manually tested?

- Please include the steps to be done inorder to setup and test this PR.

#### What are the relevant tickets?

- Closes #<enter issue number here>
- [Jira_card_number]() (If exists)

#### Screenshots (optional)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced error logging for Bloc events and uncaught errors during app startup and runtime.
  - Added a custom Bloc observer to capture and log Bloc-related errors.

- **Refactor**
  - Improved the app's error handling by using a global error handler for asynchronous and Flutter framework errors.
  - Updated log forwarding to Slack to be more selective and centralized within a new logging printer.

- **Chores**
  - Streamlined and simplified the internal logging setup for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->