### PR TITLE
Add comprehensive public-facing API docs for partners and cities

### DIFF
--- a/src/docs-website/docs/api/analytics-api/_category_.json
+++ b/src/docs-website/docs/api/analytics-api/_category_.json
@@ -1,0 +1,6 @@
+{
+  "label": "Analytics API",
+  "position": 5,
+  "collapsible": true,
+  "collapsed": true
+}

--- a/src/docs-website/docs/api/analytics-api/calibrated-data.md
+++ b/src/docs-website/docs/api/analytics-api/calibrated-data.md
@@ -1,0 +1,186 @@
+---
+sidebar_position: 2
+sidebar_label: Calibrated Data Download
+---
+
+# Calibrated Data Download
+
+Retrieve AI-calibrated PM2.5 and PM10 measurements at hourly or daily resolution. Calibrated data has been processed through AirQo's machine learning models to correct for environmental factors such as temperature and humidity, making it more suitable for analysis and reporting than raw readings.
+
+:::info Tier requirement
+Requires a **Standard Tier** subscription or above.
+:::
+
+---
+
+## Endpoint
+
+```
+POST https://api.airqo.net/api/v3/public/analytics/data-download
+Content-Type: application/json
+Authorization: Bearer YOUR_SECRET_TOKEN
+```
+
+---
+
+## Request parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `network` | string | Yes | Always `"airqo"` |
+| `startDateTime` | string | Yes | Start timestamp (ISO 8601) |
+| `endDateTime` | string | Yes | End timestamp (ISO 8601) |
+| `datatype` | string | Yes | Must be `"calibrated"` |
+| `downloadType` | string | Yes | Must be `"json"` |
+| `frequency` | string | Yes | `"hourly"` or `"daily"` |
+| `device_category` | string | No | Filter by device type (e.g. `"lowcost"`) |
+| `device_names` | array | No | Specific device identifiers |
+| `sites` | array | No | Specific Site IDs |
+| `pollutants` | array | No | e.g. `["pm2_5", "pm10"]` |
+| `metaDataFields` | array | No | e.g. `["latitude", "longitude"]` |
+| `weatherFields` | array | No | e.g. `["temperature", "humidity"]` |
+| `cursor` | string | No | Pagination cursor from previous response |
+
+---
+
+## Example request — hourly calibrated data
+
+```bash
+curl -X POST "https://api.airqo.net/api/v3/public/analytics/data-download" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_SECRET_TOKEN" \
+  -d '{
+    "network": "airqo",
+    "datatype": "calibrated",
+    "downloadType": "json",
+    "startDateTime": "2025-01-01T00:00:00Z",
+    "endDateTime": "2025-01-02T00:00:00Z",
+    "device_category": "lowcost",
+    "pollutants": ["pm2_5", "pm10"],
+    "metaDataFields": ["latitude", "longitude"],
+    "weatherFields": ["temperature", "humidity"],
+    "frequency": "hourly"
+  }'
+```
+
+**Python:**
+
+```python
+import requests
+
+token = 'YOUR_SECRET_TOKEN'
+
+payload = {
+    "network": "airqo",
+    "datatype": "calibrated",
+    "downloadType": "json",
+    "startDateTime": "2025-01-01T00:00:00Z",
+    "endDateTime": "2025-01-31T23:59:59Z",
+    "pollutants": ["pm2_5", "pm10"],
+    "metaDataFields": ["latitude", "longitude"],
+    "frequency": "hourly"
+}
+
+response = requests.post(
+    "https://api.airqo.net/api/v3/public/analytics/data-download",
+    json=payload,
+    headers={"Authorization": f"Bearer {token}"}
+)
+data = response.json()
+
+for record in data['data']:
+    print(f"{record['datetime']} — {record['device_name']}: PM2.5 = {record['pm2_5']} μg/m³")
+```
+
+**JavaScript:**
+
+```js
+const response = await fetch(
+  'https://api.airqo.net/api/v3/public/analytics/data-download',
+  {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer YOUR_SECRET_TOKEN'
+    },
+    body: JSON.stringify({
+      network: 'airqo',
+      datatype: 'calibrated',
+      downloadType: 'json',
+      startDateTime: '2025-01-01T00:00:00Z',
+      endDateTime: '2025-01-31T23:59:59Z',
+      pollutants: ['pm2_5', 'pm10'],
+      metaDataFields: ['latitude', 'longitude'],
+      frequency: 'hourly'
+    })
+  }
+);
+const data = await response.json();
+```
+
+---
+
+## Example response
+
+```json
+{
+  "status": "success",
+  "message": "Data downloaded successfully",
+  "data": [
+    {
+      "site_name": "Kampala Road",
+      "device_name": "airqo_bx2847",
+      "datetime": "2025-01-01 10:00:00Z",
+      "pm2_5": 12.45,
+      "pm10": 15.32,
+      "latitude": 0.33,
+      "longitude": 32.56,
+      "temperature": 24.5,
+      "humidity": 65.4,
+      "network": "airqo",
+      "frequency": "hourly"
+    }
+  ],
+  "metadata": {
+    "total_count": 500,
+    "has_more": false,
+    "next": null
+  }
+}
+```
+
+---
+
+## Response fields
+
+| Field | Description |
+|-------|-------------|
+| `site_name` | Human-readable site name |
+| `device_name` | Device identifier |
+| `datetime` | Measurement timestamp |
+| `pm2_5` | Calibrated PM2.5 in μg/m³ |
+| `pm10` | Calibrated PM10 in μg/m³ |
+| `latitude` / `longitude` | Device location |
+| `temperature` | Ambient temperature (°C) |
+| `humidity` | Relative humidity (%) |
+| `frequency` | `"hourly"` or `"daily"` |
+| `metadata.has_more` | Whether more pages are available |
+| `metadata.next` | Cursor for the next page |
+
+---
+
+## Calibrated vs raw data
+
+| Aspect | Calibrated | Raw |
+|--------|-----------|-----|
+| Endpoint | `data-download` | `raw-data` |
+| Processing | ML-corrected for temperature & humidity | Unprocessed sensor output |
+| Resolution | Hourly or daily | Minute-level |
+| Use case | Analysis, dashboards, reporting | Advanced research, custom calibration |
+| Data quality | Higher (validated) | Lower (may have noise) |
+
+---
+
+## Pagination
+
+Use cursor-based pagination for large date ranges. See [Pagination →](../reference/pagination) for a complete walkthrough.

--- a/src/docs-website/docs/api/analytics-api/calibrated-data.md
+++ b/src/docs-website/docs/api/analytics-api/calibrated-data.md
@@ -16,9 +16,8 @@ Requires a **Standard Tier** subscription or above.
 ## Endpoint
 
 ```
-POST https://api.airqo.net/api/v3/public/analytics/data-download
+POST https://api.airqo.net/api/v3/public/analytics/data-download?token=YOUR_SECRET_TOKEN
 Content-Type: application/json
-Authorization: Bearer YOUR_SECRET_TOKEN
 ```
 
 ---
@@ -46,9 +45,8 @@ Authorization: Bearer YOUR_SECRET_TOKEN
 ## Example request — hourly calibrated data
 
 ```bash
-curl -X POST "https://api.airqo.net/api/v3/public/analytics/data-download" \
+curl -X POST "https://api.airqo.net/api/v3/public/analytics/data-download?token=YOUR_SECRET_TOKEN" \
   -H "Content-Type: application/json" \
-  -H "Authorization: Bearer YOUR_SECRET_TOKEN" \
   -d '{
     "network": "airqo",
     "datatype": "calibrated",
@@ -82,9 +80,8 @@ payload = {
 }
 
 response = requests.post(
-    "https://api.airqo.net/api/v3/public/analytics/data-download",
-    json=payload,
-    headers={"Authorization": f"Bearer {token}"}
+    f"https://api.airqo.net/api/v3/public/analytics/data-download?token={token}",
+    json=payload
 )
 data = response.json()
 
@@ -96,12 +93,11 @@ for record in data['data']:
 
 ```js
 const response = await fetch(
-  'https://api.airqo.net/api/v3/public/analytics/data-download',
+  `https://api.airqo.net/api/v3/public/analytics/data-download?token=${token}`,
   {
     method: 'POST',
     headers: {
-      'Content-Type': 'application/json',
-      Authorization: 'Bearer YOUR_SECRET_TOKEN'
+      'Content-Type': 'application/json'
     },
     body: JSON.stringify({
       network: 'airqo',

--- a/src/docs-website/docs/api/analytics-api/raw-data.md
+++ b/src/docs-website/docs/api/analytics-api/raw-data.md
@@ -15,7 +15,7 @@ Requires a **Standard Tier** subscription or above.
 
 ## Endpoint
 
-```
+```http
 POST https://api.airqo.net/api/v3/public/analytics/raw-data?token=YOUR_SECRET_TOKEN
 Content-Type: application/json
 ```

--- a/src/docs-website/docs/api/analytics-api/raw-data.md
+++ b/src/docs-website/docs/api/analytics-api/raw-data.md
@@ -1,0 +1,212 @@
+---
+sidebar_position: 1
+sidebar_label: Raw Sensor Data
+---
+
+# Raw Sensor Data
+
+Retrieve uncalibrated, minute-level sensor readings directly from AirQo devices. This endpoint is suited for advanced users who need high-resolution data or want to apply their own calibration.
+
+:::info Tier requirement
+Requires a **Standard Tier** subscription or above.
+:::
+
+---
+
+## Endpoint
+
+```
+POST https://api.airqo.net/api/v3/public/analytics/raw-data
+Content-Type: application/json
+Authorization: Bearer YOUR_SECRET_TOKEN
+```
+
+---
+
+## Request parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `network` | string | Yes | Always `"airqo"` |
+| `startDateTime` | string | Yes | Start timestamp (ISO 8601) |
+| `endDateTime` | string | Yes | End timestamp (ISO 8601) |
+| `pollutants` | array | Yes | Pollutants to retrieve (e.g. `["pm2_5", "pm10", "no2"]`) |
+| `device_category` | string | No | Filter by device type, e.g. `"lowcost"` or `"mobile"` |
+| `device_names` | array | No | Filter to specific device identifiers |
+| `metaDataFields` | array | No | Additional metadata (e.g. `["latitude", "longitude"]`) |
+| `weatherFields` | array | No | Weather data (e.g. `["temperature", "humidity"]`) |
+| `frequency` | string | No | `"raw"` (default) or `"aggregated"` |
+| `cursor` | string | No | Pagination cursor from previous response |
+
+---
+
+## Available pollutants
+
+| Pollutant field | Description |
+|----------------|-------------|
+| `pm2_5` | Fine particulate matter (calibrated channel 1) |
+| `pm10` | Coarse particulate matter |
+| `no2` | Nitrogen dioxide |
+| `s1_pm2_5` | Raw sensor channel 1 PM2.5 |
+| `s2_pm2_5` | Raw sensor channel 2 PM2.5 |
+| `s1_pm10` | Raw sensor channel 1 PM10 |
+| `s2_pm10` | Raw sensor channel 2 PM10 |
+
+---
+
+## Example request
+
+```bash
+curl -X POST "https://api.airqo.net/api/v3/public/analytics/raw-data" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_SECRET_TOKEN" \
+  -d '{
+    "network": "airqo",
+    "startDateTime": "2025-01-01T00:00:00Z",
+    "endDateTime": "2025-01-01T06:00:00Z",
+    "device_names": ["airqo_bx2847"],
+    "pollutants": ["pm2_5", "pm10", "no2"],
+    "metaDataFields": ["latitude", "longitude"],
+    "weatherFields": ["temperature", "humidity"],
+    "frequency": "raw"
+  }'
+```
+
+**Python:**
+
+```python
+import requests
+
+token = 'YOUR_SECRET_TOKEN'
+
+payload = {
+    "network": "airqo",
+    "startDateTime": "2025-01-01T00:00:00Z",
+    "endDateTime": "2025-01-01T06:00:00Z",
+    "device_names": ["airqo_bx2847"],
+    "pollutants": ["pm2_5", "pm10"],
+    "metaDataFields": ["latitude", "longitude"],
+    "weatherFields": ["temperature", "humidity"],
+    "frequency": "raw"
+}
+
+response = requests.post(
+    "https://api.airqo.net/api/v3/public/analytics/raw-data",
+    json=payload,
+    headers={"Authorization": f"Bearer {token}"}
+)
+data = response.json()
+
+print(f"Retrieved {len(data['data'])} raw readings")
+```
+
+**JavaScript:**
+
+```js
+const response = await fetch(
+  'https://api.airqo.net/api/v3/public/analytics/raw-data',
+  {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer YOUR_SECRET_TOKEN'
+    },
+    body: JSON.stringify({
+      network: 'airqo',
+      startDateTime: '2025-01-01T00:00:00Z',
+      endDateTime: '2025-01-01T06:00:00Z',
+      device_names: ['airqo_bx2847'],
+      pollutants: ['pm2_5', 'pm10'],
+      metaDataFields: ['latitude', 'longitude'],
+      frequency: 'raw'
+    })
+  }
+);
+const data = await response.json();
+```
+
+---
+
+## Example response
+
+```json
+{
+  "status": "success",
+  "message": "Data downloaded successfully",
+  "data": [
+    {
+      "device_name": "airqo_bx2847",
+      "datetime": "2025-01-01 00:05:00Z",
+      "s1_pm2_5": 14.2,
+      "s2_pm2_5": 14.8,
+      "s1_pm10": 18.4,
+      "s2_pm10": 18.9,
+      "latitude": 0.3476,
+      "longitude": 32.5825,
+      "temperature": 24.1,
+      "humidity": 68.5,
+      "network": "airqo",
+      "frequency": "raw"
+    }
+  ],
+  "metadata": {
+    "total_count": 2000,
+    "has_more": true,
+    "next": "eyJsYXN0SWQiOiI2NWM4Z..."
+  }
+}
+```
+
+---
+
+## Response fields
+
+| Field | Description |
+|-------|-------------|
+| `device_name` | Device identifier |
+| `datetime` | Timestamp of reading |
+| `s1_pm2_5` / `s2_pm2_5` | Raw dual-channel PM2.5 readings in μg/m³ |
+| `s1_pm10` / `s2_pm10` | Raw dual-channel PM10 readings in μg/m³ |
+| `latitude` / `longitude` | Device location |
+| `temperature` | Ambient temperature (°C) |
+| `humidity` | Relative humidity (%) |
+| `frequency` | Always `"raw"` for this endpoint |
+| `metadata.has_more` | Whether more pages exist |
+| `metadata.next` | Cursor to pass in the next request |
+
+---
+
+## Pagination
+
+Raw data queries can return millions of rows. Always paginate:
+
+```python
+all_records = []
+cursor = None
+
+while True:
+    payload = {**your_base_payload}
+    if cursor:
+        payload['cursor'] = cursor
+
+    response = requests.post(
+        "https://api.airqo.net/api/v3/public/analytics/raw-data",
+        json=payload,
+        headers={"Authorization": f"Bearer {token}"}
+    ).json()
+
+    all_records.extend(response['data'])
+
+    if not response['metadata']['has_more']:
+        break
+
+    cursor = response['metadata']['next']
+```
+
+---
+
+## Tips
+
+- **Limit date ranges** — raw data is high-volume. Use windows of 1–6 hours for exploratory queries.
+- **Specify only the pollutants you need** — omitting unused fields speeds up the response.
+- **Use mobile category** (`"device_category": "mobile"`) to query data from mobile monitoring units.

--- a/src/docs-website/docs/api/analytics-api/raw-data.md
+++ b/src/docs-website/docs/api/analytics-api/raw-data.md
@@ -16,9 +16,8 @@ Requires a **Standard Tier** subscription or above.
 ## Endpoint
 
 ```
-POST https://api.airqo.net/api/v3/public/analytics/raw-data
+POST https://api.airqo.net/api/v3/public/analytics/raw-data?token=YOUR_SECRET_TOKEN
 Content-Type: application/json
-Authorization: Bearer YOUR_SECRET_TOKEN
 ```
 
 ---
@@ -57,9 +56,8 @@ Authorization: Bearer YOUR_SECRET_TOKEN
 ## Example request
 
 ```bash
-curl -X POST "https://api.airqo.net/api/v3/public/analytics/raw-data" \
+curl -X POST "https://api.airqo.net/api/v3/public/analytics/raw-data?token=YOUR_SECRET_TOKEN" \
   -H "Content-Type: application/json" \
-  -H "Authorization: Bearer YOUR_SECRET_TOKEN" \
   -d '{
     "network": "airqo",
     "startDateTime": "2025-01-01T00:00:00Z",
@@ -91,9 +89,8 @@ payload = {
 }
 
 response = requests.post(
-    "https://api.airqo.net/api/v3/public/analytics/raw-data",
-    json=payload,
-    headers={"Authorization": f"Bearer {token}"}
+    f"https://api.airqo.net/api/v3/public/analytics/raw-data?token={token}",
+    json=payload
 )
 data = response.json()
 
@@ -104,12 +101,11 @@ print(f"Retrieved {len(data['data'])} raw readings")
 
 ```js
 const response = await fetch(
-  'https://api.airqo.net/api/v3/public/analytics/raw-data',
+  `https://api.airqo.net/api/v3/public/analytics/raw-data?token=${token}`,
   {
     method: 'POST',
     headers: {
-      'Content-Type': 'application/json',
-      Authorization: 'Bearer YOUR_SECRET_TOKEN'
+      'Content-Type': 'application/json'
     },
     body: JSON.stringify({
       network: 'airqo',
@@ -190,9 +186,8 @@ while True:
         payload['cursor'] = cursor
 
     response = requests.post(
-        "https://api.airqo.net/api/v3/public/analytics/raw-data",
-        json=payload,
-        headers={"Authorization": f"Bearer {token}"}
+        f"https://api.airqo.net/api/v3/public/analytics/raw-data?token={token}",
+        json=payload
     ).json()
 
     all_records.extend(response['data'])

--- a/src/docs-website/docs/api/for-cities/_category_.json
+++ b/src/docs-website/docs/api/for-cities/_category_.json
@@ -1,0 +1,6 @@
+{
+  "label": "For Cities",
+  "position": 4,
+  "collapsible": true,
+  "collapsed": false
+}

--- a/src/docs-website/docs/api/for-cities/historical-data.md
+++ b/src/docs-website/docs/api/for-cities/historical-data.md
@@ -21,7 +21,7 @@ To query historical data for your Grid, use the site names or device names from 
 
 ## Endpoint
 
-```
+```http
 POST https://api.airqo.net/api/v3/public/analytics/data-download?token=YOUR_SECRET_TOKEN
 Content-Type: application/json
 ```

--- a/src/docs-website/docs/api/for-cities/historical-data.md
+++ b/src/docs-website/docs/api/for-cities/historical-data.md
@@ -22,9 +22,8 @@ To query historical data for your Grid, use the site names or device names from 
 ## Endpoint
 
 ```
-POST https://api.airqo.net/api/v3/public/analytics/data-download
+POST https://api.airqo.net/api/v3/public/analytics/data-download?token=YOUR_SECRET_TOKEN
 Content-Type: application/json
-Authorization: Bearer YOUR_SECRET_TOKEN
 ```
 
 ---
@@ -51,9 +50,8 @@ Authorization: Bearer YOUR_SECRET_TOKEN
 ## Example request — daily aggregated data for a city
 
 ```bash
-curl -X POST "https://api.airqo.net/api/v3/public/analytics/data-download" \
+curl -X POST "https://api.airqo.net/api/v3/public/analytics/data-download?token=YOUR_SECRET_TOKEN" \
   -H "Content-Type: application/json" \
-  -H "Authorization: Bearer YOUR_SECRET_TOKEN" \
   -d '{
     "network": "airqo",
     "datatype": "calibrated",
@@ -95,9 +93,8 @@ while True:
         payload['cursor'] = cursor
 
     response = requests.post(
-        "https://api.airqo.net/api/v3/public/analytics/data-download",
-        json=payload,
-        headers={"Authorization": f"Bearer {token}"}
+        f"https://api.airqo.net/api/v3/public/analytics/data-download?token={token}",
+        json=payload
     ).json()
 
     all_records.extend(response['data'])
@@ -133,12 +130,11 @@ async function fetchAllCityHistory(siteIds, token) {
     const payload = cursor ? { ...basePayload, cursor } : basePayload;
 
     const response = await fetch(
-      'https://api.airqo.net/api/v3/public/analytics/data-download',
+      `https://api.airqo.net/api/v3/public/analytics/data-download?token=${token}`,
       {
         method: 'POST',
         headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${token}`
+          'Content-Type': 'application/json'
         },
         body: JSON.stringify(payload)
       }

--- a/src/docs-website/docs/api/for-cities/historical-data.md
+++ b/src/docs-website/docs/api/for-cities/historical-data.md
@@ -1,0 +1,202 @@
+---
+sidebar_position: 3
+sidebar_label: Historical Data
+---
+
+# Historical Data — Grid ID
+
+Access up to one year of calibrated air quality measurements for all sites within your city's Grid. Historical data is retrieved through the Analytics API using a `POST` request.
+
+:::info Tier requirement
+Historical data access requires a **Standard Tier** subscription or above.
+:::
+
+---
+
+## Overview
+
+To query historical data for your Grid, use the site names or device names from your Grid in the Analytics API request. You can discover the sites in your Grid by calling the [recent measurements endpoint](./recent-measurements) first and collecting the `site_id` and `device` values.
+
+---
+
+## Endpoint
+
+```
+POST https://api.airqo.net/api/v3/public/analytics/data-download
+Content-Type: application/json
+Authorization: Bearer YOUR_SECRET_TOKEN
+```
+
+---
+
+## Request parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `network` | string | Yes | Always `"airqo"` |
+| `startDateTime` | string | Yes | Start of range (ISO 8601) |
+| `endDateTime` | string | Yes | End of range (ISO 8601) |
+| `datatype` | string | Yes | `"calibrated"` |
+| `downloadType` | string | Yes | `"json"` |
+| `frequency` | string | Yes | `"hourly"` or `"daily"` |
+| `sites` | array | No | Filter to specific Site IDs in your Grid |
+| `device_names` | array | No | Filter to specific device names |
+| `pollutants` | array | No | e.g. `["pm2_5", "pm10"]` |
+| `metaDataFields` | array | No | e.g. `["latitude", "longitude"]` |
+| `weatherFields` | array | No | e.g. `["temperature", "humidity"]` |
+| `cursor` | string | No | Pagination cursor from previous response |
+
+---
+
+## Example request — daily aggregated data for a city
+
+```bash
+curl -X POST "https://api.airqo.net/api/v3/public/analytics/data-download" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_SECRET_TOKEN" \
+  -d '{
+    "network": "airqo",
+    "datatype": "calibrated",
+    "downloadType": "json",
+    "startDateTime": "2025-01-01T00:00:00Z",
+    "endDateTime": "2025-03-31T23:59:59Z",
+    "sites": ["64f7b3e8c9d25a0013f2d456", "64f7b3e8c9d25a0013f2d789"],
+    "pollutants": ["pm2_5", "pm10"],
+    "metaDataFields": ["latitude", "longitude"],
+    "frequency": "daily"
+  }'
+```
+
+**Python (with pagination):**
+
+```python
+import requests
+
+token = 'YOUR_SECRET_TOKEN'
+
+base_payload = {
+    "network": "airqo",
+    "datatype": "calibrated",
+    "downloadType": "json",
+    "startDateTime": "2025-01-01T00:00:00Z",
+    "endDateTime": "2025-03-31T23:59:59Z",
+    "sites": ["64f7b3e8c9d25a0013f2d456", "64f7b3e8c9d25a0013f2d789"],
+    "pollutants": ["pm2_5", "pm10"],
+    "metaDataFields": ["latitude", "longitude"],
+    "frequency": "daily"
+}
+
+all_records = []
+cursor = None
+
+while True:
+    payload = {**base_payload}
+    if cursor:
+        payload['cursor'] = cursor
+
+    response = requests.post(
+        "https://api.airqo.net/api/v3/public/analytics/data-download",
+        json=payload,
+        headers={"Authorization": f"Bearer {token}"}
+    ).json()
+
+    all_records.extend(response['data'])
+
+    if not response['metadata']['has_more']:
+        break
+
+    cursor = response['metadata']['next']
+
+print(f"Total records: {len(all_records)}")
+```
+
+**JavaScript (async):**
+
+```js
+async function fetchAllCityHistory(siteIds, token) {
+  const basePayload = {
+    network: 'airqo',
+    datatype: 'calibrated',
+    downloadType: 'json',
+    startDateTime: '2025-01-01T00:00:00Z',
+    endDateTime: '2025-03-31T23:59:59Z',
+    sites: siteIds,
+    pollutants: ['pm2_5', 'pm10'],
+    metaDataFields: ['latitude', 'longitude'],
+    frequency: 'daily'
+  };
+
+  let allRecords = [];
+  let cursor = null;
+
+  do {
+    const payload = cursor ? { ...basePayload, cursor } : basePayload;
+
+    const response = await fetch(
+      'https://api.airqo.net/api/v3/public/analytics/data-download',
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`
+        },
+        body: JSON.stringify(payload)
+      }
+    );
+
+    const data = await response.json();
+    allRecords = allRecords.concat(data.data);
+    cursor = data.metadata.has_more ? data.metadata.next : null;
+  } while (cursor);
+
+  return allRecords;
+}
+```
+
+---
+
+## Example response
+
+```json
+{
+  "status": "success",
+  "message": "Data downloaded successfully",
+  "data": [
+    {
+      "site_name": "Nairobi CBD",
+      "device_name": "airqo_k001",
+      "datetime": "2025-01-01 00:00:00Z",
+      "pm2_5": 18.7,
+      "pm10": 24.3,
+      "latitude": -1.2921,
+      "longitude": 36.8219,
+      "temperature": 21.4,
+      "humidity": 70.2,
+      "network": "airqo",
+      "frequency": "daily"
+    }
+  ],
+  "metadata": {
+    "total_count": 2400,
+    "has_more": true,
+    "next": "eyJsYXN0SWQiOiI2NWM4Z..."
+  }
+}
+```
+
+---
+
+## Choosing frequency
+
+| `frequency` value | Description | When to use |
+|-------------------|-------------|-------------|
+| `"hourly"` | One row per device per hour | Time-series analysis, charts |
+| `"daily"` | One row per device per day (average) | Monthly reports, trend summaries |
+
+---
+
+## Best practices
+
+- **Break large date ranges into months** — this avoids query timeouts and keeps responses manageable.
+- **Filter to only the sites you need** — specifying `sites` reduces the data returned.
+- **Cache your results** — historical data does not change, so you can store it locally and avoid re-querying.

--- a/src/docs-website/docs/api/for-cities/intro.md
+++ b/src/docs-website/docs/api/for-cities/intro.md
@@ -1,0 +1,82 @@
+---
+sidebar_position: 1
+sidebar_label: Overview
+---
+
+# For Cities — Grid ID Access
+
+This guide is for **city authorities, municipal agencies, and urban planners** who want to monitor air quality across an entire geographical area. Grid ID access groups all public AirQo monitoring sites within a defined administrative boundary — giving you a single identifier that covers your whole city or region.
+
+---
+
+## What is a Grid?
+
+A **Grid** is a geographically-defined grouping of monitoring sites. Every site within a city's or district's administrative boundary is automatically included. When you query a Grid ID, you get data from every public sensor in that area — with no need to manage individual site or device IDs.
+
+Grids are **inherently public** and are designed for transparency in regional air quality reporting.
+
+:::note Devices in private Cohorts
+If a device belongs to an organisation's private Cohort, it will **not** appear in Grid data unless the Cohort owner has made it public. Grid data reflects publicly accessible sensors only.
+:::
+
+---
+
+## Why Grid ID is the right choice for cities
+
+| Use case | How Grid ID helps |
+|----------|-------------------|
+| City-wide air quality dashboards | One query covers every public sensor |
+| Urban planning and policy decisions | Regional view aligned with administrative boundaries |
+| Public health studies | Population-level exposure data |
+| Environmental compliance reporting | Area-wide measurement history |
+| Spatial visualisation | Heatmap images with geo-boundaries included |
+
+---
+
+## Your Grid ID endpoint structure
+
+| Data | Endpoint |
+|------|----------|
+| Recent measurements | `GET /api/v2/devices/measurements/grids/{GRID_ID}?token={SECRET_TOKEN}` |
+| Historical measurements | `POST /api/v3/public/analytics/data-download` |
+| Spatial heatmap (city) | `GET /api/v2/spatial/heatmaps/{GRID_ID}?token={SECRET_TOKEN}` |
+| All available heatmaps | `GET /api/v2/spatial/heatmaps?token={SECRET_TOKEN}` |
+
+---
+
+## Finding your Grid ID
+
+- **Browse the metadata endpoints** at [docs.airqo.net/airqo-rest-api-documentation/api-endpoints/metadata](https://docs.airqo.net/airqo-rest-api-documentation/api-endpoints/metadata)
+- **Filter by location** using the `admin_level` query parameter (country, province, or city)
+- **Example:** The Grid ID for Nairobi is `64b7ac8fd7249f0029feca80`
+
+---
+
+## What data is available?
+
+| Data type | Available? | Notes |
+|-----------|-----------|-------|
+| Recent hourly measurements | ✅ Free | Last 7 days |
+| Spatial heatmaps | ✅ Free | Base64 PNG with boundary coordinates |
+| Historical calibrated data | ✅ Standard+ | Via Analytics API |
+| Raw sensor readings | ✅ Standard+ | Via Analytics API |
+| Air quality forecasts | ✅ Premium | Via site or device ID from your Grid |
+
+---
+
+## Real-world integrations
+
+City authorities already using Grid ID access:
+
+- **Kampala Capital City Authority** — [kcca.go.ug/kampala-air-quality-monitoring-network](https://kcca.go.ug/kampala-air-quality-monitoring-network)
+- **Lagos State Environmental Protection Agency** — [aqi.lasepa.gov.ng](https://aqi.lasepa.gov.ng/)
+- **Nairobi City County** — [nairobi.go.ke/nairobi-air-quality](https://nairobi.go.ke/nairobi-air-quality)
+
+---
+
+## Next steps
+
+- [Fetch recent measurements →](./recent-measurements)
+- [Access historical data →](./historical-data)
+- [Generate spatial heatmaps →](./spatial-heatmaps)
+- [Set up your account →](../getting-started/authentication)

--- a/src/docs-website/docs/api/for-cities/recent-measurements.md
+++ b/src/docs-website/docs/api/for-cities/recent-measurements.md
@@ -15,7 +15,7 @@ Available on all tiers including Free.
 
 ## Endpoint
 
-```
+```http
 GET https://api.airqo.net/api/v2/devices/measurements/grids/{GRID_ID}?token={SECRET_TOKEN}
 ```
 

--- a/src/docs-website/docs/api/for-cities/recent-measurements.md
+++ b/src/docs-website/docs/api/for-cities/recent-measurements.md
@@ -1,0 +1,172 @@
+---
+sidebar_position: 2
+sidebar_label: Recent Measurements
+---
+
+# Recent Measurements — Grid ID
+
+Retrieve the latest hourly calibrated air quality measurements from all public monitoring sites within your city's Grid. This endpoint returns data from approximately the last 7 days.
+
+:::info Tier requirement
+Available on all tiers including Free.
+:::
+
+---
+
+## Endpoint
+
+```
+GET https://api.airqo.net/api/v2/devices/measurements/grids/{GRID_ID}?token={SECRET_TOKEN}
+```
+
+### Path parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `GRID_ID` | string | Yes | Your city's Grid identifier |
+
+### Query parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `token` | string | Yes | Your SECRET TOKEN from Account Settings |
+
+---
+
+## Example request
+
+```bash
+curl -X GET \
+  "https://api.airqo.net/api/v2/devices/measurements/grids/64b7ac8fd7249f0029feca80?token=YOUR_SECRET_TOKEN"
+```
+
+**JavaScript (fetch):**
+
+```js
+const gridId = '64b7ac8fd7249f0029feca80'; // Nairobi example
+const token = 'YOUR_SECRET_TOKEN';
+
+const response = await fetch(
+  `https://api.airqo.net/api/v2/devices/measurements/grids/${gridId}?token=${token}`
+);
+const data = await response.json();
+
+console.log(`City has ${data.meta.total} total measurements.`);
+data.measurements.forEach(m => {
+  console.log(`[${m.time}] ${m.device}: PM2.5 = ${m.pm2_5?.value} μg/m³`);
+});
+```
+
+**Python:**
+
+```python
+import requests
+
+grid_id = '64b7ac8fd7249f0029feca80'  # Nairobi example
+token = 'YOUR_SECRET_TOKEN'
+
+response = requests.get(
+    f'https://api.airqo.net/api/v2/devices/measurements/grids/{grid_id}',
+    params={'token': token}
+)
+data = response.json()
+
+for m in data['measurements']:
+    print(f"[{m['time']}] {m['device']}: PM2.5 = {m['pm2_5']['value']} μg/m³")
+```
+
+---
+
+## Example response
+
+```json
+{
+  "success": true,
+  "isCache": false,
+  "message": "successfully returned the measurements",
+  "meta": {
+    "total": 420,
+    "skip": 0,
+    "limit": 50,
+    "page": 1,
+    "pages": 9,
+    "startTime": "2025-09-21T11:00:00.000Z",
+    "endTime": "2025-09-28T11:00:00.000Z"
+  },
+  "measurements": [
+    {
+      "device": "airqo_bx2847",
+      "device_id": "65c8d4a2f1b45c0012a3e789",
+      "site_id": "64f7b3e8c9d25a0013f2d456",
+      "time": "2025-09-25T14:00:00.000Z",
+      "pm2_5": {
+        "value": 23.45
+      },
+      "pm10": {
+        "value": 31.82
+      },
+      "frequency": "hourly",
+      "deviceDetails": {
+        "name": "airqo_bx2847",
+        "isOnline": true,
+        "status": "deployed",
+        "latitude": -1.2921,
+        "longitude": 36.8219,
+        "lastActive": "2025-09-25T14:00:00.000Z"
+      }
+    }
+  ]
+}
+```
+
+---
+
+## Response fields
+
+### `meta` object
+
+| Field | Description |
+|-------|-------------|
+| `total` | Total measurements matching the query |
+| `skip` | Records skipped (pagination) |
+| `limit` | Max records per page |
+| `page` | Current page |
+| `pages` | Total pages |
+| `startTime` | Query start (ISO 8601) |
+| `endTime` | Query end (ISO 8601) |
+
+### Measurement object
+
+| Field | Description |
+|-------|-------------|
+| `device` | Device name |
+| `device_id` | Unique device identifier |
+| `site_id` | Location identifier |
+| `time` | Reading timestamp (ISO 8601) |
+| `pm2_5.value` | PM2.5 concentration in μg/m³ |
+| `pm10.value` | PM10 concentration in μg/m³ |
+| `frequency` | Always `"hourly"` for this endpoint |
+| `deviceDetails.latitude` | Device latitude |
+| `deviceDetails.longitude` | Device longitude |
+| `deviceDetails.isOnline` | Whether device is currently active |
+
+---
+
+## Pagination
+
+Large city Grids can return hundreds of measurements. Use `limit` and `skip` to page through:
+
+```bash
+# Get next page (records 51–100)
+curl "https://api.airqo.net/api/v2/devices/measurements/grids/{GRID_ID}?token={SECRET_TOKEN}&limit=50&skip=50"
+```
+
+---
+
+## Need data older than 7 days?
+
+Use the [Analytics API for historical city data →](./historical-data).
+
+## Want a visual map of your city's air quality?
+
+See [Spatial Heatmaps →](./spatial-heatmaps) for generating Base64-encoded PNG heatmap images.

--- a/src/docs-website/docs/api/for-cities/spatial-heatmaps.md
+++ b/src/docs-website/docs/api/for-cities/spatial-heatmaps.md
@@ -1,0 +1,170 @@
+---
+sidebar_position: 4
+sidebar_label: Spatial Heatmaps
+---
+
+# Spatial Heatmaps — Grid ID
+
+Generate visual air quality heatmaps for your city. Heatmaps are returned as **Base64-encoded PNG images** with the geographic bounding box included, making them easy to overlay on maps.
+
+:::info Tier requirement
+Available on all tiers including Free.
+:::
+
+---
+
+## What is a heatmap?
+
+A spatial heatmap is a colour-coded image showing air quality levels across a city or region. Higher pollution levels appear in warmer colours; cleaner air appears in cooler colours. The `bounds` field gives you the southwest and northeast corners so you can position the image precisely on a map.
+
+---
+
+## Endpoints
+
+### Get heatmap for a specific city Grid
+
+```
+GET https://api.airqo.net/api/v2/spatial/heatmaps/{GRID_ID}?token={SECRET_TOKEN}
+```
+
+### Get all available heatmaps
+
+```
+GET https://api.airqo.net/api/v2/spatial/heatmaps?token={SECRET_TOKEN}
+```
+
+---
+
+## Example requests
+
+```bash
+# Single city heatmap
+curl -X GET \
+  "https://api.airqo.net/api/v2/spatial/heatmaps/64b7ac8fd7249f0029feca80?token=YOUR_SECRET_TOKEN"
+
+# All available city heatmaps
+curl -X GET \
+  "https://api.airqo.net/api/v2/spatial/heatmaps?token=YOUR_SECRET_TOKEN"
+```
+
+---
+
+## Example response
+
+```json
+[
+  {
+    "bounds": [
+      [-1.444, 36.650],
+      [-1.163, 37.102]
+    ],
+    "city": "nairobi_city",
+    "id": "64b7ac8fd7249f0029feca80",
+    "image": "data:image/png;base64,iVBORw0KGgo...",
+    "message": "✅ AQI image generated for nairobi_city"
+  }
+]
+```
+
+---
+
+## Response fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `bounds` | array | `[[sw_lat, sw_lng], [ne_lat, ne_lng]]` — bounding box corners |
+| `city` | string | City slug identifier |
+| `id` | string | The Grid ID used in the request |
+| `image` | string | Base64-encoded PNG heatmap (`data:image/png;base64,...`) |
+| `message` | string | Generation status message |
+
+---
+
+## Displaying the heatmap in a web page
+
+### Plain HTML
+
+```html
+<img
+  id="airquality-heatmap"
+  src=""
+  alt="City air quality heatmap"
+  style="width: 100%; border-radius: 8px;"
+/>
+
+<script>
+  async function loadHeatmap(gridId, token) {
+    const response = await fetch(
+      `https://api.airqo.net/api/v2/spatial/heatmaps/${gridId}?token=${token}`
+    );
+    const [heatmap] = await response.json();
+    document.getElementById('airquality-heatmap').src = heatmap.image;
+  }
+
+  loadHeatmap('64b7ac8fd7249f0029feca80', 'YOUR_SECRET_TOKEN');
+</script>
+```
+
+### Leaflet map overlay (JavaScript)
+
+```js
+import L from 'leaflet';
+
+async function addHeatmapOverlay(map, gridId, token) {
+  const response = await fetch(
+    `https://api.airqo.net/api/v2/spatial/heatmaps/${gridId}?token=${token}`
+  );
+  const [heatmap] = await response.json();
+
+  const [[swLat, swLng], [neLat, neLng]] = heatmap.bounds;
+
+  L.imageOverlay(
+    heatmap.image,
+    [[swLat, swLng], [neLat, neLng]],
+    { opacity: 0.7 }
+  ).addTo(map);
+}
+```
+
+### Python
+
+```python
+import requests
+import base64
+
+def save_heatmap(grid_id, token, output_path='heatmap.png'):
+    response = requests.get(
+        f'https://api.airqo.net/api/v2/spatial/heatmaps/{grid_id}',
+        params={'token': token}
+    )
+    heatmaps = response.json()
+
+    if not heatmaps:
+        print("No heatmap available for this Grid ID.")
+        return
+
+    heatmap = heatmaps[0]
+    # Strip the data URL prefix
+    image_data = heatmap['image'].split(',', 1)[1]
+    with open(output_path, 'wb') as f:
+        f.write(base64.b64decode(image_data))
+
+    print(f"Heatmap saved to {output_path}")
+    print(f"Bounds: SW {heatmap['bounds'][0]}, NE {heatmap['bounds'][1]}")
+
+save_heatmap('64b7ac8fd7249f0029feca80', 'YOUR_SECRET_TOKEN')
+```
+
+---
+
+## Update frequency
+
+Heatmaps are regenerated periodically as new sensor data arrives. For the freshest image, check the `message` field — a `✅` prefix confirms a successfully generated image.
+
+---
+
+## Tips
+
+- **Cache heatmap images** on your end (e.g. every 30–60 minutes) to reduce API calls.
+- The `bounds` array uses `[latitude, longitude]` order — check your mapping library's expected order before positioning the overlay.
+- For all-city dashboards, use the `/heatmaps` endpoint (without a Grid ID) to retrieve every available city heatmap in a single call.

--- a/src/docs-website/docs/api/for-partners/_category_.json
+++ b/src/docs-website/docs/api/for-partners/_category_.json
@@ -1,0 +1,6 @@
+{
+  "label": "For Partners",
+  "position": 3,
+  "collapsible": true,
+  "collapsed": false
+}

--- a/src/docs-website/docs/api/for-partners/historical-data.md
+++ b/src/docs-website/docs/api/for-partners/historical-data.md
@@ -1,0 +1,216 @@
+---
+sidebar_position: 3
+sidebar_label: Historical Data
+---
+
+# Historical Data — Cohort ID
+
+Access calibrated air quality measurements going back up to one year for the devices in your Cohort. Historical data is retrieved through the Analytics API using a `POST` request.
+
+:::info Tier requirement
+Historical data access requires a **Standard Tier** subscription or above.
+:::
+
+---
+
+## Overview
+
+Historical data for your Cohort is fetched via the Analytics API by specifying the device names that belong to your Cohort. If you do not know the device names, use the recent measurements endpoint first — the `device` field in each measurement is the device name.
+
+---
+
+## Endpoint
+
+```
+POST https://api.airqo.net/api/v3/public/analytics/data-download
+Content-Type: application/json
+Authorization: Bearer YOUR_SECRET_TOKEN
+```
+
+---
+
+## Request parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `network` | string | Yes | Always `"airqo"` |
+| `startDateTime` | string | Yes | Start of range (ISO 8601) |
+| `endDateTime` | string | Yes | End of range (ISO 8601) |
+| `datatype` | string | Yes | `"calibrated"` for quality-controlled data |
+| `downloadType` | string | Yes | `"json"` |
+| `frequency` | string | Yes | `"hourly"` or `"daily"` |
+| `device_names` | array | No | Filter to specific devices in your Cohort |
+| `pollutants` | array | No | e.g. `["pm2_5", "pm10"]` |
+| `metaDataFields` | array | No | e.g. `["latitude", "longitude"]` |
+| `weatherFields` | array | No | e.g. `["temperature", "humidity"]` |
+| `cursor` | string | No | Pagination cursor from previous response |
+
+---
+
+## Example request — hourly calibrated data
+
+```bash
+curl -X POST "https://api.airqo.net/api/v3/public/analytics/data-download" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_SECRET_TOKEN" \
+  -d '{
+    "network": "airqo",
+    "datatype": "calibrated",
+    "downloadType": "json",
+    "startDateTime": "2025-01-01T00:00:00Z",
+    "endDateTime": "2025-01-31T23:59:59Z",
+    "device_names": ["airqo_bx2847", "airqo_cy1523"],
+    "pollutants": ["pm2_5", "pm10"],
+    "metaDataFields": ["latitude", "longitude"],
+    "frequency": "hourly"
+  }'
+```
+
+**Python:**
+
+```python
+import requests
+
+token = 'YOUR_SECRET_TOKEN'
+
+payload = {
+    "network": "airqo",
+    "datatype": "calibrated",
+    "downloadType": "json",
+    "startDateTime": "2025-01-01T00:00:00Z",
+    "endDateTime": "2025-01-31T23:59:59Z",
+    "device_names": ["airqo_bx2847", "airqo_cy1523"],
+    "pollutants": ["pm2_5", "pm10"],
+    "metaDataFields": ["latitude", "longitude"],
+    "frequency": "hourly"
+}
+
+response = requests.post(
+    "https://api.airqo.net/api/v3/public/analytics/data-download",
+    json=payload,
+    headers={"Authorization": f"Bearer {token}"}
+)
+
+data = response.json()
+print(f"Retrieved {len(data['data'])} records. More available: {data['metadata']['has_more']}")
+```
+
+**JavaScript:**
+
+```js
+const response = await fetch(
+  'https://api.airqo.net/api/v3/public/analytics/data-download',
+  {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': 'Bearer YOUR_SECRET_TOKEN'
+    },
+    body: JSON.stringify({
+      network: 'airqo',
+      datatype: 'calibrated',
+      downloadType: 'json',
+      startDateTime: '2025-01-01T00:00:00Z',
+      endDateTime: '2025-01-31T23:59:59Z',
+      device_names: ['airqo_bx2847', 'airqo_cy1523'],
+      pollutants: ['pm2_5', 'pm10'],
+      metaDataFields: ['latitude', 'longitude'],
+      frequency: 'hourly'
+    })
+  }
+);
+const data = await response.json();
+```
+
+---
+
+## Example response
+
+```json
+{
+  "status": "success",
+  "message": "Data downloaded successfully",
+  "data": [
+    {
+      "site_name": "Kampala Road",
+      "device_name": "airqo_bx2847",
+      "datetime": "2025-01-01 10:00:00Z",
+      "pm2_5": 12.45,
+      "pm10": 15.32,
+      "latitude": 0.33,
+      "longitude": 32.56,
+      "temperature": 24.5,
+      "humidity": 65.4,
+      "network": "airqo",
+      "frequency": "hourly"
+    }
+  ],
+  "metadata": {
+    "total_count": 500,
+    "has_more": false,
+    "next": null
+  }
+}
+```
+
+---
+
+## Paginating through large datasets
+
+When `metadata.has_more` is `true`, pass the `metadata.next` cursor in your next request:
+
+```python
+import requests
+
+token = 'YOUR_SECRET_TOKEN'
+base_payload = {
+    "network": "airqo",
+    "datatype": "calibrated",
+    "downloadType": "json",
+    "startDateTime": "2025-01-01T00:00:00Z",
+    "endDateTime": "2025-03-31T23:59:59Z",
+    "device_names": ["airqo_bx2847"],
+    "pollutants": ["pm2_5", "pm10"],
+    "frequency": "hourly"
+}
+
+all_records = []
+cursor = None
+
+while True:
+    payload = {**base_payload}
+    if cursor:
+        payload['cursor'] = cursor
+
+    response = requests.post(
+        "https://api.airqo.net/api/v3/public/analytics/data-download",
+        json=payload,
+        headers={"Authorization": f"Bearer {token}"}
+    ).json()
+
+    all_records.extend(response['data'])
+
+    if not response['metadata']['has_more']:
+        break
+
+    cursor = response['metadata']['next']
+
+print(f"Total records fetched: {len(all_records)}")
+```
+
+---
+
+## Choosing frequency
+
+| Frequency | When to use |
+|-----------|-------------|
+| `"hourly"` | Time-series charts, detailed trend analysis |
+| `"daily"` | Monthly reports, long-term comparisons |
+
+---
+
+## Tips
+
+- **Limit your date range** to 30-day windows for faster responses on large device networks.
+- **Request only the pollutants you need** — omitting unused fields reduces response size.
+- **Cache results** on your side to avoid repeating identical queries.

--- a/src/docs-website/docs/api/for-partners/historical-data.md
+++ b/src/docs-website/docs/api/for-partners/historical-data.md
@@ -22,9 +22,8 @@ Historical data for your Cohort is fetched via the Analytics API by specifying t
 ## Endpoint
 
 ```
-POST https://api.airqo.net/api/v3/public/analytics/data-download
+POST https://api.airqo.net/api/v3/public/analytics/data-download?token=YOUR_SECRET_TOKEN
 Content-Type: application/json
-Authorization: Bearer YOUR_SECRET_TOKEN
 ```
 
 ---
@@ -50,9 +49,8 @@ Authorization: Bearer YOUR_SECRET_TOKEN
 ## Example request — hourly calibrated data
 
 ```bash
-curl -X POST "https://api.airqo.net/api/v3/public/analytics/data-download" \
+curl -X POST "https://api.airqo.net/api/v3/public/analytics/data-download?token=YOUR_SECRET_TOKEN" \
   -H "Content-Type: application/json" \
-  -H "Authorization: Bearer YOUR_SECRET_TOKEN" \
   -d '{
     "network": "airqo",
     "datatype": "calibrated",
@@ -86,9 +84,8 @@ payload = {
 }
 
 response = requests.post(
-    "https://api.airqo.net/api/v3/public/analytics/data-download",
-    json=payload,
-    headers={"Authorization": f"Bearer {token}"}
+    f"https://api.airqo.net/api/v3/public/analytics/data-download?token={token}",
+    json=payload
 )
 
 data = response.json()
@@ -99,12 +96,11 @@ print(f"Retrieved {len(data['data'])} records. More available: {data['metadata']
 
 ```js
 const response = await fetch(
-  'https://api.airqo.net/api/v3/public/analytics/data-download',
+  `https://api.airqo.net/api/v3/public/analytics/data-download?token=${token}`,
   {
     method: 'POST',
     headers: {
-      'Content-Type': 'application/json',
-      'Authorization': 'Bearer YOUR_SECRET_TOKEN'
+      'Content-Type': 'application/json'
     },
     body: JSON.stringify({
       network: 'airqo',
@@ -183,9 +179,8 @@ while True:
         payload['cursor'] = cursor
 
     response = requests.post(
-        "https://api.airqo.net/api/v3/public/analytics/data-download",
-        json=payload,
-        headers={"Authorization": f"Bearer {token}"}
+        f"https://api.airqo.net/api/v3/public/analytics/data-download?token={token}",
+        json=payload
     ).json()
 
     all_records.extend(response['data'])

--- a/src/docs-website/docs/api/for-partners/intro.md
+++ b/src/docs-website/docs/api/for-partners/intro.md
@@ -1,0 +1,76 @@
+---
+sidebar_position: 1
+sidebar_label: Overview
+---
+
+# For Partners — Cohort ID Access
+
+This guide is for **organisations, NGOs, research networks, and corporate partners** who have a group of AirQo devices deployed across multiple locations. Cohort ID access lets you retrieve air quality data from all of your devices with a single API call, regardless of where they are physically located.
+
+---
+
+## What is a Cohort?
+
+A **Cohort** is an organisationally-defined group of devices. Unlike Grid IDs, which are determined by geography, a Cohort is created and managed by AirQo based on your organisation's needs. Your devices might be spread across different cities or even countries — the Cohort groups them together under a single identifier.
+
+:::note Cohort access is currently managed by AirQo
+At this time, Cohorts are created and configured by the AirQo team on behalf of partner organisations. Contact [support@airqo.net](mailto:support@airqo.net) to request a Cohort for your network.
+:::
+
+---
+
+## Why use Cohort ID access?
+
+| Use case | How Cohort ID helps |
+|----------|---------------------|
+| Multi-location monitoring | Get all your data with one API call |
+| Organisational dashboards | Unified view across your entire network |
+| Corporate air quality reporting | Filter to exactly your devices |
+| Research networks | Pull data from all participating devices |
+| NGO environmental programmes | Monitor all programme sites centrally |
+
+---
+
+## Your Cohort ID endpoint structure
+
+Once you have your Cohort ID, two endpoints cover your primary data needs:
+
+| Data | Endpoint |
+|------|----------|
+| Recent measurements (last 7 days) | `GET /api/v2/devices/measurements/cohorts/{COHORT_ID}?token={SECRET_TOKEN}` |
+| Historical measurements | `POST /api/v3/public/analytics/data-download` |
+
+---
+
+## Privacy and your Cohort
+
+By default, Cohorts are **private** — meaning the devices in your Cohort are not visible through Grid ID (city) endpoints unless you explicitly make them public. This is important for partners who manage proprietary sensor networks.
+
+To change the privacy setting of your Cohort, contact [support@airqo.net](mailto:support@airqo.net).
+
+---
+
+## Getting your Cohort ID
+
+- **Public Cohorts:** Browse the metadata endpoints at [docs.airqo.net/airqo-rest-api-documentation/api-endpoints/metadata](https://docs.airqo.net/airqo-rest-api-documentation/api-endpoints/metadata)
+- **Private Cohorts:** Contact [support@airqo.net](mailto:support@airqo.net) — your Cohort ID will be shared securely
+
+---
+
+## What data is available?
+
+| Data type | Available? | Notes |
+|-----------|-----------|-------|
+| Recent hourly measurements | ✅ Free | Last 7 days |
+| Historical calibrated data | ✅ Standard+ | Via Analytics API |
+| Raw sensor readings | ✅ Standard+ | Via Analytics API |
+| Air quality forecasts | ❌ | Not currently available per Cohort ID |
+| Spatial heatmaps | ❌ | Heatmaps use Grid ID |
+
+---
+
+## Next steps
+
+- [Fetch recent measurements →](./recent-measurements)
+- [Access historical data →](./historical-data)
+- [Set up your account →](../getting-started/authentication)

--- a/src/docs-website/docs/api/for-partners/recent-measurements.md
+++ b/src/docs-website/docs/api/for-partners/recent-measurements.md
@@ -1,0 +1,177 @@
+---
+sidebar_position: 2
+sidebar_label: Recent Measurements
+---
+
+# Recent Measurements — Cohort ID
+
+Retrieve the latest hourly calibrated air quality measurements from all devices in your Cohort. This endpoint returns data from approximately the last 7 days.
+
+:::info Tier requirement
+Available on all tiers including Free.
+:::
+
+---
+
+## Endpoint
+
+```
+GET https://api.airqo.net/api/v2/devices/measurements/cohorts/{COHORT_ID}?token={SECRET_TOKEN}
+```
+
+### Path parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `COHORT_ID` | string | Yes | Your unique Cohort identifier |
+
+### Query parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `token` | string | Yes | Your SECRET TOKEN from Account Settings |
+
+---
+
+## Example request
+
+```bash
+curl -X GET \
+  "https://api.airqo.net/api/v2/devices/measurements/cohorts/64b9c7d5e3f82b0014c5a123?token=YOUR_SECRET_TOKEN"
+```
+
+**JavaScript (fetch):**
+
+```js
+const cohortId = '64b9c7d5e3f82b0014c5a123';
+const token = 'YOUR_SECRET_TOKEN';
+
+const response = await fetch(
+  `https://api.airqo.net/api/v2/devices/measurements/cohorts/${cohortId}?token=${token}`
+);
+const data = await response.json();
+
+console.log(`Found ${data.meta.total} measurements across your devices.`);
+```
+
+**Python:**
+
+```python
+import requests
+
+cohort_id = '64b9c7d5e3f82b0014c5a123'
+token = 'YOUR_SECRET_TOKEN'
+
+response = requests.get(
+    f'https://api.airqo.net/api/v2/devices/measurements/cohorts/{cohort_id}',
+    params={'token': token}
+)
+data = response.json()
+
+for measurement in data['measurements']:
+    print(f"{measurement['device']} at {measurement['time']}: PM2.5 = {measurement['pm2_5']['value']} μg/m³")
+```
+
+---
+
+## Example response
+
+```json
+{
+  "success": true,
+  "isCache": false,
+  "message": "successfully returned the measurements",
+  "meta": {
+    "total": 168,
+    "skip": 0,
+    "limit": 50,
+    "page": 1,
+    "pages": 4,
+    "startTime": "2025-09-21T11:00:00.000Z",
+    "endTime": "2025-09-28T11:00:00.000Z"
+  },
+  "measurements": [
+    {
+      "device": "airqo_bx2847",
+      "device_id": "65c8d4a2f1b45c0012a3e789",
+      "site_id": "64f7b3e8c9d25a0013f2d456",
+      "time": "2025-09-25T14:00:00.000Z",
+      "pm2_5": {
+        "value": 23.45
+      },
+      "pm10": {
+        "value": 31.82
+      },
+      "frequency": "hourly",
+      "deviceDetails": {
+        "name": "airqo_bx2847",
+        "isOnline": true,
+        "status": "deployed",
+        "latitude": 0.3476,
+        "longitude": 32.5825,
+        "lastActive": "2025-09-25T14:00:00.000Z"
+      }
+    }
+  ]
+}
+```
+
+---
+
+## Response fields
+
+### Top-level
+
+| Field | Description |
+|-------|-------------|
+| `success` | `true` if the request succeeded |
+| `isCache` | Whether the response was served from cache |
+| `message` | Human-readable status message |
+| `meta` | Pagination and query metadata |
+| `measurements` | Array of measurement objects |
+
+### `meta` object
+
+| Field | Description |
+|-------|-------------|
+| `total` | Total matching measurements |
+| `skip` | Records skipped (for pagination) |
+| `limit` | Max records per page |
+| `page` | Current page number |
+| `pages` | Total number of pages |
+| `startTime` | Query start (ISO 8601) |
+| `endTime` | Query end (ISO 8601) |
+
+### Measurement object
+
+| Field | Description |
+|-------|-------------|
+| `device` | Device name |
+| `device_id` | Unique device identifier |
+| `site_id` | Location identifier |
+| `time` | Reading timestamp (ISO 8601) |
+| `pm2_5.value` | PM2.5 in μg/m³ |
+| `pm10.value` | PM10 in μg/m³ |
+| `frequency` | Always `"hourly"` for this endpoint |
+| `deviceDetails.isOnline` | Whether device is currently active |
+| `deviceDetails.latitude` | Device latitude |
+| `deviceDetails.longitude` | Device longitude |
+
+---
+
+## Pagination
+
+If your Cohort has many devices, results are paginated. Use `skip` and `limit` to page through:
+
+```bash
+# Page 2: skip the first 50 records
+curl "https://api.airqo.net/api/v2/devices/measurements/cohorts/{COHORT_ID}?token={SECRET_TOKEN}&limit=50&skip=50"
+```
+
+See [Pagination reference →](../reference/pagination) for a full walkthrough.
+
+---
+
+## Need data older than 7 days?
+
+The recent measurements endpoint returns approximately the last 7 days. For historical data, use the [Analytics API →](./historical-data).

--- a/src/docs-website/docs/api/forecasts/_category_.json
+++ b/src/docs-website/docs/api/forecasts/_category_.json
@@ -1,0 +1,6 @@
+{
+  "label": "Forecasts",
+  "position": 6,
+  "collapsible": true,
+  "collapsed": true
+}

--- a/src/docs-website/docs/api/forecasts/overview.md
+++ b/src/docs-website/docs/api/forecasts/overview.md
@@ -1,0 +1,254 @@
+---
+sidebar_position: 1
+sidebar_label: Forecast API
+---
+
+# Forecast API
+
+Get hourly and daily air quality predictions for up to 7 days ahead, with health recommendations based on predicted pollution levels.
+
+:::info Tier requirement
+Forecasts require a **Premium Tier** subscription.
+:::
+
+---
+
+## What you get
+
+- **7-day hourly forecasts** — one prediction per hour for the next 168 hours
+- **7-day daily forecasts** — one prediction per day for the next 7 days
+- **Health tips** — contextual recommendations based on predicted PM2.5 levels
+- **Forecast metadata** — model version, generation timestamp, and location details
+
+Forecasts are available for any active monitoring site or device. They are regenerated every 6 hours (00:00, 06:00, 12:00, 18:00 UTC).
+
+---
+
+## Endpoints
+
+### Hourly forecasts
+
+#### By Device ID
+
+```
+GET https://api.airqo.net/api/v2/predict/hourly-forecast?device_id={DEVICE_ID}&token={SECRET_TOKEN}
+```
+
+#### By Site ID
+
+```
+GET https://api.airqo.net/api/v2/predict/hourly-forecast?site_id={SITE_ID}&token={SECRET_TOKEN}
+```
+
+### Daily forecasts
+
+#### By Device ID
+
+```
+GET https://api.airqo.net/api/v2/predict/daily-forecast?device_id={DEVICE_ID}&token={SECRET_TOKEN}
+```
+
+#### By Site ID
+
+```
+GET https://api.airqo.net/api/v2/predict/daily-forecast?site_id={SITE_ID}&token={SECRET_TOKEN}
+```
+
+---
+
+## Query parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `device_id` | string | Conditional | Device identifier (use either `device_id` or `site_id`) |
+| `site_id` | string | Conditional | Site identifier (use either `site_id` or `device_id`) |
+| `token` | string | Yes | Your SECRET TOKEN |
+
+---
+
+## Example requests
+
+```bash
+# Hourly forecast by site ID
+curl -X GET \
+  "https://api.airqo.net/api/v2/predict/hourly-forecast?site_id=64f7b3e8c9d25a0013f2d456&token=YOUR_SECRET_TOKEN"
+
+# Daily forecast by device ID
+curl -X GET \
+  "https://api.airqo.net/api/v2/predict/daily-forecast?device_id=65c8d4a2f1b45c0012a3e789&token=YOUR_SECRET_TOKEN"
+```
+
+**JavaScript — hourly forecast:**
+
+```js
+async function getHourlyForecast(siteId, token) {
+  const url = `https://api.airqo.net/api/v2/predict/hourly-forecast?site_id=${siteId}&token=${token}`;
+  const response = await fetch(url);
+  const data = await response.json();
+
+  if (data.success) {
+    console.log(`Retrieved ${data.forecasts.length} hourly forecasts`);
+
+    // Show next 24 hours
+    data.forecasts.slice(0, 24).forEach(forecast => {
+      console.log(`${forecast.time}: PM2.5 = ${forecast.pm2_5} μg/m³`);
+      console.log(`Tips: ${forecast.health_tips.join(' | ')}`);
+    });
+  }
+
+  return data;
+}
+
+getHourlyForecast('64f7b3e8c9d25a0013f2d456', 'YOUR_SECRET_TOKEN');
+```
+
+**Python — daily forecast:**
+
+```python
+import requests
+from datetime import datetime
+
+def get_daily_forecast(device_id, token):
+    response = requests.get(
+        "https://api.airqo.net/api/v2/predict/daily-forecast",
+        params={"device_id": device_id, "token": token}
+    )
+    data = response.json()
+
+    if data['success']:
+        for forecast in data['forecasts']:
+            date = datetime.fromisoformat(forecast['time'].replace('+00:00', ''))
+            print(f"\n{date.strftime('%Y-%m-%d')}: PM2.5 = {forecast['pm2_5']} μg/m³")
+            for tip in forecast['health_tips']:
+                print(f"  • {tip}")
+
+    return data
+
+get_daily_forecast('65c8d4a2f1b45c0012a3e789', 'YOUR_SECRET_TOKEN')
+```
+
+---
+
+## Example response
+
+```json
+{
+  "success": true,
+  "message": "Forecasts retrieved successfully",
+  "forecasts": [
+    {
+      "time": "2025-09-29T14:00:00+00:00",
+      "pm2_5": 24.5,
+      "health_tips": [
+        "Air quality is acceptable for most people",
+        "Unusually sensitive individuals should consider reducing prolonged outdoor exertion"
+      ]
+    },
+    {
+      "time": "2025-09-29T15:00:00+00:00",
+      "pm2_5": 28.3,
+      "health_tips": [
+        "Air quality is acceptable for most people",
+        "Consider reducing outdoor activities if you experience symptoms"
+      ]
+    }
+  ],
+  "forecast_metadata": {
+    "model_version": "v2.3",
+    "generated_at": "2025-09-29T12:00:00+00:00",
+    "location": {
+      "site_id": "64f7b3e8c9d25a0013f2d456",
+      "device_id": "65c8d4a2f1b45c0012a3e789",
+      "latitude": 0.3476,
+      "longitude": 32.5825
+    },
+    "forecast_horizon_hours": 168
+  }
+}
+```
+
+---
+
+## Response fields
+
+### Forecast object
+
+| Field | Description |
+|-------|-------------|
+| `time` | Forecast timestamp (ISO 8601 with timezone) |
+| `pm2_5` | Predicted PM2.5 in μg/m³ |
+| `health_tips` | Array of health recommendations for the predicted air quality level |
+
+### `forecast_metadata` object
+
+| Field | Description |
+|-------|-------------|
+| `model_version` | Version of the forecasting model |
+| `generated_at` | When this forecast was created |
+| `location.site_id` | Site the forecast applies to |
+| `location.device_id` | Device the forecast applies to |
+| `forecast_horizon_hours` | Total hours covered (168 = 7 days) |
+
+---
+
+## Error responses
+
+### 401 Unauthorised — invalid token
+
+```json
+{
+  "success": false,
+  "message": "Invalid authentication",
+  "error": "Unauthorized"
+}
+```
+
+### 403 Forbidden — not on Premium Tier
+
+```json
+{
+  "success": false,
+  "message": "Forecast access requires Premium Tier subscription",
+  "error": "Forbidden",
+  "upgrade_url": "https://analytics.airqo.net/account/subscription"
+}
+```
+
+### 404 Not Found — invalid ID
+
+```json
+{
+  "success": false,
+  "message": "Device or site not found",
+  "error": "Not Found"
+}
+```
+
+---
+
+## Best practices
+
+- **Cache forecast results** — forecasts update every 6 hours. Caching for 1–2 hours reduces API calls with minimal freshness trade-off.
+- **Check `generated_at`** — use this to tell users how recent the forecast is.
+- **Always display health tips** — they are the most user-actionable part of the forecast.
+- **Prefer near-term data** — the first 48 hours are more accurate than days 4–7.
+- **Implement graceful fallback** — if the forecast call fails, display the most recent historical reading instead.
+
+---
+
+## Forecast availability
+
+| Detail | Value |
+|--------|-------|
+| Update frequency | Every 6 hours (00:00, 06:00, 12:00, 18:00 UTC) |
+| Hourly horizon | 168 hours (7 days) |
+| Daily horizon | 7 days |
+| Coverage | All active monitoring sites |
+| Historical forecasts | Not available |
+| Pollutants | PM2.5 (PM10 in future versions) |
+
+---
+
+## Upgrade to Premium
+
+To unlock forecast access, log in to [analytics.airqo.net](https://analytics.airqo.net), go to **Account Settings → Subscription**, and select Premium Tier.

--- a/src/docs-website/docs/api/getting-started/_category_.json
+++ b/src/docs-website/docs/api/getting-started/_category_.json
@@ -1,0 +1,6 @@
+{
+  "label": "Getting Started",
+  "position": 2,
+  "collapsible": true,
+  "collapsed": false
+}

--- a/src/docs-website/docs/api/getting-started/authentication.md
+++ b/src/docs-website/docs/api/getting-started/authentication.md
@@ -33,22 +33,19 @@ Your `SECRET TOKEN` grants access to all data your account is authorised for. Tr
 
 ## Step 3 — Using your credentials
 
-### GET endpoints (measurements, heatmaps, forecasts)
+All AirQo API endpoints — both GET and POST — authenticate via the `token` query parameter. Append `?token=YOUR_SECRET_TOKEN` to every request URL.
 
-Pass your `SECRET TOKEN` as a query parameter:
+**GET request example:**
 
 ```
 GET https://api.airqo.net/api/v2/devices/measurements/cohorts/{COHORT_ID}?token=YOUR_SECRET_TOKEN
 ```
 
-### POST endpoints (Analytics API)
+**POST request example:**
 
-Pass your token in the `Authorization` header:
-
-```http
-POST https://api.airqo.net/api/v3/public/analytics/raw-data
+```
+POST https://api.airqo.net/api/v3/public/analytics/raw-data?token=YOUR_SECRET_TOKEN
 Content-Type: application/json
-Authorization: Bearer YOUR_SECRET_TOKEN
 ```
 
 ---

--- a/src/docs-website/docs/api/getting-started/authentication.md
+++ b/src/docs-website/docs/api/getting-started/authentication.md
@@ -1,0 +1,86 @@
+---
+sidebar_position: 1
+sidebar_label: Authentication & Setup
+---
+
+# Authentication & Setup
+
+Before making any API requests, you need an AirQo account and a set of API credentials. This page walks you through the complete setup process.
+
+---
+
+## Step 1 — Create an AirQo account
+
+Go to [https://analytics.airqo.net](https://analytics.airqo.net) and sign up for a free account. Once registered, you will be taken to the AirQo Analytics dashboard.
+
+---
+
+## Step 2 — Generate your API credentials
+
+1. Click your profile icon in the top-right corner of the dashboard.
+2. Navigate to **Account Settings**.
+3. Find the **API Access** or **Credentials** section.
+4. Click **Generate Credentials** to create a new key pair.
+5. You will receive two values:
+   - **CLIENT** — identifies your application
+   - **SECRET TOKEN** — used to authenticate API requests
+
+:::warning Store your credentials securely
+Your `SECRET TOKEN` grants access to all data your account is authorised for. Treat it like a password — never expose it in client-side code or public repositories.
+:::
+
+---
+
+## Step 3 — Using your credentials
+
+### GET endpoints (measurements, heatmaps, forecasts)
+
+Pass your `SECRET TOKEN` as a query parameter:
+
+```
+GET https://api.airqo.net/api/v2/devices/measurements/cohorts/{COHORT_ID}?token=YOUR_SECRET_TOKEN
+```
+
+### POST endpoints (Analytics API)
+
+Pass your token in the `Authorization` header:
+
+```http
+POST https://api.airqo.net/api/v3/public/analytics/raw-data
+Content-Type: application/json
+Authorization: Bearer YOUR_SECRET_TOKEN
+```
+
+---
+
+## Token expiration
+
+API tokens are valid for **7 months** from the date they are generated. AirQo will send you an email notification before your token expires.
+
+:::tip Avoid service interruption
+Rotate your token before it expires. After generating a new token, update it in all places where it is used — server environment variables, configuration files, or secrets managers.
+:::
+
+---
+
+## IP whitelisting
+
+If you are making API calls from a server (as opposed to a browser), you must whitelist your server's public IP address in your AirQo account settings.
+
+**Without IP whitelisting, requests from server IPs will return empty data or an unauthorised error**, even when a valid token is supplied.
+
+To whitelist your IP:
+1. Go to **Account Settings** in [analytics.airqo.net](https://analytics.airqo.net).
+2. Find the **IP Whitelist** section.
+3. Add each public IP address that your servers will use.
+
+:::note Dynamic IPs
+If your servers use dynamic IP addresses (e.g. ephemeral cloud instances), consider routing API requests through a static NAT gateway or egress IP so you can maintain a stable whitelist.
+:::
+
+---
+
+## Next steps
+
+- [Choose a subscription tier →](./pricing-tiers)
+- [Make your first API call →](./quick-start)

--- a/src/docs-website/docs/api/getting-started/authentication.md
+++ b/src/docs-website/docs/api/getting-started/authentication.md
@@ -37,13 +37,13 @@ All AirQo API endpoints — both GET and POST — authenticate via the `token` q
 
 **GET request example:**
 
-```
+```http
 GET https://api.airqo.net/api/v2/devices/measurements/cohorts/{COHORT_ID}?token=YOUR_SECRET_TOKEN
 ```
 
 **POST request example:**
 
-```
+```http
 POST https://api.airqo.net/api/v3/public/analytics/raw-data?token=YOUR_SECRET_TOKEN
 Content-Type: application/json
 ```

--- a/src/docs-website/docs/api/getting-started/pricing-tiers.md
+++ b/src/docs-website/docs/api/getting-started/pricing-tiers.md
@@ -1,0 +1,94 @@
+---
+sidebar_position: 2
+sidebar_label: Pricing & Tiers
+---
+
+# Pricing & Access Tiers
+
+The AirQo API is available on three tiers. Start for free and upgrade as your needs grow.
+
+---
+
+## Tier comparison
+
+| Feature | Free | Standard | Premium |
+|---------|------|----------|---------|
+| Recent hourly measurements (last 7 days) | ✅ | ✅ | ✅ |
+| Spatial heatmaps | ✅ | ✅ | ✅ |
+| Historical data (up to 1 year) | ❌ | ✅ | ✅ |
+| Raw sensor data | ❌ | ✅ | ✅ |
+| Daily aggregations | ❌ | ✅ | ✅ |
+| Bulk data exports | ❌ | ✅ | ✅ |
+| Hourly forecasts (7-day) | ❌ | ❌ | ✅ |
+| Daily forecasts (7-day) | ❌ | ❌ | ✅ |
+| Health tips with forecasts | ❌ | ❌ | ✅ |
+| **Price** | **$0/month** | **$50/month** | **$150/month** |
+| Support | Community | Email | Priority |
+
+---
+
+## Free Tier — $0/month
+
+Best for individual developers, students, and small proof-of-concept projects.
+
+**What you get:**
+- Recent hourly calibrated measurements (last 7 days)
+- Access via Site ID, Device ID, Cohort ID, and Grid ID
+- Spatial heatmap visualisations
+
+**Limitations:**
+- No access to data older than 7 days
+- No raw sensor readings
+- No forecast data
+- Standard rate limits apply
+
+---
+
+## Standard Tier — $50/month
+
+Best for research projects, NGOs, small businesses, and applications that need historical context.
+
+**What you get:**
+- Everything in the Free Tier
+- Full historical data access (up to 1 year)
+- Raw sensor readings via the Analytics API
+- Daily and weekly aggregated data
+- Bulk data export functionality
+- Pagination support for large queries
+
+---
+
+## Premium Tier — $150/month
+
+Best for commercial applications, government agencies, and any use case requiring predictive capability.
+
+**What you get:**
+- Everything in the Standard Tier
+- 7-day hourly air quality forecasts
+- 7-day daily air quality forecasts
+- Health recommendations based on predicted pollution levels
+- Priority API access and higher rate limits
+- Dedicated technical support
+
+---
+
+## How to upgrade
+
+1. Log in at [analytics.airqo.net](https://analytics.airqo.net).
+2. Go to **Account Settings → Subscription**.
+3. Select your desired tier and complete payment.
+4. Your access is upgraded immediately.
+
+---
+
+## Special pricing
+
+- **Academic institutions and non-profits:** Discounts available. Email [support@airqo.net](mailto:support@airqo.net) with proof of status.
+- **Annual subscriptions:** 20% discount applied automatically.
+- **Enterprise:** Custom plans for organisations requiring dedicated infrastructure, white-label options, SLA guarantees, or on-premises deployment. Contact [support@airqo.net](mailto:support@airqo.net).
+
+---
+
+## Rate limits
+
+If you exceed your tier's rate limit, you will receive an `HTTP 429 Too Many Requests` response. Implement exponential backoff and retry logic in your application, or upgrade to a higher tier for increased limits.

--- a/src/docs-website/docs/api/getting-started/quick-start.md
+++ b/src/docs-website/docs/api/getting-started/quick-start.md
@@ -1,0 +1,92 @@
+---
+sidebar_position: 3
+sidebar_label: Quick Start
+---
+
+# Quick Start
+
+This page gets you to your first successful API response in under five minutes.
+
+---
+
+## Prerequisites checklist
+
+Before you begin, make sure you have:
+
+- [ ] An AirQo account at [analytics.airqo.net](https://analytics.airqo.net)
+- [ ] A `SECRET TOKEN` generated from **Account Settings**
+- [ ] Your server's IP address whitelisted (if calling from a server)
+- [ ] A Cohort ID or Grid ID to query (see [Finding IDs →](../reference/finding-ids))
+
+---
+
+## Your first request
+
+### Fetch recent measurements for a Cohort
+
+Replace `YOUR_COHORT_ID` and `YOUR_SECRET_TOKEN` with your actual values:
+
+```bash
+curl -X GET \
+  "https://api.airqo.net/api/v2/devices/measurements/cohorts/YOUR_COHORT_ID?token=YOUR_SECRET_TOKEN"
+```
+
+### Fetch recent measurements for a Grid (city)
+
+```bash
+curl -X GET \
+  "https://api.airqo.net/api/v2/devices/measurements/grids/YOUR_GRID_ID?token=YOUR_SECRET_TOKEN"
+```
+
+A successful response looks like this:
+
+```json
+{
+  "success": true,
+  "message": "successfully returned the measurements",
+  "meta": {
+    "total": 168,
+    "skip": 0,
+    "limit": 50,
+    "page": 1,
+    "pages": 4
+  },
+  "measurements": [
+    {
+      "device": "airqo_bx2847",
+      "device_id": "65c8d4a2f1b45c0012a3e789",
+      "site_id": "64f7b3e8c9d25a0013f2d456",
+      "time": "2025-09-25T14:00:00.000Z",
+      "pm2_5": { "value": 23.45 },
+      "pm10": { "value": 31.82 },
+      "frequency": "hourly"
+    }
+  ]
+}
+```
+
+---
+
+## Understand the response
+
+| Field | What it tells you |
+|-------|-------------------|
+| `success` | Whether the request succeeded |
+| `meta.total` | Total matching measurements |
+| `meta.pages` | How many pages of results exist |
+| `measurements[].time` | ISO 8601 timestamp of the reading |
+| `measurements[].pm2_5.value` | PM2.5 in μg/m³ |
+| `measurements[].pm10.value` | PM10 in μg/m³ |
+
+For the full response reference, see [Response Structure →](../reference/response-structure).
+
+---
+
+## What to do next
+
+You have confirmed that your credentials work. Now choose the path that matches your use case:
+
+- **Partner or organisation using Cohort ID?** → [For Partners →](../for-partners/intro)
+- **City or municipality using Grid ID?** → [For Cities →](../for-cities/intro)
+- **Need historical or raw data?** → [Analytics API →](../analytics-api/raw-data)
+- **Need air quality forecasts?** → [Forecasts →](../forecasts/overview)

--- a/src/docs-website/docs/api/intro.md
+++ b/src/docs-website/docs/api/intro.md
@@ -1,9 +1,72 @@
 ---
 sidebar_position: 1
+sidebar_label: Overview
 ---
 
-# API
+# AirQo API
 
-Welcome to the AirQo API documentation.
+The AirQo API gives you programmatic access to air quality measurements from our sensor network across Africa. Whether you are building a public dashboard, powering a city's environmental platform, or integrating air quality data into a research workflow, the API is designed to fit your use case.
 
-Access AirQo's air quality data programmatically via our REST API.
+---
+
+## Who is this for?
+
+| I am a... | I should use... |
+|-----------|-----------------|
+| **Partner or organisation** managing devices across multiple locations | [Cohort ID Access →](./for-partners/intro) |
+| **City or municipality** monitoring a defined geographical area | [Grid ID Access →](./for-cities/intro) |
+| **Developer** who needs historical or raw sensor data at scale | [Analytics API →](./analytics-api/raw-data) |
+| **Researcher or planner** who needs predictive air quality data | [Forecast API →](./forecasts/overview) |
+
+---
+
+## Available data types
+
+| Data Type | Resolution | Use case | Tier |
+|-----------|-----------|----------|------|
+| Hourly calibrated measurements | Hourly | Dashboards, monitoring | Free+ |
+| Raw sensor readings | Minute-level | Advanced analysis | Standard+ |
+| Daily aggregated data | Daily | Trend analysis, reporting | Standard+ |
+| Spatial heatmaps | Per grid area | Visualisations, city maps | Free+ |
+| Air quality forecasts | Hourly & daily (7-day) | Planning, alerts | Premium |
+
+---
+
+## How data access is organised
+
+All measurements can be fetched through four different grouping methods:
+
+- **Site ID** — a specific physical monitoring location
+- **Device ID** — a specific sensor unit, wherever it is deployed
+- **Cohort ID** — a custom group of devices, typically managed by one organisation
+- **Grid ID** — all public devices within a defined geographical boundary
+
+:::tip Choosing the right method
+Partners and organisations typically use **Cohort ID** because it groups their devices across regions. Cities and municipalities typically use **Grid ID** because it captures all sensors within their administrative boundary.
+:::
+
+---
+
+## Base URL
+
+All API requests are made to:
+
+```
+https://api.airqo.net
+```
+
+---
+
+## Authentication
+
+All endpoints require authentication via a `token` query parameter (for GET requests) or a `Bearer` token in the `Authorization` header (for POST analytics endpoints).
+
+See [Authentication & Setup](./getting-started/authentication) for step-by-step instructions on generating your credentials.
+
+---
+
+## Next steps
+
+1. [Set up your account and generate credentials →](./getting-started/authentication)
+2. [Choose your subscription tier →](./getting-started/pricing-tiers)
+3. [Make your first API call →](./getting-started/quick-start)

--- a/src/docs-website/docs/api/intro.md
+++ b/src/docs-website/docs/api/intro.md
@@ -51,7 +51,7 @@ Partners and organisations typically use **Cohort ID** because it groups their d
 
 All API requests are made to:
 
-```
+```text
 https://api.airqo.net
 ```
 

--- a/src/docs-website/docs/api/intro.md
+++ b/src/docs-website/docs/api/intro.md
@@ -59,7 +59,7 @@ https://api.airqo.net
 
 ## Authentication
 
-All endpoints require authentication via a `token` query parameter (for GET requests) or a `Bearer` token in the `Authorization` header (for POST analytics endpoints).
+All endpoints require authentication via a `token` query parameter. Pass your `SECRET TOKEN` as `?token=YOUR_SECRET_TOKEN` on every request — both GET and POST.
 
 See [Authentication & Setup](./getting-started/authentication) for step-by-step instructions on generating your credentials.
 

--- a/src/docs-website/docs/api/reference/_category_.json
+++ b/src/docs-website/docs/api/reference/_category_.json
@@ -1,0 +1,6 @@
+{
+  "label": "Reference",
+  "position": 7,
+  "collapsible": true,
+  "collapsed": true
+}

--- a/src/docs-website/docs/api/reference/best-practices.md
+++ b/src/docs-website/docs/api/reference/best-practices.md
@@ -54,12 +54,11 @@ Follow these guidelines to build reliable, efficient integrations with the AirQo
 import time
 import requests
 
-def api_request_with_backoff(url, payload, token, max_retries=4):
+def api_request_with_backoff(url, token, payload, max_retries=4):
     for attempt in range(max_retries):
         response = requests.post(
-            url,
-            json=payload,
-            headers={"Authorization": f"Bearer {token}"}
+            f"{url}?token={token}",
+            json=payload
         )
         if response.status_code in (429, 500):
             wait = 2 ** attempt

--- a/src/docs-website/docs/api/reference/best-practices.md
+++ b/src/docs-website/docs/api/reference/best-practices.md
@@ -1,0 +1,100 @@
+---
+sidebar_position: 5
+sidebar_label: Best Practices
+---
+
+# Best Practices
+
+Follow these guidelines to build reliable, efficient integrations with the AirQo API.
+
+---
+
+## Authentication
+
+- **Rotate tokens before they expire.** Tokens are valid for 7 months. Set a calendar reminder 2–3 weeks before expiry and update your token in all environments.
+- **Never expose your token in client-side code.** Always proxy API calls through your own backend when building web or mobile apps.
+- **Use environment variables** to store credentials — not hardcoded strings.
+
+---
+
+## IP whitelisting
+
+- **Whitelist all egress IPs** your application uses. If you use load balancers or NAT gateways, whitelist those IPs too.
+- **Use a static egress IP** where possible to avoid maintaining a changing whitelist.
+- If you receive `200 OK` with empty `measurements`, check your whitelist first — this is the most common cause.
+
+---
+
+## Query design
+
+- **Limit your date ranges.** For hourly data, query 7–30 days at a time. For raw data, use windows of 1–6 hours.
+- **Request only the fields you need.** Specify `pollutants`, `metaDataFields`, and `weatherFields` explicitly instead of requesting everything.
+- **Filter at the API level.** Use `device_names` or `sites` to narrow results rather than fetching everything and filtering locally.
+
+---
+
+## Caching
+
+| Data type | Recommended cache duration |
+|-----------|--------------------------|
+| Recent hourly measurements | 30–60 minutes |
+| Historical calibrated data | 24 hours (data does not change) |
+| Heatmap images | 30–60 minutes |
+| Forecasts | 1–3 hours (updated every 6 hours) |
+
+---
+
+## Error handling
+
+- **Implement exponential backoff** for `429 Too Many Requests` and `500` responses.
+- **Never retry immediately** — use increasing wait times (e.g. 1s, 2s, 4s, 8s).
+- **Log the full response** when errors occur, including the request body and timestamp, to help with debugging.
+
+```python
+import time
+import requests
+
+def api_request_with_backoff(url, payload, token, max_retries=4):
+    for attempt in range(max_retries):
+        response = requests.post(
+            url,
+            json=payload,
+            headers={"Authorization": f"Bearer {token}"}
+        )
+        if response.status_code in (429, 500):
+            wait = 2 ** attempt
+            time.sleep(wait)
+            continue
+        return response.json()
+    raise Exception("Request failed after maximum retries")
+```
+
+---
+
+## Large data exports
+
+- **Use the cursor-based Analytics API** (v3) for bulk exports rather than looping through the GET measurement endpoints.
+- **Process pages as you receive them** rather than loading everything into memory first.
+- **Break quarterly or annual exports into monthly chunks** to stay within timeout limits.
+
+---
+
+## Development checklist
+
+- [ ] Token stored in environment variable, not code
+- [ ] Server IPs whitelisted
+- [ ] Date ranges bounded (not open-ended)
+- [ ] Only necessary fields requested
+- [ ] Retry logic with exponential backoff implemented
+- [ ] Caching in place for frequently accessed data
+- [ ] Token expiry reminder set
+
+---
+
+## Getting help
+
+| Contact | Purpose |
+|---------|---------|
+| [network@airqo.net](mailto:network@airqo.net) | Technical integration support |
+| [support@airqo.net](mailto:support@airqo.net) | Account, billing, and access questions |
+| [github.com/airqo-platform/code-samples](https://github.com/airqo-platform/code-samples) | Ready-to-use integration examples |

--- a/src/docs-website/docs/api/reference/error-codes.md
+++ b/src/docs-website/docs/api/reference/error-codes.md
@@ -1,0 +1,148 @@
+---
+sidebar_position: 2
+sidebar_label: Error Codes
+---
+
+# Error Codes
+
+All AirQo API endpoints return consistent error responses so you can handle failures programmatically.
+
+---
+
+## Error response format
+
+```json
+{
+  "status": "error",
+  "message": "Detailed error message",
+  "code": "ERROR_CODE"
+}
+```
+
+For forecast endpoints, the shape uses `success: false`:
+
+```json
+{
+  "success": false,
+  "message": "Detailed error message",
+  "error": "Unauthorized"
+}
+```
+
+---
+
+## HTTP status codes
+
+| Status | Meaning | Common causes |
+|--------|---------|---------------|
+| `200 OK` | Request succeeded | — |
+| `400 Bad Request` | Invalid request | Missing required fields, bad date format, invalid parameter values |
+| `401 Unauthorized` | Authentication failed | Missing, expired, or invalid token |
+| `403 Forbidden` | Insufficient permissions | Accessing a feature not included in your tier (e.g. forecasts on Free) |
+| `404 Not Found` | Resource not found | Invalid Cohort ID, Grid ID, Site ID, or Device ID — or no data for the requested range |
+| `429 Too Many Requests` | Rate limit exceeded | Too many requests in a short period |
+| `500 Internal Server Error` | Server error | AirQo-side issue; retry after a short delay |
+
+---
+
+## Common errors and solutions
+
+### Empty measurements array
+
+**Symptom:** Response is `200 OK` with `"measurements": []` or `"data": []`.
+
+**Most likely cause:** Your server's public IP is not whitelisted.
+
+**Solution:** Log in to [analytics.airqo.net](https://analytics.airqo.net) → Account Settings → IP Whitelist. Add the public IP your server uses to make API requests.
+
+---
+
+### 401 Unauthorized
+
+```json
+{
+  "success": false,
+  "message": "Invalid authentication",
+  "error": "Unauthorized"
+}
+```
+
+**Causes:**
+- Token is missing from the request
+- Token has expired (tokens are valid for 7 months)
+- Token was copied incorrectly
+
+**Solution:** Generate a new token from Account Settings and update it in your application.
+
+---
+
+### 403 Forbidden — tier restriction
+
+```json
+{
+  "success": false,
+  "message": "Forecast access requires Premium Tier subscription",
+  "error": "Forbidden",
+  "upgrade_url": "https://analytics.airqo.net/account/subscription"
+}
+```
+
+**Cause:** You are trying to access a feature (e.g. forecasts, historical data) not included in your current tier.
+
+**Solution:** Upgrade your subscription at [analytics.airqo.net](https://analytics.airqo.net) → Account Settings → Subscription.
+
+---
+
+### 404 Not Found
+
+```json
+{
+  "status": "error",
+  "message": "No data found for the requested device(s) or time range",
+  "code": "NOT_FOUND"
+}
+```
+
+**Causes:**
+- The ID you provided does not exist or is incorrect
+- No measurements exist for the device in the requested date range
+- The device was offline for the entire period
+
+**Solution:** Verify the ID using the [Finding IDs guide](./finding-ids). Try a shorter or more recent date range.
+
+---
+
+### 429 Too Many Requests
+
+**Cause:** You have exceeded the rate limit for your tier.
+
+**Solution:**
+1. Implement exponential backoff — wait before retrying.
+2. Cache responses to avoid repeating identical queries.
+3. Upgrade to a higher tier for increased rate limits.
+
+```python
+import time
+import requests
+
+def request_with_retry(url, params, max_retries=3):
+    for attempt in range(max_retries):
+        response = requests.get(url, params=params)
+        if response.status_code == 429:
+            wait = 2 ** attempt  # 1s, 2s, 4s
+            print(f"Rate limited. Retrying in {wait}s...")
+            time.sleep(wait)
+        else:
+            return response
+    raise Exception("Max retries exceeded")
+```
+
+---
+
+## Support
+
+If you consistently receive `500` errors or unexpected responses, contact [network@airqo.net](mailto:network@airqo.net) with:
+- The endpoint you called
+- The request body or query parameters (redact your token)
+- The full response you received
+- The timestamp of the request

--- a/src/docs-website/docs/api/reference/finding-ids.md
+++ b/src/docs-website/docs/api/reference/finding-ids.md
@@ -1,0 +1,80 @@
+---
+sidebar_position: 3
+sidebar_label: Finding IDs
+---
+
+# Finding IDs
+
+To use the AirQo API, you need the right identifier for your data source. This page explains how to find Cohort IDs, Grid IDs, Site IDs, and Device IDs.
+
+---
+
+## Cohort ID
+
+A Cohort ID groups your organisation's devices together. Cohorts are managed by AirQo.
+
+**How to find your Cohort ID:**
+- **Public Cohorts:** Browse the metadata endpoints at [docs.airqo.net/airqo-rest-api-documentation/api-endpoints/metadata](https://docs.airqo.net/airqo-rest-api-documentation/api-endpoints/metadata)
+- **Private Cohorts:** Contact [support@airqo.net](mailto:support@airqo.net) — your Cohort ID will be shared securely once your organisation's Cohort is set up
+
+A Cohort ID looks like: `64b9c7d5e3f82b0014c5a123`
+
+---
+
+## Grid ID
+
+A Grid ID represents a geographical area (typically a city or district). Grids are public.
+
+**How to find your Grid ID:**
+
+1. Visit the [metadata documentation](https://docs.airqo.net/airqo-rest-api-documentation/api-endpoints/metadata)
+2. Use the `admin_level` query parameter to filter by country, province, or city
+
+**Known Grid IDs (examples):**
+
+| City | Grid ID |
+|------|---------|
+| Nairobi | `64b7ac8fd7249f0029feca80` |
+
+For other cities, use the metadata endpoint to browse all available Grids.
+
+---
+
+## Site ID
+
+A Site ID identifies a specific physical monitoring location.
+
+**How to find Site IDs:**
+- Call the [recent measurements endpoint](../for-cities/recent-measurements) for your Grid and collect the `site_id` field from each measurement
+- Browse the metadata endpoints for a full list: [docs.airqo.net/airqo-rest-api-documentation/api-endpoints/metadata](https://docs.airqo.net/airqo-rest-api-documentation/api-endpoints/metadata)
+
+A Site ID looks like: `64f7b3e8c9d25a0013f2d456`
+
+---
+
+## Device ID and Device Name
+
+A Device ID uniquely identifies a sensor unit. Device names follow the pattern `airqo_XXXXX`.
+
+**How to find Device IDs:**
+- Call any measurements endpoint and look at the `device_id` and `device` fields in each measurement record
+- The `device` field (e.g. `airqo_bx2847`) is the **device name** used in Analytics API requests
+- The `device_id` field (e.g. `65c8d4a2f1b45c0012a3e789`) is used for forecast requests
+
+---
+
+## ID format reference
+
+| Identifier | Format | Example |
+|-----------|--------|---------|
+| Cohort ID | 24-char hex string | `64b9c7d5e3f82b0014c5a123` |
+| Grid ID | 24-char hex string | `64b7ac8fd7249f0029feca80` |
+| Site ID | 24-char hex string | `64f7b3e8c9d25a0013f2d456` |
+| Device ID | 24-char hex string | `65c8d4a2f1b45c0012a3e789` |
+| Device Name | `airqo_XXXXX` | `airqo_bx2847` |
+
+---
+
+## Still can't find your ID?
+
+Contact [support@airqo.net](mailto:support@airqo.net) with your organisation's name or the city/region you are monitoring. The team can look up the correct IDs for you.

--- a/src/docs-website/docs/api/reference/pagination.md
+++ b/src/docs-website/docs/api/reference/pagination.md
@@ -107,9 +107,8 @@ def fetch_all_pages(base_payload, token):
             payload['cursor'] = cursor
 
         response = requests.post(
-            "https://api.airqo.net/api/v3/public/analytics/data-download",
-            json=payload,
-            headers={"Authorization": f"Bearer {token}"}
+            f"https://api.airqo.net/api/v3/public/analytics/data-download?token={token}",
+            json=payload
         ).json()
 
         all_records.extend(response['data'])
@@ -133,12 +132,11 @@ async function fetchAllPages(basePayload, token) {
     const payload = cursor ? { ...basePayload, cursor } : basePayload;
 
     const response = await fetch(
-      'https://api.airqo.net/api/v3/public/analytics/data-download',
+      `https://api.airqo.net/api/v3/public/analytics/data-download?token=${token}`,
       {
         method: 'POST',
         headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${token}`
+          'Content-Type': 'application/json'
         },
         body: JSON.stringify(payload)
       }

--- a/src/docs-website/docs/api/reference/pagination.md
+++ b/src/docs-website/docs/api/reference/pagination.md
@@ -1,0 +1,166 @@
+---
+sidebar_position: 4
+sidebar_label: Pagination
+---
+
+# Pagination
+
+The AirQo API uses two pagination styles depending on the endpoint type.
+
+---
+
+## Skip-based pagination (GET measurement endpoints)
+
+Used by: Cohort ID, Grid ID, Site ID, and Device ID measurement endpoints.
+
+Add `limit` and `skip` as query parameters:
+
+| Parameter | Default | Max | Description |
+|-----------|---------|-----|-------------|
+| `limit` | 100 | 300 | Records per page |
+| `skip` | 0 | — | Records to skip |
+| `sortBy` | `createdAt` | — | Field to sort by |
+| `order` | `desc` | — | `"asc"` or `"desc"` |
+
+### Example
+
+```bash
+# Page 1 (records 1–100)
+GET .../cohorts/{COHORT_ID}?token={SECRET_TOKEN}&limit=100&skip=0
+
+# Page 2 (records 101–200)
+GET .../cohorts/{COHORT_ID}?token={SECRET_TOKEN}&limit=100&skip=100
+```
+
+### Pagination response shape
+
+```json
+{
+  "meta": {
+    "total": 5250,
+    "limit": 100,
+    "skip": 0,
+    "page": 1,
+    "pages": 53
+  }
+}
+```
+
+Use `meta.pages` to know when you have reached the last page.
+
+### JavaScript — paginate through all records
+
+```js
+async function fetchAllMeasurements(cohortId, token) {
+  const limit = 100;
+  let skip = 0;
+  let allMeasurements = [];
+  let totalPages = 1;
+
+  do {
+    const response = await fetch(
+      `https://api.airqo.net/api/v2/devices/measurements/cohorts/${cohortId}?token=${token}&limit=${limit}&skip=${skip}`
+    );
+    const data = await response.json();
+
+    allMeasurements = allMeasurements.concat(data.measurements);
+    totalPages = data.meta.pages;
+    skip += limit;
+  } while (skip < totalPages * limit);
+
+  return allMeasurements;
+}
+```
+
+---
+
+## Cursor-based pagination (Analytics API POST endpoints)
+
+Used by: `raw-data` and `data-download` endpoints.
+
+The first request has no cursor. If `metadata.has_more` is `true`, pass the value of `metadata.next` as `cursor` in the next request.
+
+### Response shape
+
+```json
+{
+  "metadata": {
+    "total_count": 2000,
+    "has_more": true,
+    "next": "eyJsYXN0SWQiOiI2NWM4Z..."
+  }
+}
+```
+
+### Python — fetch all pages
+
+```python
+import requests
+
+def fetch_all_pages(base_payload, token):
+    all_records = []
+    cursor = None
+
+    while True:
+        payload = {**base_payload}
+        if cursor:
+            payload['cursor'] = cursor
+
+        response = requests.post(
+            "https://api.airqo.net/api/v3/public/analytics/data-download",
+            json=payload,
+            headers={"Authorization": f"Bearer {token}"}
+        ).json()
+
+        all_records.extend(response['data'])
+
+        if not response['metadata']['has_more']:
+            break
+
+        cursor = response['metadata']['next']
+
+    return all_records
+```
+
+### JavaScript — fetch all pages
+
+```js
+async function fetchAllPages(basePayload, token) {
+  let allRecords = [];
+  let cursor = null;
+
+  do {
+    const payload = cursor ? { ...basePayload, cursor } : basePayload;
+
+    const response = await fetch(
+      'https://api.airqo.net/api/v3/public/analytics/data-download',
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`
+        },
+        body: JSON.stringify(payload)
+      }
+    );
+
+    const data = await response.json();
+    allRecords = allRecords.concat(data.data);
+    cursor = data.metadata.has_more ? data.metadata.next : null;
+  } while (cursor);
+
+  return allRecords;
+}
+```
+
+---
+
+## Choosing the right page size
+
+| Scenario | Recommended `limit` |
+|----------|-------------------|
+| Interactive dashboards | 50–100 |
+| Background data sync | 200–300 |
+| One-off bulk export | Max (300) |
+
+For Analytics API cursor pagination, the page size is determined server-side. Keep re-requesting until `has_more` is `false`.

--- a/src/docs-website/docs/api/reference/response-structure.md
+++ b/src/docs-website/docs/api/reference/response-structure.md
@@ -1,0 +1,216 @@
+---
+sidebar_position: 1
+sidebar_label: Response Structure
+---
+
+# Response Structure
+
+This page documents the response format for each category of AirQo API endpoint.
+
+---
+
+## Hourly measurements (GET endpoints)
+
+Used by: Site ID, Device ID, Cohort ID, and Grid ID recent measurement endpoints.
+
+```json
+{
+  "success": true,
+  "isCache": false,
+  "message": "successfully returned the measurements",
+  "meta": {
+    "total": 168,
+    "skip": 0,
+    "limit": 50,
+    "page": 1,
+    "pages": 4,
+    "startTime": "2025-09-21T11:00:00.000Z",
+    "endTime": "2025-09-28T11:00:00.000Z",
+    "optimized": true
+  },
+  "measurements": [
+    {
+      "device": "airqo_bx2847",
+      "device_id": "65c8d4a2f1b45c0012a3e789",
+      "site_id": "64f7b3e8c9d25a0013f2d456",
+      "time": "2025-09-25T14:00:00.000Z",
+      "pm2_5": { "value": 23.45 },
+      "pm10": { "value": 31.82 },
+      "frequency": "hourly",
+      "deviceDetails": {
+        "_id": "65c8d4a2f1b45c0012a3e789",
+        "cohorts": ["64b9c7d5e3f82b0014c5a123"],
+        "isOnline": true,
+        "status": "deployed",
+        "isPrimaryInLocation": true,
+        "category": "lowcost",
+        "network": "airqo",
+        "name": "airqo_bx2847",
+        "serial_number": "3456789",
+        "latitude": 0.3476,
+        "longitude": 32.5825,
+        "lastActive": "2025-09-25T14:00:00.000Z",
+        "lastRawData": "2025-09-28T08:45:00.000Z",
+        "rawOnlineStatus": true
+      }
+    }
+  ]
+}
+```
+
+### Field reference
+
+**Top-level**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `success` | boolean | `true` if request succeeded |
+| `isCache` | boolean | Whether response was served from cache |
+| `message` | string | Human-readable status |
+| `meta` | object | Pagination and query metadata |
+| `measurements` | array | Measurement records |
+
+**`meta` object**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `total` | number | Total matching records |
+| `skip` | number | Records skipped |
+| `limit` | number | Records per page |
+| `page` | number | Current page |
+| `pages` | number | Total pages |
+| `startTime` | string | Query start (ISO 8601) |
+| `endTime` | string | Query end (ISO 8601) |
+
+**Measurement record**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `device` | string | Device name |
+| `device_id` | string | Unique device identifier |
+| `site_id` | string | Location identifier |
+| `time` | string | Reading timestamp (ISO 8601) |
+| `pm2_5.value` | number | PM2.5 in μg/m³ |
+| `pm10.value` | number | PM10 in μg/m³ |
+| `frequency` | string | Always `"hourly"` |
+
+**`deviceDetails` object** (key fields)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `isOnline` | boolean | Whether device is currently active |
+| `status` | string | `"deployed"`, `"maintenance"`, etc. |
+| `category` | string | `"lowcost"` or `"reference"` |
+| `latitude` | number | Device latitude |
+| `longitude` | number | Device longitude |
+| `lastActive` | string | Last calibrated reading timestamp |
+| `lastRawData` | string | Last raw reading timestamp |
+
+---
+
+## Analytics API responses (POST endpoints)
+
+Used by: `raw-data` and `data-download` endpoints.
+
+```json
+{
+  "status": "success",
+  "message": "Data downloaded successfully",
+  "data": [
+    {
+      "site_name": "Kampala Road",
+      "device_name": "airqo_bx2847",
+      "datetime": "2025-01-01 10:00:00Z",
+      "pm2_5": 12.45,
+      "pm10": 15.32,
+      "latitude": 0.33,
+      "longitude": 32.56,
+      "temperature": 24.5,
+      "humidity": 65.4,
+      "network": "airqo",
+      "frequency": "hourly"
+    }
+  ],
+  "metadata": {
+    "total_count": 500,
+    "has_more": false,
+    "next": null
+  }
+}
+```
+
+**Top-level**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `status` | string | `"success"` or `"error"` |
+| `message` | string | Human-readable status |
+| `data` | array | Data records |
+| `metadata` | object | Pagination metadata |
+
+**`metadata` object**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `total_count` | number | Total matching records |
+| `has_more` | boolean | Whether additional pages exist |
+| `next` | string or null | Cursor for the next page (pass as `cursor` parameter) |
+
+---
+
+## Heatmap response
+
+Used by: `/api/v2/spatial/heatmaps` endpoints.
+
+```json
+[
+  {
+    "bounds": [
+      [-1.444, 36.650],
+      [-1.163, 37.102]
+    ],
+    "city": "nairobi_city",
+    "id": "64b7ac8fd7249f0029feca80",
+    "image": "data:image/png;base64,iVBORw0KGgo...",
+    "message": "✅ AQI image generated for nairobi_city"
+  }
+]
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `bounds` | array | `[[sw_lat, sw_lng], [ne_lat, ne_lng]]` bounding box |
+| `city` | string | City slug |
+| `id` | string | Grid ID |
+| `image` | string | Base64-encoded PNG (`data:image/png;base64,...`) |
+| `message` | string | Generation status |
+
+---
+
+## Forecast response
+
+Used by: `/api/v2/predict/hourly-forecast` and `/api/v2/predict/daily-forecast`.
+
+```json
+{
+  "success": true,
+  "message": "Forecasts retrieved successfully",
+  "forecasts": [
+    {
+      "time": "2025-09-29T14:00:00+00:00",
+      "pm2_5": 24.5,
+      "health_tips": ["Air quality is acceptable for most people"]
+    }
+  ],
+  "forecast_metadata": {
+    "model_version": "v2.3",
+    "generated_at": "2025-09-29T12:00:00+00:00",
+    "location": {
+      "site_id": "64f7b3e8c9d25a0013f2d456",
+      "latitude": 0.3476,
+      "longitude": 32.5825
+    },
+    "forecast_horizon_hours": 168
+  }
+}
+```

--- a/src/docs-website/docs/api/reference/response-structure.md
+++ b/src/docs-website/docs/api/reference/response-structure.md
@@ -81,6 +81,7 @@ Used by: Site ID, Device ID, Cohort ID, and Grid ID recent measurement endpoints
 | `pages` | number | Total pages |
 | `startTime` | string | Query start (ISO 8601) |
 | `endTime` | string | Query end (ISO 8601) |
+| `optimized` | boolean | `true` when the query used an optimized execution path (e.g. index scan, caching, or approximation) |
 
 **Measurement record**
 


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?

Replaces the minimal `docs/api/intro.md` stub with a full, structured API documentation suite inside `src/docs-website/docs/api/`. The new documentation covers all public-facing AirQo API capabilities across 25 pages, organised into six sidebar sections: Getting Started, For Partners (Cohort ID), For Cities (Grid ID), Analytics API, Forecasts, and Reference.

### Why is this change needed?

The existing API section contained a single placeholder page. As AirQo grows its partner and city integrations, public-facing documentation needs to be comprehensive enough for new organisations to self-onboard without direct support. This documentation is designed to be shared publicly and focuses on the two primary access patterns — Cohort ID for partners and Grid ID for cities — with clear user-story-driven structure and code examples in curl, Python, and JavaScript.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [x] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:** N/A — documentation only. References endpoints from `auth-service` (token generation), `device-registry` (measurements), `analytics` (historical/raw data), and the forecast service.

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:** Verified Docusaurus auto-generates the sidebar correctly from the folder structure and `_category_.json` files. All internal cross-links use relative paths consistent with the Docusaurus routing convention. No `sidebars.ts` changes required — the existing `apiSidebar` autogenerated config picks up the new structure automatically.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

- All historical measurement examples use the Analytics microservice endpoints (`/api/v3/public/analytics/`) — no device registry historical endpoints are referenced per product decision.
- No tenant query parameter appears anywhere in the documentation.
- The **For Cities** section is intentionally separate from **For Partners** to support distinct onboarding flows: cities use Grid ID (geographical) and partners use Cohort ID (organisational).
- Forecasts section is clearly gated behind Premium Tier with upgrade prompts.
- Heatmap documentation includes Leaflet overlay example directly relevant to city integrations already live (Kampala, Lagos, Nairobi).

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive API docs suite: Analytics API (raw & calibrated data export), For Cities (grid guides, recent measurements, heatmaps, historical data), For Partners (cohort guides, recent & historical data), Forecasts, and Getting Started (auth, quick start, pricing).
  * New reference material: best practices, pagination, response structure, error codes, finding IDs.
  * Updated API overview and sidebar/category organization for clearer navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->