### PR TITLE
Vertex: Custom field exports + recall “Previous site” details

### DIFF
--- a/src/vertex/app/types/devices.ts
+++ b/src/vertex/app/types/devices.ts
@@ -35,6 +35,17 @@ export interface DeviceGrid {
   long_name: string;
 }
 
+export interface DevicePreviousSite {
+  _id: string;
+  visibility?: boolean;
+  rawOnlineStatus?: boolean;
+  lastRawData?: string | null;
+  name?: string;
+  location_name?: string;
+  search_name?: string;
+  [key: string]: unknown;
+}
+
 export interface DeviceCategoryHierarchy {
   level: string;
   category: string;
@@ -99,7 +110,7 @@ export interface Device {
   phoneNumber?: string;
   generation_version?: number | undefined | string;
   generation_count?: number | undefined | string;
-  previous_sites?: string[];
+  previous_sites?: Array<DevicePreviousSite | string>;
   grids?: DeviceGrid[];
   site?: DeviceSite[] | {
     _id: string;

--- a/src/vertex/components/features/devices/device-activity-item.tsx
+++ b/src/vertex/components/features/devices/device-activity-item.tsx
@@ -1,22 +1,33 @@
-import React from "react";
+import React, { useState } from "react";
 import { format, parseISO, isValid } from "date-fns";
-import { AqMonitor } from "@airqo/icons-react";
+import { AqCopy01, AqChevronDown, AqChevronUp, AqMonitor } from "@airqo/icons-react";
 import { DeviceActivity } from "@/core/apis/devices";
+import ReusableToast from "@/components/shared/toast/ReusableToast";
+import ReusableButton from "@/components/shared/button/ReusableButton";
 
 interface DeviceActivityItemProps {
     activity: DeviceActivity;
     isLast: boolean;
     showDeviceName?: boolean;
+    previousSiteId?: string;
+    previousSiteName?: string;
 }
 
 const DeviceActivityItem: React.FC<DeviceActivityItemProps> = ({
     activity,
     isLast,
     showDeviceName = false,
+    previousSiteId,
+    previousSiteName,
 }) => {
     const parsedDate =
         typeof activity.date === "string" ? parseISO(activity.date) : null;
     const hasValidDate = parsedDate !== null && isValid(parsedDate);
+    const isRecall =
+        activity.activityType === "recall" ||
+        (typeof activity.description === "string" && /recalled/i.test(activity.description));
+
+    const [isPreviousSiteOpen, setIsPreviousSiteOpen] = useState(false);
 
     return (
         <div className="relative pl-14 pb-2">
@@ -63,6 +74,50 @@ const DeviceActivityItem: React.FC<DeviceActivityItemProps> = ({
                     {showDeviceName && activity.device && (
                         <div className="text-sm text-blue-600 mt-1">
                             Device: {activity.device}
+                        </div>
+                    )}
+                    {isRecall && previousSiteId && previousSiteName && (
+                        <div className="mt-1 space-y-1">
+                            <div className="text-xs text-muted-foreground">
+                                Previous site
+                            </div>
+                            <div className="inline-flex items-center gap-1">
+                                <button
+                                    type="button"
+                                    className="text-sm text-blue-600 hover:underline font-medium"
+                                    onClick={() => setIsPreviousSiteOpen((v) => !v)}
+                                >
+                                    {previousSiteName}
+                                </button>
+                                {isPreviousSiteOpen ? (
+                                    <AqChevronUp className="w-4 h-4 text-blue-600" aria-hidden="true" />
+                                ) : (
+                                    <AqChevronDown className="w-4 h-4 text-blue-600" aria-hidden="true" />
+                                )}
+                            </div>
+
+                            {isPreviousSiteOpen && (
+                                <div className="space-y-1">
+                                    <div className="text-xs text-muted-foreground">
+                                        Site ID
+                                    </div>
+                                    <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                                        <span className="font-mono select-all overflow-x-auto whitespace-nowrap scrollbar-hide max-w-full text-gray-700 dark:text-gray-300">
+                                            {previousSiteId}
+                                        </span>
+                                        <ReusableButton
+                                            variant="text"
+                                            onClick={() => {
+                                                navigator.clipboard.writeText(previousSiteId);
+                                                ReusableToast({ message: "Copied", type: "SUCCESS" });
+                                            }}
+                                            className="p-1"
+                                            Icon={AqCopy01}
+                                            aria-label="Copy site ID"
+                                        />
+                                    </div>
+                                </div>
+                            )}
                         </div>
                     )}
                     {/* If we had file attachments in the activity object, we would render them here */}

--- a/src/vertex/components/features/devices/device-activity-item.tsx
+++ b/src/vertex/components/features/devices/device-activity-item.tsx
@@ -107,9 +107,13 @@ const DeviceActivityItem: React.FC<DeviceActivityItemProps> = ({
                                         </span>
                                         <ReusableButton
                                             variant="text"
-                                            onClick={() => {
-                                                navigator.clipboard.writeText(previousSiteId);
-                                                ReusableToast({ message: "Copied", type: "SUCCESS" });
+                                            onClick={async () => {
+                                                try {
+                                                    await navigator.clipboard.writeText(previousSiteId);
+                                                    ReusableToast({ message: "Copied", type: "SUCCESS" });
+                                                } catch {
+                                                    ReusableToast({ message: "Failed to copy", type: "ERROR" });
+                                                }
                                             }}
                                             className="p-1"
                                             Icon={AqCopy01}

--- a/src/vertex/components/features/devices/device-details-layout.tsx
+++ b/src/vertex/components/features/devices/device-details-layout.tsx
@@ -153,6 +153,8 @@ export default function DeviceDetailsLayout({ deviceId }: DeviceDetailsLayoutPro
                     <div className="break-inside-avoid mb-4 inline-block w-full order-4">
                         <DeviceHistoryCard
                             deviceName={device.name}
+                            previousSites={device.previous_sites}
+                            currentSite={device.site}
                         />
                     </div>
                     <div className="break-inside-avoid mb-4 inline-block w-full order-3">

--- a/src/vertex/components/features/devices/device-history-card.tsx
+++ b/src/vertex/components/features/devices/device-history-card.tsx
@@ -105,12 +105,18 @@ const DeviceHistoryCard: React.FC<DeviceHistoryCardProps> = ({
 
     const isRecallActivity = (activity: Pick<DeviceActivity, "activityType" | "description">) => {
         if (activity.activityType === "recall") return true;
-        return typeof activity.description === "string" && /recalled/i.test(activity.description);
+        return (
+            typeof activity.description === "string" &&
+            /\brecalled\b/i.test(activity.description)
+        );
     };
 
     const isDeploymentActivity = (activity: Pick<DeviceActivity, "activityType" | "description">) => {
         if (activity.activityType === "deployment") return true;
-        return typeof activity.description === "string" && /deployed/i.test(activity.description);
+        return (
+            typeof activity.description === "string" &&
+            /\bdeployed\b/i.test(activity.description)
+        );
     };
 
     const resolvePreviousSiteLabel = (activity: DeviceActivity, index: number) => {
@@ -125,6 +131,7 @@ const DeviceHistoryCard: React.FC<DeviceHistoryCardProps> = ({
         if (!inferredSiteId) {
             for (let j = index + 1; j < activities.length; j += 1) {
                 const next = activities[j];
+                if (isRecallActivity(next)) break;
                 const siteId =
                     typeof next.site_id === "string" && next.site_id.trim()
                         ? next.site_id

--- a/src/vertex/components/features/devices/device-history-card.tsx
+++ b/src/vertex/components/features/devices/device-history-card.tsx
@@ -103,18 +103,6 @@ const DeviceHistoryCard: React.FC<DeviceHistoryCardProps> = ({
         return map;
     }, [currentSite, previousSites]);
 
-    const firstPreviousSiteId = (() => {
-        if (!previousSites || previousSites.length === 0) return undefined;
-        const objectSite = previousSites.find(
-            (s) => typeof s === "object" && s && "_id" in s
-        ) as DevicePreviousSite | undefined;
-        if (objectSite?._id) return objectSite._id;
-        const stringSite = previousSites.find(
-            (s) => typeof s === "string" && s.trim()
-        ) as string | undefined;
-        return stringSite;
-    })();
-
     const isRecallActivity = (activity: Pick<DeviceActivity, "activityType" | "description">) => {
         if (activity.activityType === "recall") return true;
         return typeof activity.description === "string" && /recalled/i.test(activity.description);
@@ -148,7 +136,6 @@ const DeviceHistoryCard: React.FC<DeviceHistoryCardProps> = ({
             }
         }
 
-        if (!inferredSiteId) inferredSiteId = firstPreviousSiteId;
         if (!inferredSiteId) return undefined;
 
         const info = siteInfoById.get(inferredSiteId);

--- a/src/vertex/components/features/devices/device-history-card.tsx
+++ b/src/vertex/components/features/devices/device-history-card.tsx
@@ -1,16 +1,39 @@
 import { Card } from "@/components/ui/card";
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useMemo, useRef } from "react";
 import { useDeviceActivities } from "@/core/hooks/useDevices";
 import DeviceActivityItem from "@/components/features/devices/device-activity-item";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Loader2 } from "lucide-react";
+import type { DevicePreviousSite, DeviceSite } from "@/app/types/devices";
+import type { DeviceActivity } from "@/core/apis/devices";
+
+const shortId = (id: string) =>
+    id.length > 12 ? `${id.slice(0, 6)}…${id.slice(-4)}` : id;
+
+const getSiteName = (site: {
+    _id: string;
+    location_name?: string;
+    name?: string;
+    search_name?: string;
+}) => {
+    return (
+        (typeof site.name === "string" && site.name.trim()) ||
+        (typeof site.location_name === "string" && site.location_name.trim()) ||
+        (typeof site.search_name === "string" && site.search_name.trim()) ||
+        shortId(site._id)
+    );
+};
 
 interface DeviceHistoryCardProps {
     deviceName: string;
+    previousSites?: Array<DevicePreviousSite | string>;
+    currentSite?: DeviceSite[] | { _id: string; name: string };
 }
 
 const DeviceHistoryCard: React.FC<DeviceHistoryCardProps> = ({
     deviceName,
+    previousSites,
+    currentSite,
 }) => {
     const {
         data,
@@ -47,6 +70,94 @@ const DeviceHistoryCard: React.FC<DeviceHistoryCardProps> = ({
 
     const activities = data?.pages.flatMap((page) => page.site_activities) || [];
 
+    const siteInfoById = useMemo(() => {
+        const map = new Map<string, { name?: string; label: string }>();
+
+        if (currentSite) {
+            if (Array.isArray(currentSite)) {
+                currentSite.forEach((s) => {
+                    if (!s?._id) return;
+                    const label = getSiteName(s);
+                    map.set(s._id, { name: s.name, label });
+                });
+            } else if (currentSite?._id) {
+                const label =
+                    (typeof currentSite.name === "string" && currentSite.name.trim()) ||
+                    shortId(currentSite._id);
+                map.set(currentSite._id, { name: currentSite.name, label });
+            }
+        }
+
+        if (previousSites && previousSites.length > 0) {
+            previousSites.forEach((s) => {
+                if (typeof s === "string") {
+                    if (s.trim()) map.set(s, { label: shortId(s) });
+                    return;
+                }
+                if (!s?._id) return;
+                const label = getSiteName(s);
+                map.set(s._id, { name: s.name, label });
+            });
+        }
+
+        return map;
+    }, [currentSite, previousSites]);
+
+    const firstPreviousSiteId = (() => {
+        if (!previousSites || previousSites.length === 0) return undefined;
+        const objectSite = previousSites.find(
+            (s) => typeof s === "object" && s && "_id" in s
+        ) as DevicePreviousSite | undefined;
+        if (objectSite?._id) return objectSite._id;
+        const stringSite = previousSites.find(
+            (s) => typeof s === "string" && s.trim()
+        ) as string | undefined;
+        return stringSite;
+    })();
+
+    const isRecallActivity = (activity: Pick<DeviceActivity, "activityType" | "description">) => {
+        if (activity.activityType === "recall") return true;
+        return typeof activity.description === "string" && /recalled/i.test(activity.description);
+    };
+
+    const isDeploymentActivity = (activity: Pick<DeviceActivity, "activityType" | "description">) => {
+        if (activity.activityType === "deployment") return true;
+        return typeof activity.description === "string" && /deployed/i.test(activity.description);
+    };
+
+    const resolvePreviousSiteLabel = (activity: DeviceActivity, index: number) => {
+        if (!isRecallActivity(activity)) return undefined;
+
+        const directSiteId =
+            typeof activity.site_id === "string" && activity.site_id.trim()
+                ? activity.site_id
+                : undefined;
+
+        let inferredSiteId: string | undefined = directSiteId;
+        if (!inferredSiteId) {
+            for (let j = index + 1; j < activities.length; j += 1) {
+                const next = activities[j];
+                const siteId =
+                    typeof next.site_id === "string" && next.site_id.trim()
+                        ? next.site_id
+                        : undefined;
+                if (siteId && isDeploymentActivity(next)) {
+                    inferredSiteId = siteId;
+                    break;
+                }
+            }
+        }
+
+        if (!inferredSiteId) inferredSiteId = firstPreviousSiteId;
+        if (!inferredSiteId) return undefined;
+
+        const info = siteInfoById.get(inferredSiteId);
+        return {
+            id: inferredSiteId,
+            name: (typeof info?.name === "string" && info.name.trim()) ? info.name : (info?.label || shortId(inferredSiteId)),
+        };
+    };
+
     return (
         <Card className="w-full rounded-lg">
             <div className="flex items-center justify-between px-3 py-2 border-b">
@@ -63,13 +174,18 @@ const DeviceHistoryCard: React.FC<DeviceHistoryCardProps> = ({
                 ) : (
                     <ScrollArea className="h-[300px] pr-4">
                         <div className="space-y-0 pt-3">
-                            {activities.map((activity, index) => (
-                                <DeviceActivityItem
-                                    key={`${activity._id}-${index}`}
-                                    activity={activity}
-                                    isLast={index === activities.length - 1 && !hasNextPage}
-                                />
-                            ))}
+                            {activities.map((activity, index) => {
+                                const previousSite = resolvePreviousSiteLabel(activity, index);
+                                return (
+                                    <DeviceActivityItem
+                                        key={`${activity._id}-${index}`}
+                                        activity={activity}
+                                        isLast={index === activities.length - 1 && !hasNextPage}
+                                        previousSiteId={previousSite?.id}
+                                        previousSiteName={previousSite?.name}
+                                    />
+                                );
+                            })}
                             {/* Loading spinner for infinite scroll */}
                             <div ref={observerTarget} className="py-2 flex justify-center h-4">
                                 {isFetchingNextPage && (

--- a/src/vertex/components/features/devices/device-list-table.tsx
+++ b/src/vertex/components/features/devices/device-list-table.tsx
@@ -112,11 +112,23 @@ export default function DevicesTable({
       )
       .map((device) => ({
         ...device,
+        site_id:
+          typeof device.site_id === "string" && device.site_id.trim() !== ""
+            ? device.site_id
+            : Array.isArray(device.site)
+              ? device.site?.[0]?._id
+              : device.site?._id,
         id: device._id,
       }));
   }, [devices]);
 
   const columns = useMemo(() => getColumns(isInternalView), [isInternalView]);
+
+  const additionalExportFields = useMemo(() => [
+    { key: "site_id", title: "Site ID" },
+    { key: "_id", title: "Device ID" },
+    { key: "category", title: "Category" },
+  ], []);
 
   return (
     <div className={`space-y-4 ${className}`}>
@@ -124,6 +136,7 @@ export default function DevicesTable({
         title="Devices"
         data={devicesWithId}
         columns={columns}
+        additionalExportFields={additionalExportFields}
         loading={isFetching}
         pageSize={itemsPerPage}
         onRowClick={handleDeviceClick}

--- a/src/vertex/components/features/devices/utils/table-columns.tsx
+++ b/src/vertex/components/features/devices/utils/table-columns.tsx
@@ -127,6 +127,22 @@ export const getColumns = (
           : "-";
       },
     },
+    {
+      key: "latitude",
+      label: "Latitude",
+      render: (value) => {
+        const num = parseFloat(String(value));
+        return !isNaN(num) ? num.toFixed(6) : "-";
+      },
+    },
+    {
+      key: "longitude",
+      label: "Longitude",
+      render: (value) => {
+        const num = parseFloat(String(value));
+        return !isNaN(num) ? num.toFixed(6) : "-";
+      },
+    },
   ];
 
   if (isInternalView) {

--- a/src/vertex/components/shared/table/ReusableTable.tsx
+++ b/src/vertex/components/shared/table/ReusableTable.tsx
@@ -1494,13 +1494,17 @@ const ReusableTable = <T extends TableItem>({
           isOpen={isExportModalOpen}
           onClose={() => setIsExportModalOpen(false)}
           onExport={handleExport}
-          columns={[
-            ...columns.map(col => ({
+          columns={columns
+            .map(col => ({
               key: String(col.key),
-              title: col.title || (typeof col.label === 'string' ? col.label : String(col.key))
-            })),
-            ...additionalExportFields
-          ].filter(c => c.key !== 'checkbox' && c.key !== 'actions')}
+              title:
+                col.title ||
+                (typeof col.label === 'string' ? col.label : String(col.key)),
+            }))
+            .filter(c => c.key !== 'checkbox' && c.key !== 'actions')}
+          additionalColumns={additionalExportFields.filter(
+            c => c.key !== 'checkbox' && c.key !== 'actions'
+          )}
           totalRows={serverSidePagination ? (pageCount * pageSize) : filteredData.length}
           currentPageRows={finalPaginatedData.length}
           hasServerSidePagination={serverSidePagination}

--- a/src/vertex/components/shared/table/ReusableTable.tsx
+++ b/src/vertex/components/shared/table/ReusableTable.tsx
@@ -60,6 +60,11 @@ export type TableItem<T = unknown> = {
   id: string | number;
 } & Record<string, T>;
 
+export interface AdditionalExportField {
+  key: string;
+  title: string;
+}
+
 interface SortConfig {
   key: string | null;
   direction: "asc" | "desc";
@@ -565,6 +570,7 @@ interface ReusableTableProps<T extends TableItem> {
   searchTerm?: string;
   exportable?: boolean;
   onExport?: (format: 'csv', selectedColumns: string[]) => Promise<void>;
+  additionalExportFields?: AdditionalExportField[];
   customHeaderContent?: ReactNode;
 }
 
@@ -629,6 +635,7 @@ const ReusableTable = <T extends TableItem>({
   stickyHeader = false,
   exportable = true,
   onExport,
+  additionalExportFields = [],
   customHeaderContent,
 }: ReusableTableProps<T>) => {
   const router = useRouter();
@@ -812,6 +819,8 @@ const ReusableTable = <T extends TableItem>({
       const row: Record<string, string> = {};
       selectedColumns.forEach(colKey => {
         const colDef = columns.find(c => c.key === colKey);
+        const additionalField = additionalExportFields.find(f => f.key === colKey);
+
         if (colDef) {
           // Use the column's render function to get the exact displayed value
           const rawValue = item[colKey as keyof T];
@@ -853,6 +862,10 @@ const ReusableTable = <T extends TableItem>({
           // Use the column title (or label) as it appears in the table header
           const columnHeader = colDef.title || (typeof colDef.label === 'string' ? colDef.label : String(colKey));
           row[columnHeader] = displayValue;
+        } else if (additionalField) {
+          // If it's an additional field, use raw value
+          const rawValue = item[colKey as keyof T];
+          row[additionalField.title] = normalizeToString(rawValue);
         }
       });
       return row;
@@ -1481,10 +1494,13 @@ const ReusableTable = <T extends TableItem>({
           isOpen={isExportModalOpen}
           onClose={() => setIsExportModalOpen(false)}
           onExport={handleExport}
-          columns={columns.map(col => ({
-            key: String(col.key),
-            title: col.title || (typeof col.label === 'string' ? col.label : String(col.key))
-          })).filter(c => c.key !== 'checkbox' && c.key !== 'actions')}
+          columns={[
+            ...columns.map(col => ({
+              key: String(col.key),
+              title: col.title || (typeof col.label === 'string' ? col.label : String(col.key))
+            })),
+            ...additionalExportFields
+          ].filter(c => c.key !== 'checkbox' && c.key !== 'actions')}
           totalRows={serverSidePagination ? (pageCount * pageSize) : filteredData.length}
           currentPageRows={finalPaginatedData.length}
           hasServerSidePagination={serverSidePagination}

--- a/src/vertex/components/shared/table/TableExportModal.tsx
+++ b/src/vertex/components/shared/table/TableExportModal.tsx
@@ -97,8 +97,8 @@ export const TableExportModal: React.FC<TableExportModalProps> = ({
                     dense
                     message={
                         hasMoreThanOnePage
-                            ? "Exports only this table's page’s rows. For more, select all & export each page. Select columns below to customize."
-                            : "Exports only this table's page's rows. Select columns below to customize."
+                            ? "Exports only this table page's rows. For more, select all & export each page. Select columns below to customize."
+                            : "Exports only this table page's rows. Select columns below to customize."
                     }
                 />
 

--- a/src/vertex/components/shared/table/TableExportModal.tsx
+++ b/src/vertex/components/shared/table/TableExportModal.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect } from 'react';
 import ReusableDialog from '@/components/shared/dialog/ReusableDialog';
+import { InfoBanner } from '@/components/ui/banner';
 
 interface TableExportModalProps {
     isOpen: boolean;
@@ -20,21 +21,17 @@ export const TableExportModal: React.FC<TableExportModalProps> = ({
     columns,
     totalRows,
     currentPageRows,
-    hasServerSidePagination,
 }) => {
     const [selectedColumns, setSelectedColumns] = useState<string[]>([]);
-    const [scope, setScope] = useState<'current' | 'all'>('current');
+    const hasMoreThanOnePage = totalRows > currentPageRows;
 
     // Initialize selected columns with all columns when modal opens
     useEffect(() => {
         if (isOpen) {
             setSelectedColumns(columns.map(col => col.key));
-            // For client-side pagination, default to 'all' since all data is available
-            // For server-side pagination, only allow 'current' page
-            setScope(hasServerSidePagination ? 'current' : 'all');
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [isOpen, hasServerSidePagination]);
+    }, [isOpen]);
 
     const handleColumnToggle = (key: string) => {
         setSelectedColumns(prev =>
@@ -53,11 +50,11 @@ export const TableExportModal: React.FC<TableExportModalProps> = ({
     };
 
     const handleExport = () => {
-        onExport(selectedColumns, scope);
+        onExport(selectedColumns, 'current');
         onClose();
     };
 
-    const exportCount = scope === 'current' ? currentPageRows : totalRows;
+    const exportCount = currentPageRows;
 
     return (
         <ReusableDialog
@@ -78,46 +75,14 @@ export const TableExportModal: React.FC<TableExportModalProps> = ({
             }}
         >
             <div className="space-y-6">
-                {/* Scope Selection */}
-                <div className="space-y-3">
-                    <label className="text-sm font-medium text-gray-700 dark:text-gray-200">
-                        Export Scope
-                    </label>
-                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                        <label className={`flex items-center p-3 border rounded-lg cursor-pointer transition-colors ${scope === 'current' ? 'border-blue-500 bg-blue-50 dark:bg-blue-900/20' : 'border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800'}`}>
-                            <input
-                                type="radio"
-                                name="scope"
-                                value="current"
-                                checked={scope === 'current'}
-                                onChange={() => setScope('current')}
-                                className="w-4 h-4 text-blue-600 border-gray-300 focus:ring-blue-500"
-                            />
-                            <div className="ml-3">
-                                <span className="block text-sm font-medium text-gray-900 dark:text-white">Current Page</span>
-                                <span className="block text-xs text-gray-500 dark:text-gray-400">{currentPageRows} rows</span>
-                            </div>
-                        </label>
-
-                        <label className={`flex items-center p-3 border rounded-lg ${hasServerSidePagination ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'} transition-colors ${scope === 'all' ? 'border-blue-500 bg-blue-50 dark:bg-blue-900/20' : 'border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800'}`}>
-                            <input
-                                type="radio"
-                                name="scope"
-                                value="all"
-                                checked={scope === 'all'}
-                                onChange={() => setScope('all')}
-                                disabled={hasServerSidePagination}
-                                className="w-4 h-4 text-blue-600 border-gray-300 focus:ring-blue-500 disabled:cursor-not-allowed"
-                            />
-                            <div className="ml-3">
-                                <span className="block text-sm font-medium text-gray-900 dark:text-white">All Data</span>
-                                <span className="block text-xs text-gray-500 dark:text-gray-400">
-                                    {hasServerSidePagination ? 'Not available for server-side pagination' : `${totalRows} rows`}
-                                </span>
-                            </div>
-                        </label>
-                    </div>
-                </div>
+                <InfoBanner
+                    dense
+                    message={
+                        hasMoreThanOnePage
+                            ? "Exports only this page’s rows. For more, export each page. Select columns below to customize."
+                            : "Exports only this page’s rows. Select columns below to customize."
+                    }
+                />
 
                 <div className="border-t border-gray-200 dark:border-gray-700 pt-4 space-y-3">
                     <div className="flex items-center justify-between">

--- a/src/vertex/components/shared/table/TableExportModal.tsx
+++ b/src/vertex/components/shared/table/TableExportModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
+import React, { useMemo, useState, useEffect } from 'react';
 import ReusableDialog from '@/components/shared/dialog/ReusableDialog';
 import { InfoBanner } from '@/components/ui/banner';
 
@@ -9,6 +9,7 @@ interface TableExportModalProps {
     onClose: () => void;
     onExport: (selectedColumns: string[], scope: 'current' | 'all') => void;
     columns: { key: string; title: string }[];
+    additionalColumns?: { key: string; title: string }[];
     totalRows: number;
     currentPageRows: number;
     hasServerSidePagination: boolean;
@@ -19,19 +20,36 @@ export const TableExportModal: React.FC<TableExportModalProps> = ({
     onClose,
     onExport,
     columns,
+    additionalColumns,
     totalRows,
     currentPageRows,
 }) => {
     const [selectedColumns, setSelectedColumns] = useState<string[]>([]);
     const hasMoreThanOnePage = totalRows > currentPageRows;
 
+    const allColumns = useMemo(() => {
+        const merged = [...(columns || []), ...(additionalColumns || [])];
+        const seen = new Set<string>();
+        return merged.filter((c) => {
+            if (!c?.key) return false;
+            if (seen.has(c.key)) return false;
+            seen.add(c.key);
+            return true;
+        });
+    }, [columns, additionalColumns]);
+
+    const additionalOnlyColumns = useMemo(() => {
+        if (!additionalColumns || additionalColumns.length === 0) return [];
+        const baseKeys = new Set((columns || []).map((c) => c.key));
+        return additionalColumns.filter((c) => c?.key && !baseKeys.has(c.key));
+    }, [additionalColumns, columns]);
+
     // Initialize selected columns with all columns when modal opens
     useEffect(() => {
         if (isOpen) {
-            setSelectedColumns(columns.map(col => col.key));
+            setSelectedColumns(allColumns.map(col => col.key));
         }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [isOpen]);
+    }, [isOpen, allColumns]);
 
     const handleColumnToggle = (key: string) => {
         setSelectedColumns(prev =>
@@ -42,10 +60,10 @@ export const TableExportModal: React.FC<TableExportModalProps> = ({
     };
 
     const handleSelectAll = () => {
-        if (selectedColumns.length === columns.length) {
+        if (selectedColumns.length === allColumns.length) {
             setSelectedColumns([]);
         } else {
-            setSelectedColumns(columns.map(col => col.key));
+            setSelectedColumns(allColumns.map(col => col.key));
         }
     };
 
@@ -93,12 +111,32 @@ export const TableExportModal: React.FC<TableExportModalProps> = ({
                             onClick={handleSelectAll}
                             className="text-xs text-blue-600 dark:text-blue-400 hover:underline"
                         >
-                            {selectedColumns.length === columns.length ? 'Deselect All' : 'Select All'}
+                            {selectedColumns.length === allColumns.length ? 'Deselect All' : 'Select All'}
                         </button>
                     </div>
 
                     <div className="grid grid-cols-2 gap-2 max-h-60 overflow-y-auto p-1">
                         {columns.map((col) => (
+                            <label key={col.key} className="flex items-center space-x-2 p-2 rounded hover:bg-gray-50 dark:hover:bg-gray-800 cursor-pointer">
+                                <input
+                                    type="checkbox"
+                                    checked={selectedColumns.includes(col.key)}
+                                    onChange={() => handleColumnToggle(col.key)}
+                                    className="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                                />
+                                <span className="text-sm text-gray-700 dark:text-gray-300 truncate" title={col.title}>
+                                    {col.title}
+                                </span>
+                            </label>
+                        ))}
+
+                        {additionalOnlyColumns.length > 0 && (
+                            <div className="col-span-2 px-2 pt-2 text-[10px] uppercase tracking-wide text-muted-foreground">
+                                Extra fields
+                            </div>
+                        )}
+
+                        {additionalOnlyColumns.map((col) => (
                             <label key={col.key} className="flex items-center space-x-2 p-2 rounded hover:bg-gray-50 dark:hover:bg-gray-800 cursor-pointer">
                                 <input
                                     type="checkbox"

--- a/src/vertex/components/shared/table/TableExportModal.tsx
+++ b/src/vertex/components/shared/table/TableExportModal.tsx
@@ -79,8 +79,8 @@ export const TableExportModal: React.FC<TableExportModalProps> = ({
                     dense
                     message={
                         hasMoreThanOnePage
-                            ? "Exports only this page’s rows. For more, export each page. Select columns below to customize."
-                            : "Exports only this page’s rows. Select columns below to customize."
+                            ? "Exports only this table's page’s rows. For more, select all & export each page. Select columns below to customize."
+                            : "Exports only this table's page's rows. Select columns below to customize."
                     }
                 />
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added previous-site tracking and display in device activity/recall history, including expandable site details and copy-to-clipboard for Site ID.
  * Added latitude and longitude columns with six-decimal formatting.
  * Enabled exporting additional device fields (Site ID, Device ID, Category).

* **Refactor**
  * Simplified export modal UI: merged column selection with extra fields and now exports only the current page selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Summary of changes
- Improve Vertex table exports (more fields, better CSV values, current-page-only export UX).
- Show “Previous site” on recall activities with a collapsible details row + copyable Site ID.

## Changes
- Devices table: export `site_id` derived from `site_id` or `site._id`.
- ReusableTable export: supports additional export fields and uses rendered column values where possible.
- Export modal: removed scope selector; always exports current page and shows a short InfoBanner.
- Device details activity: “Previous site” appears on recall entries; click site name to expand and copy Site ID.

## Testing
- `cd src/vertex && npm run lint`

## Screenshots
<img width="486" height="540" alt="image" src="https://github.com/user-attachments/assets/68c4f52e-6987-4a5c-b8f6-0b0818ad2e7b" />
<img width="477" height="527" alt="image" src="https://github.com/user-attachments/assets/f8cc8137-0493-45b2-af6b-cb95879354fd" />
<img width="1026" height="809" alt="image" src="https://github.com/user-attachments/assets/f123ca8e-4311-4a84-9201-569d7b4635c7" />
