### PR TITLE
Vertex: resolve network request submission 404 in staging & harden error handling

### DIFF
--- a/.github/workflows/deploy-frontend-azurepreview.yml
+++ b/.github/workflows/deploy-frontend-azurepreview.yml
@@ -432,13 +432,29 @@ jobs:
 
       - name: Pull secrets from Key Vault
         run: |
+          BRANCH="${{ needs.branch-name.outputs.lowercase }}"
+          APP="${BRANCH:0:12}-vertex-preview"
+
+          DEFAULT_DOMAIN=$(az containerapp env show \
+            --name ${{ env.PR_PREVIEW_ENV }} \
+            --resource-group ${{ env.RG }} \
+            --query properties.defaultDomain -o tsv)
+
+          NEXTAUTH_URL="https://$APP.$DEFAULT_DOMAIN"
+
           az keyvault secret show \
             --vault-name ${{ env.KEYVAULT }} \
             --name sta-env-vertex \
             --query value -o tsv > secrets.json
 
-          # Write .env into the build context for Next.js build time, excluding the staging auth URL.
-          jq -r 'to_entries | .[] | select(.key != "NEXTAUTH_URL") | "\(.key)=\(.value|tojson)"' secrets.json > src/vertex/.env
+          # Write .env into the build context for Next.js build time, excluding static auth values
+          # that are wrong for per-PR Azure preview hostnames.
+          jq -r 'to_entries | .[] | select(.key != "NEXTAUTH_URL" and .key != "NEXTAUTH_URL_INTERNAL" and .key != "NEXTAUTH_COOKIE_DOMAIN") | "\(.key)=\(.value|tojson)"' secrets.json > src/vertex/.env
+          {
+            echo "NEXTAUTH_URL=$NEXTAUTH_URL"
+            echo "NEXTAUTH_URL_INTERNAL=$NEXTAUTH_URL"
+            echo "AUTH_TRUST_HOST=true"
+          } >> src/vertex/.env
 
       - name: Build image
         run: |
@@ -451,12 +467,12 @@ jobs:
           APP="${BRANCH:0:12}-vertex-preview"
 
           # Build env vars string separately to avoid nested YAML/shell escaping issues.
-          # The shared staging secret contains a NEXTAUTH_URL value that is wrong for per-PR
-          # preview hostnames. Drop it and inject the Container Apps preview URL below.
-          ENV_VARS=$(jq -r 'to_entries | map(select(.key != "NEXTAUTH_URL")) | map("\(.key)=\(.value|tostring)") | join(" ")' secrets.json)
+          # The shared staging secret contains static auth values that are wrong for per-PR
+          # preview hostnames. Drop them and inject the Container Apps preview URL below.
+          ENV_VARS=$(jq -r 'to_entries | map(select(.key != "NEXTAUTH_URL" and .key != "NEXTAUTH_URL_INTERNAL" and .key != "NEXTAUTH_COOKIE_DOMAIN")) | map("\(.key)=\(.value|tostring)") | join(" ")' secrets.json)
 
           # Fail fast if the secret is missing (NextAuth requires this in production).
-          jq -e '.NEXTAUTH_SECRET and (.NEXTAUTH_SECRET|length > 0)' secrets.json >/dev/null
+          jq -e '((.NEXTAUTH_SECRET // .AUTH_SECRET) | length > 0)' secrets.json >/dev/null
 
           DEFAULT_DOMAIN=$(az containerapp env show \
             --name ${{ env.PR_PREVIEW_ENV }} \
@@ -475,7 +491,18 @@ jobs:
             --registry-server ${{ env.REGISTRY_URL }} \
             --registry-username airqoacr \
             --registry-password ${{ secrets.ACR_PASSWORD }} \
-            --env-vars "$ENV_VARS NEXTAUTH_URL=$NEXTAUTH_URL"
+            --env-vars "$ENV_VARS NEXTAUTH_URL=$NEXTAUTH_URL NEXTAUTH_URL_INTERNAL=$NEXTAUTH_URL AUTH_TRUST_HOST=true"
+
+          AUTH_STATUS=$(curl -sS -o /tmp/nextauth-providers.json -w "%{http_code}" "$NEXTAUTH_URL/api/auth/providers")
+          if [ "$AUTH_STATUS" != "200" ]; then
+            echo "NextAuth providers endpoint returned HTTP $AUTH_STATUS"
+            cat /tmp/nextauth-providers.json || true
+            az containerapp logs show \
+              --name $APP \
+              --resource-group ${{ env.RG }} \
+              --tail 80 || true
+            exit 1
+          fi
 
       - id: preview
         run: |

--- a/.github/workflows/deploy-frontend-azurepreview.yml
+++ b/.github/workflows/deploy-frontend-azurepreview.yml
@@ -466,10 +466,13 @@ jobs:
           BRANCH="${{ needs.branch-name.outputs.lowercase }}"
           APP="${BRANCH:0:12}-vertex-preview"
 
-          # Build env vars string separately to avoid nested YAML/shell escaping issues.
+          # Build env vars as an array so each KEY=VALUE is passed to Azure CLI as its own argument.
           # The shared staging secret contains static auth values that are wrong for per-PR
           # preview hostnames. Drop them and inject the Container Apps preview URL below.
-          ENV_VARS=$(jq -r 'to_entries | map(select(.key != "NEXTAUTH_URL" and .key != "NEXTAUTH_URL_INTERNAL" and .key != "NEXTAUTH_COOKIE_DOMAIN")) | map("\(.key)=\(.value|tostring)") | join(" ")' secrets.json)
+          mapfile -t ENV_VARS < <(jq -r 'to_entries[] | select(.key != "NEXTAUTH_URL" and .key != "NEXTAUTH_URL_INTERNAL" and .key != "NEXTAUTH_COOKIE_DOMAIN") | "\(.key)=\(.value|tostring)"' secrets.json)
+          ENV_VARS+=("NEXTAUTH_URL=$NEXTAUTH_URL")
+          ENV_VARS+=("NEXTAUTH_URL_INTERNAL=$NEXTAUTH_URL")
+          ENV_VARS+=("AUTH_TRUST_HOST=true")
 
           # Fail fast if the secret is missing (NextAuth requires this in production).
           jq -e '((.NEXTAUTH_SECRET // .AUTH_SECRET) | length > 0)' secrets.json >/dev/null
@@ -491,7 +494,18 @@ jobs:
             --registry-server ${{ env.REGISTRY_URL }} \
             --registry-username airqoacr \
             --registry-password ${{ secrets.ACR_PASSWORD }} \
-            --env-vars "$ENV_VARS NEXTAUTH_URL=$NEXTAUTH_URL NEXTAUTH_URL_INTERNAL=$NEXTAUTH_URL AUTH_TRUST_HOST=true"
+            --env-vars "${ENV_VARS[@]}"
+
+          az containerapp update \
+            --name $APP \
+            --resource-group ${{ env.RG }} \
+            --replace-env-vars "${ENV_VARS[@]}"
+
+          az containerapp show \
+            --name $APP \
+            --resource-group ${{ env.RG }} \
+            --query "properties.template.containers[0].env[].name" \
+            -o tsv | sort
 
           AUTH_STATUS=$(curl -sS -o /tmp/nextauth-providers.json -w "%{http_code}" "$NEXTAUTH_URL/api/auth/providers")
           if [ "$AUTH_STATUS" != "200" ]; then

--- a/.github/workflows/deploy-frontend-azurepreview.yml
+++ b/.github/workflows/deploy-frontend-azurepreview.yml
@@ -477,13 +477,6 @@ jobs:
           # Fail fast if the secret is missing (NextAuth requires this in production).
           jq -e '((.NEXTAUTH_SECRET // .AUTH_SECRET) | length > 0)' secrets.json >/dev/null
 
-          DEFAULT_DOMAIN=$(az containerapp env show \
-            --name ${{ env.PR_PREVIEW_ENV }} \
-            --resource-group ${{ env.RG }} \
-            --query properties.defaultDomain -o tsv)
-
-          NEXTAUTH_URL="https://$APP.$DEFAULT_DOMAIN"
-
           az containerapp up \
             --name $APP \
             --resource-group ${{ env.RG }} \
@@ -506,6 +499,13 @@ jobs:
             --resource-group ${{ env.RG }} \
             --query "properties.template.containers[0].env[].name" \
             -o tsv | sort
+
+          DEFAULT_DOMAIN=$(az containerapp env show \
+            --name ${{ env.PR_PREVIEW_ENV }} \
+            --resource-group ${{ env.RG }} \
+            --query properties.defaultDomain -o tsv)
+
+          NEXTAUTH_URL="https://$APP.$DEFAULT_DOMAIN"
 
           AUTH_STATUS=$(curl -sS -o /tmp/nextauth-providers.json -w "%{http_code}" "$NEXTAUTH_URL/api/auth/providers")
           if [ "$AUTH_STATUS" != "200" ]; then

--- a/.github/workflows/deploy-frontend-azurepreview.yml
+++ b/.github/workflows/deploy-frontend-azurepreview.yml
@@ -437,8 +437,8 @@ jobs:
             --name sta-env-vertex \
             --query value -o tsv > secrets.json
 
-          # Write .env into the build context for Next.js build time, excluding static URLs 
-          jq -r 'to_entries | .[] | select(.key != "NEXTAUTH_URL" and .key != "NEXTAUTH_COOKIE_DOMAIN") | "\(.key)=\(.value|tojson)"' secrets.json > src/vertex/.env
+          # Write .env into the build context for Next.js build time, excluding the staging auth URL.
+          jq -r 'to_entries | .[] | select(.key != "NEXTAUTH_URL") | "\(.key)=\(.value|tojson)"' secrets.json > src/vertex/.env
 
       - name: Build image
         run: |
@@ -451,10 +451,9 @@ jobs:
           APP="${BRANCH:0:12}-vertex-preview"
 
           # Build env vars string separately to avoid nested YAML/shell escaping issues.
-          # The shared staging secret contains NEXTAUTH_URL / NEXTAUTH_COOKIE_DOMAIN values that are wrong for
-          # per-PR preview hostnames. We drop them and inject a correct NEXTAUTH_URL based on the Container Apps
-          # Environment default domain.
-          ENV_VARS=$(jq -r 'to_entries | map(select(.key != "NEXTAUTH_URL" and .key != "NEXTAUTH_COOKIE_DOMAIN")) | map("\(.key)=\(.value|tostring)") | join(" ")' secrets.json)
+          # The shared staging secret contains a NEXTAUTH_URL value that is wrong for per-PR
+          # preview hostnames. Drop it and inject the Container Apps preview URL below.
+          ENV_VARS=$(jq -r 'to_entries | map(select(.key != "NEXTAUTH_URL")) | map("\(.key)=\(.value|tostring)") | join(" ")' secrets.json)
 
           # Fail fast if the secret is missing (NextAuth requires this in production).
           jq -e '.NEXTAUTH_SECRET and (.NEXTAUTH_SECRET|length > 0)' secrets.json >/dev/null

--- a/src/vertex/Dockerfile
+++ b/src/vertex/Dockerfile
@@ -26,6 +26,7 @@ COPY --from=builder /app/.next ./.next
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/package*.json ./
 COPY --from=builder /app/public ./public
+COPY --from=builder /app/start-next.js ./start-next.js
 
 # Add healthcheck
 HEALTHCHECK --interval=30s --timeout=3s \

--- a/src/vertex/app/api/auth/[...nextauth]/options.ts
+++ b/src/vertex/app/api/auth/[...nextauth]/options.ts
@@ -12,6 +12,20 @@ import logger from '@/lib/logger';
 
 const isProduction = process.env.NODE_ENV === 'production';
 
+const getValidUrl = (value?: string) => {
+  const url = value?.trim();
+
+  if (!url) {
+    return null;
+  }
+
+  try {
+    return new URL(url).toString().replace(/\/$/, '');
+  } catch {
+    return null;
+  }
+};
+
 const getAzureContainerAppsUrl = () => {
   const appName = process.env.CONTAINER_APP_NAME;
   const dnsSuffix = process.env.CONTAINER_APP_ENV_DNS_SUFFIX;
@@ -24,7 +38,22 @@ const getAzureContainerAppsUrl = () => {
 };
 
 const azureContainerAppsUrl = getAzureContainerAppsUrl();
-if (azureContainerAppsUrl) {
+const nextAuthUrl = getValidUrl(process.env.NEXTAUTH_URL);
+const nextAuthUrlInternal = getValidUrl(process.env.NEXTAUTH_URL_INTERNAL);
+
+if (nextAuthUrl) {
+  process.env.NEXTAUTH_URL = nextAuthUrl;
+} else {
+  delete process.env.NEXTAUTH_URL;
+}
+
+if (nextAuthUrlInternal) {
+  process.env.NEXTAUTH_URL_INTERNAL = nextAuthUrlInternal;
+} else {
+  delete process.env.NEXTAUTH_URL_INTERNAL;
+}
+
+if (!process.env.NEXTAUTH_URL && azureContainerAppsUrl) {
   process.env.NEXTAUTH_URL = azureContainerAppsUrl;
   process.env.NEXTAUTH_URL_INTERNAL =
     process.env.NEXTAUTH_URL_INTERNAL || azureContainerAppsUrl;

--- a/src/vertex/app/api/auth/[...nextauth]/options.ts
+++ b/src/vertex/app/api/auth/[...nextauth]/options.ts
@@ -19,19 +19,6 @@ if (isProduction && !process.env.NEXTAUTH_SECRET) {
 if (isProduction && !process.env.NEXTAUTH_URL && !process.env.AUTH_TRUST_HOST) {
   logger.warn('[NextAuth] WARNING: NEXTAUTH_URL is missing. Dynamic host detection will be used.');
 }
-const sessionCookieName = isProduction
-  ? '__Secure-next-auth.session-token'
-  : 'vertex.next-auth.session-token';
-
-const sessionCookieConfig = {
-  name: sessionCookieName,
-  options: {
-    httpOnly: true,
-    sameSite: 'lax' as const,
-    path: '/',
-    secure: isProduction,
-  },
-};
 
 export const options: NextAuthOptions = {
   secret: process.env.NEXTAUTH_SECRET,
@@ -93,10 +80,6 @@ export const options: NextAuthOptions = {
       },
     }),
   ],
-
-  cookies: {
-    sessionToken: sessionCookieConfig,
-  },
 
   session: {
     strategy: 'jwt',

--- a/src/vertex/app/api/auth/[...nextauth]/options.ts
+++ b/src/vertex/app/api/auth/[...nextauth]/options.ts
@@ -12,7 +12,28 @@ import logger from '@/lib/logger';
 
 const isProduction = process.env.NODE_ENV === 'production';
 
-if (isProduction && !process.env.NEXTAUTH_SECRET) {
+const getAzureContainerAppsUrl = () => {
+  const appName = process.env.CONTAINER_APP_NAME;
+  const dnsSuffix = process.env.CONTAINER_APP_ENV_DNS_SUFFIX;
+
+  if (!appName || !dnsSuffix || !appName.endsWith('-vertex-preview')) {
+    return null;
+  }
+
+  return `https://${appName}.${dnsSuffix}`;
+};
+
+const azureContainerAppsUrl = getAzureContainerAppsUrl();
+if (azureContainerAppsUrl) {
+  process.env.NEXTAUTH_URL = azureContainerAppsUrl;
+  process.env.NEXTAUTH_URL_INTERNAL =
+    process.env.NEXTAUTH_URL_INTERNAL || azureContainerAppsUrl;
+  process.env.AUTH_TRUST_HOST = process.env.AUTH_TRUST_HOST || 'true';
+}
+
+const authSecret = process.env.NEXTAUTH_SECRET || process.env.AUTH_SECRET;
+
+if (isProduction && !authSecret) {
   logger.error('[NextAuth] CRITICAL: NEXTAUTH_SECRET is missing in production environment!');
 }
 
@@ -21,7 +42,7 @@ if (isProduction && !process.env.NEXTAUTH_URL && !process.env.AUTH_TRUST_HOST) {
 }
 
 export const options: NextAuthOptions = {
-  secret: process.env.NEXTAUTH_SECRET,
+  secret: authSecret,
   useSecureCookies: isProduction,
   providers: [
     CredentialsProvider({

--- a/src/vertex/app/api/auth/[...nextauth]/route.ts
+++ b/src/vertex/app/api/auth/[...nextauth]/route.ts
@@ -14,7 +14,9 @@ const getRequestOrigin = (req: NextRequest) => {
   return `${forwardedProto}://${host}`;
 };
 
-const getHandler = (req: NextRequest) => {
+const handler = NextAuth(options);
+
+const setRuntimeAuthUrls = (req: NextRequest) => {
   const requestOrigin = getRequestOrigin(req);
 
   if (requestOrigin) {
@@ -22,14 +24,14 @@ const getHandler = (req: NextRequest) => {
     process.env.NEXTAUTH_URL_INTERNAL =
       process.env.NEXTAUTH_URL_INTERNAL || requestOrigin;
   }
-
-  return NextAuth(options);
 };
 
-export function GET(req: NextRequest) {
-  return getHandler(req)(req);
+export async function GET(req: NextRequest, context: { params: Record<string, unknown> }) {
+  setRuntimeAuthUrls(req);
+  return handler(req, context);
 }
 
-export function POST(req: NextRequest) {
-  return getHandler(req)(req);
+export async function POST(req: NextRequest, context: { params: Record<string, unknown> }) {
+  setRuntimeAuthUrls(req);
+  return handler(req, context);
 }

--- a/src/vertex/app/api/auth/[...nextauth]/route.ts
+++ b/src/vertex/app/api/auth/[...nextauth]/route.ts
@@ -1,6 +1,35 @@
 import NextAuth from 'next-auth';
 import { options } from './options';
+import type { NextRequest } from 'next/server';
 
-const handler = NextAuth(options);
+const getRequestOrigin = (req: NextRequest) => {
+  const forwardedProto = req.headers.get('x-forwarded-proto') || 'https';
+  const forwardedHost = req.headers.get('x-forwarded-host');
+  const host = forwardedHost || req.headers.get('host');
 
-export { handler as GET, handler as POST };
+  if (!host) {
+    return null;
+  }
+
+  return `${forwardedProto}://${host}`;
+};
+
+const getHandler = (req: NextRequest) => {
+  const requestOrigin = getRequestOrigin(req);
+
+  if (requestOrigin) {
+    process.env.NEXTAUTH_URL = requestOrigin;
+    process.env.NEXTAUTH_URL_INTERNAL =
+      process.env.NEXTAUTH_URL_INTERNAL || requestOrigin;
+  }
+
+  return NextAuth(options);
+};
+
+export function GET(req: NextRequest) {
+  return getHandler(req)(req);
+}
+
+export function POST(req: NextRequest) {
+  return getHandler(req)(req);
+}

--- a/src/vertex/app/api/devices/network-creation-requests/route.ts
+++ b/src/vertex/app/api/devices/network-creation-requests/route.ts
@@ -3,6 +3,7 @@ import { getServerSession } from "next-auth/next";
 import { options } from "../../auth/[...nextauth]/options";
 import logger from "@/lib/logger";
 import { networkService } from "@/core/services/network-service";
+import type { NetworkRequestValues } from "@/components/features/networks/schema";
 
 export async function GET() {
   try {
@@ -36,9 +37,9 @@ export async function GET() {
 
 export async function POST(req: NextRequest) {
   try {
-    let body: unknown;
+    let body: NetworkRequestValues;
     try {
-      body = await req.json();
+      body = (await req.json()) as NetworkRequestValues;
     } catch {
       return NextResponse.json({ message: "Invalid JSON payload" }, { status: 400 });
     }

--- a/src/vertex/app/api/devices/network-creation-requests/route.ts
+++ b/src/vertex/app/api/devices/network-creation-requests/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { getServerSession } from "next-auth/next";
 import { options } from "../../auth/[...nextauth]/options";
 import logger from "@/lib/logger";
@@ -27,6 +27,21 @@ export async function GET() {
     }
     const err = error as { message: string; status?: number; data?: unknown };
     logger.error(`Error fetching network requests in route handler: ${err.message}`);
+    return NextResponse.json(
+      err.data || { message: err.message || "Internal server error" },
+      { status: err.status || 500 }
+    );
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const data = await networkService.submitNetworkRequest(body);
+    return NextResponse.json(data, { status: 200 });
+  } catch (error: unknown) {
+    const err = error as { message: string; status?: number; data?: unknown };
+    logger.error(`Error submitting network request in route handler: ${err.message}`);
     return NextResponse.json(
       err.data || { message: err.message || "Internal server error" },
       { status: err.status || 500 }

--- a/src/vertex/app/api/devices/network-creation-requests/route.ts
+++ b/src/vertex/app/api/devices/network-creation-requests/route.ts
@@ -36,7 +36,13 @@ export async function GET() {
 
 export async function POST(req: NextRequest) {
   try {
-    const body = await req.json();
+    let body: unknown;
+    try {
+      body = await req.json();
+    } catch {
+      return NextResponse.json({ message: "Invalid JSON payload" }, { status: 400 });
+    }
+
     const data = await networkService.submitNetworkRequest(body);
     return NextResponse.json(data, { status: 200 });
   } catch (error: unknown) {

--- a/src/vertex/app/api/log-to-slack/route.ts
+++ b/src/vertex/app/api/log-to-slack/route.ts
@@ -95,8 +95,12 @@ export async function POST(request: NextRequest) {
       );
       console.warn('Expected environment variable: SLACK_WEBHOOK_URL');
       return NextResponse.json(
-        { success: false, error: 'Slack webhook URL not configured' },
-        { status: 500 }
+        {
+          success: true,
+          skipped: true,
+          reason: 'Slack webhook URL not configured',
+        },
+        { status: 200 }
       );
     }
 

--- a/src/vertex/app/changelog.md
+++ b/src/vertex/app/changelog.md
@@ -4,7 +4,48 @@
 
 ---
 
+## Version 1.23.33
+**Released:** April 29, 2026
+
+### Network Request Submission Fix & Error Handling Hardening
+
+Fixed a critical staging-environment bug where submitting a new sensor manufacturer request produced a 404 due to a malformed URL, and hardened error propagation across the network request API route handlers.
+
+<details>
+<summary><strong>Bug Fixes (4)</strong></summary>
+
+- **Network Request 404 in Staging**: Resolved a critical bug where clicking "Request New Sensor Manufacturer" in staging produced the malformed URL `/devices/undefineddevices/network-creation-requests`. Root cause: `NEXT_PUBLIC_API_URL` was not injected at build time, causing the client-side URL construction to silently embed `"undefined"`. Fixed by routing the POST through a new Next.js API route handler, removing the env-var dependency from the client entirely.
+- **Route Handler Error Shape Mismatch**: Fixed the GET handler at `/api/devices/network-creation-requests` always returning a 500 status. The handler was reading `err.response?.data` and `err.response?.status`, but `networkService` throws errors with `err.data` and `err.status` attached directly. Actual error details from the backend were being silently dropped.
+- **Consistent Error Shape on Action Route**: Applied the same error shape fix to the PUT handler at `/api/devices/network-creation-requests/[id]/[action]/route.ts` to ensure backend error payloads and status codes are correctly surfaced.
+- **"undefined" in Requester Name Pre-fill**: Fixed an edge case where the `requester_name` field in the submission dialog could display `"undefined undefined"` if `firstName` or `lastName` was missing from the user's profile. Replaced the template literal with a `.filter().join()` approach that safely omits missing name parts.
+
+</details>
+
+<details>
+<summary><strong>Refactors (3)</strong></summary>
+
+- **Server-Side URL Construction**: Added a `submitNetworkRequest` method to `networkService` that builds the backend URL server-side via `getApiBaseUrl()`, which always resolves correctly in a server context regardless of staging environment variable configuration.
+- **New Public POST Route Handler**: Added a `POST` handler to `/api/devices/network-creation-requests/route.ts` that proxies public submission requests to the backend with no auth requirement, matching the public nature of the endpoint.
+- **Collocated Mutation Logic**: Removed the intermediate `useSubmitNetworkRequest` hook and `submitNetworkRequestApi` client API method. The `useMutation` + `fetch` logic is now inlined directly in `NetworkRequestDialog`, removing unnecessary abstraction layers for a straightforward, single-use call.
+
+</details>
+
+<details>
+<summary><strong>Files Modified (6)</strong></summary>
+
+- `app/api/devices/network-creation-requests/route.ts`
+- `app/api/devices/network-creation-requests/[id]/[action]/route.ts`
+- `core/services/network-service.ts`
+- `core/apis/networks.ts`
+- `core/hooks/useNetworks.ts`
+- `components/features/networks/network-request-dialog.tsx`
+
+</details>
+
+---
+
 ## Version 1.23.32
+
 **Released:** April 27, 2026
 
 ### Cohort Performance Optimization & Request Stability

--- a/src/vertex/app/changelog.md
+++ b/src/vertex/app/changelog.md
@@ -7,40 +7,44 @@
 ## Version 1.23.33
 **Released:** April 29, 2026
 
-### Network Request Submission Fix, Auth Cookie Cleanup & Error Handling Hardening
+### Network Request Submission Fix, Azure Preview Auth Hardening & Error Handling
 
-Fixed a critical staging-environment bug where submitting a new sensor manufacturer request produced a 404 due to a malformed URL, removed obsolete custom auth cookie handling after the SSO rollback, and hardened error propagation across the network request API route handlers.
+Fixed a critical staging-environment bug where submitting a new sensor manufacturer request produced a 404 due to a malformed URL, removed obsolete custom auth cookie handling after the SSO rollback, hardened Azure preview NextAuth configuration, and improved error propagation across the network request API route handlers.
 
 <details>
-<summary><strong>Bug Fixes (6)</strong></summary>
+<summary><strong>Bug Fixes (7)</strong></summary>
 
 - **Network Request 404 in Staging**: Resolved a critical bug where clicking "Request New Sensor Manufacturer" in staging produced the malformed URL `/devices/undefineddevices/network-creation-requests`. Root cause: `NEXT_PUBLIC_API_URL` was not injected at build time, causing the client-side URL construction to silently embed `"undefined"`. Fixed by routing the POST through a new Next.js API route handler, removing the env-var dependency from the client entirely.
 - **Route Handler Error Shape Mismatch**: Fixed the GET handler at `/api/devices/network-creation-requests` always returning a 500 status. The handler was reading `err.response?.data` and `err.response?.status`, but `networkService` throws errors with `err.data` and `err.status` attached directly. Actual error details from the backend were being silently dropped.
 - **Consistent Error Shape on Action Route**: Applied the same error shape fix to the PUT handler at `/api/devices/network-creation-requests/[id]/[action]/route.ts` to ensure backend error payloads and status codes are correctly surfaced.
 - **Malformed JSON Handling**: Updated the public POST handler at `/api/devices/network-creation-requests` to return `400` for invalid JSON payloads instead of falling through to the generic internal server error path.
 - **Backend Validation Message Preservation**: Preserved backend error payloads from failed network request submissions and taught `getApiErrorMessage` to extract messages from both Axios-style `response.data` and fetch/custom `error.data` shapes.
+- **Slack Logging Noise in Preview**: Updated `/api/log-to-slack` to skip cleanly when `SLACK_WEBHOOK_URL` is not configured, preventing logging failures from adding extra 500s to the browser console.
 - **"undefined" in Requester Name Pre-fill**: Fixed an edge case where the `requester_name` field in the submission dialog could display `"undefined undefined"` if `firstName` or `lastName` was missing from the user's profile. Replaced the template literal with a `.filter().join()` approach that safely omits missing name parts.
 
 </details>
 
 <details>
-<summary><strong>Refactors & Hardening (5)</strong></summary>
+<summary><strong>Refactors & Hardening (7)</strong></summary>
 
 - **Server-Side URL Construction**: Added a `submitNetworkRequest` method to `networkService` that builds the backend URL server-side via `getApiBaseUrl()`, which always resolves correctly in a server context regardless of staging environment variable configuration.
 - **New Public POST Route Handler**: Added a `POST` handler to `/api/devices/network-creation-requests/route.ts` that proxies public submission requests to the backend with no auth requirement, matching the public nature of the endpoint.
 - **Collocated Mutation Logic**: Removed the intermediate `useSubmitNetworkRequest` hook and `submitNetworkRequestApi` client API method. The `useMutation` + `fetch` logic is now inlined directly in `NetworkRequestDialog`, removing unnecessary abstraction layers for a straightforward, single-use call.
 - **Outbound Request Timeout**: Added an `AbortController` timeout to `networkService.submitNetworkRequest` so slow or unresponsive backend calls fail with a controlled `504` response instead of hanging the route handler.
 - **NextAuth Cookie Defaults Restored**: Removed Vertex's custom session cookie override and matching middleware cookie-name lookup now that cross-subdomain SSO cookie sharing is no longer needed. NextAuth now manages session cookie naming and retrieval through its defaults.
+- **Azure Preview NextAuth URL Hardening**: The Azure preview workflow now computes the per-PR Container Apps URL before build, writes `NEXTAUTH_URL`, `NEXTAUTH_URL_INTERNAL`, and `AUTH_TRUST_HOST=true` into the image `.env`, and also injects them at runtime.
+- **Preview Auth Health Check**: Added a post-deploy check against `/api/auth/providers` so broken NextAuth preview deployments fail fast and print recent Container App logs instead of silently publishing an unusable preview.
 
 </details>
 
 <details>
-<summary><strong>Files Modified (10)</strong></summary>
+<summary><strong>Files Modified (11)</strong></summary>
 
 - `.github/workflows/deploy-frontend-azurepreview.yml`
 - `app/api/devices/network-creation-requests/route.ts`
 - `app/api/devices/network-creation-requests/[id]/[action]/route.ts`
 - `app/api/auth/[...nextauth]/options.ts`
+- `app/api/log-to-slack/route.ts`
 - `middleware.ts`
 - `core/services/network-service.ts`
 - `core/apis/networks.ts`

--- a/src/vertex/app/changelog.md
+++ b/src/vertex/app/changelog.md
@@ -7,37 +7,45 @@
 ## Version 1.23.33
 **Released:** April 29, 2026
 
-### Network Request Submission Fix & Error Handling Hardening
+### Network Request Submission Fix, Auth Cookie Cleanup & Error Handling Hardening
 
-Fixed a critical staging-environment bug where submitting a new sensor manufacturer request produced a 404 due to a malformed URL, and hardened error propagation across the network request API route handlers.
+Fixed a critical staging-environment bug where submitting a new sensor manufacturer request produced a 404 due to a malformed URL, removed obsolete custom auth cookie handling after the SSO rollback, and hardened error propagation across the network request API route handlers.
 
 <details>
-<summary><strong>Bug Fixes (4)</strong></summary>
+<summary><strong>Bug Fixes (6)</strong></summary>
 
 - **Network Request 404 in Staging**: Resolved a critical bug where clicking "Request New Sensor Manufacturer" in staging produced the malformed URL `/devices/undefineddevices/network-creation-requests`. Root cause: `NEXT_PUBLIC_API_URL` was not injected at build time, causing the client-side URL construction to silently embed `"undefined"`. Fixed by routing the POST through a new Next.js API route handler, removing the env-var dependency from the client entirely.
 - **Route Handler Error Shape Mismatch**: Fixed the GET handler at `/api/devices/network-creation-requests` always returning a 500 status. The handler was reading `err.response?.data` and `err.response?.status`, but `networkService` throws errors with `err.data` and `err.status` attached directly. Actual error details from the backend were being silently dropped.
 - **Consistent Error Shape on Action Route**: Applied the same error shape fix to the PUT handler at `/api/devices/network-creation-requests/[id]/[action]/route.ts` to ensure backend error payloads and status codes are correctly surfaced.
+- **Malformed JSON Handling**: Updated the public POST handler at `/api/devices/network-creation-requests` to return `400` for invalid JSON payloads instead of falling through to the generic internal server error path.
+- **Backend Validation Message Preservation**: Preserved backend error payloads from failed network request submissions and taught `getApiErrorMessage` to extract messages from both Axios-style `response.data` and fetch/custom `error.data` shapes.
 - **"undefined" in Requester Name Pre-fill**: Fixed an edge case where the `requester_name` field in the submission dialog could display `"undefined undefined"` if `firstName` or `lastName` was missing from the user's profile. Replaced the template literal with a `.filter().join()` approach that safely omits missing name parts.
 
 </details>
 
 <details>
-<summary><strong>Refactors (3)</strong></summary>
+<summary><strong>Refactors & Hardening (5)</strong></summary>
 
 - **Server-Side URL Construction**: Added a `submitNetworkRequest` method to `networkService` that builds the backend URL server-side via `getApiBaseUrl()`, which always resolves correctly in a server context regardless of staging environment variable configuration.
 - **New Public POST Route Handler**: Added a `POST` handler to `/api/devices/network-creation-requests/route.ts` that proxies public submission requests to the backend with no auth requirement, matching the public nature of the endpoint.
 - **Collocated Mutation Logic**: Removed the intermediate `useSubmitNetworkRequest` hook and `submitNetworkRequestApi` client API method. The `useMutation` + `fetch` logic is now inlined directly in `NetworkRequestDialog`, removing unnecessary abstraction layers for a straightforward, single-use call.
+- **Outbound Request Timeout**: Added an `AbortController` timeout to `networkService.submitNetworkRequest` so slow or unresponsive backend calls fail with a controlled `504` response instead of hanging the route handler.
+- **NextAuth Cookie Defaults Restored**: Removed Vertex's custom session cookie override and matching middleware cookie-name lookup now that cross-subdomain SSO cookie sharing is no longer needed. NextAuth now manages session cookie naming and retrieval through its defaults.
 
 </details>
 
 <details>
-<summary><strong>Files Modified (6)</strong></summary>
+<summary><strong>Files Modified (10)</strong></summary>
 
+- `.github/workflows/deploy-frontend-azurepreview.yml`
 - `app/api/devices/network-creation-requests/route.ts`
 - `app/api/devices/network-creation-requests/[id]/[action]/route.ts`
+- `app/api/auth/[...nextauth]/options.ts`
+- `middleware.ts`
 - `core/services/network-service.ts`
 - `core/apis/networks.ts`
 - `core/hooks/useNetworks.ts`
+- `core/utils/getApiErrorMessage.ts`
 - `components/features/networks/network-request-dialog.tsx`
 
 </details>

--- a/src/vertex/components/features/networks/network-request-dialog.tsx
+++ b/src/vertex/components/features/networks/network-request-dialog.tsx
@@ -30,7 +30,10 @@ export function NetworkRequestDialog({ open, onOpenChange }: NetworkRequestDialo
             });
             if (!response.ok) {
                 const errorData = await response.json().catch(() => ({ message: "Request failed" }));
-                throw Object.assign(new Error(errorData.message || "Request failed"), { status: response.status });
+                throw Object.assign(new Error("Request failed"), {
+                    status: response.status,
+                    data: errorData,
+                });
             }
             return response.json();
         },

--- a/src/vertex/components/features/networks/network-request-dialog.tsx
+++ b/src/vertex/components/features/networks/network-request-dialog.tsx
@@ -3,12 +3,14 @@
 import { useCallback, useEffect } from "react";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Form, FormField } from "@/components/ui/form";
 import ReusableDialog from "@/components/shared/dialog/ReusableDialog";
 import ReusableInputField from "@/components/shared/inputfield/ReusableInputField";
 import { networkRequestSchema, NetworkRequestValues } from "./schema";
-import { useSubmitNetworkRequest } from "@/core/hooks/useNetworks";
 import { useAppSelector } from "@/core/redux/hooks";
+import ReusableToast from "@/components/shared/toast/ReusableToast";
+import { getApiErrorMessage } from "@/core/utils/getApiErrorMessage";
 
 interface NetworkRequestDialogProps {
     open: boolean;
@@ -17,7 +19,32 @@ interface NetworkRequestDialogProps {
 
 export function NetworkRequestDialog({ open, onOpenChange }: NetworkRequestDialogProps) {
     const userDetails = useAppSelector((state) => state.user.userDetails);
-    const { mutate: submitRequest, isPending } = useSubmitNetworkRequest();
+    const queryClient = useQueryClient();
+
+    const { mutate: submitRequest, isPending } = useMutation({
+        mutationFn: async (data: NetworkRequestValues) => {
+            const response = await fetch("/api/devices/network-creation-requests", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify(data),
+            });
+            if (!response.ok) {
+                const errorData = await response.json().catch(() => ({ message: "Request failed" }));
+                throw Object.assign(new Error(errorData.message || "Request failed"), { status: response.status });
+            }
+            return response.json();
+        },
+        onSuccess: (resp) => {
+            ReusableToast({
+                message: resp.message || "Your request for a new Sensor Manufacturer has been submitted successfully!",
+                type: "SUCCESS",
+            });
+            queryClient.invalidateQueries({ queryKey: ["network-requests"] });
+        },
+        onError: (error) => {
+            ReusableToast({ message: getApiErrorMessage(error), type: "ERROR" });
+        },
+    });
 
     const form = useForm<NetworkRequestValues>({
         resolver: zodResolver(networkRequestSchema),

--- a/src/vertex/core/apis/networks.ts
+++ b/src/vertex/core/apis/networks.ts
@@ -1,6 +1,4 @@
 import createSecureApiClient from "@/core/utils/secureApiProxyClient";
-import axios from "axios";
-import { NetworkRequestValues } from "@/components/features/networks/schema";
 
 export interface NetworkManager {
   _id: string;
@@ -111,21 +109,4 @@ export const networks = {
       throw error;
     }
   },
-
-  submitNetworkRequestApi: async (data: NetworkRequestValues): Promise<NetworkRequestActionResponse> => {
-    try {
-      const apiUrl = `${process.env.NEXT_PUBLIC_API_URL}devices/network-creation-requests`;
-      
-      const response = await axios.post<NetworkRequestActionResponse>(
-        `${apiUrl}`,
-        data,
-        { headers: { "Content-Type": "application/json" } }
-      );
-      return response.data;
-    } catch (error) {
-      throw error;
-    }
-  },
-
-
-};
+};

--- a/src/vertex/core/hooks/useNetworks.ts
+++ b/src/vertex/core/hooks/useNetworks.ts
@@ -1,4 +1,4 @@
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 
 import {
   Network,
@@ -8,9 +8,6 @@ import { DeviceListingOptions } from "./useDevices";
 import { devices } from "../apis/devices";
 import { AxiosError } from "axios";
 import type { DevicesSummaryResponse } from "@/app/types/devices";
-import { NetworkRequestValues } from "@/components/features/networks/schema";
-import ReusableToast from "@/components/shared/toast/ReusableToast";
-import { getApiErrorMessage } from "@/core/utils/getApiErrorMessage";
 
 
 interface ErrorResponse {
@@ -102,25 +99,4 @@ export const useNetworkDevices = (options: DeviceListingOptions = {}) => {
     error: devicesQuery.error,
   };
 };
-
-
-
-export const useSubmitNetworkRequest = () => {
-    const queryClient = useQueryClient();
-    return useMutation({
-        mutationFn: (data: NetworkRequestValues) => networksApi.submitNetworkRequestApi(data),
-        onSuccess: (resp) => {
-            ReusableToast({ 
-                message: resp.message || 'Your request for a new Sensor Manufacturer has been submitted successfully!', 
-                type: 'SUCCESS' 
-            });
-            queryClient.invalidateQueries({ queryKey: ['network-requests'] });
-        },
-        onError: (error) => {
-            ReusableToast({ 
-                message: getApiErrorMessage(error), 
-                type: 'ERROR' 
-            });
-        }
-    });
-};
+

--- a/src/vertex/core/services/network-service.ts
+++ b/src/vertex/core/services/network-service.ts
@@ -5,6 +5,8 @@ import logger from "@/lib/logger";
 import axios from "axios";
 import { getApiErrorMessage } from "@/core/utils/getApiErrorMessage";
 
+const NETWORK_REQUEST_TIMEOUT_MS = 10_000;
+
 /**
  * Service for network-related operations on the server side.
  * This service should be used by Server Components and Route Handlers.
@@ -95,11 +97,32 @@ export const networkService = {
     const baseUrl = getApiBaseUrl();
     const url = `${baseUrl}/devices/network-creation-requests`;
 
-    const response = await fetch(url, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(data),
-    });
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), NETWORK_REQUEST_TIMEOUT_MS);
+
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(data),
+        signal: controller.signal,
+      });
+    } catch (error) {
+      if (error instanceof Error && error.name === "AbortError") {
+        const err = new Error("Network request timed out") as Error & {
+          status?: number;
+          data?: unknown;
+        };
+        err.status = 504;
+        err.data = { message: "Network request timed out" };
+        throw err;
+      }
+
+      throw error;
+    } finally {
+      clearTimeout(timeoutId);
+    }
 
     if (!response.ok) {
       const errorData = await response.json().catch(() => ({ message: "Request failed" }));

--- a/src/vertex/core/services/network-service.ts
+++ b/src/vertex/core/services/network-service.ts
@@ -1,4 +1,5 @@
-import { NetworkCreationRequest } from "@/core/apis/networks";
+import { NetworkCreationRequest, NetworkRequestActionResponse } from "@/core/apis/networks";
+import { NetworkRequestValues } from "@/components/features/networks/schema";
 import { getApiBaseUrl } from "@/lib/envConstants";
 import logger from "@/lib/logger";
 import axios from "axios";
@@ -85,5 +86,29 @@ export const networkService = {
       err.data = data;
       throw err;
     }
-  }
+  },
+
+  /**
+   * Submits a new network creation request. Public endpoint — no auth required.
+   */
+  submitNetworkRequest: async (data: NetworkRequestValues): Promise<NetworkRequestActionResponse> => {
+    const baseUrl = getApiBaseUrl();
+    const url = `${baseUrl}/devices/network-creation-requests`;
+
+    const response = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(data),
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({ message: "Request failed" }));
+      const err = new Error(errorData.message || "Request failed") as Error & { status?: number; data?: unknown };
+      err.status = response.status;
+      err.data = errorData;
+      throw err;
+    }
+
+    return response.json();
+  },
 };

--- a/src/vertex/core/urls.tsx
+++ b/src/vertex/core/urls.tsx
@@ -1,4 +1,7 @@
 import { stripTrailingSlash } from "@/lib/utils";
+
+const DEFAULT_ANALYTICS_BASE_URL = "https://staging-analytics.airqo.net";
+
 export const BASE_API_URL = stripTrailingSlash(
   process.env.NEXT_PUBLIC_API_URL || ""
 );
@@ -7,6 +10,8 @@ export const DEVICES_MGT_URL = `${BASE_API_URL}/devices`;
 export const SITES_MGT_URL = `${BASE_API_URL}/devices/sites`;
 export const ANALYTICS_MGT_URL = `${BASE_API_URL}/analytics`;
 
-const ANALYTICS_BASE_URL = stripTrailingSlash(process.env.NEXT_PUBLIC_ANALYTICS_URL || '');
-export const forgotPasswordUrl = ANALYTICS_BASE_URL ? `${ANALYTICS_BASE_URL}/user/forgotPwd` : '';
-export const signUpUrl = ANALYTICS_BASE_URL ? `${ANALYTICS_BASE_URL}/user/creation/individual/register` : '';
+const ANALYTICS_BASE_URL = stripTrailingSlash(
+  process.env.NEXT_PUBLIC_ANALYTICS_URL || DEFAULT_ANALYTICS_BASE_URL
+);
+export const forgotPasswordUrl = `${ANALYTICS_BASE_URL}/user/forgotPwd`;
+export const signUpUrl = `${ANALYTICS_BASE_URL}/user/creation/individual/register`;

--- a/src/vertex/core/utils/getApiErrorMessage.ts
+++ b/src/vertex/core/utils/getApiErrorMessage.ts
@@ -9,6 +9,47 @@ interface ApiErrorResponse {
     | string;
 }
 
+interface ErrorWithData extends Error {
+    data?: ApiErrorResponse | string;
+}
+
+const getMessageFromApiData = (data: ApiErrorResponse | string): string | null => {
+    if (typeof data === 'string') {
+        return data;
+    }
+
+    // 1. Nested validation errors: { "errors": { "field": { "msg": "..." } } } OR { "errors": { "field": "..." } }
+    if (typeof data.errors === 'object' && data.errors !== null && !('message' in data.errors)) {
+        const errorValues = Object.values(data.errors);
+        if (errorValues.length > 0) {
+            const firstError = errorValues[0];
+            if (typeof firstError === 'string') return firstError; // Handle direct string errors
+            if (Array.isArray(firstError) && firstError[0]) return String(firstError[0]);
+            if (typeof firstError === 'object') {
+                const maybeMsg = (firstError as { msg?: string; message?: string }).msg ?? (firstError as { message?: string }).message;
+                if (maybeMsg) return maybeMsg;
+            }
+        }
+    }
+
+    // 2. Simple errors object: { "errors": { "message": "..." } }
+    if (typeof data.errors === 'object' && data.errors !== null && (data.errors as { message: string }).message) {
+        return (data.errors as { message: string }).message;
+    }
+
+    // 3. String inside errors: { "errors": "..." }
+    if (typeof data.errors === 'string') {
+        return data.errors;
+    }
+
+    // 4. Top-level message: { "message": "..." }
+    if (data.message) {
+        return data.message;
+    }
+
+    return null;
+};
+
 /**
  * Extracts the most specific error message from an API error response.
  * It gracefully handles various error formats from the backend.
@@ -22,44 +63,22 @@ export const getApiErrorMessage = (error: unknown): string => {
         }
 
         if (error.response?.data) {
-        const data = error.response.data as ApiErrorResponse;
-
-        // 1. Nested validation errors: { "errors": { "field": { "msg": "..." } } } OR { "errors": { "field": "..." } }
-        if (typeof data.errors === 'object' && data.errors !== null && !('message' in data.errors)) {
-            const errorValues = Object.values(data.errors);
-            if (errorValues.length > 0) {
-                const firstError = errorValues[0];
-                if (typeof firstError === 'string') return firstError; // Handle direct string errors
-                if (Array.isArray(firstError) && firstError[0]) return String(firstError[0]);
-                if (typeof firstError === 'object') {
-                    const maybeMsg = (firstError as { msg?: string; message?: string }).msg ?? (firstError as { message?: string }).message;
-                    if (maybeMsg) return maybeMsg;
-                }
-            }
-        }
-
-        // 2. Simple errors object: { "errors": { "message": "..." } }
-        if (typeof data.errors === 'object' && data.errors !== null && (data.errors as { message: string }).message) {
-            return (data.errors as { message: string }).message;
-        }
-
-        // 3. String inside errors: { "errors": "..." }
-        if (typeof data.errors === 'string') {
-            return data.errors;
-        }
-
-        // 4. Top-level message: { "message": "..." }
-        if (data.message) {
-            return data.message;
+            const message = getMessageFromApiData(error.response.data as ApiErrorResponse | string);
+            if (message) return message;
         }
     }
+
+    // 5. Fetch/custom errors with preserved backend payload: Object.assign(new Error(...), { data })
+    if (error instanceof Error && 'data' in error) {
+        const message = getMessageFromApiData((error as ErrorWithData).data ?? {});
+        if (message) return message;
     }
 
-    // 5. Fallback to standard Error message
+    // 6. Fallback to standard Error message
     if (error instanceof Error) {
         return error.message;
     }
 
-    // 6. Generic fallback
+    // 7. Generic fallback
     return 'An unexpected error occurred. Please try again.';
 };

--- a/src/vertex/lib/logger.ts
+++ b/src/vertex/lib/logger.ts
@@ -6,6 +6,10 @@ const isProduction = process.env.NODE_ENV === 'production';
 log.setLevel(isProduction ? 'silent' : 'debug');
 
 const shouldLogToSlack = () => {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
   const env = process.env.NEXT_PUBLIC_ALLOW_DEV_TOOLS || process.env.NODE_ENV;
   return env === 'production' || env === 'staging';
 };

--- a/src/vertex/middleware.ts
+++ b/src/vertex/middleware.ts
@@ -8,7 +8,7 @@ export default async function middleware(req: NextRequest) {
 
   const token = await getToken({
     req,
-    secret: process.env.NEXTAUTH_SECRET,
+    secret: process.env.NEXTAUTH_SECRET || process.env.AUTH_SECRET,
   });
 
   if (!token) {

--- a/src/vertex/middleware.ts
+++ b/src/vertex/middleware.ts
@@ -1,11 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { getToken } from "next-auth/jwt";
 
-const isProduction = process.env.NODE_ENV === "production";
-const sessionCookieName = isProduction
-  ? "__Secure-next-auth.session-token"
-  : "vertex.next-auth.session-token";
-
 export default async function middleware(req: NextRequest) {
   if (req.nextUrl.pathname === "/") {
     return NextResponse.redirect(new URL("/home", req.url));
@@ -14,7 +9,6 @@ export default async function middleware(req: NextRequest) {
   const token = await getToken({
     req,
     secret: process.env.NEXTAUTH_SECRET,
-    cookieName: sessionCookieName,
   });
 
   if (!token) {

--- a/src/vertex/package.json
+++ b/src/vertex/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "dev:inspect": "cross-env NODE_OPTIONS='--inspect' next dev",
     "build": "next build",
-    "start": "next start",
+    "start": "node start-next.js",
     "lint": "next lint",
     "format": "prettier --write .",
     "format:check": "prettier --check .",

--- a/src/vertex/start-next.js
+++ b/src/vertex/start-next.js
@@ -1,0 +1,41 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+const { spawnSync } = require('node:child_process');
+
+const blankToUnset = key => {
+  if (typeof process.env[key] === 'string' && process.env[key].trim() === '') {
+    delete process.env[key];
+  }
+};
+
+blankToUnset('NEXTAUTH_URL');
+blankToUnset('NEXTAUTH_URL_INTERNAL');
+blankToUnset('AUTH_URL');
+
+const appName = process.env.CONTAINER_APP_NAME;
+const dnsSuffix = process.env.CONTAINER_APP_ENV_DNS_SUFFIX;
+
+if (!process.env.NEXTAUTH_URL && appName && dnsSuffix) {
+  process.env.NEXTAUTH_URL = `https://${appName}.${dnsSuffix}`;
+}
+
+if (!process.env.NEXTAUTH_URL_INTERNAL && process.env.NEXTAUTH_URL) {
+  process.env.NEXTAUTH_URL_INTERNAL = process.env.NEXTAUTH_URL;
+}
+
+if (appName?.endsWith('-vertex-preview')) {
+  process.env.AUTH_TRUST_HOST = process.env.AUTH_TRUST_HOST || 'true';
+}
+
+console.log('[startup] NextAuth runtime env:', {
+  hasNextAuthUrl: Boolean(process.env.NEXTAUTH_URL),
+  hasNextAuthUrlInternal: Boolean(process.env.NEXTAUTH_URL_INTERNAL),
+  hasNextAuthSecret: Boolean(process.env.NEXTAUTH_SECRET || process.env.AUTH_SECRET),
+  authTrustHost: process.env.AUTH_TRUST_HOST,
+});
+
+const result = spawnSync(process.execPath, ['./node_modules/next/dist/bin/next', 'start'], {
+  stdio: 'inherit',
+  env: process.env,
+});
+
+process.exit(result.status ?? 1);


### PR DESCRIPTION
### Summary
Fixes a critical bug where submitting a network creation request in the staging environment
produced a 404 due to `NEXT_PUBLIC_API_URL` being `undefined`, generating the malformed URL
`/devices/undefineddevices/network-creation-requests`. Also aligns route handler error handling
with the service layer's actual error shape and guards against `undefined` in auto-filled user name.

---

### Changes

#### 🐛 Bug Fixes

- **`core/apis/networks.ts`** — Removed raw `axios` call that relied on `NEXT_PUBLIC_API_URL`.
  Replaced with a plain `fetch` to the relative Next.js API route `/api/devices/network-creation-requests`,
  eliminating the env-var dependency from the client entirely.

- **`app/api/devices/network-creation-requests/route.ts`** — Added a `POST` handler that proxies
  the submission to the backend via `networkService`. Auth is intentionally skipped — this is a
  public endpoint. URL construction now happens server-side via `getApiBaseUrl()`, which always
  resolves correctly in server context.

- **`core/services/network-service.ts`** — Added `submitNetworkRequest` method using native `fetch`
  with no auth headers, matching the public nature of the backend endpoint.

- **`app/api/devices/network-creation-requests/route.ts`** (GET handler) — Fixed error shape mismatch:
  route handler was reading `err.response?.data` / `err.response?.status`, but the service layer
  throws errors with `err.data` / `err.status` directly. Errors were always falling back to 500.

- **`app/api/devices/network-creation-requests/[id]/[action]/route.ts`** — Same error shape fix;
  updated to also surface `err.data` payload in error responses for consistency.

- **`components/features/networks/network-request-dialog.tsx`** — Fixed `requester_name` pre-fill
  that could produce the string `"undefined undefined"` when `firstName` or `lastName` is missing.
  Replaced template literal with a `.filter().join()` approach.

#### ♻️ Refactors

- **`components/features/networks/network-request-dialog.tsx`** — Inlined `useMutation` directly
  in the dialog component. Removed the intermediate `useSubmitNetworkRequest` hook and the
  `submitNetworkRequestApi` client API method — the submission logic is simple enough to live
  where it's used.

- **`core/hooks/useNetworks.ts`** — Removed `useSubmitNetworkRequest`, `useMutation`,
  `useQueryClient`, and related imports now that the mutation is colocated with the dialog.

---

### Root Cause
`NEXT_PUBLIC_API_URL` is not injected at build time in the staging environment.
Client-side code constructing backend URLs from this variable silently produced `undefined`
prefixed paths. The fix removes this dependency from the client entirely — the Next.js route
handler owns backend URL resolution server-side.

---

### Testing
- [ ] Network request dialog submits successfully in staging
- [ ] Error responses from the backend are correctly surfaced (correct status code + message)
- [ ] Pre-filled requester name renders correctly when only one name part is available
- [ ] No regression on the admin requests list (GET `/api/devices/network-creation-requests`)
- [ ] No regression on approve/deny actions (PUT `/api/devices/network-creation-requests/[id]/[action]`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public network request submission endpoint and updated in-app submission flow for more reliable POSTs.

* **Bug Fixes**
  * Resolved staging 404s by routing submissions through the public API.
  * Improved backend error message propagation and added a 10s request timeout.
  * Skip Slack notifications when webhook is unset.
  * Fixed requester-name prefill and hardened auth URL/session behavior for previews.

* **Documentation**
  * Added changelog entry for Version 1.23.33.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->