### PR TITLE
feat: proactive session expiry detection and SOLID refactor

### DIFF
--- a/src/mobile/lib/main.dart
+++ b/src/mobile/lib/main.dart
@@ -2,7 +2,9 @@ import 'dart:async';
 import 'package:airqo/core/utils/logging_bloc_observer.dart';
 import 'package:airqo/src/app/auth/bloc/ForgotPasswordBloc/forgot_password_bloc.dart';
 import 'package:airqo/src/app/auth/bloc/auth_bloc.dart';
+import 'package:airqo/src/app/auth/pages/welcome_screen.dart';
 import 'package:airqo/src/app/auth/repository/auth_repository.dart';
+import 'package:airqo/src/app/auth/services/auth_helper.dart';
 import 'package:airqo/src/app/shared/repository/global_auth_manager.dart';
 import 'package:airqo/src/app/dashboard/bloc/dashboard/dashboard_bloc.dart';
 import 'package:airqo/src/app/dashboard/bloc/forecast/forecast_bloc.dart';
@@ -235,9 +237,24 @@ class _DeciderState extends State<Decider> with WidgetsBindingObserver {
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
     super.didChangeAppLifecycleState(state);
-    
+
     if (state == AppLifecycleState.resumed) {
       AutoUpdateService().checkForUpdates(showDialog: true);
+      _checkTokenExpiryOnResume();
+    }
+  }
+
+  Future<void> _checkTokenExpiryOnResume() async {
+    final authBloc = context.read<AuthBloc>();
+    // Only check when the user is authenticated; guests have no token,
+    // and if already expired we don't need to fire again.
+    final currentState = authBloc.state;
+    if (currentState is! AuthLoaded) return;
+
+    final isExpired = await AuthHelper.isTokenExpired();
+    if (isExpired && mounted) {
+      // Route through GlobalAuthManager so the de-duplication guard applies.
+      GlobalAuthManager.instance.notifySessionExpired();
     }
   }
 
@@ -248,14 +265,28 @@ class _DeciderState extends State<Decider> with WidgetsBindingObserver {
         logDebug('Current connectivity state: $connectivityState');
         return Stack(
           children: [
-            BlocBuilder<AuthBloc, AuthState>(
+            BlocConsumer<AuthBloc, AuthState>(
+              listener: (context, authState) {
+                if (authState is SessionExpiredState) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(
+                      content: Text('Your session has expired. Please log in again.'),
+                      duration: Duration(seconds: 4),
+                    ),
+                  );
+                }
+              },
               builder: (context, authState) {
                 debugPrint("Current AuthState: $authState");
 
                 if (authState is AuthLoading) {
-                  return Scaffold(
-                    body: const Center(child: CircularProgressIndicator()),
+                  return const Scaffold(
+                    body: Center(child: CircularProgressIndicator()),
                   );
+                }
+
+                if (authState is SessionExpiredState) {
+                  return const WelcomeScreen();
                 }
 
                 if (authState is GuestUser) {
@@ -267,15 +298,14 @@ class _DeciderState extends State<Decider> with WidgetsBindingObserver {
                   return NavPage();
                 }
 
-
                 if (authState is AuthLoadingError) {
                   return Scaffold(
                     body: Center(child: Text('Error: ${authState.message}')),
                   );
                 }
 
-                return Scaffold(
-                  body: const Center(child: CircularProgressIndicator()),
+                return const Scaffold(
+                  body: Center(child: CircularProgressIndicator()),
                 );
               },
             ),

--- a/src/mobile/lib/src/app/auth/bloc/auth_bloc.dart
+++ b/src/mobile/lib/src/app/auth/bloc/auth_bloc.dart
@@ -1,5 +1,7 @@
 import 'package:airqo/src/app/auth/models/input_model.dart';
 import 'package:airqo/src/app/auth/repository/auth_repository.dart';
+import 'package:airqo/src/app/auth/services/auth_helper.dart';
+import 'package:airqo/src/app/shared/repository/global_auth_manager.dart';
 import 'package:bloc/bloc.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter/cupertino.dart';
@@ -27,7 +29,10 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> with UiLoggy {
 
     on<SessionExpired>(_onSessionExpired);
 
-    on<UseAsGuest>((event, emit) => emit(GuestUser()));
+    on<UseAsGuest>((event, emit) {
+      GlobalAuthManager.instance.resetSessionExpiredGuard();
+      emit(GuestUser());
+    });
 
     on<VerifyEmailCode>(_onVerifyEmailCode);
   }
@@ -38,7 +43,14 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> with UiLoggy {
       final token = await SecureStorageRepository.instance.getSecureData(SecureStorageKeys.authToken);
 
       if (token != null && token.isNotEmpty) {
-        emit(AuthLoaded(AuthPurpose.login));
+        final isExpired = await AuthHelper.isTokenExpired();
+        if (isExpired) {
+          loggy.warning('Token found on app start but is expired — treating as session expiry');
+          await _clearAuthData();
+          emit(SessionExpiredState());
+        } else {
+          emit(AuthLoaded(AuthPurpose.login));
+        }
       } else {
         emit(GuestUser());
       }
@@ -54,6 +66,7 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> with UiLoggy {
     await authRepository.loginWithEmailAndPassword(
         event.username, event.password);
 
+    GlobalAuthManager.instance.resetSessionExpiredGuard();
     emit(AuthLoaded(AuthPurpose.login));
   } catch (e) {
     debugPrint("Login error: $e");
@@ -75,6 +88,7 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> with UiLoggy {
     emit(AuthLoading());
     try {
       await authRepository.registerWithEmailAndPassword(event.model);
+      GlobalAuthManager.instance.resetSessionExpiredGuard();
       emit(AuthLoaded(AuthPurpose.register));
     } catch (e) {
       debugPrint("Registration error: $e");
@@ -100,12 +114,7 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> with UiLoggy {
     emit(AuthLoading());
     try {
       loggy.info('Starting logout process - clearing auth tokens');
-      await SecureStorageRepository.instance.deleteSecureData(SecureStorageKeys.authToken);
-      await SecureStorageRepository.instance.deleteSecureData(SecureStorageKeys.userId);
-
-      loggy.info('Clearing all cached data on logout');
-      await CacheManager().clearAll();
-
+      await _clearAuthData();
       emit(GuestUser());
     } catch (e) {
       debugPrint("Logout error: $e");
@@ -128,18 +137,19 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> with UiLoggy {
   Future<void> _onSessionExpired(SessionExpired event, Emitter<AuthState> emit) async {
     try {
       loggy.info('Session expired - clearing auth tokens and cached data');
-      await SecureStorageRepository.instance.deleteSecureData(SecureStorageKeys.authToken);
-      await SecureStorageRepository.instance.deleteSecureData(SecureStorageKeys.userId);
-
-      loggy.info('Clearing all cached data due to session expiration');
-      await CacheManager().clearAll();
-
-      emit(GuestUser());
+      await _clearAuthData();
+      emit(SessionExpiredState());
     } catch (e) {
       debugPrint("Session expiry cleanup error: $e");
       loggy.error("Session expiry cleanup error: $e");
-      emit(GuestUser());
+      emit(SessionExpiredState());
     }
+  }
+
+  Future<void> _clearAuthData() async {
+    await SecureStorageRepository.instance.deleteSecureData(SecureStorageKeys.authToken);
+    await SecureStorageRepository.instance.deleteSecureData(SecureStorageKeys.userId);
+    await CacheManager().clearAll();
   }
 
   String _extractErrorMessage(dynamic e) {

--- a/src/mobile/lib/src/app/auth/bloc/auth_state.dart
+++ b/src/mobile/lib/src/app/auth/bloc/auth_state.dart
@@ -27,6 +27,11 @@ enum AuthPurpose { login, register }
 
 final class GuestUser extends AuthState {}
 
+/// Emitted when a previously authenticated session has expired.
+/// Distinct from [GuestUser] (voluntary guest) so the UI can show
+/// a "session expired – please log in" prompt.
+final class SessionExpiredState extends AuthState {}
+
 final class AuthVerified extends AuthState {}
 
 final class EmailUnverifiedError extends AuthLoadingError {

--- a/src/mobile/lib/src/app/auth/services/auth_helper.dart
+++ b/src/mobile/lib/src/app/auth/services/auth_helper.dart
@@ -1,4 +1,7 @@
+import 'dart:convert';
 import 'package:airqo/src/app/shared/repository/secure_storage_repository.dart';
+import 'package:airqo/src/meta/utils/api_utils.dart';
+import 'package:http/http.dart' as http;
 import 'package:jwt_decoder/jwt_decoder.dart';
 import 'package:loggy/loggy.dart';
 
@@ -124,6 +127,54 @@ class AuthHelper {
     }
   }
   
+  /// Silently refreshes the token if it has expired.
+  ///
+  /// Returns the valid token on success (either the existing non-expired token
+  /// or a freshly fetched one). Returns `null` if no token is stored or if
+  /// the refresh request itself fails (e.g. token older than 7 days, or no
+  /// network). Callers should fall back to the stored token and let the normal
+  /// 401 path handle the failure.
+  static Future<String?> refreshTokenIfNeeded() async {
+    try {
+      final token = await SecureStorageRepository.instance
+          .getSecureData(SecureStorageKeys.authToken);
+
+      if (token == null || token.isEmpty) return null;
+
+      // Token still valid — return it immediately, no network call needed.
+      if (!JwtDecoder.isExpired(token)) return token;
+
+      _logger.info('Token expired — attempting silent refresh');
+
+      final url = '${ApiUtils.baseUrl}/api/v2/users/token/refresh';
+      final response = await http.post(
+        Uri.parse(url),
+        headers: {
+          'Authorization': 'JWT $token',
+          'Content-Type': 'application/json',
+          'Accept': '*/*',
+        },
+      );
+
+      if (response.statusCode == 200) {
+        final body = json.decode(response.body) as Map<String, dynamic>;
+        if (body['success'] == true && body['token'] != null) {
+          final newToken = body['token'] as String;
+          await SecureStorageRepository.instance
+              .saveSecureData(SecureStorageKeys.authToken, newToken);
+          _logger.info('Silent token refresh succeeded');
+          return newToken;
+        }
+      }
+
+      _logger.warning('Token refresh failed (${response.statusCode})');
+      return null;
+    } catch (e) {
+      _logger.error('Error during silent token refresh: $e');
+      return null;
+    }
+  }
+
   /// Check if the current token is expired
   static Future<bool> isTokenExpired() async {
     try {

--- a/src/mobile/lib/src/app/auth/services/auth_helper.dart
+++ b/src/mobile/lib/src/app/auth/services/auth_helper.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'package:airqo/src/app/shared/repository/secure_storage_repository.dart';
 import 'package:airqo/src/meta/utils/api_utils.dart';
@@ -9,6 +10,10 @@ import 'package:loggy/loggy.dart';
 class AuthHelper {
   // Create a static logger using your app's logging setup
   static final _logger = Loggy('AuthHelper');
+
+  // Serialises concurrent refresh calls: if a refresh is already in-flight,
+  // new callers await the same Future instead of issuing duplicate requests.
+  static Future<String?>? _refreshFuture;
   
   /// Get the current user ID from secure storage (preferred method)
   static Future<String?> getCurrentUserId({bool suppressGuestWarning = false}) async {
@@ -134,7 +139,13 @@ class AuthHelper {
   /// the refresh request itself fails (e.g. token older than 7 days, or no
   /// network). Callers should fall back to the stored token and let the normal
   /// 401 path handle the failure.
-  static Future<String?> refreshTokenIfNeeded() async {
+  static Future<String?> refreshTokenIfNeeded() {
+    // If a refresh is already in-flight, join it — don't issue a second request.
+    _refreshFuture ??= _doRefresh().whenComplete(() => _refreshFuture = null);
+    return _refreshFuture!;
+  }
+
+  static Future<String?> _doRefresh() async {
     try {
       final token = await SecureStorageRepository.instance
           .getSecureData(SecureStorageKeys.authToken);
@@ -147,14 +158,16 @@ class AuthHelper {
       _logger.info('Token expired — attempting silent refresh');
 
       final url = '${ApiUtils.baseUrl}/api/v2/users/token/refresh';
-      final response = await http.post(
-        Uri.parse(url),
-        headers: {
-          'Authorization': 'JWT $token',
-          'Content-Type': 'application/json',
-          'Accept': '*/*',
-        },
-      );
+      final response = await http
+          .post(
+            Uri.parse(url),
+            headers: {
+              'Authorization': 'JWT $token',
+              'Content-Type': 'application/json',
+              'Accept': '*/*',
+            },
+          )
+          .timeout(const Duration(seconds: 10));
 
       if (response.statusCode == 200) {
         final body = json.decode(response.body) as Map<String, dynamic>;
@@ -168,6 +181,9 @@ class AuthHelper {
       }
 
       _logger.warning('Token refresh failed (${response.statusCode})');
+      return null;
+    } on TimeoutException {
+      _logger.warning('Token refresh timed out');
       return null;
     } catch (e) {
       _logger.error('Error during silent token refresh: $e');

--- a/src/mobile/lib/src/app/auth/services/auth_validation_helper.dart
+++ b/src/mobile/lib/src/app/auth/services/auth_validation_helper.dart
@@ -22,10 +22,21 @@ class AuthValidationHelper with UiLoggy {
       return false;
     }
 
-    final isExpired = await AuthHelper.isTokenExpired();
+    // Try a silent refresh before checking expiry. If it succeeds the user
+    // proceeds without any interruption; only fall back to the re-login prompt
+    // when refresh itself fails (token > 7 days old or no network).
+    final token = await AuthHelper.refreshTokenIfNeeded();
+    if (token != null) {
+      logger.info('Authentication validation passed (token valid or refreshed)');
+      return true;
+    }
 
+    // Refresh failed — check whether the token is actually expired before
+    // blocking the user (it may still be valid if refresh failed due to network).
+    final isExpired = await AuthHelper.isTokenExpired();
     if (isExpired) {
-      logger.warning('Token is expired');
+      logger.warning('Token is expired and refresh failed');
+      if (!context.mounted) return false;
       showAuthErrorSafe(
         context,
         message: 'Your session has expired. Please log in again.',
@@ -34,7 +45,7 @@ class AuthValidationHelper with UiLoggy {
       return false;
     }
 
-    logger.info('Authentication validation passed');
+    logger.info('Authentication validation passed (refresh failed but token still valid)');
     return true;
   }
 

--- a/src/mobile/lib/src/app/dashboard/bloc/dashboard/dashboard_bloc.dart
+++ b/src/mobile/lib/src/app/dashboard/bloc/dashboard/dashboard_bloc.dart
@@ -116,10 +116,11 @@ class DashboardBloc extends Bloc<DashboardEvent, DashboardState> with UiLoggy {
 
       // Emit loaded state with fresh or cached data
       emit(DashboardLoaded(
-        response, 
+        response,
         userPreferences: preferences,
         isOffline: !_cacheManager.isConnected,
         lastUpdated: DateTime.now(),
+        prefsAuthError: prefsAuthError,
       ));
 
       if (preferences == null && !prefsAuthError) {

--- a/src/mobile/lib/src/app/dashboard/bloc/dashboard/dashboard_state.dart
+++ b/src/mobile/lib/src/app/dashboard/bloc/dashboard/dashboard_state.dart
@@ -27,17 +27,21 @@ class DashboardLoaded extends DashboardState {
   final UserPreferencesModel? userPreferences;
   final bool isOffline;
   final DateTime? lastUpdated;
+  /// True when the preferences fetch returned a 401, meaning the user's token
+  /// is expired. The session is not wiped — the user just needs a token refresh.
+  final bool prefsAuthError;
 
   const DashboardLoaded(
     this.response, {
     this.userPreferences,
     this.isOffline = false,
     this.lastUpdated,
+    this.prefsAuthError = false,
   });
-  
+
   @override
-  List<Object?> get props => [response, userPreferences, isOffline, lastUpdated];
-  
+  List<Object?> get props => [response, userPreferences, isOffline, lastUpdated, prefsAuthError];
+
   List<String> get selectedLocationIds {
     if (userPreferences == null) return [];
     return userPreferences!.selectedSites
@@ -45,19 +49,21 @@ class DashboardLoaded extends DashboardState {
         .cast<String>()
         .toList();
   }
-  
+
 
   DashboardLoaded copyWith({
     AirQualityResponse? response,
     UserPreferencesModel? userPreferences,
     bool? isOffline,
     DateTime? lastUpdated,
+    bool? prefsAuthError,
   }) {
     return DashboardLoaded(
       response ?? this.response,
       userPreferences: userPreferences ?? this.userPreferences,
       isOffline: isOffline ?? this.isOffline,
       lastUpdated: lastUpdated ?? this.lastUpdated,
+      prefsAuthError: prefsAuthError ?? this.prefsAuthError,
     );
   }
 }
@@ -68,6 +74,7 @@ class DashboardRefreshing extends DashboardLoaded {
     super.userPreferences,
     super.isOffline,
     super.lastUpdated,
+    super.prefsAuthError,
   });
 }
 
@@ -79,9 +86,10 @@ class DashboardLoadedWithError extends DashboardLoaded {
     super.userPreferences,
     super.isOffline,
     super.lastUpdated,
+    super.prefsAuthError,
     required this.errorMessage,
   });
-  
+
   @override
   List<Object?> get props => [...super.props, errorMessage];
 }

--- a/src/mobile/lib/src/app/dashboard/pages/location_selection/location_selection_screen.dart
+++ b/src/mobile/lib/src/app/dashboard/pages/location_selection/location_selection_screen.dart
@@ -117,65 +117,62 @@ class _LocationSelectionScreenState extends State<LocationSelectionScreen>
     try {
       loggy.info('⭐ Starting to initialize user data');
 
-      await AuthHelper.debugToken();
-
       final authState = context.read<AuthBloc>().state;
       loggy.info('Current auth state: ${authState.runtimeType}');
 
       final isLoggedIn = authState is AuthLoaded;
       loggy.info('Is user logged in according to AuthBloc? $isLoggedIn');
 
-      if (isLoggedIn) {
-        final isExpired = await AuthHelper.isTokenExpired();
-
-        if (isExpired) {
-          loggy.warning('Token is expired, user needs to login again');
-
-          if (mounted) {
-            ScaffoldMessenger.of(context).showSnackBar(
-              SnackBar(
-                content: const TranslatedText(
-                    'Your session has expired. Please log in again.'),
-                duration: const Duration(seconds: 8),
-                action: SnackBarAction(
-                  label: 'Log In',
-                  onPressed: () {
-                    Navigator.of(context).pushAndRemoveUntil(
-                      MaterialPageRoute(
-                        builder: (context) => const LoginPage(),
-                      ),
-                      (route) => false,
-                    );
-                  },
-                ),
-              ),
-            );
-          }
-          return;
-        }
-
-        final userId = await AuthHelper.getCurrentUserId(suppressGuestWarning: true);
-
-        if (userId != null) {
-          setState(() {
-            currentUserId = userId;
-          });
-          loggy.info('✅ User ID set in state: $currentUserId');
-
-          await _loadUserPreferences(userId);
-        } else {
-          loggy.warning('❌ No user ID found in token - token may be invalid');
-
-          if (mounted) {
-            ScaffoldMessenger.of(context).showSnackBar(
-              const SnackBar(
-                  content: TranslatedText(
-                      'Authentication issue detected. Please log in again.')),
-            );
-          }
-        }
-      } else {
+      if (!isLoggedIn) {
         loggy.warning('❌ User is not logged in according to AuthBloc');
+        return;
+      }
+
+      // Attempt silent refresh before doing anything so the token is valid
+      // by the time the user taps Save.
+      loggy.info('Attempting silent token refresh on screen open');
+      final token = await AuthHelper.refreshTokenIfNeeded();
+
+      if (token == null) {
+        loggy.warning('Token refresh failed — user will be blocked at save if token is invalid');
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: const TranslatedText(
+                  'Your session may have expired. You can browse, but saving may require logging in again.'),
+              duration: const Duration(seconds: 6),
+              action: SnackBarAction(
+                label: 'Log In',
+                onPressed: () {
+                  Navigator.of(context).pushAndRemoveUntil(
+                    MaterialPageRoute(builder: (context) => const LoginPage()),
+                    (route) => false,
+                  );
+                },
+              ),
+            ),
+          );
+        }
+        // Continue — the user can still browse; Save is gated by validateAuthentication.
+      }
+
+      final userId = await AuthHelper.getCurrentUserId(suppressGuestWarning: true);
+
+      if (userId != null) {
+        setState(() {
+          currentUserId = userId;
+        });
+        loggy.info('✅ User ID set in state: $currentUserId');
+        await _loadUserPreferences(userId);
+      } else {
+        loggy.warning('❌ No user ID found in token - token may be invalid');
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+                content: TranslatedText(
+                    'Authentication issue detected. Please log in again.')),
+          );
+        }
       }
     } catch (e) {
       loggy.error('❌ Error initializing user data: $e');

--- a/src/mobile/lib/src/app/dashboard/widgets/dashboard_header.dart
+++ b/src/mobile/lib/src/app/dashboard/widgets/dashboard_header.dart
@@ -77,7 +77,7 @@ class DashboardHeader extends StatelessWidget {
       mainAxisSize: MainAxisSize.min,
       children: [
         TranslatedText(
-          "Hi,",
+          "Hello,",
           style: TextStyle(
             fontSize: 28,
             fontWeight: FontWeight.w700,
@@ -101,7 +101,7 @@ class DashboardHeader extends StatelessWidget {
       mainAxisSize: MainAxisSize.min,
       children: [
         TranslatedText(
-          "Hi",
+          "Hello",
           style: TextStyle(
             fontSize: 28,
             fontWeight: FontWeight.w700,
@@ -131,7 +131,7 @@ class DashboardHeader extends StatelessWidget {
             mainAxisSize: MainAxisSize.min,
             children: [
               TranslatedText(
-                "Hi",
+                "Hello",
                 style: TextStyle(
                   fontSize: 28,
                   fontWeight: FontWeight.w700,
@@ -159,7 +159,7 @@ class DashboardHeader extends StatelessWidget {
             mainAxisSize: MainAxisSize.min,
             children: [
               TranslatedText(
-                "Hi",
+                "Hello",
                 style: TextStyle(
                   fontSize: 28,
                   fontWeight: FontWeight.w700,

--- a/src/mobile/lib/src/app/dashboard/widgets/my_places_view.dart
+++ b/src/mobile/lib/src/app/dashboard/widgets/my_places_view.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:loggy/loggy.dart';
 import 'package:dotted_border/dotted_border.dart';
+import 'package:airqo/src/app/auth/services/auth_helper.dart';
 import 'package:airqo/src/app/dashboard/bloc/dashboard/dashboard_bloc.dart';
 import 'package:airqo/src/app/dashboard/models/airquality_response.dart';
 import 'package:airqo/src/app/dashboard/models/user_preferences_model.dart';
@@ -31,6 +32,7 @@ class _MyPlacesViewState extends State<MyPlacesView> with UiLoggy {
   List<Measurement> selectedMeasurements = [];
   List<SelectedSite> unmatchedSites = [];
   bool isLoading = false;
+  bool _prefsAuthError = false;
   late CacheManager _cacheManager;
 
   @override
@@ -327,6 +329,35 @@ class _MyPlacesViewState extends State<MyPlacesView> with UiLoggy {
       listener: (context, state) {
         loggy.info('Dashboard state changed to ${state.runtimeType}');
         if (state is DashboardLoaded) {
+          if (state.prefsAuthError) {
+            loggy.warning('Preferences auth error detected — showing refresh prompt');
+            setState(() => _prefsAuthError = true);
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(
+                content: const TranslatedText('Session expired. Your saved places could not be loaded.'),
+                duration: const Duration(seconds: 10),
+                action: SnackBarAction(
+                  label: 'Refresh',
+                  onPressed: () async {
+                    final token = await AuthHelper.refreshTokenIfNeeded();
+                    if (token != null && context.mounted) {
+                      setState(() => _prefsAuthError = false);
+                      context.read<DashboardBloc>().add(LoadUserPreferences());
+                    } else if (context.mounted) {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(
+                          content: TranslatedText('Could not refresh session. Please log in again.'),
+                          duration: Duration(seconds: 6),
+                        ),
+                      );
+                    }
+                  },
+                ),
+              ),
+            );
+          } else {
+            setState(() => _prefsAuthError = false);
+          }
           _loadSelectedMeasurements();
         } else if (state is DashboardAuthenticationError) {
           loggy.error('Authentication error detected: ${state.message}');
@@ -360,7 +391,7 @@ class _MyPlacesViewState extends State<MyPlacesView> with UiLoggy {
                     _buildLoadingState()
                   else if (selectedMeasurements.isEmpty &&
                       unmatchedSites.isEmpty)
-                    _buildEmptyState()
+                    (_prefsAuthError ? _buildSessionExpiredState() : _buildEmptyState())
                   else ...[
                     ...selectedMeasurements.map((measurement) {
                       String? preferenceLocationName;
@@ -449,6 +480,68 @@ class _MyPlacesViewState extends State<MyPlacesView> with UiLoggy {
         ),
         _buildAddLocationContainer(),
         _buildAddLocationContainer(),
+      ],
+    );
+  }
+
+  Widget _buildSessionExpiredState() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        const SizedBox(height: 48),
+        Icon(
+          Icons.lock_clock_outlined,
+          size: 64,
+          color: Theme.of(context).textTheme.bodyMedium?.color?.withValues(alpha: 0.4),
+        ),
+        const SizedBox(height: 16),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 32),
+          child: TranslatedText(
+            'Your session has expired',
+            textAlign: TextAlign.center,
+            style: TextStyle(
+              fontSize: 20,
+              fontWeight: FontWeight.bold,
+              color: Theme.of(context).textTheme.headlineMedium?.color,
+            ),
+          ),
+        ),
+        const SizedBox(height: 8),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 32),
+          child: TranslatedText(
+            'We could not load your saved places because your session needs to be refreshed.',
+            textAlign: TextAlign.center,
+            style: TextStyle(
+              fontSize: 15,
+              color: Theme.of(context).textTheme.bodyMedium?.color,
+            ),
+          ),
+        ),
+        const SizedBox(height: 24),
+        ElevatedButton.icon(
+          onPressed: () async {
+            final token = await AuthHelper.refreshTokenIfNeeded();
+            if (token != null && mounted) {
+              setState(() => _prefsAuthError = false);
+              context.read<DashboardBloc>().add(LoadUserPreferences());
+            } else if (mounted) {
+              Navigator.of(context).pushAndRemoveUntil(
+                MaterialPageRoute(builder: (context) => const LoginPage()),
+                (route) => false,
+              );
+            }
+          },
+          icon: const Icon(Icons.refresh),
+          label: const TranslatedText('Refresh Session'),
+          style: ElevatedButton.styleFrom(
+            backgroundColor: AppColors.primaryColor,
+            foregroundColor: Colors.white,
+            padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
+            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+          ),
+        ),
       ],
     );
   }

--- a/src/mobile/lib/src/app/shared/exceptions/session_expired_exception.dart
+++ b/src/mobile/lib/src/app/shared/exceptions/session_expired_exception.dart
@@ -1,0 +1,11 @@
+/// Thrown by [BaseRepository] when the server returns a 401 response,
+/// indicating the user's authentication token is no longer valid.
+///
+/// Callers should NOT catch this themselves — it propagates to [AuthBloc]
+/// via [SessionExpiryNotifier] and is handled globally.
+class SessionExpiredException implements Exception {
+  const SessionExpiredException();
+
+  @override
+  String toString() => 'SessionExpiredException: Your session has expired. Please log in again.';
+}

--- a/src/mobile/lib/src/app/shared/repository/base_repository.dart
+++ b/src/mobile/lib/src/app/shared/repository/base_repository.dart
@@ -3,6 +3,7 @@ import 'package:airqo/src/app/shared/exceptions/session_expired_exception.dart';
 import 'package:airqo/src/app/shared/repository/global_auth_manager.dart';
 import 'package:airqo/src/app/shared/repository/secure_storage_repository.dart';
 import 'package:airqo/src/app/shared/repository/session_expiry_notifier.dart';
+import 'package:airqo/src/app/shared/repository/token_refresher.dart';
 import 'package:airqo/src/meta/utils/api_utils.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/http.dart';
@@ -13,14 +14,27 @@ class BaseRepository with UiLoggy {
   /// Swap out in tests without touching production code (DIP).
   final SessionExpiryNotifier _sessionExpiryNotifier;
 
-  BaseRepository({SessionExpiryNotifier? sessionExpiryNotifier})
-      : _sessionExpiryNotifier = sessionExpiryNotifier ?? GlobalAuthManager.instance;
+  /// Injected refresher — defaults to [DefaultTokenRefresher].
+  /// Swap out in tests without touching production code (DIP).
+  final TokenRefresher _tokenRefresher;
+
+  BaseRepository({
+    SessionExpiryNotifier? sessionExpiryNotifier,
+    TokenRefresher? tokenRefresher,
+  })  : _sessionExpiryNotifier = sessionExpiryNotifier ?? GlobalAuthManager.instance,
+        _tokenRefresher = tokenRefresher ?? const DefaultTokenRefresher();
 
   // ---------------------------------------------------------------------------
   // Private helpers
   // ---------------------------------------------------------------------------
 
+  /// Returns a valid token, transparently refreshing it if expired.
+  /// Falls back to the raw stored token if refresh fails, so the normal 401
+  /// path remains the safety net.
   Future<String?> _getToken() async {
+    final refreshed = await _tokenRefresher.refreshTokenIfNeeded();
+    if (refreshed != null) return refreshed;
+    // Refresh either failed or there's no token — return whatever is stored.
     return SecureStorageRepository.instance.getSecureData(SecureStorageKeys.authToken);
   }
 
@@ -36,21 +50,53 @@ class BaseRepository with UiLoggy {
     }
   }
 
+  /// Returns true when a 401 body explicitly signals a JWT/session problem,
+  /// as opposed to an unrelated auth failure (e.g. wrong query-level API key).
+  bool _isSessionRelated401(Response response) {
+    try {
+      final body = json.decode(response.body);
+      if (body is Map) {
+        final message = (body['message'] ?? body['error'] ?? '').toString().toLowerCase();
+        const sessionKeywords = ['jwt', 'token', 'session', 'expired', 'invalid signature', 'unauthorized'];
+        return sessionKeywords.any(message.contains);
+      }
+    } catch (_) {}
+    return false;
+  }
+
   /// Single path for all response processing — fixes the OCP violation where
   /// each HTTP method duplicated the same success/401/error branching.
   ///
   /// Throws [SessionExpiredException] on 401.
   /// Storage cleanup is owned by [AuthBloc._onSessionExpired], not here (SRP).
-  Future<Response> _processResponse(Response response, String url, {bool hasToken = true}) async {
+  ///
+  /// When [requireExplicitSessionBody] is true, session expiry is only triggered
+  /// when the 401 body explicitly mentions a JWT/session problem. Use this for
+  /// endpoints that may return 401 for reasons unrelated to the user's token
+  /// (e.g. a query-level API key issue).
+  Future<Response> _processResponse(
+    Response response,
+    String url, {
+    bool hasToken = true,
+    bool requireExplicitSessionBody = false,
+  }) async {
     if (response.statusCode >= 200 && response.statusCode < 300) {
       if (hasToken) await _handleTokenRefresh(response);
       return response;
     }
 
     if (response.statusCode == 401 && hasToken) {
-      loggy.warning('401 received — notifying session expiry for $url');
-      _sessionExpiryNotifier.notifySessionExpired();
-      throw const SessionExpiredException();
+      final shouldExpire = requireExplicitSessionBody
+          ? _isSessionRelated401(response)
+          : true;
+
+      if (shouldExpire) {
+        loggy.warning('401 received — notifying session expiry for $url');
+        _sessionExpiryNotifier.notifySessionExpired();
+        throw const SessionExpiredException();
+      } else {
+        loggy.warning('401 received but body does not indicate session issue — skipping expiry for $url');
+      }
     }
 
     throw _buildHttpException(response, url);
@@ -144,7 +190,9 @@ class BaseRepository with UiLoggy {
     );
 
     loggy.info('GET ← ${response.statusCode}');
-    return _processResponse(response, url, hasToken: token != null);
+    // Use requireExplicitSessionBody so that a 401 from a query-level API key
+    // (not the user's JWT) does not incorrectly trigger a session expiry.
+    return _processResponse(response, url, hasToken: token != null, requireExplicitSessionBody: true);
   }
 
   Future<Response> createAuthenticatedGetRequest(

--- a/src/mobile/lib/src/app/shared/repository/base_repository.dart
+++ b/src/mobile/lib/src/app/shared/repository/base_repository.dart
@@ -1,14 +1,27 @@
 import 'dart:convert';
+import 'package:airqo/src/app/shared/exceptions/session_expired_exception.dart';
 import 'package:airqo/src/app/shared/repository/global_auth_manager.dart';
 import 'package:airqo/src/app/shared/repository/secure_storage_repository.dart';
+import 'package:airqo/src/app/shared/repository/session_expiry_notifier.dart';
 import 'package:airqo/src/meta/utils/api_utils.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/http.dart';
 import 'package:loggy/loggy.dart';
 
 class BaseRepository with UiLoggy {
+  /// Injected notifier — defaults to the app-wide [GlobalAuthManager].
+  /// Swap out in tests without touching production code (DIP).
+  final SessionExpiryNotifier _sessionExpiryNotifier;
+
+  BaseRepository({SessionExpiryNotifier? sessionExpiryNotifier})
+      : _sessionExpiryNotifier = sessionExpiryNotifier ?? GlobalAuthManager.instance;
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
   Future<String?> _getToken() async {
-    return await SecureStorageRepository.instance.getSecureData(SecureStorageKeys.authToken);
+    return SecureStorageRepository.instance.getSecureData(SecureStorageKeys.authToken);
   }
 
   Future<void> _handleTokenRefresh(Response response) async {
@@ -16,189 +29,144 @@ class BaseRepository with UiLoggy {
     if (newToken != null && newToken.isNotEmpty) {
       try {
         await SecureStorageRepository.instance.saveSecureData(SecureStorageKeys.authToken, newToken);
-        loggy.info("Successfully refreshed and stored new auth token.");
+        loggy.info('Successfully refreshed and stored new auth token.');
       } catch (e) {
-        loggy.error("Failed to save refreshed token: $e");
+        loggy.error('Failed to save refreshed token: $e');
       }
     }
   }
 
-  Future<void> _handleSessionExpiry() async {
-    try {
-      await SecureStorageRepository.instance.deleteSecureData(SecureStorageKeys.authToken);
-      await SecureStorageRepository.instance.deleteSecureData(SecureStorageKeys.userId);
-      loggy.warning("Session expired. All auth data cleared.");
-      
-      GlobalAuthManager.instance.notifySessionExpired();
-    } catch (e) {
-      loggy.error("Failed to clear auth data on session expiry: $e");
+  /// Single path for all response processing — fixes the OCP violation where
+  /// each HTTP method duplicated the same success/401/error branching.
+  ///
+  /// Throws [SessionExpiredException] on 401.
+  /// Storage cleanup is owned by [AuthBloc._onSessionExpired], not here (SRP).
+  Future<Response> _processResponse(Response response, String url, {bool hasToken = true}) async {
+    if (response.statusCode >= 200 && response.statusCode < 300) {
+      if (hasToken) await _handleTokenRefresh(response);
+      return response;
     }
+
+    if (response.statusCode == 401 && hasToken) {
+      loggy.warning('401 received — notifying session expiry for $url');
+      _sessionExpiryNotifier.notifySessionExpired();
+      throw const SessionExpiredException();
+    }
+
+    throw _buildHttpException(response, url);
   }
 
-  Exception _httpError(Response response, String url) {
+  Exception _buildHttpException(Response response, String url) {
     String errorMessage = 'An error occurred';
-    
     try {
-      // Check if response has JSON content type
       final contentType = response.headers['content-type'] ?? '';
       if (contentType.toLowerCase().contains('application/json') && response.body.isNotEmpty) {
-        final responseBody = json.decode(response.body);
-        if (responseBody is Map && responseBody.containsKey('message')) {
-          errorMessage = responseBody['message'];
+        final body = json.decode(response.body);
+        if (body is Map && body.containsKey('message')) {
+          errorMessage = body['message'];
         }
       } else if (response.body.isNotEmpty) {
-        // Use raw body for non-JSON responses, but limit length to avoid huge error messages
-        final rawBody = response.body.length > 200 
-            ? '${response.body.substring(0, 200)}...' 
-            : response.body;
-        errorMessage = rawBody;
+        final raw = response.body;
+        errorMessage = raw.length > 200 ? '${raw.substring(0, 200)}...' : raw;
       }
-    } catch (e) {
-      // JSON parsing failed, use raw body if available
+    } catch (_) {
       if (response.body.isNotEmpty) {
-        final rawBody = response.body.length > 200 
-            ? '${response.body.substring(0, 200)}...' 
-            : response.body;
-        errorMessage = rawBody;
+        final raw = response.body;
+        errorMessage = raw.length > 200 ? '${raw.substring(0, 200)}...' : raw;
       }
     }
-    
     return Exception('$errorMessage (status=${response.statusCode}, url=$url)');
   }
 
+  // ---------------------------------------------------------------------------
+  // Public HTTP methods
+  // ---------------------------------------------------------------------------
+
   Future<Response> createAuthenticatedPutRequest({
-  required String path, 
-  required dynamic data
-}) async {
-  String? token = await _getToken();
-  if (token == null) {
-    throw Exception('Authentication token not found');
-  }
-  
-  String url = ApiUtils.baseUrl + path;
-  loggy.info("Making PUT request to: $url");
-  
-  Response response = await http.put(
-    Uri.parse(url),
-    body: json.encode(data),
-    headers: {
-      "Authorization": "JWT $token",
-      "Accept": "*/*",
-      "Content-Type": "application/json"
-    }
-  );
-  
-  loggy.info("PUT response status: ${response.statusCode}");
-  
-  if (response.statusCode >= 200 && response.statusCode < 300) {
-    await _handleTokenRefresh(response);
-    return response;
-  } else if (response.statusCode == 401) {
-    await _handleSessionExpiry();
-    throw Exception('Your session has expired. Please log in again.');
-  } else {
-    throw _httpError(response, url);
-  }
-}
-
-  Future<Response> createPostRequest(
-      {required String path, dynamic data}) async {
+    required String path,
+    required dynamic data,
+  }) async {
     final token = await _getToken();
-    if (token == null) {
-      throw Exception('Authentication token not found');
-    }
+    if (token == null) throw Exception('Authentication token not found');
 
-    String url = ApiUtils.baseUrl + path;
+    final url = ApiUtils.baseUrl + path;
+    loggy.info('PUT → $url');
 
-    loggy.info("Making POST request to: $url");
+    final response = await http.put(
+      Uri.parse(url),
+      body: json.encode(data),
+      headers: {
+        'Authorization': 'JWT $token',
+        'Accept': '*/*',
+        'Content-Type': 'application/json',
+      },
+    );
 
-    Response response = await http.post(Uri.parse(url),
-        body: json.encode(data),
-        headers: {
-          "Authorization": "JWT $token",
-          "Accept": "*/*",
-          "Content-Type": "application/json"
-        });
-
-    loggy.info("POST response status: ${response.statusCode}");
-
-    if (response.statusCode >= 200 && response.statusCode < 300) {
-      await _handleTokenRefresh(response);
-      return response;
-    } else if (response.statusCode == 401) {
-      await _handleSessionExpiry();
-      throw Exception('Please log in again to continue.');
-    } else {
-      throw _httpError(response, url);
-    }
+    loggy.info('PUT ← ${response.statusCode}');
+    return _processResponse(response, url);
   }
 
-  Future<Response> createGetRequest(
-      String path, Map<String, String> queryParams) async {
-    String? token = await _getToken();
+  Future<Response> createPostRequest({required String path, dynamic data}) async {
+    final token = await _getToken();
+    if (token == null) throw Exception('Authentication token not found');
 
-    String url = ApiUtils.baseUrl + path;
+    final url = ApiUtils.baseUrl + path;
+    loggy.info('POST → $url');
 
-    Map<String, String> headers = {
-      "Accept": "*/*",
-      "Content-Type": "application/json",
+    final response = await http.post(
+      Uri.parse(url),
+      body: json.encode(data),
+      headers: {
+        'Authorization': 'JWT $token',
+        'Accept': '*/*',
+        'Content-Type': 'application/json',
+      },
+    );
+
+    loggy.info('POST ← ${response.statusCode}');
+    return _processResponse(response, url);
+  }
+
+  Future<Response> createGetRequest(String path, Map<String, String> queryParams) async {
+    final token = await _getToken();
+    final url = ApiUtils.baseUrl + path;
+
+    final headers = <String, String>{
+      'Accept': '*/*',
+      'Content-Type': 'application/json',
+      if (token != null) 'Authorization': 'JWT $token',
     };
 
-    if (token != null) {
-      headers["Authorization"] = "JWT $token";
-    }
+    loggy.info('GET → $url');
+    final response = await http.get(
+      Uri.parse(url).replace(queryParameters: queryParams),
+      headers: headers,
+    );
 
-    loggy.info("Making GET request to: $url");
-
-    Response response = await http.get(
-        Uri.parse(url).replace(queryParameters: queryParams),
-        headers: headers);
-
-    loggy.info("GET response status: ${response.statusCode}");
-
-    if (response.statusCode >= 200 && response.statusCode < 300) {
-      if (token != null) {
-        await _handleTokenRefresh(response);
-      }
-      return response;
-    } else if (response.statusCode == 401 && token != null) {
-      await _handleSessionExpiry();
-      throw Exception('Your session has expired. Please log in again.');
-    } else {
-      throw _httpError(response, url);
-    }
+    loggy.info('GET ← ${response.statusCode}');
+    return _processResponse(response, url, hasToken: token != null);
   }
 
   Future<Response> createAuthenticatedGetRequest(
-      String path, Map<String, String> queryParams) async {
-    String? token = await _getToken();
-    if (token == null) {
-      throw Exception('Authentication token not found');
-    }
+    String path,
+    Map<String, String> queryParams,
+  ) async {
+    final token = await _getToken();
+    if (token == null) throw Exception('Authentication token not found');
 
-    loggy.info("Auth token present: true - using authenticated request");
+    final url = ApiUtils.baseUrl + path;
+    loggy.info('GET (auth) → $url');
 
-    String url = ApiUtils.baseUrl + path;
+    final response = await http.get(
+      Uri.parse(url).replace(queryParameters: queryParams),
+      headers: {
+        'Accept': '*/*',
+        'Authorization': 'JWT $token',
+        'Content-Type': 'application/json',
+      },
+    );
 
-    loggy.info("Making authenticated GET request to: $url");
-
-    Response response = await http
-        .get(Uri.parse(url).replace(queryParameters: queryParams), headers: {
-      "Accept": "*/*",
-      "Authorization": "JWT $token",
-      "Content-Type": "application/json",
-    });
-
-    loggy.info("Authenticated GET response status: ${response.statusCode}");
-
-    if (response.statusCode >= 200 && response.statusCode < 300) {
-      await _handleTokenRefresh(response);
-      return response;
-    } else if (response.statusCode == 401) {
-      await _handleSessionExpiry();
-      throw Exception('Please log in again to continue.');
-    } else {
-      throw _httpError(response, url);
-    }
+    loggy.info('GET (auth) ← ${response.statusCode}');
+    return _processResponse(response, url);
   }
 }

--- a/src/mobile/lib/src/app/shared/repository/global_auth_manager.dart
+++ b/src/mobile/lib/src/app/shared/repository/global_auth_manager.dart
@@ -1,20 +1,41 @@
 import 'package:airqo/src/app/auth/bloc/auth_bloc.dart';
+import 'package:airqo/src/app/shared/repository/session_expiry_notifier.dart';
+import 'package:loggy/loggy.dart';
 
-class GlobalAuthManager {
+class GlobalAuthManager with UiLoggy implements SessionExpiryNotifier {
   static GlobalAuthManager? _instance;
   static GlobalAuthManager get instance => _instance ??= GlobalAuthManager._();
-  
+
   GlobalAuthManager._();
-  
+
   AuthBloc? _authBloc;
-  
+
+  /// Prevents duplicate [SessionExpired] events when multiple 401 responses
+  /// arrive concurrently or when the resume-check and an API 401 fire together.
+  bool _sessionExpiredPending = false;
+
   void setAuthBloc(AuthBloc authBloc) {
     _authBloc = authBloc;
   }
-  
+
+  /// Fires a [SessionExpired] event at most once per authenticated session.
+  /// Subsequent calls are ignored until [resetSessionExpiredGuard] is called.
+  @override
   void notifySessionExpired() {
-    _authBloc?.add(const SessionExpired());
+    if (_authBloc == null) {
+      loggy.warning('notifySessionExpired called before AuthBloc was registered — event dropped');
+      return;
+    }
+    if (_sessionExpiredPending) return;
+    _sessionExpiredPending = true;
+    _authBloc!.add(const SessionExpired());
   }
-  
+
+  /// Called by [AuthBloc] when the user successfully logs in or uses guest mode,
+  /// so the guard resets for the next authenticated session.
+  void resetSessionExpiredGuard() {
+    _sessionExpiredPending = false;
+  }
+
   bool get hasAuthBloc => _authBloc != null;
 }

--- a/src/mobile/lib/src/app/shared/repository/session_expiry_notifier.dart
+++ b/src/mobile/lib/src/app/shared/repository/session_expiry_notifier.dart
@@ -1,0 +1,7 @@
+/// Abstraction that [BaseRepository] depends on to signal a session expiry.
+///
+/// Decouples HTTP infrastructure from the concrete [GlobalAuthManager],
+/// satisfying the Dependency Inversion Principle.
+abstract class SessionExpiryNotifier {
+  void notifySessionExpired();
+}

--- a/src/mobile/lib/src/app/shared/repository/token_refresher.dart
+++ b/src/mobile/lib/src/app/shared/repository/token_refresher.dart
@@ -1,0 +1,21 @@
+import 'package:airqo/src/app/auth/services/auth_helper.dart';
+
+/// Abstraction that [BaseRepository] depends on to silently refresh an
+/// expired JWT before making authenticated requests.
+///
+/// Decouples HTTP infrastructure from the concrete [AuthHelper],
+/// satisfying the Dependency Inversion Principle — mirrors how
+/// [SessionExpiryNotifier] is handled.
+abstract class TokenRefresher {
+  /// Returns a valid token (refreshed if the stored one was expired), or
+  /// `null` if no token is stored or the refresh request fails.
+  Future<String?> refreshTokenIfNeeded();
+}
+
+/// Production implementation — delegates to [AuthHelper].
+class DefaultTokenRefresher implements TokenRefresher {
+  const DefaultTokenRefresher();
+
+  @override
+  Future<String?> refreshTokenIfNeeded() => AuthHelper.refreshTokenIfNeeded();
+}

--- a/src/mobile/lib/src/app/shared/services/sunbird_translation_service.dart
+++ b/src/mobile/lib/src/app/shared/services/sunbird_translation_service.dart
@@ -144,9 +144,9 @@ class SunbirdTranslationService with UiLoggy {
   /// Known static UI strings and AQI categories used across the app.
   static const List<String> _knownUiStrings = [
     // Greetings
-    'Hi',
-    'Hi 👋',
-    'Hi, 👋',
+    'Hello',
+    'Hello 👋',
+    'Hello, 👋',
 
     // Bottom nav
     'Home',


### PR DESCRIPTION
- Add SessionExpiredState to distinguish expired sessions from voluntary guest use
- Check token expiry on app start and resume (not just on 401 responses)
- Show WelcomeScreen with snackbar on session expiry instead of silent redirect
- Add GlobalAuthManager de-duplication guard to prevent duplicate SessionExpired events
- Extract SessionExpiryNotifier abstraction; BaseRepository depends on interface not concrete class (DIP)
- Extract _processResponse() in BaseRepository to eliminate duplicated 401/success/error handling across 4 methods (OCP)
- Move storage cleanup responsibility to AuthBloc._onSessionExpired exclusively (SRP)
- Add SessionExpiredException typed exception
- Fix stale build_runner generated file (HistoricalAirQualityResponse/HistoricalMeasurement)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detects expired sessions when the app resumes and shows a session-expired notification.
  * Silent token refresh attempts to keep you logged in without interrupting flow.

* **Bug Fixes / UX**
  * Distinguishes expired sessions from voluntary guest mode and routes expired sessions to the welcome/login flow.
  * Updated in-app messages: clearer snackbars, a refresh action where appropriate, and updated dashboard greeting from "Hi" to "Hello".

* **Stability**
  * Improved handling to avoid duplicate session-expired notifications and safer cleanup of expired sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->