### PR TITLE
Vertex: Login refresh, Windows-only downloads, and info banner adoption

### DIFF
--- a/src/vertex/app/changelog.md
+++ b/src/vertex/app/changelog.md
@@ -4,6 +4,51 @@
 
 ---
  
+## Version 1.23.26
+**Released:** April 09, 2026
+
+### Login Copy Refresh, Windows-Only Downloads, and Info Banner Component
+
+Refined the login messaging, limited desktop downloads to Windows, and introduced a reusable Info Banner to standardize contextual messaging.
+
+<details>
+<summary><strong>Login Experience (3)</strong></summary>
+
+- **Updated Hero Copy**: Refreshed the login title and subtitle messaging to emphasize device deployment and data sharing.
+- **Two-Line Title Layout**: Split the login title across two lines for clearer visual hierarchy.
+- **Windows-Only Download**: Limited the login download button to Windows devices only.
+
+</details>
+
+<details>
+<summary><strong>Navigation & Sidebar (2)</strong></summary>
+
+- **Sidebar Download Restriction**: Secondary sidebar download button now appears only on Windows.
+- **macOS Logic Removal**: Removed macOS detection/architecture logic tied to download visibility.
+
+</details>
+
+<details>
+<summary><strong>UI Components (2)</strong></summary>
+
+- **Info Banner Component**: Added a reusable banner component (matching Platform) to Vertex UI.
+- **Context Header Upgrade**: Updated the home context header to use the new Info Banner.
+
+</details>
+
+<details>
+<summary><strong>Files Modified (5)</strong></summary>
+
+- `app/login/page.tsx`
+- `components/layout/secondary-sidebar.tsx`
+- `components/ui/banner.tsx`
+- `components/features/home/context-header.tsx`
+- `app/changelog.md`
+
+</details>
+
+---
+
 ## Version 1.23.25
 **Released:** April 09, 2026
 

--- a/src/vertex/app/changelog.md
+++ b/src/vertex/app/changelog.md
@@ -21,28 +21,31 @@ Refined the login messaging, limited desktop downloads to Windows, and introduce
 </details>
 
 <details>
-<summary><strong>Navigation & Sidebar (2)</strong></summary>
+<summary><strong>Navigation & Sidebar (3)</strong></summary>
 
 - **Sidebar Download Restriction**: Secondary sidebar download button now appears only on Windows.
 - **macOS Logic Removal**: Removed macOS detection/architecture logic tied to download visibility.
+- **Centralized Download Link**: Desktop download URL now comes from a shared constant to keep sidebar and login in sync.
 
 </details>
 
 <details>
-<summary><strong>UI Components (2)</strong></summary>
+<summary><strong>UI Components (3)</strong></summary>
 
 - **Info Banner Component**: Added a reusable banner component (matching Platform) to Vertex UI.
 - **Context Header Upgrade**: Updated the home context header to use the new Info Banner.
+- **Severity-Aware Live Regions**: Non-error banners now announce politely to reduce screen reader noise.
 
 </details>
 
 <details>
-<summary><strong>Files Modified (5)</strong></summary>
+<summary><strong>Files Modified (6)</strong></summary>
 
 - `app/login/page.tsx`
 - `components/layout/secondary-sidebar.tsx`
 - `components/ui/banner.tsx`
 - `components/features/home/context-header.tsx`
+- `core/constants/app-downloads.ts`
 - `app/changelog.md`
 
 </details>

--- a/src/vertex/app/login/page.tsx
+++ b/src/vertex/app/login/page.tsx
@@ -20,7 +20,6 @@ import {
   setLoggingOut,
 } from "@/core/redux/slices/userSlice";
 import { getLastActiveModule } from "@/core/utils/userPreferences";
-import { getMacArchitecture } from "@/core/utils/platform";
 
 const loginSchema = z.object({
   userName: z.string().email({ message: "Please enter a valid email address" }),
@@ -54,8 +53,7 @@ export default function LoginPage() {
   const dispatch = useAppDispatch();
   const isMounted = useRef(true);
 
-  const [platform, setPlatform] = useState<'mac' | 'win' | 'linux' | 'other' | null>(null);
-  const [architecture, setArchitecture] = useState<'arm64' | 'x64' | 'unknown'>('unknown');
+  const [platform, setPlatform] = useState<'win' | 'linux' | 'other' | null>(null);
   const [isElectron, setIsElectron] = useState(false);
 
   useEffect(() => {
@@ -65,18 +63,13 @@ export default function LoginPage() {
 
     // OS Detection for download link and platform check
     const userAgent = window.navigator.userAgent.toLowerCase();
-    const isMac = userAgent.includes('mac');
     const isWin = userAgent.includes('win');
     const isLinux = userAgent.includes('linux');
     setIsElectron(userAgent.includes('electron'));
     
-    if (isMac) {
-      setPlatform('mac');
-      getMacArchitecture().then(setArchitecture);
-      setDownloadUrl("https://github.com/airqo-platform/AirQo-frontend/releases/download/v0.1.0/vertex-desktop-v0.1.0-arm64.dmg");
-    } else if (isWin) {
+    if (isWin) {
       setPlatform('win');
-      setDownloadUrl("https://github.com/airqo-platform/AirQo-frontend/releases/download/v0.1.0/vertex-desktop-v0.1.0.exe");
+      setDownloadUrl("https://github.com/airqo-platform/AirQo-frontend/releases/download/v0.1.7/AirQo-Vertex-Setup-0.1.7.exe");
     } else if (isLinux) {
       setPlatform('linux');
     } else {
@@ -147,7 +140,7 @@ export default function LoginPage() {
             />
           </div>
           
-          {!isElectron && (platform === 'win' || (platform === 'mac' && architecture === 'arm64')) && (
+          {!isElectron && platform === 'win' && (
             <div className="flex items-center">
               <a
                 href={downloadUrl}
@@ -155,16 +148,10 @@ export default function LoginPage() {
                 rel="noopener noreferrer"
                 className="inline-flex items-center gap-2 rounded-md border border-border bg-primary px-4 py-2 text-sm font-medium text-white transition-all hover:bg-primary/80 hover:border-foreground/20 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
               >
-                {platform === 'mac' ? (
-                  <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
-                    <path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.1 2.48-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .76-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.81-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.36 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z"/>
-                  </svg>
-                ) : (
-                  <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor">
-                    <path d="M0 3.449L9.75 2.1V11.7H0V3.449zm0 9.151h9.75v9.6L0 20.551V12.6zm10.55-10.701L24 0v11.7h-13.45V1.899zm0 10.701H24V24l-13.45-1.899V12.6z"/>
-                  </svg>
-                )}
-                Download for {platform === 'mac' ? 'macOS' : 'Windows'}
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor">
+                  <path d="M0 3.449L9.75 2.1V11.7H0V3.449zm0 9.151h9.75v9.6L0 20.551V12.6zm10.55-10.701L24 0v11.7h-13.45V1.899zm0 10.701H24V24l-13.45-1.899V12.6z"/>
+                </svg>
+                Download for Windows
               </a>
             </div>
           )}

--- a/src/vertex/app/login/page.tsx
+++ b/src/vertex/app/login/page.tsx
@@ -20,6 +20,7 @@ import {
   setLoggingOut,
 } from "@/core/redux/slices/userSlice";
 import { getLastActiveModule } from "@/core/utils/userPreferences";
+import { VERTEX_DESKTOP_DOWNLOADS } from "@/core/constants/app-downloads";
 
 const loginSchema = z.object({
   userName: z.string().email({ message: "Please enter a valid email address" }),
@@ -28,7 +29,7 @@ const loginSchema = z.object({
 
 export default function LoginPage() {
   const [isLoading, setIsLoading] = useState(false)
-  const [downloadUrl, setDownloadUrl] = useState("https://github.com/airqo-platform/AirQo-frontend/releases/download/v0.1.0/vertex-desktop-v0.1.0.exe");
+  const [downloadUrl, setDownloadUrl] = useState(VERTEX_DESKTOP_DOWNLOADS.windows);
   const searchParams = useSearchParams();
   const callbackUrl = useMemo(() => {
     const raw = searchParams.get("callbackUrl");
@@ -69,7 +70,7 @@ export default function LoginPage() {
     
     if (isWin) {
       setPlatform('win');
-      setDownloadUrl("https://github.com/airqo-platform/AirQo-frontend/releases/download/v0.1.7/AirQo-Vertex-Setup-0.1.7.exe");
+      setDownloadUrl(VERTEX_DESKTOP_DOWNLOADS.windows);
     } else if (isLinux) {
       setPlatform('linux');
     } else {

--- a/src/vertex/app/login/page.tsx
+++ b/src/vertex/app/login/page.tsx
@@ -174,13 +174,14 @@ export default function LoginPage() {
       {/* Main Content Area */}
       <main className="flex flex-1 overflow-y-auto">
         <div className="flex flex-1 flex-col px-4 py-12 sm:px-6">
-          <div className="mx-auto w-full max-w-[400px] my-auto">
+          <div className="mx-auto w-full max-w-[450px] my-auto">
             <div className="mb-10 text-center">
               <h1 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
-                Deploy and track air quality devices
+                <span className="block">Deploy devices,</span>
+                <span className="block">Share your data</span>
               </h1>
               <p className="mt-4 text-base text-muted-foreground leading-relaxed max-w-sm mx-auto">
-                Unified device management with AirQo Vertex.
+                Add your devices, manage their details, and stream live air quality data through AirQo&apos;s open data channels.
               </p>
             </div>
 

--- a/src/vertex/components/features/home/context-header.tsx
+++ b/src/vertex/components/features/home/context-header.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useAppSelector } from "@/core/redux/hooks";
 import { useUserContext } from "@/core/hooks/useUserContext";
-import { Info } from "lucide-react";
+import { InfoBanner } from "@/components/ui/banner";
 
 const ContextHeader = () => {
     const { userContext } = useUserContext();
@@ -41,14 +41,14 @@ const ContextHeader = () => {
                 Hi, {firstName} 👋
             </h1>
 
-            <div className="bg-[#EFF8FF] border border-[#B2DDFF] rounded-xl p-4 md:p-5 flex gap-3 md:gap-4 items-start">
-                <div className="shrink-0 mt-0.5">
-                    <Info className="w-5 h-5 text-[#2E90FA]" />
-                </div>
-                <p className="text-[#175CD3] text-sm md:text-[14px] leading-relaxed font-medium">
-                    You&apos;re in <span className="capitalize">{getContextTitle()}.</span> {getContextDescription()}
-                </p>
-            </div>
+            <InfoBanner
+                message={
+                    <span className="font-medium">
+                        You&apos;re in <span className="capitalize">{getContextTitle()}.</span>{" "}
+                        {getContextDescription()}
+                    </span>
+                }
+            />
         </div>
     );
 };

--- a/src/vertex/components/features/home/context-header.tsx
+++ b/src/vertex/components/features/home/context-header.tsx
@@ -37,7 +37,7 @@ const ContextHeader = () => {
 
     return (
         <div className="mb-8">
-            <h1 className="text-2xl md:text-3xl font-bold text-[#101828] mb-5">
+            <h1 className="text-2xl md:text-3xl font-bold mb-5">
                 Hi, {firstName} 👋
             </h1>
 

--- a/src/vertex/components/layout/secondary-sidebar.tsx
+++ b/src/vertex/components/layout/secondary-sidebar.tsx
@@ -15,7 +15,6 @@ import { useUserContext } from '@/core/hooks/useUserContext';
 import { ROUTE_LINKS } from '@/core/routes';
 import Card from '../shared/card/CardWrapper';
 import { NavItem } from './NavItem';
-import { getMacArchitecture } from '@/core/utils/platform';
 
 interface SecondarySidebarProps {
   isCollapsed: boolean;
@@ -49,19 +48,14 @@ const SecondarySidebar: React.FC<SecondarySidebarProps> = ({
     useUserContext();
   const contextPermissions = getContextPermissions();
 
-  const [platform, setPlatform] = React.useState<'mac' | 'win' | 'linux' | 'other' | null>(null);
-  const [architecture, setArchitecture] = React.useState<'arm64' | 'x64' | 'unknown'>('unknown');
+  const [platform, setPlatform] = React.useState<'win' | 'linux' | 'other' | null>(null);
   const [downloadUrl, setDownloadUrl] = React.useState("");
   const [isElectron, setIsElectron] = React.useState(false);
 
   React.useEffect(() => {
     const userAgent = window.navigator.userAgent.toLowerCase();
     setIsElectron(userAgent.includes('electron'));
-    if (userAgent.includes('mac')) {
-      setPlatform('mac');
-      getMacArchitecture().then(setArchitecture);
-      setDownloadUrl("https://github.com/airqo-platform/AirQo-frontend/releases/download/v0.1.0/vertex-desktop-v0.1.0-arm64.dmg");
-    } else if (userAgent.includes('win')) {
+    if (userAgent.includes('win')) {
       setPlatform('win');
       setDownloadUrl("https://github.com/airqo-platform/AirQo-frontend/releases/download/v0.1.0/vertex-desktop-v0.1.0.exe");
     } else if (userAgent.includes('linux')) {
@@ -99,7 +93,7 @@ const SecondarySidebar: React.FC<SecondarySidebarProps> = ({
           overflow
           overflowType="auto"
           contentClassName={`flex flex-col h-full overflow-x-hidden scrollbar-thin ${styles.scrollbar}`}
-          footer={!isCollapsed && !isElectron && (platform === 'win' || (platform === 'mac' && architecture === 'arm64')) && (
+          footer={!isCollapsed && !isElectron && platform === 'win' && (
             <div className="px-1 pb-2">
               <a
                 href={downloadUrl}
@@ -107,16 +101,10 @@ const SecondarySidebar: React.FC<SecondarySidebarProps> = ({
                 rel="noopener noreferrer"
                 className="inline-flex items-center justify-center gap-2 w-full rounded-md border border-border bg-primary px-4 py-2 text-sm font-medium text-white transition-all hover:bg-primary/80 hover:border-foreground/20 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
               >
-                {platform === 'mac' ? (
-                  <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
-                    <path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.1 2.48-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .76-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.81-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.36 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z" />
-                  </svg>
-                ) : (
-                  <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor">
-                    <path d="M0 3.449L9.75 2.1V11.7H0V3.449zm0 9.151h9.75v9.6L0 20.551V12.6zm10.55-10.701L24 0v11.7h-13.45V1.899zm0 10.701H24V24l-13.45-1.899V12.6z" />
-                  </svg>
-                )}
-                <span className="truncate">Download for {platform === 'mac' ? 'macOS' : 'Windows'}</span>
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor">
+                  <path d="M0 3.449L9.75 2.1V11.7H0V3.449zm0 9.151h9.75v9.6L0 20.551V12.6zm10.55-10.701L24 0v11.7h-13.45V1.899zm0 10.701H24V24l-13.45-1.899V12.6z" />
+                </svg>
+                <span className="truncate">Download for Windows</span>
               </a>
             </div>
           )}

--- a/src/vertex/components/layout/secondary-sidebar.tsx
+++ b/src/vertex/components/layout/secondary-sidebar.tsx
@@ -13,6 +13,7 @@ import {
 import { Button } from '@/components/ui/button';
 import { useUserContext } from '@/core/hooks/useUserContext';
 import { ROUTE_LINKS } from '@/core/routes';
+import { VERTEX_DESKTOP_DOWNLOADS } from '@/core/constants/app-downloads';
 import Card from '../shared/card/CardWrapper';
 import { NavItem } from './NavItem';
 
@@ -57,7 +58,7 @@ const SecondarySidebar: React.FC<SecondarySidebarProps> = ({
     setIsElectron(userAgent.includes('electron'));
     if (userAgent.includes('win')) {
       setPlatform('win');
-      setDownloadUrl("https://github.com/airqo-platform/AirQo-frontend/releases/download/v0.1.0/vertex-desktop-v0.1.0.exe");
+      setDownloadUrl(VERTEX_DESKTOP_DOWNLOADS.windows);
     } else if (userAgent.includes('linux')) {
       setPlatform('linux');
     } else {

--- a/src/vertex/components/ui/banner.tsx
+++ b/src/vertex/components/ui/banner.tsx
@@ -1,0 +1,164 @@
+import React from 'react';
+import { cn } from '@/lib/utils';
+import {
+  AqMessageCheckCircle,
+  AqMessageXCircle,
+  AqAlertTriangle,
+  AqAnnotationInfo,
+  AqXClose,
+} from '@airqo/icons-react';
+
+// ============================================================================
+// Types & Interfaces
+// ============================================================================
+
+export type BannerSeverity = 'success' | 'error' | 'warning' | 'info';
+
+export interface BannerProps {
+  severity: BannerSeverity;
+  title?: React.ReactNode;
+  message?: React.ReactNode;
+  icon?: React.ReactNode;
+  actions?: React.ReactNode;
+  dismissible?: boolean;
+  onDismiss?: () => void;
+  className?: string;
+  dense?: boolean;
+  showIcon?: boolean;
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const SEVERITY_CONFIG: Record<
+  BannerSeverity,
+  {
+    bgColor: string;
+    borderColor: string;
+    textColor: string;
+    icon: React.ReactNode;
+    iconColor: string;
+  }
+> = {
+  success: {
+    bgColor: 'bg-emerald-100 dark:bg-emerald-950/20',
+    borderColor: 'border-emerald-200 dark:border-emerald-800',
+    textColor: 'text-emerald-800 dark:text-emerald-200',
+    icon: <AqMessageCheckCircle className="h-5 w-5" />,
+    iconColor: 'text-emerald-600 dark:text-emerald-400',
+  },
+  error: {
+    bgColor: 'bg-destructive/20',
+    borderColor: 'border-destructive/30',
+    textColor: 'text-destructive',
+    icon: <AqMessageXCircle className="h-5 w-5" />,
+    iconColor: 'text-destructive',
+  },
+  warning: {
+    bgColor: 'bg-amber-100 dark:bg-amber-950/20',
+    borderColor: 'border-amber-200 dark:border-amber-800',
+    textColor: 'text-amber-800 dark:text-amber-200',
+    icon: <AqAlertTriangle className="h-5 w-5" />,
+    iconColor: 'text-amber-600 dark:text-amber-400',
+  },
+  info: {
+    bgColor: 'bg-blue-100 dark:bg-blue-950/20',
+    borderColor: 'border-blue-200 dark:border-blue-800',
+    textColor: 'text-blue-800 dark:text-blue-200',
+    icon: <AqAnnotationInfo className="h-5 w-5" />,
+    iconColor: 'text-blue-600 dark:text-blue-400',
+  },
+};
+
+// ============================================================================
+// Banner Component
+// ============================================================================
+
+export const Banner: React.FC<BannerProps> = ({
+  severity,
+  title,
+  message,
+  icon,
+  actions,
+  dismissible = false,
+  onDismiss,
+  className,
+  dense = false,
+  showIcon = true,
+}) => {
+  const config = SEVERITY_CONFIG[severity];
+  const displayIcon = icon || (showIcon ? config.icon : null);
+
+  const paddingClass = dense ? 'py-2 px-3' : 'p-4';
+
+  return (
+    <div
+      className={cn(
+        'flex items-start gap-3 rounded-md border shadow-sm',
+        paddingClass,
+        config.bgColor,
+        config.borderColor,
+        className
+      )}
+      role="alert"
+    >
+      {/* Icon */}
+      {displayIcon && (
+        <div className={cn('flex-shrink-0', config.iconColor)}>
+          {displayIcon}
+        </div>
+      )}
+
+      {/* Content */}
+      <div className="flex-1 min-w-0">
+        {title && <h4 className={cn('text-sm', config.textColor)}>{title}</h4>}
+        {message && (
+          <div className={cn('text-sm', config.textColor)}>{message}</div>
+        )}
+        {actions && (
+          <div
+            className={cn(dense ? 'mt-0' : 'mt-3', 'flex items-center gap-2')}
+          >
+            {actions}
+          </div>
+        )}
+      </div>
+
+      {/* Dismiss Button */}
+      {dismissible && onDismiss && (
+        <button
+          type="button"
+          onClick={onDismiss}
+          className={cn(
+            'flex-shrink-0 rounded-md p-1 transition-colors hover:bg-black/5 dark:hover:bg-white/10',
+            config.textColor
+          )}
+          aria-label="Dismiss"
+        >
+          <AqXClose className="h-4 w-4" />
+        </button>
+      )}
+    </div>
+  );
+};
+
+// ============================================================================
+// Convenience Components for Specific Severities
+// ============================================================================
+
+export const SuccessBanner: React.FC<Omit<BannerProps, 'severity'>> = props => (
+  <Banner {...props} severity="success" />
+);
+
+export const ErrorBanner: React.FC<Omit<BannerProps, 'severity'>> = props => (
+  <Banner {...props} severity="error" />
+);
+
+export const WarningBanner: React.FC<Omit<BannerProps, 'severity'>> = props => (
+  <Banner {...props} severity="warning" />
+);
+
+export const InfoBanner: React.FC<Omit<BannerProps, 'severity'>> = props => (
+  <Banner {...props} severity="info" />
+);

--- a/src/vertex/components/ui/banner.tsx
+++ b/src/vertex/components/ui/banner.tsx
@@ -101,7 +101,8 @@ export const Banner: React.FC<BannerProps> = ({
         config.borderColor,
         className
       )}
-      role="alert"
+      role={severity === 'error' ? 'alert' : 'status'}
+      aria-live={severity === 'error' ? 'assertive' : 'polite'}
     >
       {/* Icon */}
       {displayIcon && (

--- a/src/vertex/core/constants/app-downloads.ts
+++ b/src/vertex/core/constants/app-downloads.ts
@@ -1,0 +1,4 @@
+export const VERTEX_DESKTOP_DOWNLOADS = {
+  windows:
+    "https://github.com/airqo-platform/AirQo-frontend/releases/download/v0.1.7/AirQo-Vertex-Setup-0.1.7.exe",
+};


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

- Refreshes the Vertex login hero copy and enforces a two-line title layout.
- Limits desktop download buttons to Windows only in the login topbar and secondary sidebar (removes macOS-specific logic).
- Adds a reusable Info Banner component in Vertex (mirrors Platform) and updates the home context header to use it.
- Updates the Vertex changelog with Version 1.23.26 describing these changes.

#### Status of maturity (all need to be checked before merging):

- [x] I've tested this locally
- [x] I consider this code done
- [x] This change ready to hit production in its current state
- [x] The title of the PR states what changed and the related issues number (used for the release note).

#### How should this be manually tested?

- Navigate to the Vertex login page and confirm the title is split across two lines and matches the updated copy.
- On Windows, verify the download button appears in the login topbar and secondary sidebar, linking to the Windows installer.
- On macOS/Linux, confirm the download button does not appear in the login topbar or sidebar.
- Navigate to the home dashboard and confirm the context header uses the Info Banner styling.

#### What are the relevant tickets?

- Closes #<enter issue number here>
- [Jira_card_number]() (If exists)

#### Screenshots (optional)
<img width="1920" height="893" alt="image" src="https://github.com/user-attachments/assets/c9c2b883-c5a9-4e3e-8c55-1241aa584f1c" />
<img width="1920" height="886" alt="image" src="https://github.com/user-attachments/assets/0507ac19-6ea3-4493-bf90-a9bdd3d35d78" />
<img width="1920" height="884" alt="image" src="https://github.com/user-attachments/assets/13841067-fc79-4c4f-a857-61ddd8a9aadb" />
