### PR TITLE
fix: block language selection until translations are ready and add cache TTL

### DIFF
--- a/src/mobile/lib/src/app/dashboard/pages/location_selection/components/location_list_view.dart
+++ b/src/mobile/lib/src/app/dashboard/pages/location_selection/components/location_list_view.dart
@@ -383,6 +383,20 @@ class LocationListView extends StatelessWidget with UiLoggy {
     );
   }
 
+  Widget _buildLocationTitle(
+      Measurement measurement, BuildContext context, bool isSelected) {
+    final name = measurement.siteDetails?.city ??
+        measurement.siteDetails?.town ??
+        measurement.siteDetails?.locationName;
+    final style = TextStyle(
+      color: Theme.of(context).textTheme.bodyLarge?.color,
+      fontWeight: isSelected ? FontWeight.bold : FontWeight.normal,
+    );
+    return name != null
+        ? Text(name, style: style)
+        : TranslatedText('Unknown location', style: style);
+  }
+
   Widget _buildLocationTile(Measurement measurement,
       {required BuildContext context}) {
     final isSelected = selectedLocations.contains(measurement.siteId);
@@ -413,16 +427,7 @@ class LocationListView extends StatelessWidget with UiLoggy {
                 color: isSelected ? AppColors.primaryColor : null,
               ),
             ),
-            title: Text(
-              measurement.siteDetails?.city ??
-                  measurement.siteDetails?.town ??
-                  measurement.siteDetails?.locationName ??
-                  "Unknown Location",
-              style: TextStyle(
-                color: Theme.of(context).textTheme.bodyLarge?.color,
-                fontWeight: isSelected ? FontWeight.bold : FontWeight.normal,
-              ),
-            ),
+            title: _buildLocationTitle(measurement, context, isSelected),
             subtitle: Text(
               measurement.siteDetails?.searchName ??
                   measurement.siteDetails?.name ??

--- a/src/mobile/lib/src/app/dashboard/pages/location_selection/components/location_list_view.dart
+++ b/src/mobile/lib/src/app/dashboard/pages/location_selection/components/location_list_view.dart
@@ -385,9 +385,10 @@ class LocationListView extends StatelessWidget with UiLoggy {
 
   Widget _buildLocationTitle(
       Measurement measurement, BuildContext context, bool isSelected) {
-    final name = measurement.siteDetails?.city ??
-        measurement.siteDetails?.town ??
-        measurement.siteDetails?.locationName;
+    final details = measurement.siteDetails;
+    final name = (details?.city?.isNotEmpty == true ? details!.city : null) ??
+        (details?.town?.isNotEmpty == true ? details!.town : null) ??
+        (details?.locationName?.isNotEmpty == true ? details!.locationName : null);
     final style = TextStyle(
       color: Theme.of(context).textTheme.bodyLarge?.color,
       fontWeight: isSelected ? FontWeight.bold : FontWeight.normal,

--- a/src/mobile/lib/src/app/dashboard/pages/location_selection/components/location_search_bar.dart
+++ b/src/mobile/lib/src/app/dashboard/pages/location_selection/components/location_search_bar.dart
@@ -8,11 +8,13 @@ import 'package:flutter_svg/svg.dart';
 class LocationSearchBar extends StatefulWidget {
   final TextEditingController controller;
   final ValueChanged<String> onChanged;
+  final VoidCallback? onTap;
 
   const LocationSearchBar({
     super.key,
     required this.controller,
     required this.onChanged,
+    this.onTap,
   });
 
   @override
@@ -63,6 +65,7 @@ class _LocationSearchBarState extends State<LocationSearchBar> {
             controller: widget.controller,
             style: TextStyle(color: Theme.of(context).textTheme.bodyLarge?.color),
             onChanged: widget.onChanged,
+            onTap: widget.onTap,
             decoration: InputDecoration(
               hintText: _hint,
               hintStyle: TextStyle(

--- a/src/mobile/lib/src/app/dashboard/pages/location_selection/components/location_search_bar.dart
+++ b/src/mobile/lib/src/app/dashboard/pages/location_selection/components/location_search_bar.dart
@@ -9,12 +9,14 @@ class LocationSearchBar extends StatefulWidget {
   final TextEditingController controller;
   final ValueChanged<String> onChanged;
   final VoidCallback? onTap;
+  final EdgeInsetsGeometry padding;
 
   const LocationSearchBar({
     super.key,
     required this.controller,
     required this.onChanged,
     this.onTap,
+    this.padding = const EdgeInsets.symmetric(horizontal: 16),
   });
 
   @override
@@ -60,12 +62,13 @@ class _LocationSearchBarState extends State<LocationSearchBar> {
         }
 
         return Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 16),
+          padding: widget.padding,
           child: TextField(
             controller: widget.controller,
             style: TextStyle(color: Theme.of(context).textTheme.bodyLarge?.color),
             onChanged: widget.onChanged,
             onTap: widget.onTap,
+            onTapAlwaysCalled: true,
             decoration: InputDecoration(
               hintText: _hint,
               hintStyle: TextStyle(

--- a/src/mobile/lib/src/app/map/pages/map_page.dart
+++ b/src/mobile/lib/src/app/map/pages/map_page.dart
@@ -1035,6 +1035,7 @@ class _MapScreenState extends State<MapScreen>
               SizedBox(height: 16),
               LocationSearchBar(
                 controller: searchController,
+                padding: EdgeInsets.zero,
                 onTap: () => toggleModal(true),
                 onChanged: (value) {
                   if (value.isEmpty) {

--- a/src/mobile/lib/src/app/map/pages/map_page.dart
+++ b/src/mobile/lib/src/app/map/pages/map_page.dart
@@ -1,5 +1,6 @@
 import 'package:airqo/src/app/dashboard/bloc/dashboard/dashboard_bloc.dart';
 import 'package:airqo/src/app/dashboard/models/airquality_response.dart';
+import 'package:airqo/src/app/dashboard/pages/location_selection/components/location_search_bar.dart';
 import 'package:airqo/src/app/dashboard/pages/location_selection/utils/location_helpers.dart';
 import 'package:airqo/src/app/dashboard/widgets/analytics_card.dart';
 import 'package:airqo/src/app/dashboard/widgets/analytics_details.dart';
@@ -808,7 +809,7 @@ class _MapScreenState extends State<MapScreen>
                       mainAxisAlignment: MainAxisAlignment.spaceBetween,
                       crossAxisAlignment: CrossAxisAlignment.center,
                       children: [
-                        Text("Today",
+                        TranslatedText("Today",
                             style: TextStyle(
                                 fontWeight: FontWeight.w600,
                                 fontSize: 20,
@@ -1032,79 +1033,27 @@ class _MapScreenState extends State<MapScreen>
                 ],
               ),
               SizedBox(height: 16),
-              SizedBox(
-                height: 45,
-                child: Padding(
-                  padding: const EdgeInsets.only(top: 0),
-                  child: TextField(
-                    controller: searchController,
-                    onChanged: (value) {
-                      if (value.isEmpty) {
-                        googlePlacesBloc!.add(ResetGooglePlaces());
-                        if (mounted) {
-                          setState(() {
-                            localSearchResults = [];
-                          });
-                        }
-                      } else {
-                        googlePlacesBloc!.add(SearchPlace(value));
-                        if (mounted) {
-                          setState(() {
-                            localSearchResults =
-                                LocationHelper.searchAirQualityLocations(value, allMeasurements);
-                          });
-                        }
-                      }
-                    },
-                    style: TextStyle(fontSize: 14),
-                    onTap: () => toggleModal(true),
-                    decoration: InputDecoration(
-                      contentPadding: const EdgeInsets.only(top: 24),
-                      hintText: "Search Villages, Cities or Countries",
-                      prefixIcon: Padding(
-                        padding: const EdgeInsets.all(11.0),
-                        child: SvgPicture.asset(
-                          "assets/icons/search_icon.svg",
-                          height: 15,
-                          colorFilter: ColorFilter.mode(
-                            Theme.of(context).textTheme.headlineLarge?.color ??
-                                Theme.of(context).iconTheme.color ??
-                                Colors.black,
-                            BlendMode.srcIn,
-                          ),
-                        ),
-                      ),
-                      suffixIcon:
-                          BlocBuilder<GooglePlacesBloc, GooglePlacesState>(
-                        builder: (context, state) {
-                          if (state is SearchLoaded || state is SearchLoading) {
-                            return GestureDetector(
-                                onTap: () => clearGooglePlaces(),
-                                child: Icon(
-                                  Icons.close,
-                                  color: Theme.of(context)
-                                      .textTheme
-                                      .headlineLarge!
-                                      .color,
-                                ));
-                          }
-                          return SizedBox();
-                        },
-                      ),
-                      focusedBorder: OutlineInputBorder(
-                          borderSide:
-                              BorderSide(color: AppColors.primaryColor)),
-                      enabledBorder: OutlineInputBorder(
-                          borderSide: BorderSide(
-                              color: Theme.of(context).highlightColor)),
-                      border: OutlineInputBorder(
-                        borderSide: BorderSide(
-                          color: Colors.white,
-                        ),
-                      ),
-                    ),
-                  ),
-                ),
+              LocationSearchBar(
+                controller: searchController,
+                onTap: () => toggleModal(true),
+                onChanged: (value) {
+                  if (value.isEmpty) {
+                    googlePlacesBloc!.add(ResetGooglePlaces());
+                    if (mounted) {
+                      setState(() {
+                        localSearchResults = [];
+                      });
+                    }
+                  } else {
+                    googlePlacesBloc!.add(SearchPlace(value));
+                    if (mounted) {
+                      setState(() {
+                        localSearchResults = LocationHelper.searchAirQualityLocations(
+                            value, allMeasurements);
+                      });
+                    }
+                  }
+                },
               ),
               BlocBuilder<GooglePlacesBloc, GooglePlacesState>(
                 builder: (context, placesState) {

--- a/src/mobile/lib/src/app/profile/pages/languages/select_language_page.dart
+++ b/src/mobile/lib/src/app/profile/pages/languages/select_language_page.dart
@@ -172,39 +172,56 @@ class _SelectLanguagePageState extends State<SelectLanguagePage> {
             currentLanguageCode = state.languageCode;
           }
 
+          final hasUndownloadedMlKitLanguage = languages.any(
+            (l) =>
+                MlKitTranslationService().supportsTranslation(l.code) &&
+                !MlKitTranslationService().isModelReady(l.code),
+          );
+
           return Padding(
             padding: const EdgeInsets.symmetric(horizontal: 16.0),
-            child: ListView.separated(
-              itemCount: languages.length,
-              separatorBuilder: (context, index) => Divider(
-                color: dividerColor,
-                height: 1,
-              ),
-              itemBuilder: (context, index) {
-                final language = languages[index];
-                final isSelected = language.code == currentLanguageCode;
+            child: Column(
+              children: [
+                Expanded(
+                  child: ListView.separated(
+                    itemCount: languages.length,
+                    separatorBuilder: (context, index) => Divider(
+                      color: dividerColor,
+                      height: 1,
+                    ),
+                    itemBuilder: (context, index) {
+                      final language = languages[index];
+                      final isSelected = language.code == currentLanguageCode;
+                      final isPreparing = _preparingCode == language.code;
 
-                return ListTile(
-                  contentPadding: const EdgeInsets.symmetric(vertical: 12),
-                  title: Text(
-                    language.name,
-                    style: TextStyle(
-                      fontSize: 18,
-                      fontWeight: FontWeight.w400,
-                      color: isDarkMode
-                          ? AppColors.highlightColor2
-                          : AppColors.boldHeadlineColor4,
-                    ),
-                  ),
-                  subtitle: Text(
-                    language.nativeName,
-                    style: TextStyle(
-                      fontSize: 14,
-                      color: isDarkMode ? Colors.grey : Colors.grey.shade700,
-                    ),
-                  ),
-                  trailing: _preparingCode == language.code
-                      ? SizedBox(
+                      return ListTile(
+                        contentPadding:
+                            const EdgeInsets.symmetric(vertical: 12),
+                        title: Text(
+                          language.name,
+                          style: TextStyle(
+                            fontSize: 18,
+                            fontWeight: FontWeight.w400,
+                            color: isDarkMode
+                                ? AppColors.highlightColor2
+                                : AppColors.boldHeadlineColor4,
+                          ),
+                        ),
+                        subtitle: Text(
+                          isPreparing
+                              ? 'Preparing translation...'
+                              : language.nativeName,
+                          style: TextStyle(
+                            fontSize: 14,
+                            color: isPreparing
+                                ? AppColors.primaryColor
+                                : isDarkMode
+                                    ? Colors.grey
+                                    : Colors.grey.shade700,
+                          ),
+                        ),
+                        trailing: isPreparing
+                            ? SizedBox(
                           width: 24,
                           height: 24,
                           child: CircularProgressIndicator(
@@ -238,11 +255,41 @@ class _SelectLanguagePageState extends State<SelectLanguagePage> {
                                 borderRadius: BorderRadius.circular(4),
                               ),
                             ),
-                  onTap: _preparingCode != null
-                      ? null
-                      : () => _selectLanguage(context, language),
-                );
-              },
+                        onTap: _preparingCode != null
+                            ? null
+                            : () => _selectLanguage(context, language),
+                      );
+                    },
+                  ),
+                ),
+                if (hasUndownloadedMlKitLanguage)
+                  Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 16.0),
+                    child: Row(
+                      children: [
+                        Icon(
+                          Icons.info_outline,
+                          size: 14,
+                          color: isDarkMode
+                              ? Colors.grey
+                              : Colors.grey.shade600,
+                        ),
+                        const SizedBox(width: 6),
+                        Expanded(
+                          child: Text(
+                            'Some languages download a small pack on first use.',
+                            style: TextStyle(
+                              fontSize: 12,
+                              color: isDarkMode
+                                  ? Colors.grey
+                                  : Colors.grey.shade600,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+              ],
             ),
           );
         },

--- a/src/mobile/lib/src/app/profile/pages/languages/select_language_page.dart
+++ b/src/mobile/lib/src/app/profile/pages/languages/select_language_page.dart
@@ -1,3 +1,6 @@
+import 'dart:async';
+import 'dart:io';
+
 import 'package:airqo/src/app/shared/services/mlkit_translation_service.dart';
 import 'package:airqo/src/app/shared/services/sunbird_translation_service.dart';
 import 'package:airqo/src/app/shared/widgets/translated_text.dart';
@@ -43,7 +46,8 @@ class _SelectLanguagePageState extends State<SelectLanguagePage> {
         MlKitTranslationService().supportsTranslation(language.code) &&
             !MlKitTranslationService().isModelReady(language.code);
     final needsSunbirdPrepare =
-        SunbirdTranslationService().supportsTranslation(language.code);
+        SunbirdTranslationService().supportsTranslation(language.code) &&
+            !SunbirdTranslationService().isPrepared(language.code);
     final needsPrepare = needsMlKitDownload || needsSunbirdPrepare;
 
     // Capture context-dependent references before any await.
@@ -59,17 +63,26 @@ class _SelectLanguagePageState extends State<SelectLanguagePage> {
     setState(() => _preparingCode = language.code);
     try {
       if (needsMlKitDownload) {
-        await MlKitTranslationService().prepareModel(language.code);
+        await MlKitTranslationService()
+            .prepareModel(language.code)
+            .timeout(const Duration(seconds: 30));
       }
       if (needsSunbirdPrepare) {
-        await SunbirdTranslationService().prepare(targetLocale: language.code);
+        await SunbirdTranslationService()
+            .prepare(targetLocale: language.code)
+            .timeout(const Duration(seconds: 30));
       }
-    } catch (_) {
+    } catch (e, stackTrace) {
+      debugPrint('Language preparation failed: $e\n$stackTrace');
       if (!mounted) return;
       setState(() => _preparingCode = null);
+      final isNetworkError = e is SocketException || e is TimeoutException;
+      final message = isNetworkError
+          ? 'No internet connection. Please check your network and try again.'
+          : 'Failed to prepare language. Please try again.';
       messenger.showSnackBar(
         SnackBar(
-          content: const Text('Failed to prepare language. Please try again.'),
+          content: Text(message),
           backgroundColor: Colors.red.shade700,
           behavior: SnackBarBehavior.floating,
           margin: const EdgeInsets.all(16),
@@ -182,89 +195,9 @@ class _SelectLanguagePageState extends State<SelectLanguagePage> {
             padding: const EdgeInsets.symmetric(horizontal: 16.0),
             child: Column(
               children: [
-                Expanded(
-                  child: ListView.separated(
-                    itemCount: languages.length,
-                    separatorBuilder: (context, index) => Divider(
-                      color: dividerColor,
-                      height: 1,
-                    ),
-                    itemBuilder: (context, index) {
-                      final language = languages[index];
-                      final isSelected = language.code == currentLanguageCode;
-                      final isPreparing = _preparingCode == language.code;
-
-                      return ListTile(
-                        contentPadding:
-                            const EdgeInsets.symmetric(vertical: 12),
-                        title: Text(
-                          language.name,
-                          style: TextStyle(
-                            fontSize: 18,
-                            fontWeight: FontWeight.w400,
-                            color: isDarkMode
-                                ? AppColors.highlightColor2
-                                : AppColors.boldHeadlineColor4,
-                          ),
-                        ),
-                        subtitle: Text(
-                          isPreparing
-                              ? 'Preparing translation...'
-                              : language.nativeName,
-                          style: TextStyle(
-                            fontSize: 14,
-                            color: isPreparing
-                                ? AppColors.primaryColor
-                                : isDarkMode
-                                    ? Colors.grey
-                                    : Colors.grey.shade700,
-                          ),
-                        ),
-                        trailing: isPreparing
-                            ? SizedBox(
-                          width: 24,
-                          height: 24,
-                          child: CircularProgressIndicator(
-                            strokeWidth: 2.5,
-                            color: AppColors.primaryColor,
-                          ),
-                        )
-                      : isSelected
-                          ? Container(
-                              width: 24,
-                              height: 24,
-                              decoration: BoxDecoration(
-                                color: AppColors.primaryColor,
-                                borderRadius: BorderRadius.circular(4),
-                              ),
-                              child: const Icon(
-                                Icons.check,
-                                color: Colors.white,
-                                size: 18,
-                              ),
-                            )
-                          : Container(
-                              width: 24,
-                              height: 24,
-                              decoration: BoxDecoration(
-                                border: Border.all(
-                                  color: isDarkMode
-                                      ? AppColors.secondaryHeadlineColor2
-                                      : AppColors.borderColor2,
-                                ),
-                                borderRadius: BorderRadius.circular(4),
-                              ),
-                            ),
-                        onTap: _preparingCode != null
-                            ? null
-                            : () => _selectLanguage(context, language),
-                      );
-                    },
-                  ),
-                ),
                 if (hasUndownloadedMlKitLanguage)
                   Padding(
-                    padding: const EdgeInsets.symmetric(vertical: 16.0),
+                    padding: const EdgeInsets.only(top: 8.0, bottom: 4.0),
                     child: Row(
                       children: [
                         Icon(
@@ -289,6 +222,98 @@ class _SelectLanguagePageState extends State<SelectLanguagePage> {
                       ],
                     ),
                   ),
+                Expanded(
+                  child: ListView.separated(
+                    itemCount: languages.length,
+                    separatorBuilder: (context, index) => Divider(
+                      color: dividerColor,
+                      height: 1,
+                    ),
+                    itemBuilder: (context, index) {
+                      final language = languages[index];
+                      final isSelected = language.code == currentLanguageCode;
+                      final isPreparing = _preparingCode == language.code;
+
+                      final isMlKitDownloading = isPreparing &&
+                          MlKitTranslationService()
+                              .supportsTranslation(language.code) &&
+                          !MlKitTranslationService()
+                              .isModelReady(language.code);
+                      final preparingLabel = isMlKitDownloading
+                          ? 'Downloading language pack…'
+                          : 'Loading translations…';
+
+                      return ListTile(
+                        enabled: _preparingCode == null || isPreparing,
+                        contentPadding:
+                            const EdgeInsets.symmetric(vertical: 12),
+                        title: Text(
+                          language.name,
+                          style: TextStyle(
+                            fontSize: 18,
+                            fontWeight: FontWeight.w400,
+                            color: isDarkMode
+                                ? AppColors.highlightColor2
+                                : AppColors.boldHeadlineColor4,
+                          ),
+                        ),
+                        subtitle: Text(
+                          isPreparing ? preparingLabel : language.nativeName,
+                          style: TextStyle(
+                            fontSize: 14,
+                            color: isPreparing
+                                ? AppColors.primaryColor
+                                : isDarkMode
+                                    ? Colors.grey
+                                    : Colors.grey.shade700,
+                          ),
+                        ),
+                        trailing: isPreparing
+                            ? Semantics(
+                                label: 'Preparing ${language.name}',
+                                liveRegion: true,
+                                child: SizedBox(
+                                  width: 24,
+                                  height: 24,
+                                  child: CircularProgressIndicator(
+                                    strokeWidth: 2.5,
+                                    color: AppColors.primaryColor,
+                                  ),
+                                ),
+                              )
+                            : isSelected
+                                ? Container(
+                                    width: 24,
+                                    height: 24,
+                                    decoration: BoxDecoration(
+                                      color: AppColors.primaryColor,
+                                      borderRadius: BorderRadius.circular(4),
+                                    ),
+                                    child: const Icon(
+                                      Icons.check,
+                                      color: Colors.white,
+                                      size: 18,
+                                    ),
+                                  )
+                                : Container(
+                                    width: 24,
+                                    height: 24,
+                                    decoration: BoxDecoration(
+                                      border: Border.all(
+                                        color: isDarkMode
+                                            ? AppColors.secondaryHeadlineColor2
+                                            : AppColors.borderColor2,
+                                      ),
+                                      borderRadius: BorderRadius.circular(4),
+                                    ),
+                                  ),
+                        onTap: _preparingCode != null
+                            ? null
+                            : () => _selectLanguage(context, language),
+                      );
+                    },
+                  ),
+                ),
               ],
             ),
           );

--- a/src/mobile/lib/src/app/profile/pages/languages/select_language_page.dart
+++ b/src/mobile/lib/src/app/profile/pages/languages/select_language_page.dart
@@ -1,3 +1,5 @@
+import 'package:airqo/src/app/shared/services/mlkit_translation_service.dart';
+import 'package:airqo/src/app/shared/services/sunbird_translation_service.dart';
 import 'package:airqo/src/app/shared/widgets/translated_text.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -31,11 +33,62 @@ class _SelectLanguagePageState extends State<SelectLanguagePage> {
     LanguageOption(code: 'fr', name: 'French', nativeName: 'Français'),
   ];
 
-  void _showLanguageChangeNotification(
-      BuildContext context, LanguageOption language) {
-    //final isDarkMode = Theme.of(context).brightness == Brightness.dark;
+  String? _preparingCode;
 
-    ScaffoldMessenger.of(context).showSnackBar(
+  Future<void> _selectLanguage(
+      BuildContext context, LanguageOption language) async {
+    if (_preparingCode != null) return;
+
+    final needsMlKitDownload =
+        MlKitTranslationService().supportsTranslation(language.code) &&
+            !MlKitTranslationService().isModelReady(language.code);
+    final needsSunbirdPrepare =
+        SunbirdTranslationService().supportsTranslation(language.code);
+    final needsPrepare = needsMlKitDownload || needsSunbirdPrepare;
+
+    // Capture context-dependent references before any await.
+    final bloc = context.read<LanguageBloc>();
+    final messenger = ScaffoldMessenger.of(context);
+
+    if (!needsPrepare) {
+      bloc.add(ChangeLanguage(language.code));
+      _showLanguageChangeNotification(messenger, language);
+      return;
+    }
+
+    setState(() => _preparingCode = language.code);
+    try {
+      if (needsMlKitDownload) {
+        await MlKitTranslationService().prepareModel(language.code);
+      }
+      if (needsSunbirdPrepare) {
+        await SunbirdTranslationService().prepare(targetLocale: language.code);
+      }
+    } catch (_) {
+      if (!mounted) return;
+      setState(() => _preparingCode = null);
+      messenger.showSnackBar(
+        SnackBar(
+          content: const Text('Failed to prepare language. Please try again.'),
+          backgroundColor: Colors.red.shade700,
+          behavior: SnackBarBehavior.floating,
+          margin: const EdgeInsets.all(16),
+          shape:
+              RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+        ),
+      );
+      return;
+    }
+
+    if (!mounted) return;
+    setState(() => _preparingCode = null);
+    bloc.add(ChangeLanguage(language.code));
+    _showLanguageChangeNotification(messenger, language);
+  }
+
+  void _showLanguageChangeNotification(
+      ScaffoldMessengerState messenger, LanguageOption language) {
+    messenger.showSnackBar(
       SnackBar(
         content: Row(
           children: [
@@ -150,39 +203,44 @@ class _SelectLanguagePageState extends State<SelectLanguagePage> {
                       color: isDarkMode ? Colors.grey : Colors.grey.shade700,
                     ),
                   ),
-                  trailing: isSelected
-                      ? Container(
+                  trailing: _preparingCode == language.code
+                      ? SizedBox(
                           width: 24,
                           height: 24,
-                          decoration: BoxDecoration(
+                          child: CircularProgressIndicator(
+                            strokeWidth: 2.5,
                             color: AppColors.primaryColor,
-                            borderRadius: BorderRadius.circular(4),
-                          ),
-                          child: const Icon(
-                            Icons.check,
-                            color: Colors.white,
-                            size: 18,
                           ),
                         )
-                      : Container(
-                          width: 24,
-                          height: 24,
-                          decoration: BoxDecoration(
-                            border: Border.all(
-                              color: isDarkMode
-                                  ? AppColors.secondaryHeadlineColor2
-                                  : AppColors.borderColor2,
+                      : isSelected
+                          ? Container(
+                              width: 24,
+                              height: 24,
+                              decoration: BoxDecoration(
+                                color: AppColors.primaryColor,
+                                borderRadius: BorderRadius.circular(4),
+                              ),
+                              child: const Icon(
+                                Icons.check,
+                                color: Colors.white,
+                                size: 18,
+                              ),
+                            )
+                          : Container(
+                              width: 24,
+                              height: 24,
+                              decoration: BoxDecoration(
+                                border: Border.all(
+                                  color: isDarkMode
+                                      ? AppColors.secondaryHeadlineColor2
+                                      : AppColors.borderColor2,
+                                ),
+                                borderRadius: BorderRadius.circular(4),
+                              ),
                             ),
-                            borderRadius: BorderRadius.circular(4),
-                          ),
-                        ),
-                  onTap: () {
-                    context
-                        .read<LanguageBloc>()
-                        .add(ChangeLanguage(language.code));
-
-                        _showLanguageChangeNotification(context, language);
-                  },
+                  onTap: _preparingCode != null
+                      ? null
+                      : () => _selectLanguage(context, language),
                 );
               },
             ),

--- a/src/mobile/lib/src/app/shared/services/mlkit_translation_service.dart
+++ b/src/mobile/lib/src/app/shared/services/mlkit_translation_service.dart
@@ -42,6 +42,18 @@ class MlKitTranslationService with UiLoggy {
   bool supportsTranslation(String localeCode) =>
       _localeToMlKit.containsKey(localeCode);
 
+  bool isModelReady(String localeCode) =>
+      _downloadedModels.contains(localeCode);
+
+  /// Downloads the translation model for [localeCode] if not already present.
+  /// Safe to call multiple times — returns immediately if already downloaded.
+  Future<void> prepareModel(String localeCode) async {
+    final targetLang = _localeToMlKit[localeCode];
+    if (targetLang == null) return;
+    if (_downloadedModels.contains(localeCode)) return;
+    await _ensureModelDownloaded(targetLang, localeCode);
+  }
+
   Future<String> translate(String text, {required String targetLocale}) async {
     if (text.isEmpty) return text;
 

--- a/src/mobile/lib/src/app/shared/services/sunbird_translation_service.dart
+++ b/src/mobile/lib/src/app/shared/services/sunbird_translation_service.dart
@@ -13,6 +13,7 @@ class SunbirdTranslationService with UiLoggy {
 
   static const String _baseUrl = 'https://api.sunbird.ai';
   static const String _boxName = 'sunbirdTranslationBox';
+  static const int _cacheTtlDays = 7;
 
   // Concurrency limiter: at most 3 simultaneous HTTP requests
   static const int _maxConcurrent = 3;
@@ -39,12 +40,30 @@ class SunbirdTranslationService with UiLoggy {
     final box = _box;
     if (box == null) return;
     final value = box.get(cacheKey) as String?;
-    if (value != null) _cache[cacheKey] = value;
+    if (value == null) return;
+
+    final tsKey = '$cacheKey\$ts';
+    final ts = box.get(tsKey) as int?;
+    if (ts != null) {
+      final age = DateTime.now().millisecondsSinceEpoch - ts;
+      if (age > _cacheTtlDays * Duration.millisecondsPerDay) {
+        // Expired — drop from disk so next translate() re-fetches.
+        box.delete(cacheKey);
+        box.delete(tsKey);
+        return;
+      }
+    }
+    // Entries with no timestamp (written before TTL was added) are treated as
+    // expired on their first load, which re-fetches once and then stamps them.
+
+    _cache[cacheKey] = value;
   }
 
   Future<void> _saveToDisk(String cacheKey, String value) async {
     try {
+      final now = DateTime.now().millisecondsSinceEpoch;
       await _box?.put(cacheKey, value);
+      await _box?.put('$cacheKey\$ts', now);
     } catch (e) {
       loggy.warning('Failed to persist Sunbird translation: $e');
     }
@@ -397,6 +416,24 @@ class SunbirdTranslationService with UiLoggy {
     'Location Services Disabled',
     'Location permission was denied. Please try again.',
   ];
+
+  // Strings visible immediately on the home screen — translated before confirming language change.
+  static const List<String> _criticalUiStrings = [
+    'Home', 'Search', 'Exposure', 'Learn',
+    'Near You', 'Favorites', "Today's Air Quality", 'Settings',
+    'Good', 'Moderate', 'Unhealthy for Sensitive Groups',
+    'Unhealthy', 'Very Unhealthy', 'Hazardous', 'Unknown',
+  ];
+
+  /// Awaits translation of the most visible UI strings, then fires the rest
+  /// in the background. Call this before confirming a language change.
+  Future<void> prepare({required String targetLocale}) async {
+    if (!supportsTranslation(targetLocale)) return;
+    await Future.wait(
+      _criticalUiStrings.map((s) => translate(s, targetLocale: targetLocale)),
+    );
+    prewarm(targetLocale: targetLocale);
+  }
 
   /// Fire-and-forget: translates all known UI strings so the cache is warm
   /// before widgets render. Already-cached strings resolve instantly.

--- a/src/mobile/lib/src/app/shared/services/sunbird_translation_service.dart
+++ b/src/mobile/lib/src/app/shared/services/sunbird_translation_service.dart
@@ -427,11 +427,31 @@ class SunbirdTranslationService with UiLoggy {
 
   /// Awaits translation of the most visible UI strings, then fires the rest
   /// in the background. Call this before confirming a language change.
+  ///
+  /// Short-circuits (no spinner) if all critical strings are already in the
+  /// in-memory cache. Throws if every result fell back to the source text,
+  /// meaning the API was unreachable.
   Future<void> prepare({required String targetLocale}) async {
     if (!supportsTranslation(targetLocale)) return;
-    await Future.wait(
+
+    // Cache keys use the Sunbird lang code, not the locale code.
+    final targetLang = _localeToSunbird[targetLocale]!;
+    if (_criticalUiStrings.every((s) => _cache.containsKey('$targetLang:$s'))) {
+      prewarm(targetLocale: targetLocale);
+      return;
+    }
+
+    final results = await Future.wait(
       _criticalUiStrings.map((s) => translate(s, targetLocale: targetLocale)),
     );
+
+    final allFailed = results.asMap().entries.every(
+      (e) => e.value == _criticalUiStrings[e.key],
+    );
+    if (allFailed) {
+      throw Exception('Sunbird translation unavailable for $targetLocale');
+    }
+
     prewarm(targetLocale: targetLocale);
   }
 

--- a/src/mobile/lib/src/app/shared/services/sunbird_translation_service.dart
+++ b/src/mobile/lib/src/app/shared/services/sunbird_translation_service.dart
@@ -15,12 +15,10 @@ class SunbirdTranslationService with UiLoggy {
   static const String _boxName = 'sunbirdTranslationBox';
   static const int _cacheTtlDays = 7;
 
-  // Concurrency limiter: at most 3 simultaneous HTTP requests
   static const int _maxConcurrent = 3;
   int _activeRequests = 0;
   final List<Completer<void>> _requestQueue = [];
 
-  // Maps Flutter locale codes to Sunbird language codes
   static const Map<String, String> _localeToSunbird = {
     'lg': 'lug', // Luganda
     'ach': 'ach', // Acholi
@@ -31,7 +29,6 @@ class SunbirdTranslationService with UiLoggy {
 
   final Map<String, String> _cache = {};
 
-  // Deduplicates in-flight requests: same text+lang shares one API call
   final Map<String, Future<String>> _inFlight = {};
 
   Box? get _box => Hive.isBoxOpen(_boxName) ? Hive.box(_boxName) : null;
@@ -44,17 +41,18 @@ class SunbirdTranslationService with UiLoggy {
 
     final tsKey = '$cacheKey\$ts';
     final ts = box.get(tsKey) as int?;
-    if (ts != null) {
-      final age = DateTime.now().millisecondsSinceEpoch - ts;
-      if (age > _cacheTtlDays * Duration.millisecondsPerDay) {
-        // Expired — drop from disk so next translate() re-fetches.
-        box.delete(cacheKey);
-        box.delete(tsKey);
-        return;
-      }
+
+    // Entries with no timestamp (written before TTL was added) and genuinely
+    // expired entries are both dropped so the next translate() re-fetches.
+    final isExpired = ts == null ||
+        DateTime.now().millisecondsSinceEpoch - ts >
+            _cacheTtlDays * Duration.millisecondsPerDay;
+
+    if (isExpired) {
+      box.delete(cacheKey).ignore();
+      box.delete(tsKey).ignore();
+      return;
     }
-    // Entries with no timestamp (written before TTL was added) are treated as
-    // expired on their first load, which re-fetches once and then stamps them.
 
     _cache[cacheKey] = value;
   }
@@ -90,6 +88,22 @@ class SunbirdTranslationService with UiLoggy {
   bool supportsTranslation(String localeCode) =>
       _localeToSunbird.containsKey(localeCode);
 
+  bool isPrepared(String localeCode) {
+    if (!supportsTranslation(localeCode)) return false;
+    _hydrateCritical(_localeToSunbird[localeCode]!);
+    return _areCriticalStringsCached(_localeToSunbird[localeCode]!);
+  }
+
+  void _hydrateCritical(String targetLang) {
+    for (final s in _criticalUiStrings) {
+      final key = '$targetLang:$s';
+      if (!_cache.containsKey(key)) _loadFromDisk(key);
+    }
+  }
+
+  bool _areCriticalStringsCached(String targetLang) =>
+      _criticalUiStrings.every((s) => _cache.containsKey('$targetLang:$s'));
+
   Future<String> translate(
     String text, {
     required String targetLocale,
@@ -103,7 +117,6 @@ class SunbirdTranslationService with UiLoggy {
     if (!_cache.containsKey(cacheKey)) _loadFromDisk(cacheKey);
     if (_cache.containsKey(cacheKey)) return _cache[cacheKey]!;
 
-    // Reuse any in-flight request for the same text
     if (_inFlight.containsKey(cacheKey)) return _inFlight[cacheKey]!;
 
     _inFlight[cacheKey] = _doTranslate(text, targetLang, cacheKey);
@@ -160,19 +173,13 @@ class SunbirdTranslationService with UiLoggy {
     }
   }
 
-  /// Known static UI strings and AQI categories used across the app.
   static const List<String> _knownUiStrings = [
-    // Greetings
     'Hello',
     'Hello 👋',
     'Hello, 👋',
-
-    // Bottom nav
     'Home',
     'Search',
     'Exposure',
-
-    // Dashboard
     'Near You',
     'Favorites',
     "Today's Air Quality",
@@ -190,8 +197,6 @@ class SunbirdTranslationService with UiLoggy {
     'No locations available',
     'All',
     'Please log in to save your locations',
-
-    // AQI categories
     'Good',
     'Moderate',
     'Unhealthy for Sensitive Groups',
@@ -199,8 +204,6 @@ class SunbirdTranslationService with UiLoggy {
     'Very Unhealthy',
     'Hazardous',
     'Unknown',
-
-    // Tooltip messages
     'View air quality in locations closest to you',
     'Save your most relevant locations in one place',
     'Sign in or create an account',
@@ -215,8 +218,6 @@ class SunbirdTranslationService with UiLoggy {
     'Air Quality is Unknown',
     'Uploading...',
     'Save changes',
-
-    // Auth
     'Login',
     'Cancel',
     'Verify Now',
@@ -240,8 +241,6 @@ class SunbirdTranslationService with UiLoggy {
     'You can now log in to your account using your new password.',
     'Already have an account?',
     'No, Thanks',
-
-    // Learn
     'Learn',
     'Explore lessons to understand air quality, or take surveys to help us learn about your experience.',
     'Lessons',
@@ -258,11 +257,7 @@ class SunbirdTranslationService with UiLoggy {
     'Already Submitted',
     'OK',
     'Previous',
-
-    // Map
     'AirQo map',
-
-    // Common actions
     'Open Settings',
     'Close',
     'Delete',
@@ -282,8 +277,6 @@ class SunbirdTranslationService with UiLoggy {
     'Delete Range',
     'Add Zone',
     'Manage Sharing Preferences',
-
-    // Profile / Edit
     'Edit your profile',
     'Loading your profile...',
     'Settings',
@@ -294,8 +287,6 @@ class SunbirdTranslationService with UiLoggy {
     'Choose from library',
     'Take photo',
     'This is where you\'ll manage your AirQo devices.',
-
-    // Location & Privacy
     'Location & Privacy',
     'Data Management',
     'Location History',
@@ -306,8 +297,6 @@ class SunbirdTranslationService with UiLoggy {
     'Are you sure you want to remove this privacy zone?',
     'Location Details',
     'My Location Data',
-
-    // Research
     'Research Settings',
     'Research Consent',
     'Manage your research participation preferences',
@@ -328,16 +317,12 @@ class SunbirdTranslationService with UiLoggy {
     'Study Progress',
     'Research Study',
     'Thank you for joining our research study!',
-
-    // Onboarding
     '👋 Welcome to AirQo!',
     'Clean Air for all African Cities.',
     '🌿 Breathe Clean',
     'Track and monitor the quality of air you breathe',
     '✨ Know Your Air',
     'Learn and reduce air pollution in your community',
-
-    // Dashboard empty / location selection
     'Add places you love',
     'Start by adding locations you care about.',
     '+Add Location',
@@ -346,9 +331,7 @@ class SunbirdTranslationService with UiLoggy {
     'Select Locations',
     'Search Villages, Cities or Countries',
     'Swipe left to remove location',
-    'Remove',
     'Unknown location',
-    'Unknown',
     'PM2.5',
     'Low Cost Sensor',
     'Reference Monitor',
@@ -361,9 +344,6 @@ class SunbirdTranslationService with UiLoggy {
     'Your session has expired. Please log in again.',
     'Authentication issue detected. Please log in again.',
     'Clear All',
-    'Save',
-
-    // Health tip taglines
     'Enjoy outdoor activities in good air quality',
     'Air quality is acceptable for most people',
     'Sensitive groups should limit outdoor exertion',
@@ -371,21 +351,13 @@ class SunbirdTranslationService with UiLoggy {
     'Everyone should avoid outdoor activities',
     'Everyone should avoid all outdoor activities',
     'Stay informed about air quality',
-
-    // Guest profile
     'Guest User',
-
-    // Notifications
     'No Notifications',
     "Here you'll find all updates on our Air Quality network",
     "You're all cleared up",
     'You deserve some ice cream!',
-
-    // Maintenance
     'The app is currently under maintenance',
     "We're having issues with our network\nno worries, we'll be back up soon.",
-
-    // Profile / edit
     'Image selected. Save to upload.',
     'First name cannot be empty',
     'Last name cannot be empty',
@@ -396,14 +368,10 @@ class SunbirdTranslationService with UiLoggy {
     'Unable to update profile. Please try again.',
     'Check your internet connection and try again.',
     'Something went wrong. Please try again later.',
-
-    // Settings snackbars
     'Please enable location services in settings.',
     'Location permission denied.',
     'Location permission permanently denied. Please enable it in settings.',
     'An unexpected error occurred during logout',
-
-    // Shared / System
     'An Error Occurred',
     'Skip This Version',
     'Later',
@@ -417,7 +385,7 @@ class SunbirdTranslationService with UiLoggy {
     'Location permission was denied. Please try again.',
   ];
 
-  // Strings visible immediately on the home screen — translated before confirming language change.
+  // MAINTENANCE: matched by exact string value as cache keys — update here if any UI string changes.
   static const List<String> _criticalUiStrings = [
     'Home', 'Search', 'Exposure', 'Learn',
     'Near You', 'Favorites', "Today's Air Quality", 'Settings',
@@ -425,18 +393,13 @@ class SunbirdTranslationService with UiLoggy {
     'Unhealthy', 'Very Unhealthy', 'Hazardous', 'Unknown',
   ];
 
-  /// Awaits translation of the most visible UI strings, then fires the rest
-  /// in the background. Call this before confirming a language change.
-  ///
-  /// Short-circuits (no spinner) if all critical strings are already in the
-  /// in-memory cache. Throws if every result fell back to the source text,
-  /// meaning the API was unreachable.
   Future<void> prepare({required String targetLocale}) async {
     if (!supportsTranslation(targetLocale)) return;
 
-    // Cache keys use the Sunbird lang code, not the locale code.
     final targetLang = _localeToSunbird[targetLocale]!;
-    if (_criticalUiStrings.every((s) => _cache.containsKey('$targetLang:$s'))) {
+    _hydrateCritical(targetLang);
+
+    if (_areCriticalStringsCached(targetLang)) {
       prewarm(targetLocale: targetLocale);
       return;
     }
@@ -455,8 +418,6 @@ class SunbirdTranslationService with UiLoggy {
     prewarm(targetLocale: targetLocale);
   }
 
-  /// Fire-and-forget: translates all known UI strings so the cache is warm
-  /// before widgets render. Already-cached strings resolve instantly.
   void prewarm({required String targetLocale}) {
     if (!supportsTranslation(targetLocale)) return;
     for (final s in _knownUiStrings) {


### PR DESCRIPTION


- Show a spinner on the selected language tile while ML Kit downloads its model (Swahili/French) or Sunbird pre-translates critical strings (Luganda), so users no longer see the app appear stuck in English after switching
- Disable all other tiles during preparation to prevent concurrent selections
- Add isModelReady() and prepareModel() to MlKitTranslationService for explicit pre-download without triggering a full translation
- Add prepare() to SunbirdTranslationService that awaits the 15 most visible strings first, then fires the full prewarm in the background
- Add 7-day TTL to Sunbird disk cache to fix stale translations being served after Sunbird model improvements; old entries without timestamps are treated as expired on first load and re-fetched automatically



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Language selection shows per-language preparation progress, disables other options during preparation, and displays success/error snackbars.
  * Info row indicates when a language model must be downloaded on first use.

* **Improvements**
  * ML Kit models can be prepared proactively for faster first use.
  * Translation cache now expires after 7 days and critical UI strings are prioritized/hydrated during language changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->