### PR TITLE
Add auto-initialization for SlackLogger and improve logging timeout

### DIFF
--- a/src/mobile-v3/lib/core/utils/slack_logger.dart
+++ b/src/mobile-v3/lib/core/utils/slack_logger.dart
@@ -161,15 +161,6 @@ Future<void> _tryAutoInitialize() async {
       return false;
     }
 
-    print(
-        "🔍 SlackLogger: Initialized? $_initialized, Enabled? $_enableSlackLogging");
-
-    if (!_initialized || !_enableSlackLogging) {
-      print(
-          "❌ SlackLogger: Not sending log - logger is not initialized or disabled");
-      return false;
-    }
-
     try {
       final url = Uri.parse(_webhookUrl!);
       print("🔍 SlackLogger: Sending to webhook URL: $_webhookUrl");


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

#### Status of maturity (all need to be checked before merging):

- [ ] I've tested this locally
- [ ] I consider this code done
- [ ] This change ready to hit production in its current state
- [ ] The title of the PR states what changed and the related issues number (used for the release note).
- [ ] I've included issue number in the "Closes #ISSUE-NUMBER" part of the "[What are the relevant tickets?](#what-are-the-relevant-tickets)" section to [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [ ] I've updated corresponding documentation for the changes in this PR.
- [ ] I have written unit and/or e2e tests for my change(s).

#### How should this be manually tested?

- Please include the steps to be done inorder to setup and test this PR.

#### What are the relevant tickets?

- Closes #<enter issue number here>
- [Jira_card_number]() (If exists)

#### Screenshots (optional)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved reliability of Slack logging by automatically initializing the logger if needed and handling missing configuration more gracefully.
	- Increased the timeout for sending logs to Slack, reducing the chance of failed log deliveries due to network delays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->