### PR TITLE
Enhance data fetching and improve terminology in client actions

### DIFF
--- a/src/platform/src/app/(dashboard)/system/clients/[clientId]/page.tsx
+++ b/src/platform/src/app/(dashboard)/system/clients/[clientId]/page.tsx
@@ -3,6 +3,7 @@
 import React, { useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { Button, Card, PageHeading } from '@/shared/components/ui';
+import { Tooltip } from 'flowbite-react';
 import { LoadingState } from '@/shared/components/ui/loading-state';
 import { toast } from '@/shared/components/ui';
 import { formatDate, parseDate } from '@/shared/utils';
@@ -115,7 +116,7 @@ const ClientDetailsPage: React.FC = () => {
     setIsRefreshingSecret(true);
     try {
       await clientService.refreshClientSecret(clientId);
-      toast.success('Client secret refreshed successfully');
+      toast.success('Client secret regenerated successfully');
       setRefreshSecretDialogOpen(false);
       mutate();
     } catch (error) {
@@ -264,7 +265,7 @@ const ClientDetailsPage: React.FC = () => {
                 Icon={AqRefreshCw05}
                 iconPosition="start"
               >
-                Refresh Secret
+                Regenerate Secret
               </Button>
             )}
             <Button
@@ -499,23 +500,27 @@ const ClientDetailsPage: React.FC = () => {
                 </div>
                 {tokenExpired && (
                   <div className="mt-4 flex justify-end">
-                    <Button
-                      variant="outlined"
-                      onClick={() => {
-                        if (!client.isActive) {
-                          setInactiveDialogState({
-                            isOpen: true,
-                            clientId: client._id,
-                            clientName: client.name,
-                          });
-                        } else {
-                          handleGenerateToken(`Token for ${client.name}`);
-                        }
-                      }}
-                      disabled={isGeneratingToken}
-                    >
-                      {isGeneratingToken ? 'Refreshing...' : 'Refresh Token'}
-                    </Button>
+                    <Tooltip content="A new token will be generated — copy it when shown to use it">
+                      <Button
+                        variant="outlined"
+                        onClick={() => {
+                          if (!client.isActive) {
+                            setInactiveDialogState({
+                              isOpen: true,
+                              clientId: client._id,
+                              clientName: client.name,
+                            });
+                          } else {
+                            handleGenerateToken(`Token for ${client.name}`);
+                          }
+                        }}
+                        disabled={isGeneratingToken}
+                      >
+                        {isGeneratingToken
+                          ? 'Regenerating...'
+                          : 'Regenerate Token'}
+                      </Button>
+                    </Tooltip>
                   </div>
                 )}
               </>
@@ -606,12 +611,12 @@ const ClientDetailsPage: React.FC = () => {
         <Dialog
           isOpen={refreshSecretDialogOpen}
           onClose={() => setRefreshSecretDialogOpen(false)}
-          title="Refresh Client Secret"
+          title="Regenerate Client Secret"
           size="md"
         >
           <div className="space-y-4">
             <p className="text-gray-700 dark:text-gray-300">
-              Are you sure you want to refresh the client secret for{' '}
+              Are you sure you want to regenerate the client secret for{' '}
               <span className="font-semibold">{client.name}</span>? The old
               secret will be invalidated and a new one will be generated.
             </p>
@@ -628,7 +633,7 @@ const ClientDetailsPage: React.FC = () => {
                 onClick={handleRefreshSecret}
                 disabled={isRefreshingSecret}
               >
-                {isRefreshingSecret ? 'Refreshing...' : 'Refresh Secret'}
+                {isRefreshingSecret ? 'Regenerating...' : 'Regenerate Secret'}
               </Button>
             </div>
           </div>

--- a/src/platform/src/app/(dashboard)/system/clients/page.tsx
+++ b/src/platform/src/app/(dashboard)/system/clients/page.tsx
@@ -169,7 +169,7 @@ const ClientsAdminPage: React.FC = () => {
       await clientService.refreshClientSecret(
         refreshSecretDialogState.clientId
       );
-      toast.success('Client secret refreshed successfully');
+      toast.success('Client secret regenerated successfully');
       setRefreshSecretDialogState({
         isOpen: false,
         clientId: '',
@@ -325,7 +325,7 @@ const ClientsAdminPage: React.FC = () => {
               </Button>
             </Tooltip>
             {hasAnyPermission(['TOKEN_MANAGE', 'TOKEN_GENERATE']) && (
-              <Tooltip content="Refresh client secret">
+              <Tooltip content="Regenerate client secret">
                 <Button
                   size="sm"
                   variant="ghost"
@@ -519,12 +519,12 @@ const ClientsAdminPage: React.FC = () => {
               clientName: '',
             })
           }
-          title="Refresh Client Secret"
+          title="Regenerate Client Secret"
           size="md"
         >
           <div className="space-y-4">
             <p className="text-gray-700 dark:text-gray-300">
-              Are you sure you want to refresh the client secret for{' '}
+              Are you sure you want to regenerate the client secret for{' '}
               <span className="font-semibold">
                 {refreshSecretDialogState.clientName}
               </span>
@@ -550,7 +550,7 @@ const ClientsAdminPage: React.FC = () => {
                 onClick={handleRefreshSecret}
                 disabled={isRefreshingSecret}
               >
-                {isRefreshingSecret ? 'Refreshing...' : 'Refresh Secret'}
+                {isRefreshingSecret ? 'Regenerating...' : 'Regenerate Secret'}
               </Button>
             </div>
           </div>

--- a/src/platform/src/modules/airqo-map/hooks/useMapReadings.ts
+++ b/src/platform/src/modules/airqo-map/hooks/useMapReadings.ts
@@ -2,6 +2,7 @@
 import { useCallback } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { deviceService } from '../../../shared/services/deviceService';
+import { useUser } from '../../../shared/hooks/useUser';
 import type {
   MapReadingsResponse,
   MapReading,
@@ -21,6 +22,7 @@ export interface UseMapReadingsResult {
 export function useMapReadings(
   cohort_id?: string | null
 ): UseMapReadingsResult {
+  const { user } = useUser();
   const normalizedCohortId =
     cohort_id === null ? 'disabled' : (cohort_id ?? 'all');
   const enabled = cohort_id !== null;
@@ -36,7 +38,8 @@ export function useMapReadings(
       const response: MapReadingsResponse =
         await deviceService.getMapReadingsWithToken(
           cohort_id || undefined,
-          signal
+          signal,
+          user?.id
         );
       return response.measurements;
     },

--- a/src/platform/src/modules/analytics/hooks/index.ts
+++ b/src/platform/src/modules/analytics/hooks/index.ts
@@ -14,6 +14,10 @@ import type {
   DataDownloadRequest,
   Site,
 } from '@/shared/types/api';
+import {
+  buildDownloadFileContent,
+  DownloadFileTransformOptions,
+} from '@/modules/data-download/utils/dataExportFile';
 
 interface AnalyticsSelections {
   selectedSiteIds: string[];
@@ -416,51 +420,38 @@ export const useDataDownload = () => {
   const { trigger, isMutating, error } = useDownloadData();
 
   const downloadData = useCallback(
-    async (request: DataDownloadRequest, customFilename?: string) => {
+    async (
+      request: DataDownloadRequest,
+      customFilename?: string,
+      transformOptions?: DownloadFileTransformOptions
+    ) => {
       try {
         const response = await trigger(request);
+        const { content, mimeType, extension } = buildDownloadFileContent(
+          response,
+          request.downloadType,
+          transformOptions?.selectedColumnKeys
+        );
 
         // Generate default filename if not provided
         const defaultFilename = `air-quality-data-${request.startDateTime.split('T')[0]}-to-${request.endDateTime.split('T')[0]}`;
         const baseFilename = customFilename || defaultFilename;
 
         // Ensure filename has correct extension
-        const extension = request.downloadType;
         const filename = baseFilename.endsWith(`.${extension}`)
           ? baseFilename
           : `${baseFilename}.${extension}`;
 
-        if (request.downloadType === 'csv') {
-          // Handle CSV download
-          const csvData = response as string;
-          const blob = new Blob([csvData], { type: 'text/csv;charset=utf-8;' });
-          const link = document.createElement('a');
-          const url = URL.createObjectURL(blob);
-          link.setAttribute('href', url);
-          link.setAttribute('download', filename);
-          link.style.visibility = 'hidden';
-          document.body.appendChild(link);
-          link.click();
-          document.body.removeChild(link);
-          URL.revokeObjectURL(url);
-        } else if (request.downloadType === 'json') {
-          // Handle JSON download
-          const jsonData =
-            response as import('@/shared/types/api').DataDownloadResponse;
-          const dataStr = JSON.stringify(jsonData, null, 2);
-          const blob = new Blob([dataStr], {
-            type: 'application/json;charset=utf-8;',
-          });
-          const link = document.createElement('a');
-          const url = URL.createObjectURL(blob);
-          link.setAttribute('href', url);
-          link.setAttribute('download', filename);
-          link.style.visibility = 'hidden';
-          document.body.appendChild(link);
-          link.click();
-          document.body.removeChild(link);
-          URL.revokeObjectURL(url);
-        }
+        const blob = new Blob([content], { type: mimeType });
+        const link = document.createElement('a');
+        const url = URL.createObjectURL(blob);
+        link.setAttribute('href', url);
+        link.setAttribute('download', filename);
+        link.style.visibility = 'hidden';
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        URL.revokeObjectURL(url);
 
         return { success: true };
       } catch (err) {

--- a/src/platform/src/modules/analytics/hooks/index.ts
+++ b/src/platform/src/modules/analytics/hooks/index.ts
@@ -122,11 +122,6 @@ export const useAnalyticsChartData = (
   selectedSiteIds: string[] = EMPTY_SELECTED_SITE_IDS,
   enabled = true
 ) => {
-  const { trigger, error, isMutating } = useGetChartData();
-
-  const [chartData, setChartData] = useState<ChartData[]>([]);
-  const [isLoading, setIsLoading] = useState(false);
-
   // Calculate date range based on filters
   const dateRange = useMemo(() => {
     return {
@@ -134,6 +129,20 @@ export const useAnalyticsChartData = (
       endDate: filters.endDate,
     };
   }, [filters.startDate, filters.endDate]);
+
+  const { trigger, error, isMutating } = useGetChartData([
+    Array.isArray(selectedSiteIds)
+      ? selectedSiteIds.join(',')
+      : selectedSiteIds,
+    dateRange.startDate,
+    dateRange.endDate,
+    chartType,
+    filters.frequency,
+    filters.pollutant,
+  ]);
+
+  const [chartData, setChartData] = useState<ChartData[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
 
   // Fetch chart data
   const fetchChartData = useCallback(

--- a/src/platform/src/modules/analytics/hooks/index.ts
+++ b/src/platform/src/modules/analytics/hooks/index.ts
@@ -223,6 +223,7 @@ export const useAnalyticsSiteCards = ({
   enabled = true,
 }: AnalyticsSelections) => {
   const { filters } = useAnalytics();
+  const { user } = useUser();
 
   const [siteCards, setSiteCards] = useState<SiteData[]>([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -253,7 +254,7 @@ export const useAnalyticsSiteCards = ({
     return () => {
       requestAbortRef.current?.abort();
     };
-  }, []);
+  }, [user?.id]);
 
   const selectedSiteIdsKey = useMemo(
     () => selectedSiteIds.join(','),
@@ -295,6 +296,7 @@ export const useAnalyticsSiteCards = ({
       const response = await analyticsService.getRecentReadings(
         {
           site_id: siteIdsParam,
+          user_id: user?.id,
         },
         controller.signal
       );
@@ -375,7 +377,7 @@ export const useAnalyticsSiteCards = ({
         requestAbortRef.current = null;
       }
     }
-  }, []);
+  }, [user?.id]);
 
   // Auto-fetch when selectedSiteIds or pollutant changes
   useEffect(() => {

--- a/src/platform/src/modules/api-client/ApiClientPage.tsx
+++ b/src/platform/src/modules/api-client/ApiClientPage.tsx
@@ -4,6 +4,7 @@ import React, { useState, useMemo, useCallback } from 'react';
 import { useSession } from 'next-auth/react';
 import { usePostHog } from 'posthog-js/react';
 import { Button, MultiSelectTable, PageHeading } from '@/shared/components/ui';
+import { Tooltip } from 'flowbite-react';
 import { toast } from '@/shared/components/ui';
 import { formatDate, parseDate } from '@/shared/utils';
 import { getUserFriendlyErrorMessage } from '@/shared/utils/errorMessages';
@@ -283,14 +284,16 @@ const ApiClientPage: React.FC = () => {
 
           if (token && expired && item.isActive) {
             return (
-              <Button
-                size="sm"
-                variant="outlined"
-                onClick={() => handleGenerateToken(item, 'refresh')}
-                disabled={isGeneratingForThis}
-              >
-                {isGeneratingForThis ? 'Refreshing...' : 'Refresh'}
-              </Button>
+              <Tooltip content="A new token will be generated — copy it when shown to use it">
+                <Button
+                  size="sm"
+                  variant="outlined"
+                  onClick={() => handleGenerateToken(item, 'refresh')}
+                  disabled={isGeneratingForThis}
+                >
+                  {isGeneratingForThis ? 'Regenerating...' : 'Regenerate Token'}
+                </Button>
+              </Tooltip>
             );
           }
 

--- a/src/platform/src/modules/data-download/DataExportPage.tsx
+++ b/src/platform/src/modules/data-download/DataExportPage.tsx
@@ -468,7 +468,9 @@ const DataExportPage = () => {
       setSelectedGridSiteIds(nextSelectedGridSiteIds);
 
       // Trigger download with the updated selections
-      await handleDownload(nextSelectedGridSiteIds);
+      await handleDownload({
+        customSelectedGridSiteIds: nextSelectedGridSiteIds,
+      });
 
       // Close dialog only on successful download
       setSiteSelectionDialogOpen(false);
@@ -598,7 +600,7 @@ const DataExportPage = () => {
               onClearSelections={handleClearSelections}
               onVisualizeData={handleVisualizeData}
               onPreview={() => setPreviewOpen(true)}
-              onDownload={handleDownload}
+              onDownload={() => setPreviewOpen(true)}
               onToggleSidebar={() => setSidebarOpen(!sidebarOpen)}
               sidebarOpen={sidebarOpen}
               isOrgFlow={isOrgFlow}
@@ -637,9 +639,9 @@ const DataExportPage = () => {
       <DataExportPreview
         isOpen={previewOpen}
         onClose={() => setPreviewOpen(false)}
-        onConfirm={() => {
+        onConfirm={selectedColumnKeys => {
           setPreviewOpen(false);
-          handleDownload();
+          handleDownload({ exportColumnKeys: selectedColumnKeys });
         }}
         isDownloading={isDownloading}
         dataType={dataType}
@@ -653,7 +655,6 @@ const DataExportPage = () => {
         selectedGridIds={selectedGridIds}
         selectedGridSites={selectedGridSites}
         selectedGridSiteIds={selectedGridSiteIds}
-        deviceCategory={deviceCategory}
       />
 
       {/* More Insights Dialog */}

--- a/src/platform/src/modules/data-download/DataExportPage.tsx
+++ b/src/platform/src/modules/data-download/DataExportPage.tsx
@@ -599,7 +599,6 @@ const DataExportPage = () => {
               onTabChange={wrappedHandleTabChange}
               onClearSelections={handleClearSelections}
               onVisualizeData={handleVisualizeData}
-              onPreview={() => setPreviewOpen(true)}
               onDownload={() => setPreviewOpen(true)}
               onToggleSidebar={() => setSidebarOpen(!sidebarOpen)}
               sidebarOpen={sidebarOpen}
@@ -639,7 +638,7 @@ const DataExportPage = () => {
       <DataExportPreview
         isOpen={previewOpen}
         onClose={() => setPreviewOpen(false)}
-        onConfirm={selectedColumnKeys => {
+        onConfirm={(selectedColumnKeys: string[]) => {
           setPreviewOpen(false);
           handleDownload({ exportColumnKeys: selectedColumnKeys });
         }}

--- a/src/platform/src/modules/data-download/DataExportPage.tsx
+++ b/src/platform/src/modules/data-download/DataExportPage.tsx
@@ -158,6 +158,12 @@ const DataExportPage = () => {
   const [selectedDevicesCache, setSelectedDevicesCache] = React.useState<
     Record<string, TableItem>
   >({});
+  const [selectedCountriesCache, setSelectedCountriesCache] = React.useState<
+    Record<string, TableItem>
+  >({});
+  const [selectedCitiesCache, setSelectedCitiesCache] = React.useState<
+    Record<string, TableItem>
+  >({});
   const [showHelpBanner, setShowHelpBanner] = React.useState(() => {
     // Check if user has dismissed the banner before
     if (typeof window !== 'undefined') {
@@ -321,14 +327,35 @@ const DataExportPage = () => {
         : displayTableData;
     }
 
+    if (activeTab === 'countries') {
+      return selectedGridIds.length > 0 &&
+        Object.keys(selectedCountriesCache).length > 0
+        ? selectedGridIds
+            .map(id => selectedCountriesCache[id])
+            .filter((item): item is TableItem => Boolean(item))
+        : displayTableData;
+    }
+
+    if (activeTab === 'cities') {
+      return selectedGridIds.length > 0 &&
+        Object.keys(selectedCitiesCache).length > 0
+        ? selectedGridIds
+            .map(id => selectedCitiesCache[id])
+            .filter((item): item is TableItem => Boolean(item))
+        : displayTableData;
+    }
+
     return displayTableData;
   }, [
     activeTab,
     displayTableData,
+    selectedCountriesCache,
+    selectedCitiesCache,
     selectedDeviceIds,
     selectedDevicesForActions,
     selectedSiteIds,
     selectedSitesForActions,
+    selectedGridIds,
   ]);
 
   // Reset device pagination when category changes
@@ -378,6 +405,8 @@ const DataExportPage = () => {
       resetGroupScopedState(!siteSelectionDownloading);
       setSelectedSitesCache({});
       setSelectedDevicesCache({});
+      setSelectedCountriesCache({});
+      setSelectedCitiesCache({});
       setSelectedGridForSites(null);
       setSiteSelectionDialogOpen(false);
       setSiteSelectionDownloading(false);
@@ -467,6 +496,16 @@ const DataExportPage = () => {
       }
       setSelectedGridSites(newSelectedGridSites);
       setSelectedGridSiteIds({}); // Reset custom selection
+
+      if (activeTab === 'countries') {
+        setSelectedCountriesCache(prevCache =>
+          rebuildSelectionCache(stringIds, processedCountriesData, prevCache)
+        );
+      } else {
+        setSelectedCitiesCache(prevCache =>
+          rebuildSelectionCache(stringIds, processedCitiesData, prevCache)
+        );
+      }
     }
   };
 
@@ -493,6 +532,30 @@ const DataExportPage = () => {
       rebuildSelectionCache(selectedDeviceIds, processedDevicesData, prevCache)
     );
   }, [selectedDeviceIds, processedDevicesData]);
+
+  // Keep selected countries cache synchronized as table pages/search results change.
+  useEffect(() => {
+    if (activeTab !== 'countries' || selectedGridIds.length === 0) {
+      setSelectedCountriesCache({});
+      return;
+    }
+
+    setSelectedCountriesCache(prevCache =>
+      rebuildSelectionCache(selectedGridIds, processedCountriesData, prevCache)
+    );
+  }, [activeTab, processedCountriesData, selectedGridIds]);
+
+  // Keep selected cities cache synchronized as table pages/search results change.
+  useEffect(() => {
+    if (activeTab !== 'cities' || selectedGridIds.length === 0) {
+      setSelectedCitiesCache({});
+      return;
+    }
+
+    setSelectedCitiesCache(prevCache =>
+      rebuildSelectionCache(selectedGridIds, processedCitiesData, prevCache)
+    );
+  }, [activeTab, processedCitiesData, selectedGridIds]);
 
   // Handle site selection dialog
   const handleSiteSelectionConfirm = async (selectedSiteIds: string[]) => {

--- a/src/platform/src/modules/data-download/DataExportPage.tsx
+++ b/src/platform/src/modules/data-download/DataExportPage.tsx
@@ -226,12 +226,18 @@ const DataExportPage = () => {
 
   // Data fetching and processing (initial call with empty array)
   const selectedDevicesForActions = useMemo(
-    () => Object.values(selectedDevicesCache),
-    [selectedDevicesCache]
+    () =>
+      selectedDeviceIds
+        .map(id => selectedDevicesCache[id])
+        .filter((item): item is TableItem => Boolean(item)),
+    [selectedDeviceIds, selectedDevicesCache]
   );
   const selectedSitesForActions = useMemo(
-    () => Object.values(selectedSitesCache),
-    [selectedSitesCache]
+    () =>
+      selectedSiteIds
+        .map(id => selectedSitesCache[id])
+        .filter((item): item is TableItem => Boolean(item)),
+    [selectedSiteIds, selectedSitesCache]
   );
 
   const {
@@ -285,7 +291,10 @@ const DataExportPage = () => {
   const currentState = tabStates[activeTab];
   const config = getTabConfig(activeTab);
   const meta = currentHook.data?.meta || { total: 0, page: 1, totalPages: 1 };
-  const displayTableData = isGroupSyncing ? [] : tableData;
+  const displayTableData = useMemo(
+    () => (isGroupSyncing ? [] : tableData),
+    [isGroupSyncing, tableData]
+  );
   const displaySitesData = isGroupSyncing
     ? undefined
     : (currentHook.data as CohortSitesResponse | undefined)?.sites;
@@ -293,6 +302,34 @@ const DataExportPage = () => {
     ? undefined
     : (currentHook.data as CohortDevicesResponse | undefined)?.devices;
   const tableLoading = isGroupSyncing || currentHook.isLoading;
+  const compactTableRows =
+    activeTab === 'devices' ||
+    activeTab === 'countries' ||
+    activeTab === 'cities';
+
+  const exportTableData = useMemo(() => {
+    if (activeTab === 'sites') {
+      return selectedSiteIds.length > 0 && selectedSitesForActions.length > 0
+        ? selectedSitesForActions
+        : displayTableData;
+    }
+
+    if (activeTab === 'devices') {
+      return selectedDeviceIds.length > 0 &&
+        selectedDevicesForActions.length > 0
+        ? selectedDevicesForActions
+        : displayTableData;
+    }
+
+    return displayTableData;
+  }, [
+    activeTab,
+    displayTableData,
+    selectedDeviceIds,
+    selectedDevicesForActions,
+    selectedSiteIds,
+    selectedSitesForActions,
+  ]);
 
   // Reset device pagination when category changes
   useEffect(() => {
@@ -608,6 +645,7 @@ const DataExportPage = () => {
             <DataExportTable
               activeTab={activeTab}
               tableData={displayTableData}
+              exportData={exportTableData}
               columns={config.columns}
               loading={tableLoading}
               error={currentHook.error?.message || null}
@@ -623,6 +661,7 @@ const DataExportPage = () => {
                     ? selectedDeviceIds
                     : selectedGridIds // countries and cities use grid IDs
               }
+              compactRows={compactTableRows}
               onPageChange={page => updateTabState(activeTab, { page })}
               onPageSizeChange={size =>
                 updateTabState(activeTab, { pageSize: size })

--- a/src/platform/src/modules/data-download/components/DataExportHeader.tsx
+++ b/src/platform/src/modules/data-download/components/DataExportHeader.tsx
@@ -72,7 +72,6 @@ export const DataExportHeader: React.FC<DataExportHeaderProps> = ({
         {/* Tab Navigation */}
         <div className="flex flex-wrap lg:flex-nowrap gap-2 gap-x-2 overflow-x-auto scrollbar-hide mt-2 lg:mt-0">
           <Button
-            variant={activeTab === 'sites' ? 'filled' : 'outlined'}
             onClick={() => onTabChange('sites')}
             disabled={isGroupSyncing}
             className="flex-shrink-0"
@@ -152,7 +151,7 @@ export const DataExportHeader: React.FC<DataExportHeaderProps> = ({
           disabled={isGroupSyncing || !isDownloadReady}
           loading={isDownloading}
         >
-          {isDownloading ? 'Downloading...' : 'Download Data'}
+          {isDownloading ? 'Downloading...' : 'Review & Download'}
         </Button>
       </div>
     </div>

--- a/src/platform/src/modules/data-download/components/DataExportHeader.tsx
+++ b/src/platform/src/modules/data-download/components/DataExportHeader.tsx
@@ -70,6 +70,7 @@ export const DataExportHeader: React.FC<DataExportHeaderProps> = ({
         {/* Tab Navigation */}
         <div className="flex flex-wrap lg:flex-nowrap gap-2 gap-x-2 overflow-x-auto scrollbar-hide mt-2 lg:mt-0">
           <Button
+            variant={activeTab === 'sites' ? 'filled' : 'outlined'}
             onClick={() => onTabChange('sites')}
             disabled={isGroupSyncing}
             className="flex-shrink-0"

--- a/src/platform/src/modules/data-download/components/DataExportHeader.tsx
+++ b/src/platform/src/modules/data-download/components/DataExportHeader.tsx
@@ -15,7 +15,6 @@ interface DataExportHeaderProps {
   onTabChange: (tab: TabType) => void;
   onClearSelections: () => void;
   onVisualizeData: () => void;
-  onPreview: () => void;
   onDownload: () => void;
   onToggleSidebar?: () => void;
   sidebarOpen?: boolean;
@@ -37,7 +36,6 @@ export const DataExportHeader: React.FC<DataExportHeaderProps> = ({
   onTabChange,
   onClearSelections,
   onVisualizeData,
-  onPreview,
   onDownload,
   onToggleSidebar,
   sidebarOpen = false,
@@ -135,14 +133,7 @@ export const DataExportHeader: React.FC<DataExportHeaderProps> = ({
         >
           Visualize Data
         </Button>
-        <Button
-          variant="outlined"
-          onClick={onPreview}
-          disabled={isGroupSyncing || !isDownloadReady}
-          className="px-4 py-2 w-full sm:w-auto"
-        >
-          Preview
-        </Button>
+        {/* Preview button removed: preview shown via Review & Download flow */}
         <Button
           variant="filled"
           onClick={onDownload}

--- a/src/platform/src/modules/data-download/components/DataExportPreview.tsx
+++ b/src/platform/src/modules/data-download/components/DataExportPreview.tsx
@@ -1,4 +1,11 @@
-import React, { useMemo, useState, useEffect } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import Checkbox from '@/shared/components/ui/checkbox';
 import ReusableDialog from '@/shared/components/ui/dialog';
 import { DateRange } from '@/shared/components/calendar/types';
 import {
@@ -6,11 +13,17 @@ import {
   DATA_TYPE_LABELS,
 } from '@/shared/components/charts/constants';
 import { InfoBanner } from '@/shared/components/ui/banner';
+import { areArraysEqual } from '@/shared/utils/arrays';
+import {
+  getDefaultDownloadColumnKeys,
+  getDownloadColumnGroups,
+  getDownloadColumnLabelMap,
+} from '../utils/dataExportFile';
 
 interface DataExportPreviewProps {
   isOpen: boolean;
   onClose: () => void;
-  onConfirm: () => void;
+  onConfirm: (selectedColumnKeys: string[]) => void;
   isDownloading: boolean;
 
   // Export configuration
@@ -25,12 +38,18 @@ interface DataExportPreviewProps {
   selectedGridIds: string[];
   selectedGridSites: Record<string, string[]>;
   selectedGridSiteIds: Record<string, string[]>;
-  deviceCategory: string;
 }
 
-interface PreviewData {
-  [key: string]: string | number | null;
-}
+type PreviewData = Record<string, string | number | null>;
+
+const SAMPLE_POLLUTANT_VALUES: Record<string, [number, number]> = {
+  pm2_5: [36.37, 30.97],
+  pm10: [46.42, 42.11],
+  no2: [18.27, 16.81],
+  so2: [8.12, 7.44],
+  o3: [22.54, 23.71],
+  co: [0.82, 0.74],
+};
 
 export const DataExportPreview: React.FC<DataExportPreviewProps> = ({
   isOpen,
@@ -48,13 +67,12 @@ export const DataExportPreview: React.FC<DataExportPreviewProps> = ({
   selectedGridIds,
   selectedGridSites,
   selectedGridSiteIds,
-  deviceCategory,
 }) => {
-  const [previewData, setPreviewData] = useState<PreviewData[]>([]);
-  const [previewLoading, setPreviewLoading] = useState(false);
-  const [previewError, setPreviewError] = useState<string | null>(null);
+  const [selectedColumnKeys, setSelectedColumnKeys] = useState<string[]>(() =>
+    getDefaultDownloadColumnKeys(activeTab, selectedPollutants)
+  );
+  const previousOpenRef = useRef(false);
 
-  // Format date range for display
   const formattedDateRange = useMemo(() => {
     if (!dateRange?.from || !dateRange?.to) return 'Not selected';
 
@@ -69,7 +87,6 @@ export const DataExportPreview: React.FC<DataExportPreviewProps> = ({
     return `${formatDate(dateRange.from)} - ${formatDate(dateRange.to)}`;
   }, [dateRange]);
 
-  // Calculate estimated days
   const estimatedDays = useMemo(() => {
     if (!dateRange?.from || !dateRange?.to) return 0;
 
@@ -79,7 +96,21 @@ export const DataExportPreview: React.FC<DataExportPreviewProps> = ({
     return Math.ceil(diffTime / (1000 * 60 * 60 * 24)) + 1;
   }, [dateRange]);
 
-  // Get selected locations
+  const columnGroups = useMemo(
+    () => getDownloadColumnGroups(activeTab, selectedPollutants),
+    [activeTab, selectedPollutants]
+  );
+
+  const columnLabelMap = useMemo(
+    () => getDownloadColumnLabelMap(activeTab, selectedPollutants),
+    [activeTab, selectedPollutants]
+  );
+
+  const defaultColumnKeys = useMemo(
+    () => getDefaultDownloadColumnKeys(activeTab, selectedPollutants),
+    [activeTab, selectedPollutants]
+  );
+
   const selectedLocations = useMemo(() => {
     switch (activeTab) {
       case 'sites':
@@ -119,174 +150,135 @@ export const DataExportPreview: React.FC<DataExportPreviewProps> = ({
     }
   }, [activeTab]);
 
-  // Fetch preview data when dialog opens
+  const locationColumnKey = useMemo(() => {
+    switch (activeTab) {
+      case 'sites':
+        return 'site_name';
+      case 'devices':
+        return 'device_name';
+      case 'countries':
+        return 'country_name';
+      case 'cities':
+        return 'city_name';
+      default:
+        return 'site_name';
+    }
+  }, [activeTab]);
+
+  const locationSampleValue = useMemo(() => {
+    switch (activeTab) {
+      case 'sites':
+        return selectedSites[0] || 'Sample Site';
+      case 'devices':
+        return selectedDevices[0] || 'sample_device';
+      case 'countries':
+        return selectedGridIds[0] || 'Sample Country';
+      case 'cities':
+        return selectedGridIds[0] || 'Sample City';
+      default:
+        return 'Sample Location';
+    }
+  }, [activeTab, selectedDevices, selectedGridIds, selectedSites]);
+
   useEffect(() => {
-    if (
-      isOpen &&
-      dateRange?.from &&
-      dateRange?.to &&
-      selectedLocations.length > 0 &&
-      selectedPollutants.length > 0
-    ) {
-      const fetchPreviewData = async () => {
-        setPreviewLoading(true);
-        setPreviewError(null);
+    if (isOpen && !previousOpenRef.current) {
+      setSelectedColumnKeys(prev =>
+        areArraysEqual(prev, defaultColumnKeys) ? prev : defaultColumnKeys
+      );
+    }
 
-        try {
-          // For preview, we'll simulate getting data or use a modified request
-          // Since we can't actually download for preview, we'll show sample structure
-          const sampleData: PreviewData[] = [
-            {
-              ...(activeTab === 'sites' && {
-                site_name: selectedLocations[0] || 'Sample Site',
-              }),
-              ...(activeTab === 'devices' && {
-                device_name: selectedLocations[0] || 'sample_device',
-              }),
-              ...(activeTab === 'countries' && {
-                country_name: selectedLocations[0] || 'Sample Country',
-              }),
-              ...(activeTab === 'cities' && {
-                city_name: selectedLocations[0] || 'Sample City',
-              }),
-              datetime: dateRange?.from
-                ? dateRange.from
-                    .toISOString()
-                    .replace('T', ' ')
-                    .replace('Z', '')
-                : '',
-              frequency: frequency,
-              network: 'airqo',
-              latitude: 0.3244820075131162,
-              longitude: 32.571073376413565,
-              temperature: 25.83641260890321,
-              humidity: 72.06045440983412,
-              pm2_5: 36.37,
-              pm2_5_calibrated_value: 36.37,
-              pm10: 46.42,
-              pm10_calibrated_value: 46.42,
-            },
-            {
-              ...(activeTab === 'sites' && {
-                site_name: selectedLocations[0] || 'Sample Site',
-              }),
-              ...(activeTab === 'devices' && {
-                device_name: selectedLocations[0] || 'sample_device',
-              }),
-              ...(activeTab === 'countries' && {
-                country_name: selectedLocations[0] || 'Sample Country',
-              }),
-              ...(activeTab === 'cities' && {
-                city_name: selectedLocations[0] || 'Sample City',
-              }),
-              datetime: dateRange?.from
-                ? new Date(dateRange.from.getTime() + 24 * 60 * 60 * 1000)
-                    .toISOString()
-                    .replace('T', ' ')
-                    .replace('Z', '')
-                : '',
-              frequency: frequency,
-              network: 'airqo',
-              latitude: 0.3244820075131162,
-              longitude: 32.571073376413565,
-              temperature: 26.85111111111112,
-              humidity: 63.484772961816304,
-              pm2_5: 30.97,
-              pm2_5_calibrated_value: 27.95,
-              pm10: 42.11,
-              pm10_calibrated_value: 38.94,
-            },
-          ];
+    previousOpenRef.current = isOpen;
+  }, [defaultColumnKeys, isOpen]);
 
-          // Filter to only show selected pollutants
-          const filteredData = sampleData.map(row => {
-            const filteredRow: PreviewData = {
-              datetime: row.datetime,
-              ...(activeTab === 'sites' && { site_name: row.site_name }),
-              ...(activeTab === 'devices' && { device_name: row.device_name }),
-              ...(activeTab === 'countries' && {
-                country_name: row.country_name,
-              }),
-              ...(activeTab === 'cities' && { city_name: row.city_name }),
-              frequency: row.frequency,
-              network: row.network,
-            };
+  const handleColumnToggle = useCallback((key: string, checked: boolean) => {
+    setSelectedColumnKeys(prev => {
+      if (checked) {
+        return prev.includes(key) ? prev : [...prev, key];
+      }
 
-            // Add selected pollutants
-            selectedPollutants.forEach(pollutant => {
-              if (row[pollutant] !== undefined) {
-                filteredRow[pollutant] = row[pollutant];
-                filteredRow[`${pollutant}_calibrated_value`] =
-                  row[`${pollutant}_calibrated_value`];
-              }
-            });
+      return prev.filter(columnKey => columnKey !== key);
+    });
+  }, []);
 
-            // Add weather fields if selected
-            if (row.temperature !== undefined)
-              filteredRow.temperature = row.temperature;
-            if (row.humidity !== undefined) filteredRow.humidity = row.humidity;
+  const sampleRows = useMemo<PreviewData[]>(() => {
+    if (!dateRange?.from) {
+      return [];
+    }
 
-            // Add location fields
-            if (row.latitude !== undefined) filteredRow.latitude = row.latitude;
-            if (row.longitude !== undefined)
-              filteredRow.longitude = row.longitude;
+    const baseDate = dateRange.from;
 
-            return filteredRow;
-          });
+    return [0, 1].map(index => {
+      const sampleDate = new Date(
+        baseDate.getTime() + index * 24 * 60 * 60 * 1000
+      );
 
-          setPreviewData(filteredData.slice(0, 5)); // Show max 5 rows
-        } catch (error) {
-          setPreviewError('Failed to load preview data');
-          console.error('Preview data fetch error:', error);
-        } finally {
-          setPreviewLoading(false);
-        }
+      const row: PreviewData = {
+        [locationColumnKey]: locationSampleValue,
+        datetime: sampleDate.toISOString().replace('T', ' ').replace('Z', ''),
+        frequency,
+        network: 'airqo',
+        latitude: 0.3244820075131162,
+        longitude: 32.571073376413565,
+        temperature: index === 0 ? 25.83641260890321 : 26.85111111111112,
+        humidity: index === 0 ? 72.06045440983412 : 63.484772961816304,
       };
 
-      fetchPreviewData();
-    }
+      selectedPollutants.forEach(pollutant => {
+        const values = SAMPLE_POLLUTANT_VALUES[pollutant] || [36.37, 30.97];
+        const value = index === 0 ? values[0] : values[1];
+
+        row[pollutant] = value;
+        row[`${pollutant}_calibrated_value`] = Number(
+          (value * 0.92).toFixed(2)
+        );
+      });
+
+      return row;
+    });
   }, [
-    isOpen,
-    dateRange,
-    selectedLocations,
-    selectedPollutants,
-    dataType,
+    dateRange?.from,
     frequency,
-    activeTab,
-    deviceCategory,
-    selectedSites,
-    selectedDevices,
-    selectedGridIds,
+    locationColumnKey,
+    locationSampleValue,
+    selectedPollutants,
   ]);
 
-  // Get table columns based on preview data
-  const tableColumns = useMemo(() => {
-    if (previewData.length === 0) return [];
+  const previewColumns = useMemo(
+    () =>
+      selectedColumnKeys.map(key => ({
+        key,
+        label: columnLabelMap[key] || key,
+      })),
+    [columnLabelMap, selectedColumnKeys]
+  );
 
-    const firstRow = previewData[0];
-    return Object.keys(firstRow).map(key => ({
-      key,
-      label: key.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase()),
-      render: (value: string | number | null) => {
-        if (typeof value === 'number') {
-          return value.toFixed(2);
-        }
-        return String(value ?? '');
-      },
-    }));
-  }, [previewData]);
+  const previewData = useMemo(() => {
+    if (selectedColumnKeys.length === 0) {
+      return [];
+    }
+
+    return sampleRows.map(row => {
+      const filteredRow: PreviewData = {};
+
+      selectedColumnKeys.forEach(key => {
+        filteredRow[key] = row[key] ?? '';
+      });
+
+      return filteredRow;
+    });
+  }, [sampleRows, selectedColumnKeys]);
 
   return (
     <ReusableDialog
       isOpen={isOpen}
       onClose={onClose}
       title="Export Preview"
-      subtitle="Review your data export configuration and preview sample data"
+      subtitle="Choose the columns you want to keep before downloading."
       size="2xl"
       primaryAction={{
         label: isDownloading ? 'Downloading...' : 'Confirm & Download',
-        onClick: onConfirm,
-        disabled: isDownloading,
+        onClick: () => onConfirm(selectedColumnKeys),
+        disabled: isDownloading || selectedColumnKeys.length === 0,
         loading: isDownloading,
         variant: 'filled',
       }}
@@ -297,6 +289,56 @@ export const DataExportPreview: React.FC<DataExportPreviewProps> = ({
       }}
     >
       <div className="space-y-6">
+        {/* Download Columns */}
+        <div className="space-y-3">
+          <div>
+            <h3 className="text-sm text-gray-900 dark:text-gray-100">
+              Download Columns
+            </h3>
+            <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+              Turn columns on or off to match the file you want.
+            </p>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            {columnGroups.map(group => (
+              <div
+                key={group.id}
+                className="rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800"
+              >
+                <h4 className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                  {group.title}
+                </h4>
+                <div className="mt-3 grid gap-2 sm:grid-cols-2">
+                  {group.options.map(option => (
+                    <label
+                      key={option.key}
+                      className="flex items-start gap-2 rounded-md border border-gray-200 px-3 py-2 text-sm transition-colors hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-700/60"
+                    >
+                      <Checkbox
+                        checked={selectedColumnKeys.includes(option.key)}
+                        onCheckedChange={checked =>
+                          handleColumnToggle(option.key, checked === true)
+                        }
+                        className="mt-0.5"
+                      />
+                      <span className="leading-5 text-gray-900 dark:text-gray-100">
+                        {option.label}
+                      </span>
+                    </label>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {selectedColumnKeys.length === 0 && (
+            <p className="text-sm text-red-600 dark:text-red-400">
+              Select at least one column to enable the download.
+            </p>
+          )}
+        </div>
+
         {/* Configuration Summary */}
         <div className="bg-gray-50 dark:bg-gray-800 rounded-lg p-4">
           <h3 className="text-sm text-gray-900 dark:text-gray-100 mb-3">
@@ -339,9 +381,10 @@ export const DataExportPreview: React.FC<DataExportPreviewProps> = ({
             </div>
           </div>
           <div className="mt-3 pt-3 border-t border-gray-200 dark:border-gray-700">
-            <div className="flex justify-between text-sm text-gray-600 dark:text-gray-400">
+            <div className="flex flex-wrap gap-3 text-sm text-gray-600 dark:text-gray-400">
               <span>Date Range: {formattedDateRange}</span>
               <span>Estimated Days: {estimatedDays}</span>
+              <span>Selected Columns: {selectedColumnKeys.length}</span>
             </div>
           </div>
         </div>
@@ -352,24 +395,18 @@ export const DataExportPreview: React.FC<DataExportPreviewProps> = ({
             Data Preview (Sample Rows)
           </h3>
 
-          {previewLoading ? (
-            <div className="flex items-center justify-center py-8">
-              <div className="text-sm text-gray-600 dark:text-gray-400">
-                Loading preview data...
-              </div>
-            </div>
-          ) : previewError ? (
+          {selectedColumnKeys.length === 0 ? (
             <InfoBanner
               title="Preview Unavailable"
-              message="Unable to load preview data. You can still proceed with the export."
+              message="Select at least one column above to preview the export output."
             />
           ) : previewData.length > 0 ? (
             <div className="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
-              <div className="max-h-64 overflow-y-auto">
+              <div className="max-h-64 overflow-auto">
                 <table className="w-full text-sm">
                   <thead className="bg-gray-50 dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700">
                     <tr>
-                      {tableColumns.map(column => (
+                      {previewColumns.map(column => (
                         <th
                           key={column.key}
                           className="px-3 py-2 text-left font-medium text-gray-700 dark:text-gray-300 border-r border-gray-200 dark:border-gray-700 last:border-r-0"
@@ -385,12 +422,14 @@ export const DataExportPreview: React.FC<DataExportPreviewProps> = ({
                         key={rowIndex}
                         className="border-b border-gray-100 dark:border-gray-700 last:border-b-0"
                       >
-                        {tableColumns.map(column => (
+                        {previewColumns.map(column => (
                           <td
                             key={column.key}
                             className="px-3 py-2 text-gray-900 dark:text-gray-100 border-r border-gray-200 dark:border-gray-700 last:border-r-0"
                           >
-                            {column.render(row[column.key])}
+                            {typeof row[column.key] === 'number'
+                              ? Number(row[column.key]).toFixed(2)
+                              : String(row[column.key] ?? '')}
                           </td>
                         ))}
                       </tr>
@@ -408,7 +447,7 @@ export const DataExportPreview: React.FC<DataExportPreviewProps> = ({
 
         {/* Export Notes */}
         <InfoBanner
-          message={`This preview shows sample data. Your actual export will include all ${selectedLocations.length} ${locationType.toLowerCase()} and ${estimatedDays} days of data in ${fileType.toUpperCase()} format.`}
+          message={`This preview is for the file setup only. Your download will use the same data selection and keep only the columns you choose here.`}
         />
       </div>
     </ReusableDialog>

--- a/src/platform/src/modules/data-download/components/DataExportSidebar.tsx
+++ b/src/platform/src/modules/data-download/components/DataExportSidebar.tsx
@@ -189,7 +189,11 @@ export const DataExportSidebar: React.FC<DataExportSidebarProps> = ({
               Pollutants
             </label>
             {pollutantError && (
-              <p className="text-sm text-red-600 dark:text-red-400" role="alert" aria-live="polite">
+              <p
+                className="text-sm text-red-600 dark:text-red-400"
+                role="alert"
+                aria-live="polite"
+              >
                 {pollutantError}
               </p>
             )}
@@ -204,7 +208,11 @@ export const DataExportSidebar: React.FC<DataExportSidebarProps> = ({
                     }
                   />
                   <label htmlFor={pollutant} className="ml-2 text-sm">
-                    {POLLUTANT_LABELS[pollutant as keyof typeof POLLUTANT_LABELS]}
+                    {
+                      POLLUTANT_LABELS[
+                        pollutant as keyof typeof POLLUTANT_LABELS
+                      ]
+                    }
                   </label>
                 </div>
               ))}
@@ -316,7 +324,11 @@ export const DataExportSidebar: React.FC<DataExportSidebarProps> = ({
                 Pollutants
               </label>
               {pollutantError && (
-                <p className="text-sm text-red-600 dark:text-red-400" role="alert" aria-live="polite">
+                <p
+                  className="text-sm text-red-600 dark:text-red-400"
+                  role="alert"
+                  aria-live="polite"
+                >
                   {pollutantError}
                 </p>
               )}
@@ -331,7 +343,11 @@ export const DataExportSidebar: React.FC<DataExportSidebarProps> = ({
                       }
                     />
                     <label htmlFor={pollutant} className="ml-2 text-sm">
-                      {POLLUTANT_LABELS[pollutant as keyof typeof POLLUTANT_LABELS]}
+                      {
+                        POLLUTANT_LABELS[
+                          pollutant as keyof typeof POLLUTANT_LABELS
+                        ]
+                      }
                     </label>
                   </div>
                 ))}

--- a/src/platform/src/modules/data-download/components/DataExportSidebar.tsx
+++ b/src/platform/src/modules/data-download/components/DataExportSidebar.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState, useCallback } from 'react';
 import { Button } from '@/shared/components/ui';
 import { Input } from '@/shared/components/ui/input';
 import Checkbox from '@/shared/components/ui/checkbox';
@@ -89,6 +89,32 @@ export const DataExportSidebar: React.FC<DataExportSidebarProps> = ({
       return allOptions.filter(option => option.value !== 'raw');
     }
   }, [deviceCategory]);
+  const [pollutantError, setPollutantError] = useState<string | null>(null);
+
+  const handlePollutantChange = useCallback(
+    (pollutant: string, checked: boolean | 'indeterminate') => {
+      // Clear previous error on any interaction
+      setPollutantError(null);
+
+      if (checked === true) {
+        setSelectedPollutants(prev =>
+          prev.includes(pollutant) ? prev : [...prev, pollutant]
+        );
+        return;
+      }
+
+      if (checked === false) {
+        // Prevent removing the last selected pollutant
+        if (selectedPollutants.length <= 1) {
+          setPollutantError('Please select at least one pollutant.');
+          return;
+        }
+
+        setSelectedPollutants(prev => prev.filter(p => p !== pollutant));
+      }
+    },
+    [selectedPollutants, setSelectedPollutants]
+  );
   return (
     <>
       {/* Sidebar - Hidden by default, shown when toggled */}
@@ -162,28 +188,23 @@ export const DataExportSidebar: React.FC<DataExportSidebarProps> = ({
             <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
               Pollutants
             </label>
+            {pollutantError && (
+              <p className="text-sm text-red-600 dark:text-red-400" role="alert" aria-live="polite">
+                {pollutantError}
+              </p>
+            )}
             <div className="space-y-2">
               {pollutants.map(pollutant => (
                 <div key={pollutant} className="flex items-center">
                   <Checkbox
                     id={pollutant}
                     checked={selectedPollutants.includes(pollutant)}
-                    onCheckedChange={(checked: boolean | 'indeterminate') => {
-                      if (checked === true) {
-                        setSelectedPollutants(prev => [...prev, pollutant]);
-                      } else if (checked === false) {
-                        setSelectedPollutants(prev =>
-                          prev.filter(p => p !== pollutant)
-                        );
-                      }
-                    }}
+                    onCheckedChange={(checked: boolean | 'indeterminate') =>
+                      handlePollutantChange(pollutant, checked)
+                    }
                   />
                   <label htmlFor={pollutant} className="ml-2 text-sm">
-                    {
-                      POLLUTANT_LABELS[
-                        pollutant as keyof typeof POLLUTANT_LABELS
-                      ]
-                    }
+                    {POLLUTANT_LABELS[pollutant as keyof typeof POLLUTANT_LABELS]}
                   </label>
                 </div>
               ))}
@@ -294,28 +315,23 @@ export const DataExportSidebar: React.FC<DataExportSidebarProps> = ({
               <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
                 Pollutants
               </label>
+              {pollutantError && (
+                <p className="text-sm text-red-600 dark:text-red-400" role="alert" aria-live="polite">
+                  {pollutantError}
+                </p>
+              )}
               <div className="space-y-2">
                 {pollutants.map(pollutant => (
                   <div key={pollutant} className="flex items-center">
                     <Checkbox
                       id={pollutant}
                       checked={selectedPollutants.includes(pollutant)}
-                      onCheckedChange={(checked: boolean | 'indeterminate') => {
-                        if (checked === true) {
-                          setSelectedPollutants(prev => [...prev, pollutant]);
-                        } else if (checked === false) {
-                          setSelectedPollutants(prev =>
-                            prev.filter(p => p !== pollutant)
-                          );
-                        }
-                      }}
+                      onCheckedChange={(checked: boolean | 'indeterminate') =>
+                        handlePollutantChange(pollutant, checked)
+                      }
                     />
                     <label htmlFor={pollutant} className="ml-2 text-sm">
-                      {
-                        POLLUTANT_LABELS[
-                          pollutant as keyof typeof POLLUTANT_LABELS
-                        ]
-                      }
+                      {POLLUTANT_LABELS[pollutant as keyof typeof POLLUTANT_LABELS]}
                     </label>
                   </div>
                 ))}

--- a/src/platform/src/modules/data-download/components/DataExportTable.tsx
+++ b/src/platform/src/modules/data-download/components/DataExportTable.tsx
@@ -2,10 +2,12 @@ import React from 'react';
 import { ServerSideTable } from '@/shared/components/ui/server-side-table';
 import { TabType, TableItem, ColumnConfig } from '../types/dataExportTypes';
 import { getTabConfig } from '../utils/tableConfig';
+import { TableExportActions } from './TableExportActions';
 
 interface DataExportTableProps {
   activeTab: TabType;
   tableData: TableItem[];
+  exportData: TableItem[];
   columns: ColumnConfig[];
   loading: boolean;
   error: string | null;
@@ -15,6 +17,7 @@ interface DataExportTableProps {
   totalItems: number;
   searchTerm: string;
   selectedItems: string[];
+  compactRows?: boolean;
   onPageChange: (page: number) => void;
   onPageSizeChange: (size: number) => void;
   onSearchChange: (search: string) => void;
@@ -27,6 +30,7 @@ interface DataExportTableProps {
 export const DataExportTable: React.FC<DataExportTableProps> = ({
   activeTab,
   tableData,
+  exportData,
   columns,
   loading,
   error,
@@ -36,6 +40,7 @@ export const DataExportTable: React.FC<DataExportTableProps> = ({
   totalItems,
   searchTerm,
   selectedItems,
+  compactRows = false,
   onPageChange,
   onPageSizeChange,
   onSearchChange,
@@ -61,7 +66,15 @@ export const DataExportTable: React.FC<DataExportTableProps> = ({
       multiSelect={activeTab !== 'countries' && activeTab !== 'cities'}
       selectedItems={selectedItems}
       onSelectedItemsChange={onSelectedItemsChange}
-      customHeader={undefined}
+      compactRows={compactRows}
+      customHeader={
+        <TableExportActions
+          title={config.title}
+          exportData={exportData}
+          columns={columns}
+          disabled={loading}
+        />
+      }
     />
   );
 };

--- a/src/platform/src/modules/data-download/components/TableExportActions.tsx
+++ b/src/platform/src/modules/data-download/components/TableExportActions.tsx
@@ -27,7 +27,7 @@ export const TableExportActions: React.FC<TableExportActionsProps> = ({
   exportData,
   columns,
   disabled = false,
-  tooltipText = 'Includes selected rows from all pages. Air quality data is excluded.',
+  tooltipText = 'Includes selected rows from all pages. Air quality data excluded.',
 }) => {
   const isDisabled = disabled || exportData.length === 0;
 

--- a/src/platform/src/modules/data-download/components/TableExportActions.tsx
+++ b/src/platform/src/modules/data-download/components/TableExportActions.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import React, { useCallback } from 'react';
+import { AqDownload01 } from '@airqo/icons-react';
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+} from '@/shared/components/ui';
+import { ColumnConfig, TableItem } from '../types/dataExportTypes';
+import { exportTableAsCsv, exportTableAsPdf } from '../utils/tableExport';
+
+interface TableExportActionsProps {
+  title: string;
+  exportData: TableItem[];
+  columns: ColumnConfig[];
+  disabled?: boolean;
+  tooltipText?: string;
+}
+
+export const TableExportActions: React.FC<TableExportActionsProps> = ({
+  title,
+  exportData,
+  columns,
+  disabled = false,
+  tooltipText = 'Rows selected across pages are included. Air quality data is not included.',
+}) => {
+  const isDisabled = disabled || exportData.length === 0;
+
+  const handleExport = useCallback(
+    (format: 'csv' | 'pdf') => {
+      if (isDisabled) {
+        return;
+      }
+
+      if (format === 'csv') {
+        exportTableAsCsv({ title, data: exportData, columns });
+        return;
+      }
+
+      exportTableAsPdf({ title, data: exportData, columns });
+    },
+    [columns, exportData, isDisabled, title]
+  );
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="outlined"
+          size="sm"
+          Icon={AqDownload01}
+          showTextOnMobile
+          disabled={isDisabled}
+          className="whitespace-nowrap"
+          title={tooltipText}
+        >
+          Export as CSV/PDF
+        </Button>
+      </DropdownMenuTrigger>
+
+      <DropdownMenuContent align="end" className="w-[260px] z-[10010]">
+        <div className="px-3 py-2 border-b border-border">
+          <p className="text-sm font-medium text-foreground">
+            Export table view
+          </p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Exports selected rows when available.
+          </p>
+        </div>
+
+        <DropdownMenuItem
+          onClick={() => handleExport('csv')}
+          className="cursor-pointer flex flex-col items-start gap-1"
+          disabled={isDisabled}
+        >
+          <span className="text-sm font-medium text-foreground">CSV</span>
+          <span className="text-xs text-muted-foreground">
+            Best for spreadsheets, analysis, and bulk sharing.
+          </span>
+        </DropdownMenuItem>
+
+        <DropdownMenuSeparator />
+
+        <DropdownMenuItem
+          onClick={() => handleExport('pdf')}
+          className="cursor-pointer flex flex-col items-start gap-1"
+          disabled={isDisabled}
+        >
+          <span className="text-sm font-medium text-foreground">PDF</span>
+          <span className="text-xs text-muted-foreground">
+            Styled report export for presentation and review.
+          </span>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};

--- a/src/platform/src/modules/data-download/components/TableExportActions.tsx
+++ b/src/platform/src/modules/data-download/components/TableExportActions.tsx
@@ -2,6 +2,7 @@
 
 import React, { useCallback } from 'react';
 import { AqDownload01 } from '@airqo/icons-react';
+import { Tooltip } from 'flowbite-react';
 import {
   Button,
   DropdownMenu,
@@ -26,7 +27,7 @@ export const TableExportActions: React.FC<TableExportActionsProps> = ({
   exportData,
   columns,
   disabled = false,
-  tooltipText = 'Rows selected across pages are included. Air quality data is not included.',
+  tooltipText = 'Includes selected rows from all pages. Air quality data is excluded.',
 }) => {
   const isDisabled = disabled || exportData.length === 0;
 
@@ -48,19 +49,22 @@ export const TableExportActions: React.FC<TableExportActionsProps> = ({
 
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button
-          variant="outlined"
-          size="sm"
-          Icon={AqDownload01}
-          showTextOnMobile
-          disabled={isDisabled}
-          className="whitespace-nowrap"
-          title={tooltipText}
-        >
-          Export as CSV/PDF
-        </Button>
-      </DropdownMenuTrigger>
+      <Tooltip content={tooltipText} placement="top">
+        <span className="inline-flex">
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="outlined"
+              size="sm"
+              Icon={AqDownload01}
+              showTextOnMobile
+              disabled={isDisabled}
+              className="whitespace-nowrap"
+            >
+              Export as CSV/PDF
+            </Button>
+          </DropdownMenuTrigger>
+        </span>
+      </Tooltip>
 
       <DropdownMenuContent align="end" className="w-[260px] z-[10010]">
         <div className="px-3 py-2 border-b border-border">
@@ -68,7 +72,7 @@ export const TableExportActions: React.FC<TableExportActionsProps> = ({
             Export table view
           </p>
           <p className="mt-1 text-xs text-muted-foreground">
-            Exports selected rows when available.
+            Exports selected rows across pages.
           </p>
         </div>
 

--- a/src/platform/src/modules/data-download/hooks/useDataExportActions.ts
+++ b/src/platform/src/modules/data-download/hooks/useDataExportActions.ts
@@ -169,6 +169,7 @@ export const useDataExportActions = (
         activeTab,
         selectedSites,
         selectedDeviceIds,
+        selectedDeviceNames: selectedDevices,
         selectedGridIds,
         selectedGridSites,
         selectedGridSiteIds: effectiveSelectedGridSiteIds,

--- a/src/platform/src/modules/data-download/hooks/useDataExportActions.ts
+++ b/src/platform/src/modules/data-download/hooks/useDataExportActions.ts
@@ -10,7 +10,6 @@ import {
   trackFeatureUsage,
 } from '@/shared/utils/enhancedAnalytics';
 import { useDataDownload } from '@/modules/analytics/hooks';
-import { DataDownloadRequest } from '@/shared/types/api';
 import { DateRange } from '@/shared/components/calendar/types';
 import { LARGE_DATE_RANGE_THRESHOLD } from '../constants/dataExportConstants';
 import { TabType, DeviceCategory, TableItem } from '../types/dataExportTypes';
@@ -19,6 +18,7 @@ import {
   createSitesFromDevicesForVisualization,
   createSitesFromGridsForVisualization,
 } from '../utils/dataExportUtils';
+import { buildDataDownloadRequest } from '../utils/dataExportRequest';
 import type { AxiosError } from 'axios';
 
 interface ApiErrorResponse {
@@ -78,9 +78,17 @@ export const useDataExportActions = (
   const posthog = usePostHog();
   const { downloadData, isDownloading } = useDataDownload();
 
+  interface HandleDownloadOptions {
+    customSelectedGridSiteIds?: Record<string, string[]>;
+    exportColumnKeys?: string[];
+  }
+
   // Handle data download
   const handleDownload = useCallback(
-    async (customSelectedGridSiteIds?: Record<string, string[]>) => {
+    async ({
+      customSelectedGridSiteIds,
+      exportColumnKeys,
+    }: HandleDownloadOptions = {}) => {
       if (!dateRange?.from || !dateRange?.to) {
         toast.error(
           'Date Range Required',
@@ -105,9 +113,20 @@ export const useDataExportActions = (
         return;
       }
 
+      if (exportColumnKeys && exportColumnKeys.length === 0) {
+        toast.error(
+          'Download Columns Required',
+          'Please select at least one column to include in the exported file.'
+        );
+        return;
+      }
+
+      const effectiveSelectedGridSiteIds =
+        customSelectedGridSiteIds || selectedGridSiteIds;
+
       if (
         (activeTab === 'countries' || activeTab === 'cities') &&
-        Object.keys(selectedGridSiteIds).length === 0 &&
+        Object.keys(effectiveSelectedGridSiteIds).length === 0 &&
         Object.keys(selectedGridSites).length === 0
       ) {
         toast.error(
@@ -144,6 +163,22 @@ export const useDataExportActions = (
         );
         return;
       }
+
+      const request = buildDataDownloadRequest({
+        dateRange,
+        activeTab,
+        selectedSites,
+        selectedDeviceIds,
+        selectedGridIds,
+        selectedGridSites,
+        selectedGridSiteIds: effectiveSelectedGridSiteIds,
+        customSelectedGridSiteIds,
+        selectedPollutants,
+        dataType,
+        fileType,
+        frequency,
+        deviceCategory,
+      });
 
       const locationNames =
         activeTab === 'sites'
@@ -202,30 +237,10 @@ export const useDataExportActions = (
         });
       }
 
-      const request: DataDownloadRequest = {
-        datatype: effectiveDataType,
-        downloadType: fileType as 'csv' | 'json',
-        startDateTime: dateRange.from.toISOString(),
-        endDateTime: dateRange.to.toISOString(),
-        frequency: frequency as 'daily',
-        minimum: true,
-        metaDataFields: ['latitude', 'longitude'],
-        weatherFields: ['temperature', 'humidity'],
-        outputFormat: 'airqo-standard',
-        pollutants: selectedPollutants,
-        device_category:
-          activeTab === 'countries' || activeTab === 'cities'
-            ? 'lowcost'
-            : deviceCategory,
-        ...(activeTab === 'sites' && { sites: selectedSites }),
-        ...(activeTab === 'devices' && { device_ids: selectedDeviceIds }),
-        ...((activeTab === 'countries' || activeTab === 'cities') && {
-          sites: sitesForDownload,
-        }),
-      };
-
       try {
-        await downloadData(request, fileTitle || undefined);
+        await downloadData(request, fileTitle || undefined, {
+          selectedColumnKeys: exportColumnKeys,
+        });
 
         // Enhanced analytics tracking with comprehensive details
         // Use the same deviceCategory logic as the API request

--- a/src/platform/src/modules/data-download/types/dataExportTypes.ts
+++ b/src/platform/src/modules/data-download/types/dataExportTypes.ts
@@ -47,6 +47,11 @@ export interface ColumnConfig {
   key: string;
   label: string;
   render?: (value: unknown) => React.ReactNode;
+  headerClassName?: string;
+  cellClassName?: string;
+  width?: string;
+  minWidth?: string;
+  maxWidth?: string;
 }
 
 export interface TabConfig {

--- a/src/platform/src/modules/data-download/utils/dataExportFile.ts
+++ b/src/platform/src/modules/data-download/utils/dataExportFile.ts
@@ -204,7 +204,6 @@ const extractDownloadRecords = (response: DataDownloadResponse | string) => {
       records,
       headers,
       responseObject: null as DataDownloadResponse | null,
-      originalCsv: response,
     };
   }
 
@@ -214,7 +213,6 @@ const extractDownloadRecords = (response: DataDownloadResponse | string) => {
     records,
     headers: getRecordHeaders(records),
     responseObject: response,
-    originalCsv: null,
   };
 };
 
@@ -317,8 +315,7 @@ export const buildDownloadFileContent = (
   downloadType: DataDownloadRequest['downloadType'],
   selectedColumnKeys?: string[]
 ) => {
-  const { records, headers, responseObject, originalCsv } =
-    extractDownloadRecords(response);
+  const { records, headers, responseObject } = extractDownloadRecords(response);
   const selectedHeaders = resolveSelectedHeaders(headers, selectedColumnKeys);
   const normalizedSelectedColumnKeys =
     normalizeSelectedColumnKeys(selectedColumnKeys);
@@ -326,17 +323,6 @@ export const buildDownloadFileContent = (
   const isCsv = downloadType === 'csv';
 
   if (isCsv) {
-    if (
-      originalCsv &&
-      (!hasExplicitColumnFilter || areArraysEqual(selectedHeaders, headers))
-    ) {
-      return {
-        content: originalCsv,
-        mimeType: 'text/csv;charset=utf-8;',
-        extension: 'csv' as const,
-      };
-    }
-
     const filteredRows = records.map(record =>
       pickRecordColumnsForCsv(record, selectedHeaders)
     );

--- a/src/platform/src/modules/data-download/utils/dataExportFile.ts
+++ b/src/platform/src/modules/data-download/utils/dataExportFile.ts
@@ -1,0 +1,387 @@
+import { DataDownloadRequest, DataDownloadResponse } from '@/shared/types/api';
+import { POLLUTANT_LABELS } from '@/shared/components/charts/constants';
+import { areArraysEqual } from '@/shared/utils/arrays';
+import { TabType } from '../types/dataExportTypes';
+
+export type DownloadColumnGroupId =
+  | 'location'
+  | 'core'
+  | 'metadata'
+  | 'pollutants';
+
+export interface DownloadColumnOption {
+  key: string;
+  label: string;
+  group: DownloadColumnGroupId;
+}
+
+export interface DownloadColumnGroup {
+  id: DownloadColumnGroupId;
+  title: string;
+  options: DownloadColumnOption[];
+}
+
+export interface DownloadFileTransformOptions {
+  selectedColumnKeys?: string[];
+}
+
+type DownloadRecord = Record<string, unknown>;
+
+const formatColumnLabel = (key: string) =>
+  key
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, char => char.toUpperCase())
+    .replace(/Pm2 5/g, 'PM2.5')
+    .replace(/Pm10/g, 'PM10');
+
+const normalizeSelectedColumnKeys = (selectedColumnKeys?: string[]) =>
+  Array.from(new Set((selectedColumnKeys || []).filter(Boolean)));
+
+const isPlainObject = (value: unknown): value is DownloadRecord =>
+  !!value && typeof value === 'object' && !Array.isArray(value);
+
+const parseCsvRows = (csvText: string): string[][] => {
+  const normalizedCsv = csvText.replace(/^\uFEFF/, '');
+  const rows: string[][] = [];
+  let currentRow: string[] = [];
+  let currentField = '';
+  let inQuotes = false;
+
+  for (let index = 0; index < normalizedCsv.length; index += 1) {
+    const char = normalizedCsv[index];
+
+    if (inQuotes) {
+      if (char === '"') {
+        const nextChar = normalizedCsv[index + 1];
+        if (nextChar === '"') {
+          currentField += '"';
+          index += 1;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        currentField += char;
+      }
+      continue;
+    }
+
+    if (char === '"') {
+      inQuotes = true;
+    } else if (char === ',') {
+      currentRow.push(currentField);
+      currentField = '';
+    } else if (char === '\n') {
+      currentRow.push(currentField);
+      rows.push(currentRow);
+      currentRow = [];
+      currentField = '';
+    } else if (char === '\r') {
+      continue;
+    } else {
+      currentField += char;
+    }
+  }
+
+  currentRow.push(currentField);
+  rows.push(currentRow);
+
+  if (rows.length > 0) {
+    const lastRow = rows[rows.length - 1];
+    if (lastRow.length === 1 && lastRow[0] === '') {
+      rows.pop();
+    }
+  }
+
+  return rows;
+};
+
+const escapeCsvValue = (value: unknown) => {
+  if (value === null || value === undefined) {
+    return '""';
+  }
+
+  const stringValue = String(value);
+  const trimmedValue = stringValue.trimStart();
+  const firstVisibleCharacter = trimmedValue[0];
+  const needsNeutralize =
+    firstVisibleCharacter === '=' ||
+    firstVisibleCharacter === '+' ||
+    firstVisibleCharacter === '-' ||
+    firstVisibleCharacter === '@' ||
+    stringValue.charAt(0) === '\t' ||
+    stringValue.charAt(0) === '\r';
+  const prefixedValue = needsNeutralize ? `'${stringValue}` : stringValue;
+
+  return `"${prefixedValue.replace(/"/g, '""')}"`;
+};
+
+const getRecordHeaders = (records: DownloadRecord[]) => {
+  const headers: string[] = [];
+  const seenHeaders = new Set<string>();
+
+  records.forEach(record => {
+    Object.keys(record).forEach(key => {
+      if (!seenHeaders.has(key)) {
+        seenHeaders.add(key);
+        headers.push(key);
+      }
+    });
+  });
+
+  return headers;
+};
+
+const pickRecordColumnsForCsv = (record: DownloadRecord, headers: string[]) => {
+  const filteredRecord: DownloadRecord = {};
+
+  headers.forEach(header => {
+    filteredRecord[header] = record[header] ?? '';
+  });
+
+  return filteredRecord;
+};
+
+const pickRecordColumnsForJson = (
+  record: DownloadRecord,
+  headers: string[]
+) => {
+  const filteredRecord: DownloadRecord = {};
+
+  headers.forEach(header => {
+    if (Object.prototype.hasOwnProperty.call(record, header)) {
+      filteredRecord[header] = record[header];
+    }
+  });
+
+  return filteredRecord;
+};
+
+const stringifyCsv = (headers: string[], records: DownloadRecord[]) => {
+  const lines = [headers.map(escapeCsvValue).join(',')];
+
+  records.forEach(record => {
+    const row = headers.map(header => escapeCsvValue(record[header]));
+    lines.push(row.join(','));
+  });
+
+  return `\uFEFF${lines.join('\n')}`;
+};
+
+const resolveSelectedHeaders = (
+  availableHeaders: string[],
+  selectedColumnKeys?: string[]
+) => {
+  const normalizedSelectedColumnKeys =
+    normalizeSelectedColumnKeys(selectedColumnKeys);
+
+  if (normalizedSelectedColumnKeys.length === 0) {
+    return availableHeaders;
+  }
+
+  const selectedHeaders = normalizedSelectedColumnKeys.filter(key =>
+    availableHeaders.includes(key)
+  );
+
+  return selectedHeaders.length > 0 ? selectedHeaders : availableHeaders;
+};
+
+const extractDownloadRecords = (response: DataDownloadResponse | string) => {
+  if (typeof response === 'string') {
+    const rows = parseCsvRows(response);
+    const [headers = [], ...dataRows] = rows;
+
+    const records = dataRows.map(row => {
+      const record: DownloadRecord = {};
+
+      headers.forEach((header, index) => {
+        record[header] = row[index] ?? '';
+      });
+
+      return record;
+    });
+
+    return {
+      records,
+      headers,
+      responseObject: null as DataDownloadResponse | null,
+      originalCsv: response,
+    };
+  }
+
+  const records = response.data.map(item => (isPlainObject(item) ? item : {}));
+
+  return {
+    records,
+    headers: getRecordHeaders(records),
+    responseObject: response,
+    originalCsv: null,
+  };
+};
+
+export const getDownloadColumnGroups = (
+  activeTab: TabType,
+  selectedPollutants: string[]
+): DownloadColumnGroup[] => {
+  const locationOption =
+    activeTab === 'sites'
+      ? { key: 'site_name', label: 'Site name' }
+      : activeTab === 'devices'
+        ? { key: 'device_name', label: 'Device name' }
+        : activeTab === 'countries'
+          ? { key: 'country_name', label: 'Country name' }
+          : { key: 'city_name', label: 'City name' };
+
+  const uniquePollutants = Array.from(
+    new Set(selectedPollutants.filter(Boolean))
+  );
+
+  return [
+    {
+      id: 'location',
+      title: 'Location',
+      options: [{ ...locationOption, group: 'location' }],
+    },
+    {
+      id: 'core',
+      title: 'Core Data',
+      options: [
+        { key: 'datetime', label: 'Date and time', group: 'core' },
+        { key: 'frequency', label: 'Frequency', group: 'core' },
+        { key: 'network', label: 'Network', group: 'core' },
+      ],
+    },
+    {
+      id: 'metadata',
+      title: 'Metadata',
+      options: [
+        { key: 'latitude', label: 'Latitude', group: 'metadata' },
+        { key: 'longitude', label: 'Longitude', group: 'metadata' },
+        { key: 'temperature', label: 'Temperature', group: 'metadata' },
+        { key: 'humidity', label: 'Humidity', group: 'metadata' },
+      ],
+    },
+    {
+      id: 'pollutants',
+      title: 'Pollutants',
+      options: uniquePollutants.flatMap(pollutant => {
+        const pollutantLabel =
+          POLLUTANT_LABELS[pollutant as keyof typeof POLLUTANT_LABELS] ||
+          formatColumnLabel(pollutant);
+
+        return [
+          {
+            key: pollutant,
+            label: pollutantLabel,
+            group: 'pollutants' as const,
+          },
+          {
+            key: `${pollutant}_calibrated_value`,
+            label: `${pollutantLabel} calibrated`,
+            group: 'pollutants' as const,
+          },
+        ];
+      }),
+    },
+  ];
+};
+
+export const getDownloadColumnOptions = (
+  activeTab: TabType,
+  selectedPollutants: string[]
+) =>
+  getDownloadColumnGroups(activeTab, selectedPollutants).flatMap(
+    group => group.options
+  );
+
+export const getDownloadColumnLabelMap = (
+  activeTab: TabType,
+  selectedPollutants: string[]
+) =>
+  Object.fromEntries(
+    getDownloadColumnOptions(activeTab, selectedPollutants).map(option => [
+      option.key,
+      option.label,
+    ])
+  );
+
+export const getDefaultDownloadColumnKeys = (
+  activeTab: TabType,
+  selectedPollutants: string[]
+) =>
+  getDownloadColumnOptions(activeTab, selectedPollutants).map(
+    option => option.key
+  );
+
+export const buildDownloadFileContent = (
+  response: DataDownloadResponse | string,
+  downloadType: DataDownloadRequest['downloadType'],
+  selectedColumnKeys?: string[]
+) => {
+  const { records, headers, responseObject, originalCsv } =
+    extractDownloadRecords(response);
+  const selectedHeaders = resolveSelectedHeaders(headers, selectedColumnKeys);
+  const normalizedSelectedColumnKeys =
+    normalizeSelectedColumnKeys(selectedColumnKeys);
+  const hasExplicitColumnFilter = normalizedSelectedColumnKeys.length > 0;
+  const isCsv = downloadType === 'csv';
+
+  if (isCsv) {
+    if (
+      originalCsv &&
+      (!hasExplicitColumnFilter || areArraysEqual(selectedHeaders, headers))
+    ) {
+      return {
+        content: originalCsv,
+        mimeType: 'text/csv;charset=utf-8;',
+        extension: 'csv' as const,
+      };
+    }
+
+    const filteredRows = records.map(record =>
+      pickRecordColumnsForCsv(record, selectedHeaders)
+    );
+
+    return {
+      content: stringifyCsv(selectedHeaders, filteredRows),
+      mimeType: 'text/csv;charset=utf-8;',
+      extension: 'csv' as const,
+    };
+  }
+
+  if (responseObject) {
+    if (!hasExplicitColumnFilter || areArraysEqual(selectedHeaders, headers)) {
+      return {
+        content: JSON.stringify(responseObject, null, 2),
+        mimeType: 'application/json;charset=utf-8;',
+        extension: 'json' as const,
+      };
+    }
+
+    const filteredData = responseObject.data.map(item =>
+      pickRecordColumnsForJson(isPlainObject(item) ? item : {}, selectedHeaders)
+    );
+
+    return {
+      content: JSON.stringify(
+        {
+          ...responseObject,
+          data: filteredData,
+        },
+        null,
+        2
+      ),
+      mimeType: 'application/json;charset=utf-8;',
+      extension: 'json' as const,
+    };
+  }
+
+  const filteredData = records.map(record =>
+    pickRecordColumnsForJson(record, selectedHeaders)
+  );
+
+  return {
+    content: JSON.stringify(filteredData, null, 2),
+    mimeType: 'application/json;charset=utf-8;',
+    extension: 'json' as const,
+  };
+};

--- a/src/platform/src/modules/data-download/utils/dataExportRequest.ts
+++ b/src/platform/src/modules/data-download/utils/dataExportRequest.ts
@@ -1,0 +1,111 @@
+import { DateRange } from '@/shared/components/calendar/types';
+import { DataDownloadRequest } from '@/shared/types/api';
+import { DeviceCategory, TabType } from '../types/dataExportTypes';
+
+interface BuildDataDownloadRequestArgs {
+  dateRange: DateRange | undefined;
+  activeTab: TabType;
+  selectedSites: string[];
+  selectedDeviceIds: string[];
+  selectedGridIds: string[];
+  selectedGridSites: Record<string, string[]>;
+  selectedGridSiteIds: Record<string, string[]>;
+  customSelectedGridSiteIds?: Record<string, string[]>;
+  selectedPollutants: string[];
+  dataType: string;
+  fileType: string;
+  frequency: string;
+  deviceCategory: DeviceCategory;
+}
+
+const toUtcDayStartIso = (date: Date) =>
+  new Date(
+    Date.UTC(date.getFullYear(), date.getMonth(), date.getDate(), 0, 0, 0, 0)
+  ).toISOString();
+
+const toUtcDayEndIso = (date: Date) =>
+  new Date(
+    Date.UTC(
+      date.getFullYear(),
+      date.getMonth(),
+      date.getDate(),
+      23,
+      59,
+      59,
+      999
+    )
+  ).toISOString();
+
+const resolveGridSitesForDownload = (
+  selectedGridIds: string[],
+  selectedGridSites: Record<string, string[]>,
+  selectedGridSiteIds: Record<string, string[]>
+) => {
+  const sitesForDownload: string[] = [];
+
+  selectedGridIds.forEach(gridId => {
+    const customSites = selectedGridSiteIds[gridId];
+    const defaultSites = selectedGridSites[gridId];
+    const sites =
+      customSites && customSites.length > 0 ? customSites : defaultSites || [];
+
+    sitesForDownload.push(...sites);
+  });
+
+  return sitesForDownload;
+};
+
+export const buildDataDownloadRequest = ({
+  dateRange,
+  activeTab,
+  selectedSites,
+  selectedDeviceIds,
+  selectedGridIds,
+  selectedGridSites,
+  selectedGridSiteIds,
+  customSelectedGridSiteIds,
+  selectedPollutants,
+  dataType,
+  fileType,
+  frequency,
+  deviceCategory,
+}: BuildDataDownloadRequestArgs): DataDownloadRequest => {
+  if (!dateRange?.from || !dateRange?.to) {
+    throw new Error('Date range is required for data export');
+  }
+
+  const effectiveDataType: DataDownloadRequest['datatype'] =
+    activeTab === 'devices' && deviceCategory === 'bam'
+      ? 'raw'
+      : (dataType as DataDownloadRequest['datatype']);
+
+  const effectiveGridSiteIds = customSelectedGridSiteIds || selectedGridSiteIds;
+
+  const sitesForDownload = resolveGridSitesForDownload(
+    selectedGridIds,
+    selectedGridSites,
+    effectiveGridSiteIds
+  );
+
+  return {
+    datatype: effectiveDataType,
+    downloadType: fileType as DataDownloadRequest['downloadType'],
+    startDateTime: toUtcDayStartIso(dateRange.from),
+    endDateTime: toUtcDayEndIso(dateRange.to),
+    frequency: frequency as DataDownloadRequest['frequency'],
+    minimum: true,
+    metaDataFields: ['latitude', 'longitude'],
+    weatherFields: ['temperature', 'humidity'],
+    outputFormat: 'airqo-standard',
+    pollutants: selectedPollutants,
+    device_category:
+      activeTab === 'countries' || activeTab === 'cities'
+        ? 'lowcost'
+        : deviceCategory,
+    ...(activeTab === 'sites' && { sites: selectedSites }),
+    ...(activeTab === 'devices' && { device_ids: selectedDeviceIds }),
+    ...((activeTab === 'countries' || activeTab === 'cities') && {
+      sites: sitesForDownload,
+    }),
+  };
+};

--- a/src/platform/src/modules/data-download/utils/dataExportRequest.ts
+++ b/src/platform/src/modules/data-download/utils/dataExportRequest.ts
@@ -45,10 +45,13 @@ const resolveGridSitesForDownload = (
   const sitesForDownload: string[] = [];
 
   selectedGridIds.forEach(gridId => {
+    const hasCustomSelection = Object.prototype.hasOwnProperty.call(
+      selectedGridSiteIds,
+      gridId
+    );
     const customSites = selectedGridSiteIds[gridId];
     const defaultSites = selectedGridSites[gridId];
-    const sites =
-      customSites && customSites.length > 0 ? customSites : defaultSites || [];
+    const sites = hasCustomSelection ? customSites || [] : defaultSites || [];
 
     sitesForDownload.push(...sites);
   });

--- a/src/platform/src/modules/data-download/utils/dataExportRequest.ts
+++ b/src/platform/src/modules/data-download/utils/dataExportRequest.ts
@@ -7,6 +7,7 @@ interface BuildDataDownloadRequestArgs {
   activeTab: TabType;
   selectedSites: string[];
   selectedDeviceIds: string[];
+  selectedDeviceNames?: string[];
   selectedGridIds: string[];
   selectedGridSites: Record<string, string[]>;
   selectedGridSiteIds: Record<string, string[]>;
@@ -69,6 +70,7 @@ export const buildDataDownloadRequest = ({
   fileType,
   frequency,
   deviceCategory,
+  selectedDeviceNames,
 }: BuildDataDownloadRequestArgs): DataDownloadRequest => {
   if (!dateRange?.from || !dateRange?.to) {
     throw new Error('Date range is required for data export');
@@ -103,7 +105,10 @@ export const buildDataDownloadRequest = ({
         ? 'lowcost'
         : deviceCategory,
     ...(activeTab === 'sites' && { sites: selectedSites }),
-    ...(activeTab === 'devices' && { device_ids: selectedDeviceIds }),
+    ...(activeTab === 'devices' &&
+      (selectedDeviceNames && selectedDeviceNames.length > 0
+        ? { device_names: selectedDeviceNames }
+        : { device_ids: selectedDeviceIds })),
     ...((activeTab === 'countries' || activeTab === 'cities') && {
       sites: sitesForDownload,
     }),

--- a/src/platform/src/modules/data-download/utils/dataExportUtils.ts
+++ b/src/platform/src/modules/data-download/utils/dataExportUtils.ts
@@ -48,6 +48,83 @@ const getSiteSearchName = (site?: SiteNameSource): string => {
   );
 };
 
+const formatCoordinateValue = (value: unknown): string | undefined => {
+  if (value === null || value === undefined || value === '') {
+    return undefined;
+  }
+
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return String(value);
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed || undefined;
+  }
+
+  return undefined;
+};
+
+const formatCoordinates = (
+  latitude: unknown,
+  longitude: unknown
+): string | undefined => {
+  const lat = formatCoordinateValue(latitude);
+  const lng = formatCoordinateValue(longitude);
+
+  if (lat && lng) {
+    return `${lat}, ${lng}`;
+  }
+
+  return undefined;
+};
+
+const resolveCoordinates = (
+  source: Record<string, unknown> | SiteNameSource | undefined
+): string => {
+  if (!source) {
+    return '--';
+  }
+
+  const nestedSite = source.site as SiteNameSource | undefined;
+  const nestedSiteDetails = source.siteDetails as SiteNameSource | undefined;
+
+  const primaryCoordinates = formatCoordinates(
+    source.approximate_latitude,
+    source.approximate_longitude
+  );
+  if (primaryCoordinates) {
+    return primaryCoordinates;
+  }
+
+  const nestedCoordinates = formatCoordinates(
+    nestedSite?.approximate_latitude ?? nestedSiteDetails?.approximate_latitude,
+    nestedSite?.approximate_longitude ??
+      nestedSiteDetails?.approximate_longitude
+  );
+  if (nestedCoordinates) {
+    return nestedCoordinates;
+  }
+
+  const fallbackCoordinates = formatCoordinates(
+    source.latitude,
+    source.longitude
+  );
+  if (fallbackCoordinates) {
+    return fallbackCoordinates;
+  }
+
+  const nestedFallbackCoordinates = formatCoordinates(
+    nestedSite?.latitude ?? nestedSiteDetails?.latitude,
+    nestedSite?.longitude ?? nestedSiteDetails?.longitude
+  );
+  if (nestedFallbackCoordinates) {
+    return nestedFallbackCoordinates;
+  }
+
+  return '--';
+};
+
 /**
  * Processes sites data for table display
  */
@@ -63,6 +140,7 @@ export const processSitesData = (
       (site._id as string | number) ||
       index,
     name: getSiteDisplayName(site as SiteNameSource),
+    coordinates: resolveCoordinates(site as Record<string, unknown>),
     city: removeUnderscores((site.city as string) || '--'),
     country: removeUnderscores((site.country as string) || '--'),
     data_provider: removeUnderscores(
@@ -86,6 +164,7 @@ export const processDevicesData = (
       (device._id as string | number) ||
       index,
     name: (device.name as string) || '--',
+    coordinates: resolveCoordinates(device as Record<string, unknown>),
     network: ((device.network as string) || '--').toUpperCase(),
     category: (device.category as string) || '--',
   }));

--- a/src/platform/src/modules/data-download/utils/tableConfig.tsx
+++ b/src/platform/src/modules/data-download/utils/tableConfig.tsx
@@ -11,7 +11,7 @@ export const getSitesColumns = (): ColumnConfig[] => [
     key: 'name',
     label: 'Location',
     render: (value: unknown) => (
-      <div className="flex items-center capitalize gap-2">
+      <div className="flex items-center gap-2 whitespace-nowrap">
         <span className="bg-gray-100 rounded-full p-1">
           <AqMarkerPin03 className="h-4 w-4 shrink-0 text-primary" />
         </span>
@@ -22,6 +22,15 @@ export const getSitesColumns = (): ColumnConfig[] => [
   { key: 'city', label: 'City' },
   { key: 'country', label: 'Country' },
   { key: 'data_provider', label: 'Owner' },
+  {
+    key: 'coordinates',
+    label: 'Coordinates',
+    render: (value: unknown) => (
+      <span className="font-mono text-sm whitespace-nowrap">
+        {value as string}
+      </span>
+    ),
+  },
 ];
 
 /**
@@ -32,7 +41,7 @@ export const getDevicesColumns = (): ColumnConfig[] => [
     key: 'name',
     label: 'Device name',
     render: (value: unknown) => (
-      <div className="flex items-center capitalize gap-2">
+      <div className="flex items-center gap-2 whitespace-nowrap">
         <span className="bg-gray-100 rounded-full p-1">
           <AqMonitor03 className="h-4 w-4 shrink-0 text-primary" />
         </span>
@@ -52,6 +61,15 @@ export const getDevicesColumns = (): ColumnConfig[] => [
       return <span>{option?.label || category}</span>;
     },
   },
+  {
+    key: 'coordinates',
+    label: 'Coordinates',
+    render: (value: unknown) => (
+      <span className="font-mono text-sm whitespace-nowrap">
+        {value as string}
+      </span>
+    ),
+  },
 ];
 
 /**
@@ -62,7 +80,7 @@ export const getCountriesColumns = (): ColumnConfig[] => [
     key: 'name',
     label: 'Country',
     render: (value: unknown) => (
-      <div className="flex items-center capitalize gap-2">
+      <div className="flex items-center capitalize gap-2 whitespace-nowrap">
         <span className="bg-gray-100 rounded-full p-1">
           <AqGlobe01 className="h-4 w-4 shrink-0 text-primary" />
         </span>
@@ -88,7 +106,7 @@ export const getCitiesColumns = (): ColumnConfig[] => [
     key: 'name',
     label: 'City',
     render: (value: unknown) => (
-      <div className="flex items-center capitalize gap-2">
+      <div className="flex items-center capitalize gap-2 whitespace-nowrap">
         <span className="bg-gray-100 rounded-full p-1">
           <AqMarkerPin03 className="h-4 w-4 shrink-0 text-primary" />
         </span>

--- a/src/platform/src/modules/data-download/utils/tableConfig.tsx
+++ b/src/platform/src/modules/data-download/utils/tableConfig.tsx
@@ -10,11 +10,11 @@ export const getSitesColumns = (): ColumnConfig[] => [
   {
     key: 'name',
     label: 'Location',
-    minWidth: '280px',
-    maxWidth: '360px',
+    minWidth: '320px',
+    maxWidth: '420px',
     cellClassName: 'whitespace-normal break-normal',
     render: (value: unknown) => (
-      <div className="flex items-start gap-2 max-w-[360px] min-w-0">
+      <div className="flex items-start gap-2 max-w-[420px] min-w-0">
         <span className="bg-gray-100 rounded-full p-1 mt-0.5 shrink-0">
           <AqMarkerPin03 className="h-4 w-4 shrink-0 text-primary" />
         </span>
@@ -24,8 +24,18 @@ export const getSitesColumns = (): ColumnConfig[] => [
       </div>
     ),
   },
-  { key: 'city', label: 'City' },
-  { key: 'country', label: 'Country' },
+  {
+    key: 'city',
+    label: 'City',
+    minWidth: '120px',
+    cellClassName: 'whitespace-nowrap',
+  },
+  {
+    key: 'country',
+    label: 'Country',
+    minWidth: '140px',
+    cellClassName: 'whitespace-nowrap',
+  },
   { key: 'data_provider', label: 'Owner' },
   {
     key: 'coordinates',

--- a/src/platform/src/modules/data-download/utils/tableConfig.tsx
+++ b/src/platform/src/modules/data-download/utils/tableConfig.tsx
@@ -10,12 +10,17 @@ export const getSitesColumns = (): ColumnConfig[] => [
   {
     key: 'name',
     label: 'Location',
+    minWidth: '280px',
+    maxWidth: '360px',
+    cellClassName: 'whitespace-normal break-normal',
     render: (value: unknown) => (
-      <div className="flex items-center gap-2 whitespace-nowrap">
-        <span className="bg-gray-100 rounded-full p-1">
+      <div className="flex items-start gap-2 max-w-[360px] min-w-0">
+        <span className="bg-gray-100 rounded-full p-1 mt-0.5 shrink-0">
           <AqMarkerPin03 className="h-4 w-4 shrink-0 text-primary" />
         </span>
-        <span>{value as string}</span>
+        <span className="min-w-0 whitespace-normal break-normal leading-5">
+          {value as string}
+        </span>
       </div>
     ),
   },
@@ -40,6 +45,7 @@ export const getDevicesColumns = (): ColumnConfig[] => [
   {
     key: 'name',
     label: 'Device name',
+    cellClassName: 'whitespace-nowrap',
     render: (value: unknown) => (
       <div className="flex items-center gap-2 whitespace-nowrap">
         <span className="bg-gray-100 rounded-full p-1">
@@ -64,6 +70,7 @@ export const getDevicesColumns = (): ColumnConfig[] => [
   {
     key: 'coordinates',
     label: 'Coordinates',
+    cellClassName: 'whitespace-nowrap',
     render: (value: unknown) => (
       <span className="font-mono text-sm whitespace-nowrap">
         {value as string}
@@ -79,6 +86,7 @@ export const getCountriesColumns = (): ColumnConfig[] => [
   {
     key: 'name',
     label: 'Country',
+    cellClassName: 'whitespace-nowrap',
     render: (value: unknown) => (
       <div className="flex items-center capitalize gap-2 whitespace-nowrap">
         <span className="bg-gray-100 rounded-full p-1">
@@ -105,6 +113,7 @@ export const getCitiesColumns = (): ColumnConfig[] => [
   {
     key: 'name',
     label: 'City',
+    cellClassName: 'whitespace-nowrap',
     render: (value: unknown) => (
       <div className="flex items-center capitalize gap-2 whitespace-nowrap">
         <span className="bg-gray-100 rounded-full p-1">

--- a/src/platform/src/modules/data-download/utils/tableExport.ts
+++ b/src/platform/src/modules/data-download/utils/tableExport.ts
@@ -1,0 +1,182 @@
+import React from 'react';
+import jsPDF from 'jspdf';
+import autoTable from 'jspdf-autotable';
+import { ColumnConfig, TableItem } from '../types/dataExportTypes';
+
+type ExportFormat = 'csv' | 'pdf';
+
+interface ExportTableArgs {
+  title: string;
+  data: TableItem[];
+  columns: ColumnConfig[];
+}
+
+interface ResolvedColumn {
+  label: string;
+  value: string;
+}
+
+const getTextFromNode = (node: React.ReactNode): string => {
+  if (node === null || node === undefined || typeof node === 'boolean') {
+    return '';
+  }
+
+  if (typeof node === 'string' || typeof node === 'number') {
+    return String(node);
+  }
+
+  if (Array.isArray(node)) {
+    return node.map(getTextFromNode).filter(Boolean).join(' ');
+  }
+
+  if (React.isValidElement(node)) {
+    return getTextFromNode(node.props.children);
+  }
+
+  if (typeof node === 'object') {
+    return JSON.stringify(node);
+  }
+
+  return String(node);
+};
+
+const getCellText = (column: ColumnConfig, item: TableItem): string => {
+  const rawValue = item[column.key];
+
+  if (column.render) {
+    return getTextFromNode(column.render(rawValue));
+  }
+
+  return getTextFromNode(rawValue as React.ReactNode);
+};
+
+const resolveColumns = (
+  data: TableItem[],
+  columns: ColumnConfig[]
+): ResolvedColumn[][] => {
+  return data.map(item =>
+    columns.map(column => ({
+      label: column.label,
+      value: getCellText(column, item),
+    }))
+  );
+};
+
+const sanitizeFileName = (value: string): string =>
+  value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+const buildExportFileName = (title: string, format: ExportFormat): string => {
+  const datePart = new Date().toISOString().split('T')[0];
+  const safeTitle = sanitizeFileName(title) || 'table-export';
+
+  return `${safeTitle}-${datePart}.${format}`;
+};
+
+const downloadBlob = (blob: Blob, fileName: string) => {
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = fileName;
+  anchor.rel = 'noopener noreferrer';
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(url);
+};
+
+const escapeCsvValue = (value: string): string => {
+  if (!value) {
+    return '';
+  }
+
+  const escaped = value.replace(/"/g, '""');
+  return /[",\n\r]/.test(escaped) ? `"${escaped}"` : escaped;
+};
+
+const buildCsvContent = (
+  columns: ColumnConfig[],
+  data: TableItem[]
+): string => {
+  const rows = resolveColumns(data, columns);
+  const headerRow = columns
+    .map(column => escapeCsvValue(column.label))
+    .join(',');
+  const bodyRows = rows.map(row =>
+    row.map(cell => escapeCsvValue(cell.value)).join(',')
+  );
+
+  return [headerRow, ...bodyRows].join('\n');
+};
+
+export const exportTableAsCsv = ({ title, data, columns }: ExportTableArgs) => {
+  const csvContent = buildCsvContent(columns, data);
+  const fileName = buildExportFileName(title, 'csv');
+  const blob = new Blob(['\uFEFF', csvContent], {
+    type: 'text/csv;charset=utf-8;',
+  });
+
+  downloadBlob(blob, fileName);
+};
+
+export const exportTableAsPdf = ({ title, data, columns }: ExportTableArgs) => {
+  const orientation = columns.length > 4 ? 'landscape' : 'portrait';
+  const doc = new jsPDF({ orientation, unit: 'pt', format: 'a4' });
+  const rows = resolveColumns(data, columns);
+  const headers = columns.map(column => column.label);
+  const generatedAt = new Date().toLocaleString();
+  const fileName = buildExportFileName(title, 'pdf');
+
+  autoTable(doc, {
+    head: [headers],
+    body: rows.map(row => row.map(cell => cell.value)),
+    startY: 54,
+    theme: 'grid',
+    margin: { top: 54, left: 24, right: 24, bottom: 32 },
+    styles: {
+      font: 'helvetica',
+      fontSize: 9,
+      cellPadding: 6,
+      overflow: 'linebreak',
+      valign: 'middle',
+      textColor: [51, 65, 85],
+    },
+    headStyles: {
+      fillColor: [15, 118, 110],
+      textColor: [255, 255, 255],
+      fontStyle: 'bold',
+    },
+    alternateRowStyles: {
+      fillColor: [248, 250, 252],
+    },
+    didDrawPage: dataPoint => {
+      const pageWidth = doc.internal.pageSize.getWidth();
+      const pageHeight = doc.internal.pageSize.getHeight();
+
+      doc.setTextColor(15, 118, 110);
+      doc.setFont('helvetica', 'bold');
+      doc.setFontSize(16);
+      doc.text(title, 24, 24);
+
+      doc.setTextColor(71, 85, 105);
+      doc.setFont('helvetica', 'normal');
+      doc.setFontSize(9);
+      doc.text(`Rows: ${data.length} • Generated: ${generatedAt}`, 24, 38);
+
+      doc.setDrawColor(226, 232, 240);
+      doc.line(24, 44, pageWidth - 24, 44);
+
+      doc.setTextColor(100, 116, 139);
+      doc.text(
+        `Page ${dataPoint.pageNumber}`,
+        pageWidth - 24,
+        pageHeight - 18,
+        { align: 'right' }
+      );
+    },
+  });
+
+  doc.save(fileName);
+};

--- a/src/platform/src/modules/location-insights/more-insights.tsx
+++ b/src/platform/src/modules/location-insights/more-insights.tsx
@@ -95,9 +95,7 @@ export const MoreInsights: React.FC<MoreInsightsProps> = ({ activeTab }) => {
     return false;
   });
 
-  // Chart data hook
-  const { trigger: getChartData, isMutating: isChartLoading } =
-    useGetChartData();
+  // Chart data hook will be created after visibleSiteIds and dateRange are defined
 
   // Download hook
   const { downloadData, isDownloading } = useDataDownload();
@@ -106,6 +104,19 @@ export const MoreInsights: React.FC<MoreInsightsProps> = ({ activeTab }) => {
   const visibleSiteIds = useMemo(() => {
     return Array.from(visibleSites);
   }, [visibleSites]);
+
+  // Chart data hook - create a per-params SWR key to avoid cross-talk between
+  // multiple chart instances elsewhere in the app.
+  const { trigger: getChartData, isMutating: isChartLoading } = useGetChartData(
+    [
+      Array.isArray(visibleSiteIds) ? visibleSiteIds.join(',') : visibleSiteIds,
+      dateRange.from.toISOString().split('T')[0],
+      dateRange.to.toISOString().split('T')[0],
+      chartType,
+      frequency,
+      pollutant,
+    ]
+  );
 
   // Filtered sites based on search query
   const filteredSites = useMemo(() => {

--- a/src/platform/src/shared/components/ui/button.tsx
+++ b/src/platform/src/shared/components/ui/button.tsx
@@ -28,6 +28,7 @@ interface ButtonProps {
   tabIndex?: number;
   'aria-label'?: string;
   'aria-describedby'?: string;
+  title?: string;
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(

--- a/src/platform/src/shared/components/ui/multi-select-table.tsx
+++ b/src/platform/src/shared/components/ui/multi-select-table.tsx
@@ -63,6 +63,11 @@ interface TableColumn<T = TableItem> {
   filterOptions?: FilterOption[];
   filterMulti?: boolean;
   render?: (value: unknown, item: T) => React.ReactNode;
+  headerClassName?: string;
+  cellClassName?: string;
+  width?: string;
+  minWidth?: string;
+  maxWidth?: string;
 }
 
 interface CustomFilterProps {
@@ -1141,10 +1146,14 @@ const MultiSelectTable = <T extends TableItem>({
                           : compactRows
                             ? 'px-2 sm:px-4 md:px-6 max-w-none'
                             : 'px-2 sm:px-4 md:px-6 max-w-[300px]'
-                      }`}
+                      } ${column.headerClassName || ''}`}
                       style={
                         column.key !== 'checkbox'
-                          ? { minWidth: '120px' }
+                          ? {
+                              minWidth: column.minWidth || '120px',
+                              width: column.width,
+                              maxWidth: column.maxWidth,
+                            }
                           : undefined
                       }
                     >
@@ -1210,10 +1219,14 @@ const MultiSelectTable = <T extends TableItem>({
                             : compactRows
                               ? 'px-2 sm:px-4 md:px-6 max-w-none'
                               : 'px-2 sm:px-4 md:px-6 max-w-[300px]'
-                        }`}
+                        } ${column.cellClassName || ''}`}
                         style={
                           column.key !== 'checkbox'
-                            ? { minWidth: '120px' }
+                            ? {
+                                minWidth: column.minWidth || '120px',
+                                width: column.width,
+                                maxWidth: column.maxWidth,
+                              }
                             : undefined
                         }
                       >
@@ -1223,7 +1236,7 @@ const MultiSelectTable = <T extends TableItem>({
                               ? ''
                               : compactRows
                                 ? 'whitespace-nowrap max-w-none'
-                                : 'break-words whitespace-normal overflow-wrap-anywhere max-w-full'
+                                : `${column.cellClassName || 'break-words whitespace-normal overflow-wrap-anywhere'} max-w-full`
                           }
                         >
                           {renderCell(item, column)}

--- a/src/platform/src/shared/components/ui/multi-select-table.tsx
+++ b/src/platform/src/shared/components/ui/multi-select-table.tsx
@@ -110,6 +110,7 @@ interface MultiSelectTableProps<T = TableItem> {
   selectedItems?: (string | number)[];
   onSelectedItemsChange?: (selectedIds: (string | number)[]) => void;
   enableColumnFilters?: boolean;
+  compactRows?: boolean;
   // Server-side search props
   searchTerm?: string;
   onSearchChange?: (search: string) => void;
@@ -161,15 +162,12 @@ const ColumnHeaderFilter = <T extends TableItem>({
 
   const isMulti = column.filterMulti ?? true;
 
-  const filteredOptions = useMemo(
-    () => {
-      const normalizedSearchTerm = normalizeText(searchTerm);
-      return filterOptions.filter(option =>
-        normalizeText(option.label).includes(normalizedSearchTerm)
-      );
-    },
-    [filterOptions, searchTerm]
-  );
+  const filteredOptions = useMemo(() => {
+    const normalizedSearchTerm = normalizeText(searchTerm);
+    return filterOptions.filter(option =>
+      normalizeText(option.label).includes(normalizedSearchTerm)
+    );
+  }, [filterOptions, searchTerm]);
 
   const handleSelect = useCallback(
     (option: FilterOption) => {
@@ -349,15 +347,12 @@ const CustomFilter: React.FC<CustomFilterProps> = ({
     }
   }, [isOpen]);
 
-  const filteredOptions = useMemo(
-    () => {
-      const normalizedSearchTerm = normalizeText(searchTerm);
-      return options.filter(option =>
-        normalizeText(option.label).includes(normalizedSearchTerm)
-      );
-    },
-    [options, searchTerm]
-  );
+  const filteredOptions = useMemo(() => {
+    const normalizedSearchTerm = normalizeText(searchTerm);
+    return options.filter(option =>
+      normalizeText(option.label).includes(normalizedSearchTerm)
+    );
+  }, [options, searchTerm]);
 
   const handleSelect = useCallback(
     (option: FilterOption) => {
@@ -524,6 +519,7 @@ const MultiSelectTable = <T extends TableItem>({
   selectedItems: controlledSelectedItems,
   onSelectedItemsChange,
   enableColumnFilters = false,
+  compactRows = false,
   // Server-side search props
   searchTerm: controlledSearchTerm,
   onSearchChange,
@@ -1142,7 +1138,9 @@ const MultiSelectTable = <T extends TableItem>({
                       className={`py-2 sm:py-3 text-xs font-medium tracking-wider text-left uppercase text-muted-foreground ${
                         column.key === 'checkbox'
                           ? 'w-12 max-w-[3rem] px-2 sm:px-3'
-                          : 'px-2 sm:px-4 md:px-6 max-w-[300px]'
+                          : compactRows
+                            ? 'px-2 sm:px-4 md:px-6 max-w-none'
+                            : 'px-2 sm:px-4 md:px-6 max-w-[300px]'
                       }`}
                       style={
                         column.key !== 'checkbox'
@@ -1209,7 +1207,9 @@ const MultiSelectTable = <T extends TableItem>({
                         className={`py-2 sm:py-4 text-sm text-foreground align-top ${
                           column.key === 'checkbox'
                             ? 'w-12 max-w-[3rem] px-2 sm:px-3'
-                            : 'px-2 sm:px-4 md:px-6 max-w-[300px]'
+                            : compactRows
+                              ? 'px-2 sm:px-4 md:px-6 max-w-none'
+                              : 'px-2 sm:px-4 md:px-6 max-w-[300px]'
                         }`}
                         style={
                           column.key !== 'checkbox'
@@ -1221,7 +1221,9 @@ const MultiSelectTable = <T extends TableItem>({
                           className={
                             column.key === 'checkbox'
                               ? ''
-                              : 'break-words whitespace-normal overflow-wrap-anywhere max-w-full'
+                              : compactRows
+                                ? 'whitespace-nowrap max-w-none'
+                                : 'break-words whitespace-normal overflow-wrap-anywhere max-w-full'
                           }
                         >
                           {renderCell(item, column)}

--- a/src/platform/src/shared/components/ui/server-side-table.tsx
+++ b/src/platform/src/shared/components/ui/server-side-table.tsx
@@ -14,6 +14,11 @@ interface TableColumn<T = TableItem> {
   sortable?: boolean;
   filterable?: boolean;
   render?: (value: unknown, item: T) => React.ReactNode;
+  headerClassName?: string;
+  cellClassName?: string;
+  width?: string;
+  minWidth?: string;
+  maxWidth?: string;
 }
 
 export interface ServerSideTableProps<T = TableItem> {

--- a/src/platform/src/shared/components/ui/server-side-table.tsx
+++ b/src/platform/src/shared/components/ui/server-side-table.tsx
@@ -43,6 +43,9 @@ export interface ServerSideTableProps<T = TableItem> {
   // Custom header component
   customHeader?: React.ReactNode;
 
+  // Keep row content on one line for compact export-style tables
+  compactRows?: boolean;
+
   // Whether to show client-side pagination from MultiSelectTable
   showClientPagination?: boolean;
 }
@@ -74,6 +77,8 @@ export function ServerSideTable<T extends TableItem>({
   onSearchChange,
 
   customHeader,
+
+  compactRows = false,
 
   showClientPagination = false,
 }: ServerSideTableProps<T>) {
@@ -177,6 +182,7 @@ export function ServerSideTable<T extends TableItem>({
         showPagination={showClientPagination} // Enable built-in pagination for client-side operations
         sortable={true}
         headerComponent={customHeader}
+        compactRows={compactRows}
         {...(searchTerm !== undefined && onSearchChange !== undefined
           ? { searchTerm, onSearchChange }
           : {})}

--- a/src/platform/src/shared/hooks/useAnalytics.ts
+++ b/src/platform/src/shared/hooks/useAnalytics.ts
@@ -10,9 +10,13 @@ import type {
 } from '../types/api';
 
 // Get chart data
-export const useGetChartData = () => {
+export const useGetChartData = (keyParts?: unknown[]) => {
+  const swrKey = Array.isArray(keyParts)
+    ? ['analytics/chart-data', ...keyParts]
+    : ['analytics/chart-data'];
+
   return useSWRMutation(
-    'analytics/chart-data',
+    swrKey,
     async (
       key,
       { arg }: { arg: AnalyticsChartRequest }

--- a/src/platform/src/shared/services/analyticsService.ts
+++ b/src/platform/src/shared/services/analyticsService.ts
@@ -66,6 +66,7 @@ export class AnalyticsService {
       {
         params: {
           site_id: normalizedSiteIds,
+          ...(request.user_id ? { user_id: request.user_id } : {}),
         },
         signal,
       }

--- a/src/platform/src/shared/services/deviceService.ts
+++ b/src/platform/src/shared/services/deviceService.ts
@@ -454,11 +454,15 @@ export class DeviceService {
   // Get map readings - API token endpoint
   async getMapReadingsWithToken(
     cohort_id?: string,
-    signal?: AbortSignal
+    signal?: AbortSignal,
+    user_id?: string
   ): Promise<MapReadingsResponse> {
     const params: Record<string, string> = {};
     if (cohort_id) {
       params.cohort_id = cohort_id;
+    }
+    if (user_id) {
+      params.user_id = user_id;
     }
 
     const response = await this.serverClient.get<

--- a/src/platform/src/shared/types/api.ts
+++ b/src/platform/src/shared/types/api.ts
@@ -1134,6 +1134,7 @@ export interface DataDownloadResponse {
 // Recent readings types
 export interface RecentReadingRequest {
   site_id: string; // comma-separated site IDs
+  user_id?: string;
 }
 
 export interface AQIRanges {


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

#### Status of maturity (all need to be checked before merging):

- [ ] I've tested this locally
- [ ] I consider this code done
- [ ] This change ready to hit production in its current state
- [ ] The title of the PR states what changed and the related issues number (used for the release note).
- [ ] I've included issue number in the "Closes #ISSUE-NUMBER" part of the "[What are the relevant tickets?](#what-are-the-relevant-tickets)" section to [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [ ] I've updated corresponding documentation for the changes in this PR.
- [ ] I have written unit and/or e2e tests for my change(s).

#### How should this be manually tested?

- Please include the steps to be done inorder to setup and test this PR.

#### What are the relevant tickets?

- Closes #<enter issue number here>
- [Jira_card_number]() (If exists)

#### Screenshots (optional)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Table export actions (CSV/PDF) and coordinate column in export tables.
  * Column selection UI for exports with sample-row preview and column-filtered CSV/JSON output.

* **UI/UX Updates**
  * Action labels and confirmations: “Refresh” → “Regenerate” for client secrets and tokens; token tooltip instructs copying the new token.

* **Improvements**
  * Download flow renamed “Review & Download”, added compact table rows and better column sizing/styling.
  * Data requests and chart caching now respect user/context and chart parameters; pollutant deselect prevented with accessible error feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->