### PR TITLE
fix: exclude lg locale from supportedLocales to prevent MaterialLocalizations crash

### DIFF
--- a/src/mobile/lib/main.dart
+++ b/src/mobile/lib/main.dart
@@ -164,9 +164,10 @@ class AirqoMobile extends StatelessWidget {
                 locale: currentLocale,
                 supportedLocales: const [
                   Locale('en', ''),
-                  Locale('lg', ''),
                   Locale('sw', ''),
                   Locale('fr', ''),
+                  // lg (Luganda) is excluded — not supported by GlobalMaterialLocalizations.
+                  // Luganda translation is handled dynamically via SunbirdTranslationService.
                 ],
                 localizationsDelegates: const [
                   AppLocalizations.delegate,

--- a/src/mobile/lib/src/app/auth/widgets/breathe_clean.dart
+++ b/src/mobile/lib/src/app/auth/widgets/breathe_clean.dart
@@ -1,3 +1,4 @@
+import 'package:airqo/src/app/shared/widgets/translated_text.dart';
 import 'package:flutter/material.dart';
 
 class BreatheClean extends StatelessWidget {
@@ -28,24 +29,24 @@ class BreatheClean extends StatelessWidget {
                   mainAxisAlignment: MainAxisAlignment.center,
                   crossAxisAlignment: CrossAxisAlignment.center,
                   children: [
-                    Text(
+                    TranslatedText(
                       '🌿 Breathe Clean',
                       textAlign: TextAlign.center,
-                      style: TextStyle(
+                      style: const TextStyle(
                         fontWeight: FontWeight.w400,
                         fontStyle: FontStyle.normal,
                         fontFamily: 'inter',
                         fontSize: 16,
                       ),
                     ),
-                    SizedBox(
+                    const SizedBox(
                       height: 16,
                     ),
-                    Text(
+                    TranslatedText(
                       'Track and monitor the quality of air you breathe',
                       maxLines: 2,
                       textAlign: TextAlign.center,
-                      style: TextStyle(
+                      style: const TextStyle(
                         fontWeight: FontWeight.w700,
                         fontSize: 20,
                       ),

--- a/src/mobile/lib/src/app/auth/widgets/know_your_air.dart
+++ b/src/mobile/lib/src/app/auth/widgets/know_your_air.dart
@@ -1,3 +1,4 @@
+import 'package:airqo/src/app/shared/widgets/translated_text.dart';
 import 'package:flutter/material.dart';
 
 class KnowYourAir extends StatelessWidget {
@@ -25,22 +26,22 @@ class KnowYourAir extends StatelessWidget {
                   mainAxisAlignment: MainAxisAlignment.center,
                   crossAxisAlignment: CrossAxisAlignment.center,
                   children: [
-                    Text(
+                    TranslatedText(
                       '✨ Know Your Air',
                       textAlign: TextAlign.center,
-                      style: TextStyle(
+                      style: const TextStyle(
                         fontWeight: FontWeight.w400,
                         fontSize: 16,
                       ),
                     ),
-                    SizedBox(
+                    const SizedBox(
                       height: 16,
                     ),
-                    Text(
+                    TranslatedText(
                       'Learn and reduce air pollution in your community',
                       maxLines: 2,
                       textAlign: TextAlign.center,
-                      style: TextStyle(
+                      style: const TextStyle(
                         fontWeight: FontWeight.w700,
                         fontSize: 20,
                       ),

--- a/src/mobile/lib/src/app/auth/widgets/welcome_widget.dart
+++ b/src/mobile/lib/src/app/auth/widgets/welcome_widget.dart
@@ -1,3 +1,4 @@
+import 'package:airqo/src/app/shared/widgets/translated_text.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 
@@ -37,8 +38,8 @@ class WelcomeWidget extends StatelessWidget {
                     height: 56.14,
                     child: SvgPicture.asset("assets/images/shared/logo.svg")),
                 Spacer(),
-                const Padding(
-                  padding: EdgeInsets.only(
+                Padding(
+                  padding: const EdgeInsets.only(
                     left: 20,
                     right: 20,
                   ),
@@ -46,10 +47,10 @@ class WelcomeWidget extends StatelessWidget {
                     mainAxisAlignment: MainAxisAlignment.center,
                     crossAxisAlignment: CrossAxisAlignment.center,
                     children: [
-                      Text(
+                      TranslatedText(
                         '👋 Welcome to AirQo!',
                         textAlign: TextAlign.center,
-                        style: TextStyle(
+                        style: const TextStyle(
                           color: Colors.white,
                           fontWeight: FontWeight.w400,
                           fontStyle: FontStyle.normal,
@@ -57,14 +58,14 @@ class WelcomeWidget extends StatelessWidget {
                           fontSize: 20,
                         ),
                       ),
-                      SizedBox(
+                      const SizedBox(
                         height: 10,
                       ),
-                      Text(
+                      TranslatedText(
                         'Clean Air for all African Cities.',
                         maxLines: 2,
                         textAlign: TextAlign.center,
-                        style: TextStyle(
+                        style: const TextStyle(
                           color: Colors.white,
                           fontWeight: FontWeight.w700,
                           fontSize: 35,

--- a/src/mobile/lib/src/app/dashboard/pages/location_selection/components/location_search_bar.dart
+++ b/src/mobile/lib/src/app/dashboard/pages/location_selection/components/location_search_bar.dart
@@ -1,7 +1,11 @@
+import 'package:airqo/src/app/other/language/bloc/language_bloc.dart';
+import 'package:airqo/src/app/shared/services/mlkit_translation_service.dart';
+import 'package:airqo/src/app/shared/services/sunbird_translation_service.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_svg/svg.dart';
 
-class LocationSearchBar extends StatelessWidget {
+class LocationSearchBar extends StatefulWidget {
   final TextEditingController controller;
   final ValueChanged<String> onChanged;
 
@@ -12,32 +16,79 @@ class LocationSearchBar extends StatelessWidget {
   });
 
   @override
+  State<LocationSearchBar> createState() => _LocationSearchBarState();
+}
+
+class _LocationSearchBarState extends State<LocationSearchBar> {
+  static const _sourceHint = 'Search Villages, Cities or Countries';
+  String _hint = _sourceHint;
+  String? _lastLocale;
+
+  void _translate(String localeCode) {
+    final isSunbird = SunbirdTranslationService().supportsTranslation(localeCode);
+    final isMlKit = MlKitTranslationService().supportsTranslation(localeCode);
+
+    if (!isSunbird && !isMlKit) {
+      if (_hint != _sourceHint) setState(() => _hint = _sourceHint);
+      return;
+    }
+
+    final requestLocale = localeCode;
+    final future = isSunbird
+        ? SunbirdTranslationService().translate(_sourceHint, targetLocale: localeCode)
+        : MlKitTranslationService().translate(_sourceHint, targetLocale: localeCode);
+
+    future.then((result) {
+      if (mounted && requestLocale == _lastLocale && _hint != result) {
+        setState(() => _hint = result);
+      }
+    });
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 16),
-      child: TextField(
-        controller: controller,
-        style: TextStyle(color: Theme.of(context).textTheme.bodyLarge?.color),
-        onChanged: onChanged,
-        decoration: InputDecoration(
-          hintText: 'Search Villages, Cities or Countries',
-          hintStyle: TextStyle(color: Theme.of(context).textTheme.bodyMedium?.color?.withOpacity(0.6)),
-          prefixIcon: Padding(
-            padding: const EdgeInsets.all(11.0),
-            child: SvgPicture.asset(
-              "assets/icons/search_icon.svg",
-              height: 15,
-              color: Theme.of(context).textTheme.headlineLarge!.color,
+    return BlocBuilder<LanguageBloc, LanguageState>(
+      builder: (context, state) {
+        final localeCode = state is LanguageLoaded ? state.languageCode : 'en';
+
+        if (localeCode != _lastLocale) {
+          _lastLocale = localeCode;
+          _hint = _sourceHint;
+          _translate(localeCode);
+        }
+
+        return Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: TextField(
+            controller: widget.controller,
+            style: TextStyle(color: Theme.of(context).textTheme.bodyLarge?.color),
+            onChanged: widget.onChanged,
+            decoration: InputDecoration(
+              hintText: _hint,
+              hintStyle: TextStyle(
+                  color: Theme.of(context)
+                      .textTheme
+                      .bodyMedium
+                      ?.color
+                      ?.withOpacity(0.6)),
+              prefixIcon: Padding(
+                padding: const EdgeInsets.all(11.0),
+                child: SvgPicture.asset(
+                  "assets/icons/search_icon.svg",
+                  height: 15,
+                  color: Theme.of(context).textTheme.headlineLarge!.color,
+                ),
+              ),
+              filled: true,
+              fillColor: Theme.of(context).highlightColor,
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(12),
+                borderSide: BorderSide.none,
+              ),
             ),
           ),
-          filled: true,
-          fillColor: Theme.of(context).highlightColor,
-          border: OutlineInputBorder(
-            borderRadius: BorderRadius.circular(12),
-            borderSide: BorderSide.none,
-          ),
-        ),
-      ),
+        );
+      },
     );
   }
 }

--- a/src/mobile/lib/src/app/dashboard/pages/location_selection/components/swipeable_analytics_card.dart
+++ b/src/mobile/lib/src/app/dashboard/pages/location_selection/components/swipeable_analytics_card.dart
@@ -3,6 +3,7 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:loggy/loggy.dart';
 import 'package:airqo/src/app/dashboard/models/airquality_response.dart';
 import 'package:airqo/src/app/dashboard/widgets/analytics_details.dart';
+import 'package:airqo/src/app/shared/widgets/translated_text.dart';
 import 'package:airqo/src/meta/utils/colors.dart';
 import 'package:airqo/src/meta/utils/utils.dart';
 import 'dart:async';
@@ -140,7 +141,7 @@ class _SwipeableAnalyticsCardState extends State<SwipeableAnalyticsCard>
                 size: 16,
               ),
               const SizedBox(width: 8),
-              const Text(
+              TranslatedText(
                 'Swipe left to remove location',
                 style: TextStyle(
                   color: Colors.white,
@@ -289,7 +290,7 @@ class _SwipeableAnalyticsCardState extends State<SwipeableAnalyticsCard>
                       size: 24,
                     ),
                                           const SizedBox(height: 4),
-                    Text(
+                    TranslatedText(
                       'Remove',
                       style: TextStyle(
                         color: Colors.white,
@@ -448,8 +449,8 @@ class _SwipeableAnalyticsCardState extends State<SwipeableAnalyticsCard>
                                                 : 'assets/images/shared/pm_rating.svg',
                                           ),
                                           const SizedBox(width: 2),
-                                          Text(
-                                            " PM2.5",
+                                          TranslatedText(
+                                            "PM2.5",
                                             style: TextStyle(
                                               color: Theme.of(context)
                                                   .textTheme
@@ -521,8 +522,8 @@ class _SwipeableAnalyticsCardState extends State<SwipeableAnalyticsCard>
                                     .withOpacity(0.15),
                                 borderRadius: BorderRadius.circular(20),
                               ),
-                              child: Text(
-                                widget.measurement.aqiCategory ?? "Unknown",
+                              child: TranslatedText(
+                                widget.measurement.aqiCategory ?? 'Unknown',
                                 style: TextStyle(
                                   fontSize: 14,
                                   fontWeight: FontWeight.w600,

--- a/src/mobile/lib/src/app/dashboard/pages/location_selection/location_selection_screen.dart
+++ b/src/mobile/lib/src/app/dashboard/pages/location_selection/location_selection_screen.dart
@@ -22,6 +22,7 @@ import 'package:airqo/src/app/auth/pages/login_page.dart';
 import 'package:airqo/src/app/auth/services/auth_validation_helper.dart';
 import 'package:airqo/src/app/shared/pages/error_page.dart';
 import 'package:airqo/src/app/shared/services/cache_manager.dart';
+import 'package:airqo/src/app/shared/widgets/translated_text.dart';
 
 class LocationSelectionScreen extends StatefulWidget with UiLoggy {
   final SitesRepository sitesRepository;
@@ -133,7 +134,7 @@ class _LocationSelectionScreenState extends State<LocationSelectionScreen>
           if (mounted) {
             ScaffoldMessenger.of(context).showSnackBar(
               SnackBar(
-                content: const Text(
+                content: const TranslatedText(
                     'Your session has expired. Please log in again.'),
                 duration: const Duration(seconds: 8),
                 action: SnackBarAction(
@@ -168,7 +169,7 @@ class _LocationSelectionScreenState extends State<LocationSelectionScreen>
           if (mounted) {
             ScaffoldMessenger.of(context).showSnackBar(
               const SnackBar(
-                  content: Text(
+                  content: TranslatedText(
                       'Authentication issue detected. Please log in again.')),
             );
           }
@@ -209,7 +210,7 @@ class _LocationSelectionScreenState extends State<LocationSelectionScreen>
       loggy.info('✅ Successfully dispatched update event');
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(
-          content: Text(
+          content: TranslatedText(
             'Locations saved successfully',
             style: TextStyle(color: Colors.white),
           ),
@@ -412,7 +413,7 @@ class _LocationSelectionScreenState extends State<LocationSelectionScreen>
                     Icon(Icons.warning_amber_rounded, color: Colors.white),
                     SizedBox(width: 8),
                     Expanded(
-                      child: Text(
+                      child: TranslatedText(
                         'Maximum of $maxLocations favorite locations reached',
                         style: TextStyle(color: Colors.white),
                       ),
@@ -439,7 +440,7 @@ class _LocationSelectionScreenState extends State<LocationSelectionScreen>
 
           ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(
-              content: Text(
+              content: TranslatedText(
                 'Location added to favorites',
                 style: TextStyle(color: Colors.white),
               ),
@@ -454,7 +455,7 @@ class _LocationSelectionScreenState extends State<LocationSelectionScreen>
 
           ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(
-              content: Text(
+              content: TranslatedText(
                 'Location removed from favorites',
                 style: TextStyle(color: Colors.white),
               ),
@@ -536,7 +537,7 @@ class _LocationSelectionScreenState extends State<LocationSelectionScreen>
         appBar: AppBar(
           backgroundColor: Colors.transparent,
           elevation: 0,
-          title: Text(
+          title: TranslatedText(
             'Select Locations',
             style: TextStyle(
                 color: Theme.of(context).textTheme.headlineLarge?.color,
@@ -601,7 +602,7 @@ class _LocationSelectionScreenState extends State<LocationSelectionScreen>
         if (showLocationLimitError)
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-            child: Text(
+            child: TranslatedText(
               'You can select up to $maxLocations locations only',
               style: TextStyle(
                 color: Colors.red[400],
@@ -614,7 +615,7 @@ class _LocationSelectionScreenState extends State<LocationSelectionScreen>
           padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
           child: Row(
             children: [
-              Text(
+              TranslatedText(
                 'Selected: ${selectedLocations.length}/$maxLocations',
                 style: TextStyle(
                   color: Theme.of(context).textTheme.headlineSmall?.color,
@@ -631,7 +632,7 @@ class _LocationSelectionScreenState extends State<LocationSelectionScreen>
                     });
                   },
                   icon: Icon(Icons.clear_all, size: 18),
-                  label: Text(
+                  label: TranslatedText(
                     "Clear All",
                     style: TextStyle(
                       fontSize: 14,
@@ -689,7 +690,7 @@ class _LocationSelectionScreenState extends State<LocationSelectionScreen>
                         strokeWidth: 2,
                       ),
                     )
-                  : Text(
+                  : TranslatedText(
                       'Save ${selectedLocations.length} Location${selectedLocations.length != 1 ? 's' : ''}',
                       style: const TextStyle(
                         fontSize: 16,

--- a/src/mobile/lib/src/app/dashboard/widgets/dashboard_app_bar.dart
+++ b/src/mobile/lib/src/app/dashboard/widgets/dashboard_app_bar.dart
@@ -1,5 +1,6 @@
 import 'package:airqo/src/app/auth/pages/login_page.dart';
 import 'package:airqo/src/app/profile/pages/profile_page.dart';
+import 'package:airqo/src/app/shared/widgets/translated_tooltip.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_svg/svg.dart';
@@ -71,7 +72,7 @@ class DashboardAppBar extends StatelessWidget implements PreferredSizeWidget {
   }
 
   Widget _buildGuestAvatar(BuildContext context) {
-    return Tooltip(
+    return TranslatedTooltip(
       message: "Sign in or create an account",
       preferBelow: true,
       verticalOffset: 20,
@@ -118,7 +119,7 @@ class DashboardAppBar extends StatelessWidget implements PreferredSizeWidget {
           String? firstName = user.firstName;
           String? lastName = user.lastName;
 
-          return Tooltip(
+          return TranslatedTooltip(
             message: "View your profile",
             preferBelow: true,
             verticalOffset: 20,
@@ -153,7 +154,7 @@ class DashboardAppBar extends StatelessWidget implements PreferredSizeWidget {
             ),
           );
         } else if (userState is UserLoadingError) {
-          return Tooltip(
+          return TranslatedTooltip(
             message: "Sign in to access your profile",
             preferBelow: true,
             verticalOffset: 20,

--- a/src/mobile/lib/src/app/dashboard/widgets/expanded_analytics_card.dart
+++ b/src/mobile/lib/src/app/dashboard/widgets/expanded_analytics_card.dart
@@ -70,20 +70,20 @@ class _ExpandedAnalyticsCardState extends State<ExpandedAnalyticsCard>
 
     switch (widget.measurement.aqiCategory?.toLowerCase() ?? '') {
       case 'good':
-        return "Enjoy outdoor activities in good air quality";
+        return 'Enjoy outdoor activities in good air quality';
       case 'moderate':
-        return "Air quality is acceptable for most people";
+        return 'Air quality is acceptable for most people';
       case 'unhealthy for sensitive groups':
       case 'u4sg':
-        return "Sensitive groups should limit outdoor exertion";
+        return 'Sensitive groups should limit outdoor exertion';
       case 'unhealthy':
-        return "Everyone should reduce prolonged outdoor activities";
+        return 'Everyone should reduce prolonged outdoor activities';
       case 'very unhealthy':
-        return "Everyone should avoid outdoor activities";
+        return 'Everyone should avoid outdoor activities';
       case 'hazardous':
-        return "Everyone should avoid all outdoor activities";
+        return 'Everyone should avoid all outdoor activities';
       default:
-        return "Stay informed about air quality";
+        return 'Stay informed about air quality';
     }
   }
 
@@ -159,8 +159,8 @@ class _ExpandedAnalyticsCardState extends State<ExpandedAnalyticsCard>
                                         : 'assets/images/shared/pm_rating.svg',
                                   ),
                                   const SizedBox(width: 2),
-                                  Text(
-                                    " PM2.5",
+                                  TranslatedText(
+                                    "PM2.5",
                                     style: TextStyle(
                                       color: Theme.of(context)
                                           .textTheme
@@ -236,8 +236,8 @@ class _ExpandedAnalyticsCardState extends State<ExpandedAnalyticsCard>
                                   .withOpacity(0.15),
                               borderRadius: BorderRadius.circular(20),
                             ),
-                            child: Text(
-                              widget.measurement.aqiCategory ?? "Unknown",
+                            child: TranslatedText(
+                              widget.measurement.aqiCategory ?? 'Unknown',
                               style: TextStyle(
                                 fontSize: 14,
                                 fontWeight: FontWeight.w600,
@@ -262,7 +262,7 @@ class _ExpandedAnalyticsCardState extends State<ExpandedAnalyticsCard>
                                     : const Color(0xFFEAEFF5),
                                 borderRadius: BorderRadius.circular(20),
                               ),
-                              child: Text(
+                              child: TranslatedText(
                                 _getDeviceCategoryLabel(widget.measurement
                                     .deviceCategories!.primaryCategory!),
                                 style: TextStyle(
@@ -291,7 +291,7 @@ class _ExpandedAnalyticsCardState extends State<ExpandedAnalyticsCard>
                     horizontal: 16,
                     vertical: 12,
                   ),
-                  child: Text(
+                  child: TranslatedText(
                     healthTipTagline,
                     style: TextStyle(
                       fontSize: 15,
@@ -339,7 +339,7 @@ class _ExpandedAnalyticsCardState extends State<ExpandedAnalyticsCard>
                 ),
                 const SizedBox(height: 16),
                 healthTipDescription != null
-                    ? Text(
+                    ? TranslatedText(
                         healthTipDescription,
                         style: TextStyle(
                           fontSize: 15,

--- a/src/mobile/lib/src/app/dashboard/widgets/my_places_view.dart
+++ b/src/mobile/lib/src/app/dashboard/widgets/my_places_view.dart
@@ -13,6 +13,7 @@ import 'package:airqo/src/app/shared/services/notification_manager.dart';
 import 'package:airqo/src/app/shared/services/cache_manager.dart';
 import 'package:airqo/src/app/auth/services/auth_validation_helper.dart';
 import 'package:airqo/src/app/auth/pages/login_page.dart';
+import 'package:airqo/src/app/shared/widgets/translated_text.dart';
 
 class MyPlacesView extends StatefulWidget {
   final UserPreferencesModel? userPreferences;
@@ -185,14 +186,14 @@ class _MyPlacesViewState extends State<MyPlacesView> with UiLoggy {
       showDialog(
         context: context,
         builder: (context) => AlertDialog(
-          title: Text(
+          title: TranslatedText(
             "Cannot Remove Default Location",
             style: TextStyle(
               fontWeight: FontWeight.bold,
               color: Theme.of(context).textTheme.headlineSmall?.color,
             ),
           ),
-          content: Text(
+          content: TranslatedText(
             "You need to have at least one location in My Places. Add another location before removing this one.",
             style: TextStyle(
               color: Theme.of(context).textTheme.bodyMedium?.color,
@@ -201,7 +202,7 @@ class _MyPlacesViewState extends State<MyPlacesView> with UiLoggy {
           actions: [
             TextButton(
               onPressed: () => Navigator.pop(context),
-              child: Text(
+              child: TranslatedText(
                 "OK",
                 style: TextStyle(
                   color: AppColors.primaryColor,
@@ -331,7 +332,7 @@ class _MyPlacesViewState extends State<MyPlacesView> with UiLoggy {
           loggy.error('Authentication error detected: ${state.message}');
           ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(
-              content: Text(state.message),
+              content: TranslatedText(state.message),
               duration: const Duration(seconds: 8),
               action: SnackBarAction(
                 label: 'Log In',
@@ -427,7 +428,7 @@ class _MyPlacesViewState extends State<MyPlacesView> with UiLoggy {
       children: [
         Padding(
           padding: const EdgeInsets.only(left: 16, top: 24, bottom: 8),
-          child: Text(
+          child: TranslatedText(
             'Add places you love',
             style: TextStyle(
               fontSize: 22,
@@ -438,7 +439,7 @@ class _MyPlacesViewState extends State<MyPlacesView> with UiLoggy {
         ),
         Padding(
           padding: const EdgeInsets.only(left: 16, bottom: 24),
-          child: Text(
+          child: TranslatedText(
             'Start by adding locations you care about.',
             style: TextStyle(
               fontSize: 16,
@@ -471,7 +472,7 @@ class _MyPlacesViewState extends State<MyPlacesView> with UiLoggy {
                 height: 160,
                 width: double.infinity,
                 alignment: Alignment.center,
-                child: Text(
+                child: TranslatedText(
                   '+Add Location',
                   style: TextStyle(
                     color: AppColors.primaryColor,

--- a/src/mobile/lib/src/app/dashboard/widgets/view_selector.dart
+++ b/src/mobile/lib/src/app/dashboard/widgets/view_selector.dart
@@ -1,6 +1,7 @@
 import 'package:airqo/src/app/dashboard/models/country_model.dart';
 import 'package:airqo/src/app/shared/widgets/country_button';
 import 'package:airqo/src/app/shared/widgets/translated_text.dart';
+import 'package:airqo/src/app/shared/widgets/translated_tooltip.dart';
 import 'package:flutter/material.dart';
 import '../../../meta/utils/colors.dart';
 import 'package:airqo/src/app/dashboard/repository/country_repository.dart';
@@ -100,8 +101,8 @@ class _ViewSelectorState extends State<ViewSelector> {
         padding: const EdgeInsets.symmetric(horizontal: 16),
         children: [
           if (!widget.isGuestUser) ...[
-            Tooltip(
-              key: _nearbyTooltipKey,
+            TranslatedTooltip(
+              tooltipKey: _nearbyTooltipKey,
               message: "View air quality in locations closest to you",
               preferBelow: true,
               verticalOffset: 20,
@@ -122,8 +123,8 @@ class _ViewSelectorState extends State<ViewSelector> {
               ),
             ),
             SizedBox(width: 8),
-            Tooltip(
-              key: _myPlacesTooltipKey,
+            TranslatedTooltip(
+              tooltipKey: _myPlacesTooltipKey,
               message: "Save your most relevant locations in one place",
               preferBelow: true,
               verticalOffset: 20,
@@ -146,7 +147,7 @@ class _ViewSelectorState extends State<ViewSelector> {
             SizedBox(width: 8),
           ],
           if (widget.isGuestUser) ...[
-            Tooltip(
+            TranslatedTooltip(
               message: "View air quality in locations closest to you",
               preferBelow: true,
               verticalOffset: 20,

--- a/src/mobile/lib/src/app/map/pages/map_page.dart
+++ b/src/mobile/lib/src/app/map/pages/map_page.dart
@@ -25,6 +25,7 @@ import 'package:airqo/src/app/dashboard/repository/country_repository.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:geocoding/geocoding.dart';
 import 'package:loggy/loggy.dart';
+import 'package:airqo/src/app/shared/widgets/translated_tooltip.dart';
 
 class MapScreen extends StatefulWidget {
   const MapScreen({super.key});
@@ -687,7 +688,7 @@ class _MapScreenState extends State<MapScreen>
                               mainAxisAlignment: MainAxisAlignment.spaceAround,
                               mainAxisSize: MainAxisSize.min,
                               children: airQualityData.map((e) {
-                                return Tooltip(
+                                return TranslatedTooltip(
                                   preferBelow: false,
                                   textStyle: TextStyle(color: Colors.white),
                                   decoration: BoxDecoration(

--- a/src/mobile/lib/src/app/notifications/pages/cleared_notifications_page.dart
+++ b/src/mobile/lib/src/app/notifications/pages/cleared_notifications_page.dart
@@ -1,3 +1,4 @@
+import 'package:airqo/src/app/shared/widgets/translated_text.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
 
@@ -22,16 +23,11 @@ class ClearedNotificationsScreen extends StatelessWidget {
                       color: Colors.grey[900],
                       shape: BoxShape.circle,
                     ),
-                    // child: Icon(
-                    //   Icons.notifications,
-                    //   color: Colors.white,
-                    //   size: maxWidth * 0.1,
-                    // ),
                     child: SvgPicture.asset(
                       "assets/icons/notification.svg",
                     )),
                 SizedBox(height: maxHeight * 0.05),
-                Text(
+                TranslatedText(
                   "You're all cleared up",
                   style: TextStyle(
                     color: Colors.white,
@@ -40,7 +36,7 @@ class ClearedNotificationsScreen extends StatelessWidget {
                   ),
                 ),
                 SizedBox(height: maxHeight * 0.02),
-                Text(
+                TranslatedText(
                   "You deserve some ice cream!",
                   style: TextStyle(
                     color: Colors.grey,

--- a/src/mobile/lib/src/app/notifications/pages/no_notifications_page.dart
+++ b/src/mobile/lib/src/app/notifications/pages/no_notifications_page.dart
@@ -1,3 +1,4 @@
+import 'package:airqo/src/app/shared/widgets/translated_text.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
 
@@ -22,16 +23,11 @@ class NoNotificationsScreen extends StatelessWidget {
                       color: Colors.grey[900],
                       shape: BoxShape.circle,
                     ),
-                    // child: Icon(
-                    //   Icons.notifications,
-                    //   color: Colors.white,
-                    //   size: maxWidth * 0.1,
-                    // ),
                     child: SvgPicture.asset(
                       "assets/icons/notification.svg",
                     )),
                 SizedBox(height: maxHeight * 0.05),
-                Text(
+                TranslatedText(
                   "No Notifications",
                   style: TextStyle(
                     color: Colors.white,
@@ -40,7 +36,7 @@ class NoNotificationsScreen extends StatelessWidget {
                   ),
                 ),
                 SizedBox(height: maxHeight * 0.02),
-                Text(
+                TranslatedText(
                   "Here you'll find all updates on our Air Quality network",
                   style: TextStyle(
                     color: Colors.grey,

--- a/src/mobile/lib/src/app/other/language/services/app_localizations.dart
+++ b/src/mobile/lib/src/app/other/language/services/app_localizations.dart
@@ -26,23 +26,9 @@ class AppLocalizations with UiLoggy {
       loggy.info(
           'Loaded translations for ${locale.languageCode}: $_localizedStrings');
       return true;
-    } catch (e) {
-      loggy
-          .warning('Error loading translations for ${locale.languageCode}: $e');
-
-      if (locale.languageCode != 'en') {
-        try {
-          String jsonString =
-              await rootBundle.loadString('assets/lang/en.json');
-          Map<String, dynamic> jsonMap = json.decode(jsonString);
-          _localizedStrings = _flattenJson(jsonMap);
-          loggy.info(
-              'Loaded fallback translations for English: $_localizedStrings');
-          return true;
-        } catch (e) {
-          loggy.error('Error loading fallback translations: $e');
-        }
-      }
+    } catch (_) {
+      // Static JSON assets are not bundled for this locale.
+      // Translations are handled dynamically via SunbirdTranslationService.
       return false;
     }
   }

--- a/src/mobile/lib/src/app/profile/pages/edit_profile.dart
+++ b/src/mobile/lib/src/app/profile/pages/edit_profile.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:airqo/src/app/profile/bloc/user_bloc.dart';
 import 'package:airqo/src/app/profile/pages/widgets/profile_picture_selector.dart';
 import 'package:airqo/src/app/shared/widgets/translated_text.dart';
+import 'package:airqo/src/app/shared/widgets/translated_tooltip.dart';
 import 'package:airqo/src/meta/utils/colors.dart';
 import 'package:airqo/src/app/auth/services/auth_helper.dart';
 import 'package:airqo/src/app/shared/repository/secure_storage_repository.dart';
@@ -586,7 +587,7 @@ class _EditProfileState extends State<EditProfile> with UiLoggy {
             actions: [
               TextButton(
                 onPressed: _isLoading ? null : _updateProfile,
-                child: Tooltip(
+                child: TranslatedTooltip(
                   message: _isLoading ? 'Uploading...' : 'Save changes',
                   child: _isLoading
                       ? SizedBox(

--- a/src/mobile/lib/src/app/profile/pages/guest_profile page.dart
+++ b/src/mobile/lib/src/app/profile/pages/guest_profile page.dart
@@ -1,5 +1,6 @@
 import 'package:airqo/src/app/auth/pages/login_page.dart';
 import 'package:airqo/src/app/profile/pages/widgets/guest_settings_widget.dart';
+import 'package:airqo/src/app/shared/widgets/translated_text.dart';
 //import 'package:airqo/src/app/profile/pages/widgets/settings_tile.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
@@ -72,7 +73,7 @@ class _GuestProfilePageState extends State<GuestProfilePage> {
                 ),
 
 
-                Text(
+                TranslatedText(
                   "Guest User",
                   style: TextStyle(
                     color: Theme.of(context).textTheme.headlineSmall?.color,
@@ -84,7 +85,7 @@ class _GuestProfilePageState extends State<GuestProfilePage> {
               SizedBox(height: 32),
               Container(
                 margin: const EdgeInsets.symmetric(horizontal: 20),
-                child: Text(
+                child: TranslatedText(
                   'Settings',
                 style:TextStyle(
                   color: Theme.of(context).textTheme.headlineSmall?.color,
@@ -125,7 +126,7 @@ class _GuestProfilePageState extends State<GuestProfilePage> {
                   child: Center(
                     child: isLoading
                         ? Spinner()
-                        : Text(
+                        : TranslatedText(
                       "Create Account",
                       style: TextStyle(
                         fontWeight: FontWeight.w500,
@@ -154,7 +155,7 @@ class _GuestProfilePageState extends State<GuestProfilePage> {
                   child: Center(
                     child: isLoading
                         ? Spinner()
-                        : Text(
+                        : TranslatedText(
                       "Login",
                       style: TextStyle(
                         fontWeight: FontWeight.w500,

--- a/src/mobile/lib/src/app/profile/pages/widgets/settings_widget.dart
+++ b/src/mobile/lib/src/app/profile/pages/widgets/settings_widget.dart
@@ -85,7 +85,7 @@ class _SettingsWidgetState extends State<SettingsWidget> {
 
   void _showSnackBar(String message) {
     ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text(message)),
+      SnackBar(content: TranslatedText(message)),
     );
   }
 

--- a/src/mobile/lib/src/app/shared/pages/maintenance_page.dart
+++ b/src/mobile/lib/src/app/shared/pages/maintenance_page.dart
@@ -1,3 +1,4 @@
+import 'package:airqo/src/app/shared/widgets/translated_text.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 
@@ -20,7 +21,7 @@ class MaintenancePage extends StatelessWidget {
               height: maxWidth * 0.5,
             ),
             SizedBox(height: maxHeight * 0.05),
-            Text(
+            TranslatedText(
               "The app is currently under maintenance",
               style: Theme.of(context).textTheme.headlineLarge!.copyWith(
                     fontSize: maxWidth * 0.06,
@@ -28,7 +29,7 @@ class MaintenancePage extends StatelessWidget {
                   ),
             ),
             SizedBox(height: maxHeight * 0.02),
-            Text(
+            TranslatedText(
               "We're having issues with our network\nno worries, we'll be back up soon.",
               textAlign: TextAlign.center,
               style: TextStyle(

--- a/src/mobile/lib/src/app/shared/services/sunbird_translation_service.dart
+++ b/src/mobile/lib/src/app/shared/services/sunbird_translation_service.dart
@@ -310,6 +310,80 @@ class SunbirdTranslationService with UiLoggy {
     'Research Study',
     'Thank you for joining our research study!',
 
+    // Onboarding
+    '👋 Welcome to AirQo!',
+    'Clean Air for all African Cities.',
+    '🌿 Breathe Clean',
+    'Track and monitor the quality of air you breathe',
+    '✨ Know Your Air',
+    'Learn and reduce air pollution in your community',
+
+    // Dashboard empty / location selection
+    'Add places you love',
+    'Start by adding locations you care about.',
+    '+Add Location',
+    'Cannot Remove Default Location',
+    'You need to have at least one location in My Places. Add another location before removing this one.',
+    'Select Locations',
+    'Search Villages, Cities or Countries',
+    'Swipe left to remove location',
+    'Remove',
+    'Unknown location',
+    'Unknown',
+    'PM2.5',
+    'Low Cost Sensor',
+    'Reference Monitor',
+    'You can select up to',
+    'Location added to favorites',
+    'Location removed from favorites',
+    'Locations saved successfully',
+    'Maximum of',
+    'favorite locations reached',
+    'Your session has expired. Please log in again.',
+    'Authentication issue detected. Please log in again.',
+    'Clear All',
+    'Save',
+
+    // Health tip taglines
+    'Enjoy outdoor activities in good air quality',
+    'Air quality is acceptable for most people',
+    'Sensitive groups should limit outdoor exertion',
+    'Everyone should reduce prolonged outdoor activities',
+    'Everyone should avoid outdoor activities',
+    'Everyone should avoid all outdoor activities',
+    'Stay informed about air quality',
+
+    // Guest profile
+    'Guest User',
+
+    // Notifications
+    'No Notifications',
+    "Here you'll find all updates on our Air Quality network",
+    "You're all cleared up",
+    'You deserve some ice cream!',
+
+    // Maintenance
+    'The app is currently under maintenance',
+    "We're having issues with our network\nno worries, we'll be back up soon.",
+
+    // Profile / edit
+    'Image selected. Save to upload.',
+    'First name cannot be empty',
+    'Last name cannot be empty',
+    'Email cannot be empty',
+    'Please enter a valid email address',
+    'Profile image successfully added',
+    'Profile updated successfully',
+    'Unable to update profile. Please try again.',
+    'Check your internet connection and try again.',
+    'Something went wrong. Please try again later.',
+
+    // Settings snackbars
+    'Please enable location services in settings.',
+    'Location permission denied.',
+    'Location permission permanently denied. Please enable it in settings.',
+    'An unexpected error occurred during logout',
+
     // Shared / System
     'An Error Occurred',
     'Skip This Version',

--- a/src/mobile/lib/src/app/shared/services/sunbird_translation_service.dart
+++ b/src/mobile/lib/src/app/shared/services/sunbird_translation_service.dart
@@ -181,6 +181,22 @@ class SunbirdTranslationService with UiLoggy {
     'Hazardous',
     'Unknown',
 
+    // Tooltip messages
+    'View air quality in locations closest to you',
+    'Save your most relevant locations in one place',
+    'Sign in or create an account',
+    'View your profile',
+    'Sign in to access your profile',
+    'Air Quality is Good',
+    'Air Quality is Moderate',
+    'Air Quality is Unhealthy for Sensitive Groups',
+    'Air Quality is Unhealthy',
+    'Air Quality is Very Unhealthy',
+    'Air Quality is Hazardous',
+    'Air Quality is Unknown',
+    'Uploading...',
+    'Save changes',
+
     // Auth
     'Login',
     'Cancel',

--- a/src/mobile/lib/src/app/shared/widgets/airqo_button.dart
+++ b/src/mobile/lib/src/app/shared/widgets/airqo_button.dart
@@ -1,4 +1,5 @@
 import 'package:airqo/src/app/shared/widgets/spinner.dart';
+import 'package:airqo/src/app/shared/widgets/translated_text.dart';
 import 'package:flutter/material.dart';
 
 class AirQoButton extends StatelessWidget {
@@ -39,7 +40,7 @@ class AirQoButton extends StatelessWidget {
                       SizedBox(
                         width: 4,
                       ),
-                      Text(
+                      TranslatedText(
                         label,
                         style: TextStyle(
                             fontSize: 15,

--- a/src/mobile/lib/src/app/shared/widgets/form_field.dart
+++ b/src/mobile/lib/src/app/shared/widgets/form_field.dart
@@ -1,7 +1,11 @@
 import 'package:airqo/src/meta/utils/colors.dart';
+import 'package:airqo/src/app/other/language/bloc/language_bloc.dart';
+import 'package:airqo/src/app/shared/services/mlkit_translation_service.dart';
+import 'package:airqo/src/app/shared/services/sunbird_translation_service.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 
-class FormFieldWidget extends StatelessWidget {
+class FormFieldWidget extends StatefulWidget {
   final bool? isAuthFormField;
   final String? Function(String? value)? validator;
   final TextEditingController controller;
@@ -19,7 +23,8 @@ class FormFieldWidget extends StatelessWidget {
   final void Function(String)? onChanged;
 
   const FormFieldWidget(
-      {super.key, this.validator,
+      {super.key,
+      this.validator,
       this.isPassword,
       this.enabled,
       this.prefixIcon,
@@ -34,76 +39,145 @@ class FormFieldWidget extends StatelessWidget {
       this.maxLines,
       this.height,
       required this.controller});
+
+  @override
+  State<FormFieldWidget> createState() => _FormFieldWidgetState();
+}
+
+class _FormFieldWidgetState extends State<FormFieldWidget> {
+  String _hint = '';
+  String _label = '';
+  String? _lastLocale;
+
+  @override
+  void initState() {
+    super.initState();
+    _hint = widget.hintText ?? '';
+    _label = widget.label ?? '';
+  }
+
+  void _translate(String localeCode) {
+    final isSunbird = SunbirdTranslationService().supportsTranslation(localeCode);
+    final isMlKit = MlKitTranslationService().supportsTranslation(localeCode);
+
+    if (!isSunbird && !isMlKit) {
+      if (_hint != (widget.hintText ?? '') || _label != (widget.label ?? '')) {
+        setState(() {
+          _hint = widget.hintText ?? '';
+          _label = widget.label ?? '';
+        });
+      }
+      return;
+    }
+
+    final requestLocale = localeCode;
+
+    if (widget.hintText != null && widget.hintText!.isNotEmpty) {
+      final future = isSunbird
+          ? SunbirdTranslationService().translate(widget.hintText!, targetLocale: localeCode)
+          : MlKitTranslationService().translate(widget.hintText!, targetLocale: localeCode);
+      future.then((result) {
+        if (mounted && requestLocale == _lastLocale && _hint != result) {
+          setState(() => _hint = result);
+        }
+      });
+    }
+
+    if (widget.label != null && widget.label!.isNotEmpty) {
+      final future = isSunbird
+          ? SunbirdTranslationService().translate(widget.label!, targetLocale: localeCode)
+          : MlKitTranslationService().translate(widget.label!, targetLocale: localeCode);
+      future.then((result) {
+        if (mounted && requestLocale == _lastLocale && _label != result) {
+          setState(() => _label = result);
+        }
+      });
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
-    return isAuthFormField == null || !isAuthFormField!
-        ? Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                label ?? "",
-                style: TextStyle(color: Color(0xff4B4E56)),
-              ),
-              SizedBox(height: 8),
-              SizedBox(
-                child: TextFormField(
-                    enabled: enabled ?? true,
-                    autofocus: false,
-                    style: TextStyle(
-                        fontSize: 14,
-                        color: Theme.of(context).brightness == Brightness.dark
-                            ? Colors.white
-                            : Colors.black),
-                    cursorColor: AppColors.primaryColor,
-                    autocorrect: false,
-                    validator: validator,
-                    onEditingComplete: onEditingComplete,
-                    onChanged: onChanged,
-                    maxLines: maxLines ?? 1,
-                    keyboardType: textInputType,
-                    obscureText: isPassword ?? false,
-                    decoration: InputDecoration(
-                        contentPadding: const EdgeInsets.symmetric(
-                            vertical: 19, horizontal: 10),
-                        hintStyle: TextStyle(color: Color(0xff7A7F87)),
-                        suffixIconColor: Colors.grey,
-                        suffixIcon: suffixIcon,
-                        fillColor: Theme.of(context).highlightColor,
-                        disabledBorder: OutlineInputBorder(
-                            borderSide: BorderSide(color: Colors.transparent)),
-                        focusedBorder: OutlineInputBorder(
-                            borderSide:
-                                BorderSide(color: AppColors.primaryColor)),
-                        enabledBorder: OutlineInputBorder(
-                            borderSide: BorderSide(color: Colors.transparent)),
-                        filled: true,
-                        prefixIcon: prefixIcon,
-                        border: InputBorder.none,
-                        hintText: hintText),
-                    controller: controller),
-              ),
-            ],
-          )
-        : SizedBox(
-            child: TextFormField(
-              cursorColor: AppColors.primaryColor,
-              controller: controller,
-              validator: validator,
-              onChanged: onChanged,
-              obscureText: isPassword ?? false,
-              decoration: InputDecoration(
-                  hintText: hintText,
-                  iconColor: AppColors.primaryColor,
-                  prefixIconColor: AppColors.primaryColor,
-                  suffixIconColor: AppColors.primaryColor,
-                  focusedBorder: UnderlineInputBorder(
-                    borderSide: BorderSide(color: AppColors.primaryColor),
+    return BlocBuilder<LanguageBloc, LanguageState>(
+      builder: (context, state) {
+        final localeCode = state is LanguageLoaded ? state.languageCode : 'en';
+
+        if (localeCode != _lastLocale) {
+          _lastLocale = localeCode;
+          _hint = widget.hintText ?? '';
+          _label = widget.label ?? '';
+          _translate(localeCode);
+        }
+
+        return widget.isAuthFormField == null || !widget.isAuthFormField!
+            ? Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    _label,
+                    style: const TextStyle(color: Color(0xff4B4E56)),
                   ),
-                  hintStyle: TextStyle(color: Colors.grey),
-                  focusColor: AppColors.primaryColor,
-                  hoverColor: AppColors.primaryColor,
-                  icon: prefixIcon),
-            ),
-          );
+                  const SizedBox(height: 8),
+                  SizedBox(
+                    child: TextFormField(
+                        enabled: widget.enabled ?? true,
+                        autofocus: false,
+                        style: TextStyle(
+                            fontSize: 14,
+                            color: Theme.of(context).brightness == Brightness.dark
+                                ? Colors.white
+                                : Colors.black),
+                        cursorColor: AppColors.primaryColor,
+                        autocorrect: false,
+                        validator: widget.validator,
+                        onEditingComplete: widget.onEditingComplete,
+                        onChanged: widget.onChanged,
+                        maxLines: widget.maxLines ?? 1,
+                        keyboardType: widget.textInputType,
+                        obscureText: widget.isPassword ?? false,
+                        decoration: InputDecoration(
+                            contentPadding: const EdgeInsets.symmetric(
+                                vertical: 19, horizontal: 10),
+                            hintStyle: const TextStyle(color: Color(0xff7A7F87)),
+                            suffixIconColor: Colors.grey,
+                            suffixIcon: widget.suffixIcon,
+                            fillColor: Theme.of(context).highlightColor,
+                            disabledBorder: const OutlineInputBorder(
+                                borderSide: BorderSide(color: Colors.transparent)),
+                            focusedBorder: OutlineInputBorder(
+                                borderSide:
+                                    BorderSide(color: AppColors.primaryColor)),
+                            enabledBorder: const OutlineInputBorder(
+                                borderSide: BorderSide(color: Colors.transparent)),
+                            filled: true,
+                            prefixIcon: widget.prefixIcon,
+                            border: InputBorder.none,
+                            hintText: _hint),
+                        controller: widget.controller),
+                  ),
+                ],
+              )
+            : SizedBox(
+                child: TextFormField(
+                  cursorColor: AppColors.primaryColor,
+                  controller: widget.controller,
+                  validator: widget.validator,
+                  onChanged: widget.onChanged,
+                  obscureText: widget.isPassword ?? false,
+                  decoration: InputDecoration(
+                      hintText: _hint,
+                      iconColor: AppColors.primaryColor,
+                      prefixIconColor: AppColors.primaryColor,
+                      suffixIconColor: AppColors.primaryColor,
+                      focusedBorder: UnderlineInputBorder(
+                        borderSide: BorderSide(color: AppColors.primaryColor),
+                      ),
+                      hintStyle: const TextStyle(color: Colors.grey),
+                      focusColor: AppColors.primaryColor,
+                      hoverColor: AppColors.primaryColor,
+                      icon: widget.prefixIcon),
+                ),
+              );
+      },
+    );
   }
 }

--- a/src/mobile/lib/src/app/shared/widgets/translated_text.dart
+++ b/src/mobile/lib/src/app/shared/widgets/translated_text.dart
@@ -50,16 +50,22 @@ class _TranslatedTextState extends State<TranslatedText> {
     }
 
     final requestLocale = localeCode;
+    final requestText = widget.text;
     final future = isSunbird
         ? SunbirdTranslationService()
-            .translate(widget.text, targetLocale: localeCode)
+            .translate(requestText, targetLocale: localeCode)
         : MlKitTranslationService()
-            .translate(widget.text, targetLocale: localeCode);
+            .translate(requestText, targetLocale: localeCode);
 
     future.then((result) {
-      if (mounted && requestLocale == _lastLocale && _displayed != result) {
+      if (mounted &&
+          requestLocale == _lastLocale &&
+          requestText == _lastSourceText &&
+          _displayed != result) {
         setState(() => _displayed = result);
       }
+    }).catchError((_) {
+      // Translation failed; keep showing the original text.
     });
   }
 

--- a/src/mobile/lib/src/app/shared/widgets/translated_tooltip.dart
+++ b/src/mobile/lib/src/app/shared/widgets/translated_tooltip.dart
@@ -65,18 +65,22 @@ class _TranslatedTooltipState extends State<TranslatedTooltip> {
     }
 
     final requestLocale = localeCode;
+    final requestMessage = widget.message;
     final future = isSunbird
         ? SunbirdTranslationService()
-            .translate(widget.message, targetLocale: localeCode)
+            .translate(requestMessage, targetLocale: localeCode)
         : MlKitTranslationService()
-            .translate(widget.message, targetLocale: localeCode);
+            .translate(requestMessage, targetLocale: localeCode);
 
     future.then((result) {
       if (mounted &&
           requestLocale == _lastLocale &&
+          requestMessage == _lastSourceMessage &&
           _translatedMessage != result) {
         setState(() => _translatedMessage = result);
       }
+    }).catchError((_) {
+      // Translation failed; keep showing the original message.
     });
   }
 

--- a/src/mobile/lib/src/app/shared/widgets/translated_tooltip.dart
+++ b/src/mobile/lib/src/app/shared/widgets/translated_tooltip.dart
@@ -1,0 +1,115 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:airqo/src/app/other/language/bloc/language_bloc.dart';
+import 'package:airqo/src/app/shared/services/mlkit_translation_service.dart';
+import 'package:airqo/src/app/shared/services/sunbird_translation_service.dart';
+
+/// A drop-in replacement for [Tooltip] that automatically translates [message]
+/// using the appropriate backend:
+/// - Luganda → Sunbird AI
+/// - Swahili, French → Google ML Kit (on-device, free)
+///
+/// Use [tooltipKey] instead of [key] when you need a [GlobalKey<TooltipState>]
+/// to programmatically show/hide the tooltip.
+class TranslatedTooltip extends StatefulWidget {
+  final String message;
+  final Widget child;
+  final GlobalKey? tooltipKey;
+  final TooltipTriggerMode? triggerMode;
+  final bool? preferBelow;
+  final double? verticalOffset;
+  final Duration? showDuration;
+  final Decoration? decoration;
+  final TextStyle? textStyle;
+  final EdgeInsetsGeometry? margin;
+
+  const TranslatedTooltip({
+    super.key,
+    required this.message,
+    required this.child,
+    this.tooltipKey,
+    this.triggerMode,
+    this.preferBelow,
+    this.verticalOffset,
+    this.showDuration,
+    this.decoration,
+    this.textStyle,
+    this.margin,
+  });
+
+  @override
+  State<TranslatedTooltip> createState() => _TranslatedTooltipState();
+}
+
+class _TranslatedTooltipState extends State<TranslatedTooltip> {
+  String _translatedMessage = '';
+  String? _lastLocale;
+  String? _lastSourceMessage;
+
+  @override
+  void initState() {
+    super.initState();
+    _translatedMessage = widget.message;
+  }
+
+  void _translate(String localeCode) {
+    final isSunbird =
+        SunbirdTranslationService().supportsTranslation(localeCode);
+    final isMlKit = MlKitTranslationService().supportsTranslation(localeCode);
+
+    if (!isSunbird && !isMlKit) {
+      if (_translatedMessage != widget.message) {
+        setState(() => _translatedMessage = widget.message);
+      }
+      return;
+    }
+
+    final requestLocale = localeCode;
+    final future = isSunbird
+        ? SunbirdTranslationService()
+            .translate(widget.message, targetLocale: localeCode)
+        : MlKitTranslationService()
+            .translate(widget.message, targetLocale: localeCode);
+
+    future.then((result) {
+      if (mounted &&
+          requestLocale == _lastLocale &&
+          _translatedMessage != result) {
+        setState(() => _translatedMessage = result);
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<LanguageBloc, LanguageState>(
+      builder: (context, state) {
+        final localeCode =
+            state is LanguageLoaded ? state.languageCode : 'en';
+
+        final localeChanged = localeCode != _lastLocale;
+        final messageChanged = widget.message != _lastSourceMessage;
+
+        if (localeChanged || messageChanged) {
+          _lastLocale = localeCode;
+          _lastSourceMessage = widget.message;
+          _translatedMessage = widget.message;
+          _translate(localeCode);
+        }
+
+        return Tooltip(
+          key: widget.tooltipKey,
+          message: _translatedMessage,
+          triggerMode: widget.triggerMode,
+          preferBelow: widget.preferBelow,
+          verticalOffset: widget.verticalOffset,
+          showDuration: widget.showDuration,
+          decoration: widget.decoration,
+          textStyle: widget.textStyle,
+          margin: widget.margin,
+          child: widget.child,
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
- Remove Locale('lg') from MaterialApp.supportedLocales; GlobalMaterialLocalizations does not support Luganda, causing cascading "No MaterialLocalizations found" errors on AppBar, TabBar, BottomNavigationBar, TextField, and RefreshIndicator widgets
- Silence noisy error logs in AppLocalizations.load() for missing assets/lang/*.json; Luganda translation is handled dynamically via SunbirdTranslationService and does not rely on bundled JSON assets



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tooltips across the app now use a translated tooltip component that displays localized messages automatically.
* **Refactor**
  * Localization handling updated: Luganda is excluded from the static supported locales and is handled dynamically.
  * JSON asset load failures for locale data now surface as a failed load (translations routed to dynamic services).
* **Chores**
  * Prewarmed translation strings expanded to cover tooltip, AQI, and save/upload messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->