### PR TITLE
Fix profile update unauthorized error and immediate UI refresh

### DIFF
--- a/src/mobile-v3/lib/src/app/profile/models/profile_response_model.dart
+++ b/src/mobile-v3/lib/src/app/profile/models/profile_response_model.dart
@@ -60,19 +60,19 @@ class User {
     });
 
     factory User.fromJson(Map<String, dynamic> json) => User(
-        id: json["_id"],
-        firstName: json["firstName"],
-        lastName: json["lastName"],
+        id: json["_id"] ?? "",
+        firstName: json["firstName"] ?? "",
+        lastName: json["lastName"] ?? "",
         profilePicture: json["profilePicture"],
-        lastLogin: DateTime.parse(json["lastLogin"]),
-        isActive: json["isActive"],
-        loginCount: json["loginCount"],
-        userName: json["userName"],
-        email: json["email"],
-        verified: json["verified"],
-        analyticsVersion: json["analyticsVersion"],
-        privilege: json["privilege"],
-        updatedAt: DateTime.parse(json["updatedAt"]),
+        lastLogin: json["lastLogin"] != null ? DateTime.parse(json["lastLogin"]) : DateTime.now(),
+        isActive: json["isActive"] ?? true,
+        loginCount: json["loginCount"] ?? 0,
+        userName: json["userName"] ?? "",
+        email: json["email"] ?? "",
+        verified: json["verified"] ?? false,
+        analyticsVersion: json["analyticsVersion"] ?? 1,
+        privilege: json["privilege"] ?? "user",
+        updatedAt: json["updatedAt"] != null ? DateTime.parse(json["updatedAt"]) : DateTime.now(),
     );
 
     Map<String, dynamic> toJson() => {

--- a/src/mobile-v3/lib/src/app/profile/pages/edit_profile.dart
+++ b/src/mobile-v3/lib/src/app/profile/pages/edit_profile.dart
@@ -263,6 +263,18 @@ class _EditProfileState extends State<EditProfile> with UiLoggy {
 
     if (!_validateForm()) return;
 
+    final isExpired = await AuthHelper.isTokenExpired();
+    if (isExpired && mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('Please log in again to continue.'),
+          backgroundColor: Colors.red,
+        ),
+      );
+      Navigator.of(context).pop();
+      return;
+    }
+
     setState(() {
       _isLoading = true;
     });
@@ -272,7 +284,7 @@ class _EditProfileState extends State<EditProfile> with UiLoggy {
         _resetLoadingState();
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
-            content: Text('Update request timed out. Please try again.'),
+            content: Text('This is taking longer than expected. Please try again.'),
             backgroundColor: Colors.red,
           ),
         );
@@ -317,18 +329,31 @@ class _EditProfileState extends State<EditProfile> with UiLoggy {
         _selectedProfileImage = null;
       });
 
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text('Error uploading/updating profile image: $e'),
-          backgroundColor: Colors.red,
-          duration: Duration(seconds: 4),
-          action: SnackBarAction(
-            label: 'Retry',
-            textColor: Colors.white,
-            onPressed: () => _updateProfile(),
+      String userFriendlyMessage = 'Unable to update profile. Please try again.';
+      
+      final errorString = e.toString().toLowerCase();
+      if (errorString.contains('unauthorized') || errorString.contains('session has expired')) {
+        userFriendlyMessage = 'Please log in again to continue.';
+      } else if (errorString.contains('network') || errorString.contains('timeout')) {
+        userFriendlyMessage = 'Check your internet connection and try again.';
+      } else if (errorString.contains('server') || errorString.contains('500')) {
+        userFriendlyMessage = 'Something went wrong. Please try again later.';
+      }
+
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(userFriendlyMessage),
+            backgroundColor: Colors.red,
+            duration: Duration(seconds: 4),
+            action: SnackBarAction(
+              label: 'Retry',
+              textColor: Colors.white,
+              onPressed: () => _updateProfile(),
+            ),
           ),
-        ),
-      );
+        );
+      }
     }
   }
 
@@ -447,7 +472,6 @@ class _EditProfileState extends State<EditProfile> with UiLoggy {
             _formChanged = false;
           });
 
-          context.read<UserBloc>().add(LoadUser());
 
           ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(
@@ -461,9 +485,20 @@ class _EditProfileState extends State<EditProfile> with UiLoggy {
         } else if (state is UserUpdateError) {
           _resetLoadingState();
 
+          String userFriendlyMessage = 'Unable to update profile. Please try again.';
+          
+          final errorString = state.message.toLowerCase();
+          if (errorString.contains('unauthorized') || errorString.contains('session has expired')) {
+            userFriendlyMessage = 'Please log in again to continue.';
+          } else if (errorString.contains('network') || errorString.contains('timeout')) {
+            userFriendlyMessage = 'Check your internet connection and try again.';
+          } else if (errorString.contains('server') || errorString.contains('500')) {
+            userFriendlyMessage = 'Something went wrong. Please try again later.';
+          }
+
           ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(
-              content: Text('Error updating profile: ${state.message}'),
+              content: Text(userFriendlyMessage),
               backgroundColor: Colors.red,
               duration: Duration(seconds: 4),
               action: SnackBarAction(

--- a/src/mobile-v3/lib/src/app/profile/repository/user_repository.dart
+++ b/src/mobile-v3/lib/src/app/profile/repository/user_repository.dart
@@ -128,11 +128,15 @@ class UserImpl extends UserRepository with UiLoggy {
       if (responseBody.containsKey('user') && responseBody['user'] != null) {
         loggy.debug("User object keys: ${(responseBody['user'] as Map).keys}");
       }
-
-      return await loadUserProfile();
     } catch (e) {
       loggy.warning("Error parsing update response");
-      throw Exception("Failed to update profile");
     }
+
+    http.Response profileResponse =
+        await createAuthenticatedGetRequest("/api/v2/users/$userId", {});
+
+    ProfileResponseModel model =
+        profileResponseModelFromJson(profileResponse.body);
+    return model;
   }
 }

--- a/src/mobile-v3/lib/src/app/shared/repository/base_repository.dart
+++ b/src/mobile-v3/lib/src/app/shared/repository/base_repository.dart
@@ -127,7 +127,7 @@ class BaseRepository with UiLoggy {
       return response;
     } else if (response.statusCode == 401) {
       await _handleSessionExpiry();
-      throw Exception('Your session has expired. Please log in again.');
+      throw Exception('Please log in again to continue.');
     } else {
       throw _httpError(response, url);
     }
@@ -196,7 +196,7 @@ class BaseRepository with UiLoggy {
       return response;
     } else if (response.statusCode == 401) {
       await _handleSessionExpiry();
-      throw Exception('Your session has expired. Please log in again.');
+      throw Exception('Please log in again to continue.');
     } else {
       throw _httpError(response, url);
     }


### PR DESCRIPTION
- Add token expiration check before profile updates
- Improve error messages to be user-friendly instead of technical
- Fix profile data not updating immediately in UI after successful update
- Handle null values in profile response model to prevent parsing errors
- Remove unnecessary LoadUser() call that was loading stale JWT token data

