### PR TITLE
Vertex: Remove manual session token expiry check

### DIFF
--- a/src/vertex/app/api/auth/[...nextauth]/options.ts
+++ b/src/vertex/app/api/auth/[...nextauth]/options.ts
@@ -212,8 +212,6 @@ export const options: NextAuthOptions = {
     },
 
     async session({ session, token }) {
-      // Let NextAuth JWT manage session expiration via maxAge
-      // Don't check backend token.exp as it can cause premature session invalidation
       if (token) {
         session.user = {
           ...session.user,

--- a/src/vertex/app/api/auth/[...nextauth]/options.ts
+++ b/src/vertex/app/api/auth/[...nextauth]/options.ts
@@ -212,15 +212,8 @@ export const options: NextAuthOptions = {
     },
 
     async session({ session, token }) {
-      // Check if token is expired
-      if (token.exp) {
-        const expirationTime = (token.exp as number) * 1000;
-        if (Date.now() >= expirationTime) {
-          // Token expired, invalidate session
-          return { ...session, user: null };
-        }
-      }
-
+      // Let NextAuth JWT manage session expiration via maxAge
+      // Don't check backend token.exp as it can cause premature session invalidation
       if (token) {
         session.user = {
           ...session.user,


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

- Stop checking token.exp in the NextAuth session callback and rely on NextAuth/JWT maxAge to manage session expiration. Removing the backend token.exp check prevents premature session invalidation and simplifies the session callback to just populate session.user when a token exists.

#### Status of maturity (all need to be checked before merging):

- [ ] I've tested this locally
- [ ] I consider this code done
- [ ] This change ready to hit production in its current state
- [ ] The title of the PR states what changed and the related issues number (used for the release note).
- [ ] I've included issue number in the "Closes #ISSUE-NUMBER" part of the "[What are the relevant tickets?](#what-are-the-relevant-tickets)" section to [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [ ] I've updated corresponding documentation for the changes in this PR.
- [ ] I have written unit and/or e2e tests for my change(s).

#### How should this be manually tested?

- Please include the steps to be done inorder to setup and test this PR.

#### What are the relevant tickets?

- Closes #<enter issue number here>
- [Jira_card_number]() (If exists)

#### Screenshots (optional)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session handling by removing token expiration validation that was causing premature session invalidation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->