### PR TITLE
(website): Remove redundant paragraph from About-Page component

### DIFF
--- a/src/website2/src/views/about/AboutPage.tsx
+++ b/src/website2/src/views/about/AboutPage.tsx
@@ -268,11 +268,6 @@ const AboutPage: React.FC = () => {
                 challenges.
               </p>
               <p className="text-lg text-gray-700 leading-relaxed">
-                We provide accurate, hyperlocal, and timely data providing
-                evidence of the magnitude and scale of air pollution across the
-                continent in African Cities.
-              </p>
-              <p className="text-lg text-gray-700 leading-relaxed">
                 We leverage advanced technologies and AI-powered models to
                 provide accurate, hyperlocal and real-time air quality data,
                 providing evidence of the magnitude and scale of air pollution


### PR DESCRIPTION
#### Status of maturity (all need to be checked before merging):

- [x] I've tested this locally
- [x] I consider this code done

#### Screenshots (optional)
<img width="2070" height="903" alt="image" src="https://github.com/user-attachments/assets/ae81d395-e045-4f9b-aa18-b027596c7ac9" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the "Our Story" section on the About page by removing a paragraph describing the scope of air pollution data provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->