### PR TITLE
Vertex: site metadata refresh, grid admin level management, and device UI refinements

### DIFF
--- a/src/vertex/app/(authenticated)/admin/grids/page.tsx
+++ b/src/vertex/app/(authenticated)/admin/grids/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { CreateGridForm } from "@/components/features/grids/create-grid";
+import { CreateAdminLevel } from "@/components/features/grids/create-admin-level";
 import { RouteGuard } from "@/components/layout/accessConfig/route-guard";
 import GridsTable from "@/components/features/grids/grids-list-table";
 
@@ -17,6 +18,7 @@ export default function GridsPage() {
           </div>
           <div className="flex gap-2">
             <CreateGridForm />
+            <CreateAdminLevel />
           </div>
         </div>
 

--- a/src/vertex/app/(authenticated)/admin/sites/[id]/page.tsx
+++ b/src/vertex/app/(authenticated)/admin/sites/[id]/page.tsx
@@ -8,7 +8,7 @@ import { useSiteDetails, useRefreshSiteMetadata } from "@/core/hooks/useSites";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { ExclamationTriangleIcon } from "@radix-ui/react-icons";
 import { useParams } from "next/navigation";
-import { Loader2, RefreshCw } from "lucide-react";
+import { RefreshCw } from "lucide-react";
 import { SiteInformationCard } from "@/components/features/sites/site-information-card";
 import { SiteMobileAppCard } from "@/components/features/sites/site-mobile-app-card";
 import { EditSiteDetailsDialog } from "@/components/features/sites/edit-site-details-dialog";
@@ -62,7 +62,7 @@ export default function SiteDetailsPage() {
           onClick={() => refreshMetadata(siteId)}
           disabled={isRefreshing || isLoading || !site}
           loading={isRefreshing}
-          Icon={isRefreshing ? Loader2 : RefreshCw}
+          Icon={RefreshCw}
           className="text-xs font-medium"
         >
           Refresh Metadata

--- a/src/vertex/app/(authenticated)/admin/sites/[id]/page.tsx
+++ b/src/vertex/app/(authenticated)/admin/sites/[id]/page.tsx
@@ -4,10 +4,11 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { AqArrowLeft } from "@airqo/icons-react";
 import ReusableButton from "@/components/shared/button/ReusableButton";
-import { useSiteDetails } from "@/core/hooks/useSites";
+import { useSiteDetails, useRefreshSiteMetadata } from "@/core/hooks/useSites";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { ExclamationTriangleIcon } from "@radix-ui/react-icons";
 import { useParams } from "next/navigation";
+import { Loader2, RefreshCw } from "lucide-react";
 import { SiteInformationCard } from "@/components/features/sites/site-information-card";
 import { SiteMobileAppCard } from "@/components/features/sites/site-mobile-app-card";
 import { EditSiteDetailsDialog } from "@/components/features/sites/edit-site-details-dialog";
@@ -27,6 +28,7 @@ export default function SiteDetailsPage() {
   const params = useParams();
   const siteId = params.id as string;
   const { data: site, isLoading, error } = useSiteDetails(siteId);
+  const { mutate: refreshMetadata, isPending: isRefreshing } = useRefreshSiteMetadata();
   const router = useRouter();
   const [editSection, setEditSection] = useState<"general" | "mobile" | null>(
     null
@@ -53,6 +55,17 @@ export default function SiteDetailsPage() {
           Icon={AqArrowLeft}
         >
           Back
+        </ReusableButton>
+
+        <ReusableButton
+          variant="outlined"
+          onClick={() => refreshMetadata(siteId)}
+          disabled={isRefreshing || isLoading || !site}
+          loading={isRefreshing}
+          Icon={isRefreshing ? Loader2 : RefreshCw}
+          className="text-xs font-medium"
+        >
+          Refresh Metadata
         </ReusableButton>
       </div>
 

--- a/src/vertex/app/changelog.md
+++ b/src/vertex/app/changelog.md
@@ -39,7 +39,7 @@ Introduced on-demand site metadata enrichment and comprehensive administrative l
 </details>
 
 <details>
-<summary><strong>Files Modified (9)</strong></summary>
+<summary><strong>Files Modified (10)</strong></summary>
 
 - `app/(authenticated)/admin/sites/[id]/page.tsx`
 - `app/(authenticated)/admin/grids/page.tsx`

--- a/src/vertex/app/changelog.md
+++ b/src/vertex/app/changelog.md
@@ -4,6 +4,56 @@
 
 ---
  
+## Version 1.23.29
+**Released:** April 27, 2026
+
+### Site Metadata Refresh & Grid Admin Level Management
+
+Introduced on-demand site metadata enrichment and comprehensive administrative level management for grids, along with critical UI refinements for device status and maintenance tracking.
+
+<details>
+<summary><strong>Site & Grid Management (3)</strong></summary>
+
+- **On-Demand Site Refresh**: Added a "Refresh Metadata" action to site details, allowing operators to trigger a full re-enrichment of site data (Google Maps, TAHMO, Grids) with intelligent feedback for partial success states.
+- **Admin Level CRUD**: Implemented a complete management workflow for grid administrative levels, including creation, listing with copiable IDs, and inline editing via a new centralized management modal.
+- **Dropdown Management Interface**: Integrated a new management dropdown on the Grids page to provide quick access to administrative level controls without cluttering the main workspace.
+
+</details>
+
+<details>
+<summary><strong>Device UI & Logic Refinements (2)</strong></summary>
+
+- **Missed Maintenance Indicators**: Overhauled the `MaintenanceStatusCard` to explicitly highlight missed maintenance tasks (past dates) using red status bars, secondary warning icons, and "Missed" badges for immediate operator awareness.
+- **Robust Telemetry Fallbacks**: Updated the `RunDeviceTestCard` to intelligently fall back to `timestamp` data when `created_at` metadata is missing, preventing "unknown" states during device diagnostics.
+
+</details>
+
+<details>
+<summary><strong>Technical Improvements (4)</strong></summary>
+
+- **Intelligent Cache Invalidation**: Optimized the `useRefreshSiteMetadata` hook to perform immediate cache updates followed by targeted invalidation, ensuring site data is consistently fresh across the application.
+- **Standardized Management Modals**: Leveraged `ReusableDialog` for administrative level management to maintain design consistency and support complex nested interactions.
+- **Enhanced Toast Feedback**: Refined notification logic to distinguish between successful, partial, and redundant (already complete) metadata enrichment cycles.
+- **Telemetry Parameter Filtering**: Cleaned up the technical parameters display in device tests to exclude redundant timing metadata, focusing on actionable device data.
+
+</details>
+
+<details>
+<summary><strong>Files Modified (9)</strong></summary>
+
+- `app/(authenticated)/admin/sites/[id]/page.tsx`
+- `app/(authenticated)/admin/grids/page.tsx`
+- `components/features/devices/maintenance-status-card.tsx`
+- `components/features/devices/run-device-test-card.tsx`
+- `components/features/grids/create-admin-level.tsx`
+- `components/features/grids/admin-levels-modal.tsx`
+- `core/apis/sites.ts`
+- `core/apis/grids.ts`
+- `core/hooks/useSites.ts`
+- `core/hooks/useGrids.ts`
+
+</details>
+
 ## Version 1.23.26
 **Released:** April 09, 2026
 

--- a/src/vertex/components/features/devices/maintenance-status-card.tsx
+++ b/src/vertex/components/features/devices/maintenance-status-card.tsx
@@ -1,7 +1,8 @@
 import { Card } from "@/components/ui/card";
 import React from "react";
-import { format, parseISO, isValid } from 'date-fns';
-
+import { format, parseISO, isValid, isBefore, startOfToday } from 'date-fns';
+import { AqTool01 } from "@airqo/icons-react";
+import { cn } from "@/lib/utils";
 
 interface MaintenanceStatusCardProps {
   nextMaintenance: string | undefined;
@@ -15,22 +16,40 @@ const MaintenanceStatusCard: React.FC<MaintenanceStatusCardProps> = ({
   const hasValidMaintenanceDate =
     maintenanceDate !== null && isValid(maintenanceDate);
 
+  const isMissed = hasValidMaintenanceDate && isBefore(maintenanceDate, startOfToday());
+
   return (
-    <Card className="w-full rounded-lg">
-      <div className="flex items-center justify-between px-3 py-2 border-b">
+    <Card className="w-full rounded-lg overflow-hidden relative">
+      <div className="flex items-center justify-between px-4 py-3 border-b">
         <h2 className="text-lg font-semibold">Next Maintenance</h2>
+        {hasValidMaintenanceDate && (
+          <span className={cn(
+            "text-xs flex items-center gap-1 font-bold px-2 py-0.5 rounded-full uppercase tracking-wider",
+            isMissed ? "bg-red-100 text-red-700" : "bg-green-100 text-green-700"
+          )}>
+            <AqTool01 className={cn(
+              "w-3 h-3",
+              isMissed ? "text-red-500" : "text-green-600"
+            )} />
+            <span className="ml-1">{isMissed ? "Missed" : "Upcoming"}</span>
+          </span>
+        )}
       </div>
 
-      <div className="px-3 py-0 space-y-3">
+      <div className="px-4 py-4">
         {hasValidMaintenanceDate ? (
-          <div className="pt-3 pb-3">
-            <div className="text-base font-normal">
-              {format(maintenanceDate, "MMM d yyyy, h:mm a")}
+          <div className="space-y-1">
+            <div className={cn(
+              "text-2xl font-bold tracking-tight",
+              isMissed ? "text-red-600" : "text-foreground"
+            )}>
+              {format(maintenanceDate, "MMM d, yyyy")}
             </div>
           </div>
         ) : (
-          <div className="p-3 text-sm text-muted-foreground">
-            No upcoming maintenance scheduled.
+          <div className="text-sm text-muted-foreground flex flex-col items-center justify-center py-4 text-center">
+            <AqTool01 className="w-8 h-8 opacity-20 mb-2" />
+            <p>No upcoming maintenance scheduled.</p>
           </div>
         )}
       </div>

--- a/src/vertex/components/features/devices/run-device-test-card.tsx
+++ b/src/vertex/components/features/devices/run-device-test-card.tsx
@@ -58,7 +58,7 @@ const RunDeviceTestCard: React.FC<RunDeviceTestCardProps> = ({ deviceNumber, get
         <>
           <div className="text-sm text-muted-foreground mb-1 px-3 py-2">
             {(() => {
-              const createdAtRaw = statusFeed.data.created_at;
+              const createdAtRaw = statusFeed.data.created_at || statusFeed.data.timestamp;
               const createdAt =
                 typeof createdAtRaw === "string" ? createdAtRaw : null;
               if (!createdAt) return null;
@@ -145,7 +145,7 @@ const RunDeviceTestCard: React.FC<RunDeviceTestCardProps> = ({ deviceNumber, get
             {Object.entries(statusFeed.data)
               .filter(
                 ([key]) =>
-                  !["created_at", "isCache", "satellites", "DeviceType", "undefined"].includes(
+                  !["created_at", "timestamp", "isCache", "satellites", "DeviceType", "undefined"].includes(
                     key
                   )
               )

--- a/src/vertex/components/features/grids/admin-levels-modal.tsx
+++ b/src/vertex/components/features/grids/admin-levels-modal.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { useState } from "react";
+import { useAdminLevels, useUpdateAdminLevel } from "@/core/hooks/useGrids";
+import ReusableDialog from "@/components/shared/dialog/ReusableDialog";
+import ReusableButton from "@/components/shared/button/ReusableButton";
+import ReusableInputField from "@/components/shared/inputfield/ReusableInputField";
+import { Copy, Edit2, Check, X } from "lucide-react";
+import ReusableToast from "@/components/shared/toast/ReusableToast";
+
+interface AdminLevelsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function AdminLevelsModal({ isOpen, onClose }: AdminLevelsModalProps) {
+  const { adminLevels, isLoading: isLoadingLevels } = useAdminLevels();
+  const { updateAdminLevel, isLoading: isUpdating } = useUpdateAdminLevel();
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editValue, setEditValue] = useState("");
+
+  const handleCopyId = (id: string) => {
+    navigator.clipboard.writeText(id);
+    ReusableToast({
+      message: "ID copied to clipboard",
+      type: "SUCCESS",
+    });
+  };
+
+  const startEditing = (id: string, name: string) => {
+    setEditingId(id);
+    setEditValue(name);
+  };
+
+  const cancelEditing = () => {
+    setEditingId(null);
+    setEditValue("");
+  };
+
+  const saveEdit = (levelId: string) => {
+    if (!editValue.trim()) return;
+    updateAdminLevel(
+      { levelId, data: { name: editValue } },
+      {
+        onSuccess: () => {
+          setEditingId(null);
+          setEditValue("");
+        },
+      }
+    );
+  };
+
+  return (
+    <ReusableDialog
+      isOpen={isOpen}
+      onClose={onClose}
+      title="Admin Levels"
+      size="2xl"
+      secondaryAction={{
+        label: "Close",
+        onClick: onClose,
+        variant: "outline",
+      }}
+    >
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm text-left">
+          <thead className="bg-muted text-muted-foreground uppercase text-xs font-medium">
+            <tr>
+              <th className="px-4 py-3">Name</th>
+              <th className="px-4 py-3">ID</th>
+              <th className="px-4 py-3 text-right">Actions</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border">
+            {isLoadingLevels ? (
+              <tr>
+                <td colSpan={3} className="px-4 py-8 text-center text-muted-foreground">
+                  Loading admin levels...
+                </td>
+              </tr>
+            ) : adminLevels.length === 0 ? (
+              <tr>
+                <td colSpan={3} className="px-4 py-8 text-center text-muted-foreground">
+                  No admin levels found.
+                </td>
+              </tr>
+            ) : (
+              adminLevels.map((level) => (
+                <tr key={level._id} className="hover:bg-muted/50 transition-colors">
+                  <td className="px-4 py-3">
+                    {editingId === level._id ? (
+                      <div className="flex items-center gap-2">
+                        <ReusableInputField
+                          value={editValue}
+                          onChange={(e) => setEditValue(e.target.value)}
+                          className="h-8 py-1"
+                          autoFocus
+                        />
+                      </div>
+                    ) : (
+                      <span className="font-medium">{level.name}</span>
+                    )}
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="flex items-center gap-2 group">
+                      <code className="bg-muted px-1.5 py-0.5 rounded text-[11px] text-muted-foreground">
+                        {level._id}
+                      </code>
+                      <button
+                        onClick={() => handleCopyId(level._id)}
+                        className="text-muted-foreground hover:text-foreground transition-colors opacity-0 group-hover:opacity-100"
+                        title="Copy ID"
+                      >
+                        <Copy size={14} />
+                      </button>
+                    </div>
+                  </td>
+                  <td className="px-4 py-3 text-right">
+                    {editingId === level._id ? (
+                      <div className="flex justify-end gap-2">
+                        <ReusableButton
+                          variant="filled"
+                          padding="p-1"
+                          onClick={() => saveEdit(level._id)}
+                          disabled={isUpdating}
+                          Icon={Check}
+                        />
+                        <ReusableButton
+                          variant="outlined"
+                          padding="p-1"
+                          onClick={cancelEditing}
+                          disabled={isUpdating}
+                          Icon={X}
+                        />
+                      </div>
+                    ) : (
+                      <ReusableButton
+                        variant="text"
+                        padding="p-1"
+                        onClick={() => startEditing(level._id, level.name)}
+                        Icon={Edit2}
+                      />
+                    )}
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </ReusableDialog>
+  );
+}

--- a/src/vertex/components/features/grids/admin-levels-modal.tsx
+++ b/src/vertex/components/features/grids/admin-levels-modal.tsx
@@ -19,12 +19,19 @@ export function AdminLevelsModal({ isOpen, onClose }: AdminLevelsModalProps) {
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editValue, setEditValue] = useState("");
 
-  const handleCopyId = (id: string) => {
-    navigator.clipboard.writeText(id);
-    ReusableToast({
-      message: "ID copied to clipboard",
-      type: "SUCCESS",
-    });
+  const handleCopyId = async (id: string) => {
+    try {
+      await navigator.clipboard.writeText(id);
+      ReusableToast({
+        message: "ID copied to clipboard",
+        type: "SUCCESS",
+      });
+    } catch {
+      ReusableToast({
+        message: "Failed to copy ID",
+        type: "ERROR",
+      });
+    }
   };
 
   const startEditing = (id: string, name: string) => {

--- a/src/vertex/components/features/grids/admin-levels-modal.tsx
+++ b/src/vertex/components/features/grids/admin-levels-modal.tsx
@@ -45,9 +45,12 @@ export function AdminLevelsModal({ isOpen, onClose }: AdminLevelsModalProps) {
   };
 
   const saveEdit = (levelId: string) => {
-    if (!editValue.trim()) return;
+    const name = editValue.trim();
+    if (!name) {
+      return;
+    }
     updateAdminLevel(
-      { levelId, data: { name: editValue } },
+      { levelId, data: { name } },
       {
         onSuccess: () => {
           setEditingId(null);

--- a/src/vertex/components/features/grids/create-admin-level.tsx
+++ b/src/vertex/components/features/grids/create-admin-level.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useState } from "react";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import * as z from "zod";
+import { Form, FormField } from "@/components/ui/form";
+import { Plus } from "lucide-react";
+import { useCreateAdminLevel } from "@/core/hooks/useGrids";
+import ReusableDialog from "@/components/shared/dialog/ReusableDialog";
+import ReusableButton from "@/components/shared/button/ReusableButton";
+import ReusableInputField from "@/components/shared/inputfield/ReusableInputField";
+
+const adminLevelFormSchema = z.object({
+  name: z.string().min(2, {
+    message: "Admin level name must be at least 2 characters.",
+  }),
+});
+
+type AdminLevelFormValues = z.infer<typeof adminLevelFormSchema>;
+
+export function CreateAdminLevel() {
+  const [open, setOpen] = useState(false);
+  const { createAdminLevel, isLoading } = useCreateAdminLevel();
+
+  const form = useForm<AdminLevelFormValues>({
+    resolver: zodResolver(adminLevelFormSchema),
+    defaultValues: {
+      name: "",
+    },
+  });
+
+  const handleClose = () => {
+    setOpen(false);
+    form.reset();
+  };
+
+  const onSubmit = (data: AdminLevelFormValues) => {
+    createAdminLevel(data, {
+      onSuccess: () => {
+        handleClose();
+      },
+    });
+  };
+
+  return (
+    <>
+      <ReusableButton onClick={() => setOpen(true)} Icon={Plus} variant="outlined">
+        New Admin Level
+      </ReusableButton>
+      <ReusableDialog
+        isOpen={open}
+        onClose={handleClose}
+        title="New Admin Level"
+        size="md"
+        primaryAction={{
+          label: isLoading ? "Submitting..." : "Submit",
+          onClick: form.handleSubmit(onSubmit),
+          disabled: isLoading,
+        }}
+        secondaryAction={{
+          label: "Cancel",
+          onClick: handleClose,
+          disabled: isLoading,
+          variant: "outline",
+        }}
+      >
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="name"
+              render={({ field, fieldState }) => (
+                <ReusableInputField
+                  label="Admin level name"
+                  placeholder="Enter admin level name (e.g. municipality)"
+                  error={fieldState.error?.message}
+                  required
+                  {...field}
+                />
+              )}
+            />
+          </form>
+        </Form>
+      </ReusableDialog>
+    </>
+  );
+}

--- a/src/vertex/components/features/grids/create-admin-level.tsx
+++ b/src/vertex/components/features/grids/create-admin-level.tsx
@@ -5,11 +5,18 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import * as z from "zod";
 import { Form, FormField } from "@/components/ui/form";
-import { Plus } from "lucide-react";
+import { Plus, MoreVertical, List } from "lucide-react";
 import { useCreateAdminLevel } from "@/core/hooks/useGrids";
 import ReusableDialog from "@/components/shared/dialog/ReusableDialog";
 import ReusableButton from "@/components/shared/button/ReusableButton";
 import ReusableInputField from "@/components/shared/inputfield/ReusableInputField";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { AdminLevelsModal } from "./admin-levels-modal";
 
 const adminLevelFormSchema = z.object({
   name: z.string().min(2, {
@@ -21,6 +28,7 @@ type AdminLevelFormValues = z.infer<typeof adminLevelFormSchema>;
 
 export function CreateAdminLevel() {
   const [open, setOpen] = useState(false);
+  const [viewModalOpen, setViewModalOpen] = useState(false);
   const { createAdminLevel, isLoading } = useCreateAdminLevel();
 
   const form = useForm<AdminLevelFormValues>({
@@ -45,9 +53,31 @@ export function CreateAdminLevel() {
 
   return (
     <>
-      <ReusableButton onClick={() => setOpen(true)} Icon={Plus} variant="outlined">
-        New Admin Level
-      </ReusableButton>
+      <div className="flex gap-1 items-center">
+        <ReusableButton onClick={() => setOpen(true)} Icon={Plus} variant="outlined">
+          New Admin Level
+        </ReusableButton>
+
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button className="p-2 hover:bg-muted rounded-md transition-colors text-muted-foreground hover:text-foreground border border-transparent hover:border-border">
+              <MoreVertical size={18} />
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-48">
+            <DropdownMenuItem onClick={() => setViewModalOpen(true)}>
+              <List size={16} className="mr-2" />
+              View Admin Levels
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+
+      <AdminLevelsModal
+        isOpen={viewModalOpen}
+        onClose={() => setViewModalOpen(false)}
+      />
+
       <ReusableDialog
         isOpen={open}
         onClose={handleClose}

--- a/src/vertex/core/apis/grids.ts
+++ b/src/vertex/core/apis/grids.ts
@@ -72,4 +72,57 @@ export const grids = {
       throw error;
     }
   },
+  createAdminLevelApi: async (data: { name: string }): Promise<AdminLevelResponse> => {
+    try {
+      const response = await jwtApiClient.post<AdminLevelResponse>(
+        `/devices/grids/levels`,
+        data,
+        { headers: { 'X-Auth-Type': 'JWT' } }
+      );
+      return response.data;
+    } catch (error) {
+      throw error;
+    }
+  },
+  getAdminLevelsApi: async (): Promise<AdminLevelsListResponse> => {
+    try {
+      const response = await jwtApiClient.get<AdminLevelsListResponse>(
+        `/devices/grids/levels`,
+        { headers: { 'X-Auth-Type': 'JWT' } }
+      );
+      return response.data;
+    } catch (error) {
+      throw error;
+    }
+  },
+  updateAdminLevelApi: async (levelId: string, data: { name: string }): Promise<AdminLevelResponse> => {
+    try {
+      const response = await jwtApiClient.put<AdminLevelResponse>(
+        `/devices/grids/levels/${levelId}`,
+        data,
+        { headers: { 'X-Auth-Type': 'JWT' } }
+      );
+      return response.data;
+    } catch (error) {
+      throw error;
+    }
+  },
 };
+
+export interface AdminLevel {
+  _id: string;
+  name: string;
+  __v?: number;
+}
+
+export interface AdminLevelResponse {
+  success: boolean;
+  message: string;
+  admin_levels: AdminLevel;
+}
+
+export interface AdminLevelsListResponse {
+  success: boolean;
+  message: string;
+  admin_levels: AdminLevel[];
+}

--- a/src/vertex/core/apis/sites.ts
+++ b/src/vertex/core/apis/sites.ts
@@ -259,7 +259,26 @@ export const sites = {
     } catch (error) {
         throw error;
     }
+  },
+
+  refreshSiteMetadata: async (siteId: string): Promise<SiteRefreshResponse> => {
+    try {
+      const response = await createSecureApiClient().put<SiteRefreshResponse>(
+        `/devices/sites/refresh?id=${siteId}`,
+        {},
+        { headers: { "X-Auth-Type": "JWT" } }
+      );
+      return response.data;
+    } catch (error) {
+      throw error;
+    }
   }
 };
+
+export interface SiteRefreshResponse {
+  success: boolean;
+  message: string;
+  site: Site;
+}
 
 export type { ApproximateCoordinatesResponse };

--- a/src/vertex/core/hooks/useGrids.ts
+++ b/src/vertex/core/hooks/useGrids.ts
@@ -4,7 +4,7 @@ import {
   useQueryClient,
 } from "@tanstack/react-query";
 import { AxiosError } from "axios";
-import { GetGridsSummaryParams, grids } from "../apis/grids";
+import { GetGridsSummaryParams, grids, AdminLevelResponse, AdminLevelsListResponse } from "../apis/grids";
 import { CreateGrid, Grid, GridsSummaryResponse } from "@/app/types/grids";
 import { setError, setGrids } from "../redux/slices/gridsSlice";
 import { useDispatch } from "react-redux";
@@ -151,6 +151,30 @@ export const useCreateGrid = () => {
 
   return {
     createGrid,
+    isLoading,
+    error,
+  };
+};
+
+export const useCreateAdminLevel = () => {
+  const { mutate: createAdminLevel, isPending: isLoading, error } = useMutation<AdminLevelResponse, AxiosError<ErrorResponse>, { name: string }>({
+    mutationFn: (data: { name: string }) => grids.createAdminLevelApi(data),
+    onSuccess: (data) => {
+      ReusableToast({
+        message: `Admin level '${data.admin_levels.name}' created successfully`,
+        type: "SUCCESS",
+      });
+    },
+    onError: (error: AxiosError<ErrorResponse>) => {
+      ReusableToast({
+        message: `Failed to create admin level: ${getApiErrorMessage(error)}`,
+        type: "ERROR",
+      });
+    },
+  });
+
+  return {
+    createAdminLevel,
     isLoading,
     error,
   };

--- a/src/vertex/core/hooks/useGrids.ts
+++ b/src/vertex/core/hooks/useGrids.ts
@@ -157,6 +157,7 @@ export const useCreateGrid = () => {
 };
 
 export const useCreateAdminLevel = () => {
+  const queryClient = useQueryClient();
   const { mutate: createAdminLevel, isPending: isLoading, error } = useMutation<AdminLevelResponse, AxiosError<ErrorResponse>, { name: string }>({
     mutationFn: (data: { name: string }) => grids.createAdminLevelApi(data),
     onSuccess: (data) => {
@@ -164,6 +165,7 @@ export const useCreateAdminLevel = () => {
         message: `Admin level '${data.admin_levels.name}' created successfully`,
         type: "SUCCESS",
       });
+      queryClient.invalidateQueries({ queryKey: ["admin-levels"] });
     },
     onError: (error: AxiosError<ErrorResponse>) => {
       ReusableToast({
@@ -175,6 +177,46 @@ export const useCreateAdminLevel = () => {
 
   return {
     createAdminLevel,
+    isLoading,
+    error,
+  };
+};
+
+export const useAdminLevels = () => {
+  const { data, isLoading, error } = useQuery<AdminLevelsListResponse, AxiosError<ErrorResponse>>({
+    queryKey: ["admin-levels"],
+    queryFn: () => grids.getAdminLevelsApi(),
+    staleTime: 300_000,
+  });
+
+  return {
+    adminLevels: data?.admin_levels ?? [],
+    isLoading,
+    error,
+  };
+};
+
+export const useUpdateAdminLevel = () => {
+  const queryClient = useQueryClient();
+  const { mutate: updateAdminLevel, isPending: isLoading, error } = useMutation<AdminLevelResponse, AxiosError<ErrorResponse>, { levelId: string; data: { name: string } }>({
+    mutationFn: ({ levelId, data }) => grids.updateAdminLevelApi(levelId, data),
+    onSuccess: (data) => {
+      ReusableToast({
+        message: `Admin level updated to '${data.admin_levels.name}' successfully`,
+        type: "SUCCESS",
+      });
+      queryClient.invalidateQueries({ queryKey: ["admin-levels"] });
+    },
+    onError: (error: AxiosError<ErrorResponse>) => {
+      ReusableToast({
+        message: `Failed to update admin level: ${getApiErrorMessage(error)}`,
+        type: "ERROR",
+      });
+    },
+  });
+
+  return {
+    updateAdminLevel,
     isLoading,
     error,
   };

--- a/src/vertex/core/hooks/useSites.ts
+++ b/src/vertex/core/hooks/useSites.ts
@@ -272,12 +272,13 @@ export const useRefreshSiteMetadata = () => {
       queryClient.invalidateQueries({ queryKey: ["sites"] });
       queryClient.invalidateQueries({ queryKey: ["site-details", siteId] });
 
-      if (data.message.includes("partially refreshed")) {
+      const msg = (data.message ?? "").toLowerCase();
+      if (msg.includes("partially refreshed")) {
         ReusableToast({
           message: data.message,
           type: "WARNING",
         });
-      } else if (data.message.includes("already complete")) {
+      } else if (msg.includes("already complete")) {
         ReusableToast({
           message: "Site metadata is already up to date.",
           type: "INFO",

--- a/src/vertex/core/hooks/useSites.ts
+++ b/src/vertex/core/hooks/useSites.ts
@@ -1,5 +1,12 @@
 import { useQuery, useMutation, useQueryClient, useInfiniteQuery } from "@tanstack/react-query";
-import { sites, ApproximateCoordinatesResponse, GetSitesSummaryParams, SitesSummaryResponse, CreateSiteResponse } from "../apis/sites";
+import {
+  sites,
+  ApproximateCoordinatesResponse,
+  GetSitesSummaryParams,
+  SitesSummaryResponse,
+  CreateSiteResponse,
+  SiteRefreshResponse,
+} from "../apis/sites";
 import { DeviceActivitiesResponse } from "../apis/devices";
 
 import { useGroupCohorts } from "./useCohorts";
@@ -248,6 +255,43 @@ export const useCreateSite = () => {
     onError: (error) => {
       ReusableToast({
         message: `Failed to create site: ${getApiErrorMessage(error)}`,
+        type: "ERROR",
+      });
+    },
+  });
+};
+
+export const useRefreshSiteMetadata = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation<SiteRefreshResponse, AxiosError<ErrorResponse>, string>({
+    mutationFn: (siteId: string) => sites.refreshSiteMetadata(siteId),
+    onSuccess: (data, siteId) => {
+      // Update the cache with the newly enriched site data
+      queryClient.setQueryData(["site-details", siteId], data.site);
+      queryClient.invalidateQueries({ queryKey: ["sites"] });
+      queryClient.invalidateQueries({ queryKey: ["site-details", siteId] });
+
+      if (data.message.includes("partially refreshed")) {
+        ReusableToast({
+          message: data.message,
+          type: "WARNING",
+        });
+      } else if (data.message.includes("already complete")) {
+        ReusableToast({
+          message: "Site metadata is already up to date.",
+          type: "INFO",
+        });
+      } else {
+        ReusableToast({
+          message: "Site metadata refreshed successfully.",
+          type: "SUCCESS",
+        });
+      }
+    },
+    onError: (error) => {
+      ReusableToast({
+        message: `Refresh Failed: ${getApiErrorMessage(error)}`,
         type: "ERROR",
       });
     },


### PR DESCRIPTION
### Description:
This PR introduces on-demand metadata enrichment for sites, comprehensive administrative level management for grids, and critical UI/logic refinements for device status tracking.

#### Key Changes:
- **Site Metadata Refresh**: Added a "Refresh Metadata" feature to the Site Details page with specialized feedback for partial success and redundancy.
- **Admin Level Management**: Implemented a complete management interface (Create, List, Edit) for grid administrative levels, including a new centralized modal with inline editing.
- **Missed Maintenance Tracking**: Overhauled the `MaintenanceStatusCard` with explicit red status indicators and badges for past-due tasks.
- **Telemetry Fallbacks**: Updated `RunDeviceTestCard` to intelligently fall back to `timestamp` metadata when `created_at` is unavailable.
- **Changelog**: Updated to version `1.23.29` to avoid conflicts with pending PRs.

#### Modified Components:
- `Sites`: API, hooks, and details page.
- `Grids`: API, hooks, management dropdown, and levels modal.
- `Devices`: Maintenance and test card components.

#### Screenshots (optional)
<img width="1280" height="598" alt="image" src="https://github.com/user-attachments/assets/87accf00-081b-4ac1-8e82-e0ed1fe00138" />
<img width="1280" height="588" alt="image" src="https://github.com/user-attachments/assets/191f06b3-30c9-48ff-80db-a648e00c4005" />
<img width="1280" height="591" alt="image" src="https://github.com/user-attachments/assets/3a21dd01-eb34-4311-8277-f00fba988433" />
<img width="1280" height="595" alt="image" src="https://github.com/user-attachments/assets/4b3bea2d-43d2-448f-9212-7e0b4659bb34" />
<img width="1528" height="695" alt="image" src="https://github.com/user-attachments/assets/6a850aba-8725-4f2f-aa89-d9be9f41a2e2" />
<img width="1490" height="603" alt="image" src="https://github.com/user-attachments/assets/ad6ee7d3-c1af-4fb6-8960-422cddf09880" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added on-demand "Refresh Metadata" action to site pages
  * Introduced complete admin level management with create, view, and edit capabilities
  * Enhanced maintenance status cards to display missed or upcoming maintenance indicators
  * Improved device test card timestamp handling with fallback support

* **Documentation**
  * Updated changelog documenting v1.23.29 release features and improvements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->