### PR TITLE
Fix enableCoreLibraryDesugaring incompatibility with AGP 8.7.0

### DIFF
--- a/src/mobile/android/app/build.gradle
+++ b/src/mobile/android/app/build.gradle
@@ -82,8 +82,7 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_9
         targetCompatibility JavaVersion.VERSION_1_9
-        // Enable Java desugaring to support newer Java APIs on older Android versions
-        enableCoreLibraryDesugaring true
+        isCoreLibraryDesugaringEnabled = true
     }
 
     kotlinOptions {


### PR DESCRIPTION
Replace deprecated enableCoreLibraryDesugaring true with isCoreLibraryDesugaringEnabled = true in compileOptions, which is required by AGP 8.7.0+.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Android build configuration for improved compatibility with the current build system toolchain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->