### PR TITLE
Reroute Failing apps to use another node

### DIFF
--- a/k8s/calibrate/values-prod.yaml
+++ b/k8s/calibrate/values-prod.yaml
@@ -29,7 +29,7 @@ autoscaling:
   maxReplicas: 3
   targetMemoryUtilizationPercentage: 70
 nodeSelector: 
-  role: control-plane
+  role: high-mem
 tolerations: []
 affinity:
   nodeAffinity:

--- a/k8s/docs/values-prod.yaml
+++ b/k8s/docs/values-prod.yaml
@@ -29,7 +29,7 @@ autoscaling:
   maxReplicas: 3
   targetCPUUtilizationPercentage: 70
 nodeSelector: 
-  role: control-plane
+  role: high-mem
 tolerations: []
 affinity:
   nodeAffinity:

--- a/k8s/inventory/values-prod.yaml
+++ b/k8s/inventory/values-prod.yaml
@@ -14,7 +14,7 @@ service:
 ingress:
   enabled: false
 nodeSelector: 
-  role: control-plane
+  role: high-mem
 torelations: {}
 resources:
   requests:

--- a/k8s/netmanager-app/values-prod.yaml
+++ b/k8s/netmanager-app/values-prod.yaml
@@ -14,7 +14,7 @@ service:
 ingress:
   enabled: false
 nodeSelector: 
-  role: control-plane
+  role: high-mem
 tolerations: {}
 resources:
   requests:

--- a/k8s/netmanager/values-prod.yaml
+++ b/k8s/netmanager/values-prod.yaml
@@ -14,7 +14,7 @@ service:
 ingress:
   enabled: false
 nodeSelector:
-  role: control-plane
+  role: high-mem
 torelations: {}
 resources:
   requests:

--- a/k8s/platform/values-prod.yaml
+++ b/k8s/platform/values-prod.yaml
@@ -30,7 +30,7 @@ autoscaling:
   targetCPUUtilizationPercentage: 70
 priorityClassName: high-priority
 nodeSelector:
-  role: control-plane
+  role: high-mem
 tolerations: []
 affinity:
   nodeAffinity:

--- a/k8s/reports/values-prod.yaml
+++ b/k8s/reports/values-prod.yaml
@@ -26,7 +26,7 @@ autoscaling:
   maxReplicas: 3
   targetMemoryUtilizationPercentage: 80
 nodeSelector: 
-  role: control-plane
+  role: high-mem
 affinity:
   nodeAffinity:
     preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)
Reroute Failing apps to use another node

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated production deployment configurations to schedule pods on nodes labeled "high-mem" instead of "control-plane". This change affects multiple services and environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->