### PR TITLE
Improve language selection UX: auto-navigate back and pre-translate settings screen

### DIFF
--- a/src/mobile/lib/src/app/profile/pages/languages/select_language_page.dart
+++ b/src/mobile/lib/src/app/profile/pages/languages/select_language_page.dart
@@ -45,17 +45,22 @@ class _SelectLanguagePageState extends State<SelectLanguagePage> {
     final needsMlKitDownload =
         MlKitTranslationService().supportsTranslation(language.code) &&
             !MlKitTranslationService().isModelReady(language.code);
+    final needsMlKitStrings =
+        MlKitTranslationService().supportsTranslation(language.code) &&
+            !MlKitTranslationService().isPrepared(language.code);
     final needsSunbirdPrepare =
         SunbirdTranslationService().supportsTranslation(language.code) &&
             !SunbirdTranslationService().isPrepared(language.code);
-    final needsPrepare = needsMlKitDownload || needsSunbirdPrepare;
+    final needsPrepare = needsMlKitDownload || needsMlKitStrings || needsSunbirdPrepare;
 
     // Capture context-dependent references before any await.
     final bloc = context.read<LanguageBloc>();
     final messenger = ScaffoldMessenger.of(context);
+    final navigator = Navigator.of(context);
 
     if (!needsPrepare) {
       bloc.add(ChangeLanguage(language.code));
+      navigator.pop();
       _showLanguageChangeNotification(messenger, language);
       return;
     }
@@ -65,6 +70,13 @@ class _SelectLanguagePageState extends State<SelectLanguagePage> {
       if (needsMlKitDownload) {
         await MlKitTranslationService()
             .prepareModel(language.code)
+            .timeout(const Duration(seconds: 30));
+        await MlKitTranslationService()
+            .prepareCriticalStrings(language.code)
+            .timeout(const Duration(seconds: 30));
+      } else if (needsMlKitStrings) {
+        await MlKitTranslationService()
+            .prepareCriticalStrings(language.code)
             .timeout(const Duration(seconds: 30));
       }
       if (needsSunbirdPrepare) {
@@ -96,6 +108,7 @@ class _SelectLanguagePageState extends State<SelectLanguagePage> {
     if (!mounted) return;
     setState(() => _preparingCode = null);
     bloc.add(ChangeLanguage(language.code));
+    navigator.pop();
     _showLanguageChangeNotification(messenger, language);
   }
 

--- a/src/mobile/lib/src/app/shared/services/mlkit_translation_service.dart
+++ b/src/mobile/lib/src/app/shared/services/mlkit_translation_service.dart
@@ -39,11 +39,41 @@ class MlKitTranslationService with UiLoggy {
     }
   }
 
+  static const List<String> _criticalUiStrings = [
+    'Home', 'Search', 'Exposure', 'Learn',
+    'Near You', 'Favorites', "Today's Air Quality", 'Settings',
+    'Good', 'Moderate', 'Unhealthy for Sensitive Groups',
+    'Unhealthy', 'Very Unhealthy', 'Hazardous', 'Unknown',
+    'Location', 'Languages', 'Log out', 'Log Out', 'Delete Account',
+  ];
+
   bool supportsTranslation(String localeCode) =>
       _localeToMlKit.containsKey(localeCode);
 
   bool isModelReady(String localeCode) =>
       _downloadedModels.contains(localeCode);
+
+  void _hydrateCritical(String localeCode) {
+    for (final s in _criticalUiStrings) {
+      final key = '$localeCode:$s';
+      if (!_cache.containsKey(key)) _loadFromDisk(key);
+    }
+  }
+
+  bool isPrepared(String localeCode) {
+    if (!supportsTranslation(localeCode) || !isModelReady(localeCode)) return false;
+    _hydrateCritical(localeCode);
+    return _criticalUiStrings.every((s) => _cache.containsKey('$localeCode:$s'));
+  }
+
+  Future<void> prepareCriticalStrings(String localeCode) async {
+    if (!supportsTranslation(localeCode)) return;
+    _hydrateCritical(localeCode);
+    if (_criticalUiStrings.every((s) => _cache.containsKey('$localeCode:$s'))) return;
+    await Future.wait(
+      _criticalUiStrings.map((s) => translate(s, targetLocale: localeCode)),
+    );
+  }
 
   /// Downloads the translation model for [localeCode] if not already present.
   /// Safe to call multiple times — returns immediately if already downloaded.

--- a/src/mobile/lib/src/app/shared/services/sunbird_translation_service.dart
+++ b/src/mobile/lib/src/app/shared/services/sunbird_translation_service.dart
@@ -383,6 +383,7 @@ class SunbirdTranslationService with UiLoggy {
     'Location Permission Required',
     'Location Services Disabled',
     'Location permission was denied. Please try again.',
+    'Location', 'Languages', 'Log out', 'Log Out', 'Delete Account',
   ];
 
   // MAINTENANCE: matched by exact string value as cache keys — update here if any UI string changes.
@@ -391,6 +392,8 @@ class SunbirdTranslationService with UiLoggy {
     'Near You', 'Favorites', "Today's Air Quality", 'Settings',
     'Good', 'Moderate', 'Unhealthy for Sensitive Groups',
     'Unhealthy', 'Very Unhealthy', 'Hazardous', 'Unknown',
+    // Settings screen
+    'Location', 'Languages', 'Log out', 'Log Out', 'Delete Account',
   ];
 
   Future<void> prepare({required String targetLocale}) async {


### PR DESCRIPTION


- Expand critical UI strings to include settings screen text (Location, Languages, Log out, Delete Account) for both Sunbird and ML Kit services
- Add isPrepared() and prepareCriticalStrings() to MlKitTranslationService so Swahili/French get the same pre-translation treatment as Luganda
- Auto-pop back to Settings after language selection so users land on an already-translated page instead of staying on the language list
