### PR TITLE
fix: resolve false positive error popup during signup when email verification is sent successfully

### DIFF
--- a/src/mobile-v3/lib/src/app/auth/bloc/auth_state.dart
+++ b/src/mobile-v3/lib/src/app/auth/bloc/auth_state.dart
@@ -29,6 +29,15 @@ final class GuestUser extends AuthState {}
 
 final class AuthVerified extends AuthState {}
 
+final class AuthLoadedWithWarning extends AuthState {
+  final AuthPurpose authPurpose;
+  final String warning;
+
+  const AuthLoadedWithWarning(this.authPurpose, this.warning);
+  
+  @override
+  List<Object> get props => [authPurpose, warning];
+}
 
 final class EmailUnverifiedError extends AuthLoadingError {
   final String email;

--- a/src/mobile-v3/lib/src/app/auth/bloc/auth_state.dart
+++ b/src/mobile-v3/lib/src/app/auth/bloc/auth_state.dart
@@ -29,16 +29,6 @@ final class GuestUser extends AuthState {}
 
 final class AuthVerified extends AuthState {}
 
-final class AuthLoadedWithWarning extends AuthState {
-  final AuthPurpose authPurpose;
-  final String warning;
-
-  const AuthLoadedWithWarning(this.authPurpose, this.warning);
-  
-  @override
-  List<Object> get props => [authPurpose, warning];
-}
-
 final class EmailUnverifiedError extends AuthLoadingError {
   final String email;
 

--- a/src/mobile-v3/lib/src/app/auth/pages/register_page.dart
+++ b/src/mobile-v3/lib/src/app/auth/pages/register_page.dart
@@ -62,6 +62,21 @@ class _CreateAccountScreenState extends State<CreateAccountScreen> {
               ),
             ),
           );
+        } else if (state is AuthLoadedWithWarning && state.authPurpose == AuthPurpose.REGISTER) {
+          Navigator.of(context).pushReplacement(
+            MaterialPageRoute(
+              builder: (context) => EmailVerificationScreen(
+                email: emailController.text.trim(),
+              ),
+            ),
+          );
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(state.warning),
+              backgroundColor: Colors.orange,
+              duration: Duration(seconds: 2),
+            ),
+          );
         } else if (state is AuthLoadingError) {
           ScaffoldMessenger.of(context)
               .showSnackBar(SnackBar(content: Text(state.message)));

--- a/src/mobile-v3/lib/src/app/auth/pages/register_page.dart
+++ b/src/mobile-v3/lib/src/app/auth/pages/register_page.dart
@@ -62,21 +62,6 @@ class _CreateAccountScreenState extends State<CreateAccountScreen> {
               ),
             ),
           );
-        } else if (state is AuthLoadedWithWarning && state.authPurpose == AuthPurpose.REGISTER) {
-          Navigator.of(context).pushReplacement(
-            MaterialPageRoute(
-              builder: (context) => EmailVerificationScreen(
-                email: emailController.text.trim(),
-              ),
-            ),
-          );
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(
-              content: Text(state.warning),
-              backgroundColor: Colors.orange,
-              duration: Duration(seconds: 2),
-            ),
-          );
         } else if (state is AuthLoadingError) {
           ScaffoldMessenger.of(context)
               .showSnackBar(SnackBar(content: Text(state.message)));

--- a/src/mobile-v3/lib/src/app/auth/repository/auth_repository.dart
+++ b/src/mobile-v3/lib/src/app/auth/repository/auth_repository.dart
@@ -60,15 +60,22 @@ class AuthImpl extends AuthRepository {
     if (registerResponse.statusCode == 200 || registerResponse.statusCode == 201) {
       return;
     } else if (registerResponse.statusCode == 409) {
-      String message = data['message'] ?? data['errors']?['message'] ?? 'User already exists';
-      if (message.toLowerCase().contains('verification') || 
-          message.toLowerCase().contains('email') ||
-          message.toLowerCase().contains('confirm')) {
+      final errors = data['errors'] as Map<String, dynamic>?;
+      String message = data['message'] ?? errors?['message'] ?? 'User already exists';
+      
+      String messageLower = message.toLowerCase();
+      if (messageLower.contains('verification sent') ||
+          messageLower.contains('verify your email') ||
+          messageLower.contains('account unverified') ||
+          messageLower.contains('verification required') ||
+          messageLower.contains('email verification') ||
+          messageLower.contains('confirmation sent')) {
         return;
       }
       throw Exception(message);
     } else {
-      String errorMessage = data['errors']?['message'] ?? data['message'] ?? 'Registration failed';
+      final errors = data['errors'] as Map<String, dynamic>?;
+      String errorMessage = data['message'] ?? errors?['message'] ?? 'Registration failed';
       throw Exception(errorMessage);
     }
   }

--- a/src/mobile-v3/lib/src/app/auth/repository/auth_repository.dart
+++ b/src/mobile-v3/lib/src/app/auth/repository/auth_repository.dart
@@ -57,8 +57,19 @@ class AuthImpl extends AuthRepository {
 
     Map<String, dynamic> data = json.decode(registerResponse.body);
 
-    if (registerResponse.statusCode != 200) {
-      throw Exception(data['errors']['message'] ?? data['message']);
+    if (registerResponse.statusCode == 200 || registerResponse.statusCode == 201) {
+      return;
+    } else if (registerResponse.statusCode == 409) {
+      String message = data['message'] ?? data['errors']?['message'] ?? 'User already exists';
+      if (message.toLowerCase().contains('verification') || 
+          message.toLowerCase().contains('email') ||
+          message.toLowerCase().contains('confirm')) {
+        return;
+      }
+      throw Exception(message);
+    } else {
+      String errorMessage = data['errors']?['message'] ?? data['message'] ?? 'Registration failed';
+      throw Exception(errorMessage);
     }
   }
 

--- a/src/mobile-v3/lib/src/app/auth/repository/auth_repository.dart
+++ b/src/mobile-v3/lib/src/app/auth/repository/auth_repository.dart
@@ -70,7 +70,7 @@ class AuthImpl extends AuthRepository {
           messageLower.contains('verification required') ||
           messageLower.contains('email verification') ||
           messageLower.contains('confirmation sent')) {
-        return;
+        throw Exception(message);
       }
       throw Exception(message);
     } else {

--- a/src/mobile-v3/lib/src/app/auth/repository/auth_repository.dart
+++ b/src/mobile-v3/lib/src/app/auth/repository/auth_repository.dart
@@ -74,8 +74,16 @@ class AuthImpl extends AuthRepository {
       }
       throw Exception(message);
     } else {
-      final errors = data['errors'] as Map<String, dynamic>?;
-      String errorMessage = data['message'] ?? errors?['message'] ?? 'Registration failed';
+      String errorMessage;
+      
+      if (registerResponse.statusCode >= 400 && registerResponse.statusCode <= 499) {
+        errorMessage = "There was an issue with your request. Please check your input and try again.";
+      } else if (registerResponse.statusCode >= 500 && registerResponse.statusCode <= 599) {
+        errorMessage = "We're experiencing technical difficulties. Please try again later.";
+      } else {
+        errorMessage = "Registration failed. Please try again.";
+      }
+      
       throw Exception(errorMessage);
     }
   }

--- a/src/mobile-v3/lib/src/app/auth/repository/auth_repository.dart
+++ b/src/mobile-v3/lib/src/app/auth/repository/auth_repository.dart
@@ -55,24 +55,8 @@ class AuthImpl extends AuthRepository {
         body: registerInputModelToJson(model),
         headers: {"Accept": "*/*", "Content-Type": "application/json"});
 
-    Map<String, dynamic> data = json.decode(registerResponse.body);
-
-    if (registerResponse.statusCode == 200 || registerResponse.statusCode == 201) {
+    if (registerResponse.statusCode >= 200 && registerResponse.statusCode <= 299) {
       return;
-    } else if (registerResponse.statusCode == 409) {
-      final errors = data['errors'] as Map<String, dynamic>?;
-      String message = data['message'] ?? errors?['message'] ?? 'User already exists';
-      
-      String messageLower = message.toLowerCase();
-      if (messageLower.contains('verification sent') ||
-          messageLower.contains('verify your email') ||
-          messageLower.contains('account unverified') ||
-          messageLower.contains('verification required') ||
-          messageLower.contains('email verification') ||
-          messageLower.contains('confirmation sent')) {
-        throw Exception(message);
-      }
-      throw Exception(message);
     } else {
       String errorMessage;
       


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Sign-up now treats any HTTP 2xx response as success (broader success detection).
  - Registration errors now show fixed, user-friendly messages by category: client (400–499) vs server (500–599).
  - Conflict (409) and other server-provided error details are no longer surfaced; users will see the standardized messages instead.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->