### PR TITLE
Fix: Bump compileSdk and targetSdk versions to 35

### DIFF
--- a/src/mobile-v3/android/app/build.gradle
+++ b/src/mobile-v3/android/app/build.gradle
@@ -76,7 +76,7 @@ if (releaseKeystorePropertiesFile.exists()) {
 
 android {
     namespace "com.airqo.app"
-    compileSdk 34
+    compileSdk 35
     ndkVersion flutter.ndkVersion
 
     compileOptions {
@@ -98,7 +98,7 @@ android {
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
         minSdkVersion 21
-        targetSdkVersion 34
+        targetSdkVersion 35
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Android app to use the latest SDK version 35 for improved compatibility and support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->