### PR TITLE
[Hotfix] Missing date field in recall device in netmanager

### DIFF
--- a/src/netmanager/src/views/components/DataDisplay/DeviceView/DeviceDeployStatus.js
+++ b/src/netmanager/src/views/components/DataDisplay/DeviceView/DeviceDeployStatus.js
@@ -318,7 +318,6 @@ export default function DeviceDeployStatus({ deviceData, handleRecall, siteOptio
         setSelectVisible(false);
         setrecallLoading(true);
         await handleRecall(selectedRecallType);
-        window.location.reload();
         setrecallLoading(false);
         setSelectedRecallType('');
       }
@@ -534,7 +533,8 @@ export default function DeviceDeployStatus({ deviceData, handleRecall, siteOptio
       userName: parsedData.email,
       email: parsedData.email,
       firstName: parsedData.firstName,
-      lastName: parsedData.lastName
+      lastName: parsedData.lastName,
+      date: new Date().toISOString()
     };
 
     // Add user_id only if it exists


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added date field to recall device request options
  * Improved device recall flow: after recalling a device, the app no longer forces a full page reload. This reduces interruptions, keeps your current view, filters, and scroll position intact, and speeds up the process. Device status updates continue to appear without leaving the page. You can continue working immediately after recall.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

#### Status of maturity (all need to be checked before merging):

- [*] I've tested this locally
- [*] I consider this code done
- [*] This change ready to hit production in its current state

#### How should this be manually tested?

- Please include the steps to be done inorder to setup and test this PR.

#### What are the relevant tickets?

- Closes #<enter issue number here>
- [Jira_card_number]() (If exists)

#### Screenshots (optional)
