### PR TITLE
Vertex: Granular Cohort Visibility and Centralized Sites Management

### DIFF
--- a/src/vertex/app/(authenticated)/sites/[id]/page.tsx
+++ b/src/vertex/app/(authenticated)/sites/[id]/page.tsx
@@ -36,18 +36,6 @@ export default function UserSiteDetailsPage() {
     null
   );
 
-  if (error) {
-    return (
-      <div className="flex items-center justify-center min-h-screen p-4">
-        <Alert variant="destructive" className="max-w-md">
-          <ExclamationTriangleIcon className="h-4 w-4" />
-          <AlertTitle>Error</AlertTitle>
-          <AlertDescription>{error.message}</AlertDescription>
-        </Alert>
-      </div>
-    );
-  }
-
   return (
     <RouteGuard permission={PERMISSIONS.SITE.VIEW}>
       <div>
@@ -72,7 +60,17 @@ export default function UserSiteDetailsPage() {
           </ReusableButton>
         </div>
 
-        {isLoading ? (
+        {error ? (
+          <div className="flex items-center justify-center min-h-[50vh] p-4">
+            <Alert variant="destructive" className="max-w-md">
+              <ExclamationTriangleIcon className="h-4 w-4" />
+              <AlertTitle>Error</AlertTitle>
+              <AlertDescription>
+                Unable to load site details. Please try again.
+              </AlertDescription>
+            </Alert>
+          </div>
+        ) : isLoading ? (
           <ContentGridSkeleton />
         ) : !site ? (
           <div className="mt-8 text-center text-sm text-muted-foreground">

--- a/src/vertex/app/(authenticated)/sites/[id]/page.tsx
+++ b/src/vertex/app/(authenticated)/sites/[id]/page.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { AqArrowLeft } from "@airqo/icons-react";
+import ReusableButton from "@/components/shared/button/ReusableButton";
+import { useSiteDetails, useRefreshSiteMetadata } from "@/core/hooks/useSites";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { ExclamationTriangleIcon } from "@radix-ui/react-icons";
+import { useParams } from "next/navigation";
+import { RefreshCw } from "lucide-react";
+import { SiteInformationCard } from "@/components/features/sites/site-information-card";
+import { SiteMobileAppCard } from "@/components/features/sites/site-mobile-app-card";
+import { EditSiteDetailsDialog } from "@/components/features/sites/edit-site-details-dialog";
+import ClientPaginatedDevicesTable from "@/components/features/devices/client-paginated-devices-table";
+import SiteMeasurementsApiCard from "@/components/features/sites/site-measurements-api-card";
+import SiteActivityCard from "@/components/features/sites/site-activity-card";
+import { RouteGuard } from "@/components/layout/accessConfig/route-guard";
+import { PERMISSIONS } from "@/core/permissions/constants";
+
+const ContentGridSkeleton = () => (
+  <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mt-6 items-start">
+    {[...Array(4)].map((_, i) => (
+      <div key={i} className="h-48 bg-gray-200 rounded-lg animate-pulse" />
+    ))}
+  </div>
+);
+
+export default function UserSiteDetailsPage() {
+  const params = useParams();
+  const siteId = params.id as string;
+  const { data: site, isLoading, error } = useSiteDetails(siteId);
+  const { mutate: refreshMetadata, isPending: isRefreshing } = useRefreshSiteMetadata();
+  const router = useRouter();
+  const [editSection, setEditSection] = useState<"general" | "mobile" | null>(
+    null
+  );
+
+  if (error) {
+    return (
+      <div className="flex items-center justify-center min-h-screen p-4">
+        <Alert variant="destructive" className="max-w-md">
+          <ExclamationTriangleIcon className="h-4 w-4" />
+          <AlertTitle>Error</AlertTitle>
+          <AlertDescription>{error.message}</AlertDescription>
+        </Alert>
+      </div>
+    );
+  }
+
+  return (
+    <RouteGuard permission={PERMISSIONS.SITE.VIEW}>
+      <div>
+        <div className="mb-6 flex justify-between items-center">
+          <ReusableButton
+            variant="text"
+            onClick={() => router.back()}
+            Icon={AqArrowLeft}
+          >
+            Back
+          </ReusableButton>
+
+          <ReusableButton
+            variant="outlined"
+            onClick={() => refreshMetadata(siteId)}
+            disabled={isRefreshing || isLoading || !site}
+            loading={isRefreshing}
+            Icon={RefreshCw}
+            className="text-xs font-medium"
+          >
+            Refresh Metadata
+          </ReusableButton>
+        </div>
+
+        {isLoading ? (
+          <ContentGridSkeleton />
+        ) : !site ? (
+          <div className="mt-8 text-center text-sm text-muted-foreground">
+            Site not found.
+          </div>
+        ) : (
+          <>
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mt-6">
+              <div className="flex flex-col gap-6">
+                <SiteInformationCard
+                  site={site}
+                  onEdit={() => setEditSection("general")}
+                />
+              </div>
+
+              <div className="flex flex-col gap-6">
+                <SiteMobileAppCard
+                  site={site}
+                  onEdit={() => setEditSection("mobile")}
+                />
+                <SiteMeasurementsApiCard siteId={siteId} />
+              </div>
+
+              <div className="flex flex-col gap-6">
+                <SiteActivityCard siteId={siteId} />
+              </div>
+            </div>
+            <div className="mt-6">
+              <ClientPaginatedDevicesTable
+                devices={site.devices || []}
+                isLoading={isLoading}
+                error={error}
+                hiddenColumns={["site", "groups"]}
+                onDeviceClick={(device) => {
+                  router.push(`/devices/overview/${device._id}`);
+                }}
+              />
+            </div>
+            <EditSiteDetailsDialog
+              open={!!editSection}
+              onOpenChange={(open) => !open && setEditSection(null)}
+              site={site}
+              section={editSection || "general"}
+            />
+          </>
+        )}
+      </div>
+    </RouteGuard>
+  );
+}

--- a/src/vertex/app/(authenticated)/sites/overview/page.tsx
+++ b/src/vertex/app/(authenticated)/sites/overview/page.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { RouteGuard } from "@/components/layout/accessConfig/route-guard";
+import SitesTable from "@/components/features/sites/sites-list-table";
+import { PERMISSIONS } from "@/core/permissions/constants";
+
+export default function SitesOverviewPage() {
+  return (
+    <RouteGuard permission={PERMISSIONS.SITE.VIEW}>
+      <div>
+        <div className="mb-3">
+          <div>
+            <h1 className="text-2xl font-semibold">Sites</h1>
+            <p className="text-sm text-muted-foreground">
+              Manage and organize your monitoring sites
+            </p>
+          </div>
+
+        </div>
+
+        <div className="flex flex-col gap-6">
+          <SitesTable basePath="/sites" />
+        </div>
+      </div>
+    </RouteGuard>
+  );
+}

--- a/src/vertex/app/changelog.md
+++ b/src/vertex/app/changelog.md
@@ -26,6 +26,8 @@ Introduced a centralized Sites management module for standard users and organiza
 
 - **Reusable Management Components**: Refactored `SitesTable` and `CreateSiteForm` to support customizable base paths, enabling seamless reuse across administrative and organizational modules.
 - **Unified Site ID Resolution**: Standardized site identification to use nested site objects instead of flat ID fields, ensuring robust navigation and data consistency.
+- **Site ID Copy Feature**: Added a convenient copy-to-clipboard button for Site IDs in the site information card to match the Cohort management experience.
+- **Sidebar Clarity**: Renamed "Assets" to "Devices" in the organization view to provide a clear distinction from the new "Sites" management section.
 
 </details>
 

--- a/src/vertex/app/changelog.md
+++ b/src/vertex/app/changelog.md
@@ -4,6 +4,39 @@
 
 ---
 
+## Version 1.23.34
+**Released:** May 03, 2026
+
+### Granular Network Visibility & Cohort Privacy Management
+
+Introduced individual visibility controls for organization cohorts, allowing for granular privacy management. The update includes a redesigned visibility dashboard with support for mixed visibility states and guarded confirmation workflows.
+
+<details>
+<summary><strong>Privacy & Visibility (4)</strong></summary>
+
+- **Individual Cohort Toggles**: Replaced the global organization visibility toggle with per-cohort switches, enabling fine-grained control over which device groups are public or private.
+- **Custom Visibility Dashboard**: Introduced a "Custom Visibility Settings" state and description for organizations with mixed public/private cohorts, ensuring clear status communication.
+- **Dynamic Status Indicators**: Added `Globe` (All Public), `Lock` (All Private), and `Shield` (Custom/Mixed) status icons with corresponding descriptions to provide clear context of the organization's privacy stance.
+- **Guarded Visibility Updates**: Every visibility change is now protected by a confirmation dialog that identifies the specific cohort by name and explains the impact of the change.
+
+</details>
+
+<details>
+<summary><strong>UI/UX Improvements (1)</strong></summary>
+
+- **Enhanced Cohort List**: Refined the cohort list layout with status indicators, responsive grid support, and hover effects for better scannability and interaction.
+
+</details>
+
+<details>
+<summary><strong>Files Modified (1)</strong></summary>
+
+- `components/features/home/network-visibility-card.tsx`
+
+</details>
+
+---
+
 ## Version 1.23.33
 **Released:** April 29, 2026
 

--- a/src/vertex/app/changelog.md
+++ b/src/vertex/app/changelog.md
@@ -4,6 +4,48 @@
 
 ---
 
+## Version 1.23.35
+**Released:** May 03, 2026
+
+### Sites Management Overview & Contextual Navigation
+
+Introduced a centralized Sites management module for standard users and organizations, bridging the gap between admin-only site management and organizational asset visibility.
+
+<details>
+<summary><strong>New Features (4)</strong></summary>
+
+- **Sites Overview Page**: Created a new management dashboard (`/sites/overview`) featuring site statistics, searchable tables, and site creation workflows tailored for standard user contexts.
+- **Contextual Site Details**: Implemented a user-facing site details page (`/sites/[id]`) that mirrors the rich administrative interface, allowing users to view metadata, app settings, and telemetry for their specific sites.
+- **Granular Scoped Fetching**: Enhanced the sites data hook to automatically resolve cohort-based visibility, ensuring users only manage sites they own or have access to in their active context.
+- **Dynamic Site Redirection**: Added contextual routing logic to device location cards that intelligently navigates to either the Admin or User sites view based on the current browsing context.
+
+</details>
+
+<details>
+<summary><strong>Core Improvements (2)</strong></summary>
+
+- **Reusable Management Components**: Refactored `SitesTable` and `CreateSiteForm` to support customizable base paths, enabling seamless reuse across administrative and organizational modules.
+- **Unified Site ID Resolution**: Standardized site identification to use nested site objects instead of flat ID fields, ensuring robust navigation and data consistency.
+
+</details>
+
+<details>
+<summary><strong>Files Modified (9)</strong></summary>
+
+- `app/(authenticated)/sites/overview/page.tsx`
+- `app/(authenticated)/sites/[id]/page.tsx`
+- `core/hooks/useSites.ts`
+- `components/features/sites/sites-list-table.tsx`
+- `components/features/sites/create-site-form.tsx`
+- `components/features/devices/device-location-card.tsx`
+- `core/hooks/useUserContext.ts`
+- `components/layout/secondary-sidebar.tsx`
+- `core/routes.ts`
+
+</details>
+
+---
+
 ## Version 1.23.34
 **Released:** May 03, 2026
 

--- a/src/vertex/components/features/devices/device-location-card.tsx
+++ b/src/vertex/components/features/devices/device-location-card.tsx
@@ -1,5 +1,5 @@
 import { Card } from "@/components/ui/card";
-import { useRouter } from "next/navigation";
+import { useRouter, usePathname } from "next/navigation";
 import { Device, DeviceSite } from "@/app/types/devices";
 import ReusableButton from "@/components/shared/button/ReusableButton";
 
@@ -9,6 +9,8 @@ interface DeviceLocationCardProps {
 
 export function DeviceLocationCard({ device }: DeviceLocationCardProps) {
   const router = useRouter();
+  const pathname = usePathname();
+  const isAdminMode = pathname.startsWith("/admin");
 
   const toNumberOrNull = (v: unknown) => {
     if (v === null || v === undefined || v === '') return null;
@@ -19,9 +21,14 @@ export function DeviceLocationCard({ device }: DeviceLocationCardProps) {
   const lat = toNumberOrNull(device.latitude);
   const lon = toNumberOrNull(device.longitude);
 
+  const siteId = Array.isArray(device.site)
+    ? device.site[0]?._id
+    : (device.site as { _id: string })?._id;
+
   const handleEditLocation = () => {
-    if (device.site_id) {
-      router.push(`/admin/sites/${device.site_id}`);
+    if (siteId) {
+      const basePath = isAdminMode ? "/admin/sites" : "/sites";
+      router.push(`${basePath}/${siteId}`);
     }
   };
 
@@ -71,7 +78,7 @@ export function DeviceLocationCard({ device }: DeviceLocationCardProps) {
         </div>
       </div>
 
-      {device.site_id && (
+      {siteId && (
         <div className="border-t px-2 flex justify-end">
           <ReusableButton
             variant="text"

--- a/src/vertex/components/features/home/network-visibility-card.tsx
+++ b/src/vertex/components/features/home/network-visibility-card.tsx
@@ -130,7 +130,12 @@ const NetworkVisibilityCard = () => {
                                         "w-2 h-2 rounded-full transition-all duration-300",
                                         cohort.visibility ? "bg-green-500 shadow-[0_0_8px_rgba(34,197,94,0.4)]" : "bg-gray-300"
                                     )} />
-                                    <span className="text-sm font-medium text-gray-700 dark:text-gray-200 group-hover:text-gray-900 dark:group-hover:text-white transition-colors">{cohort.name}</span>
+                                    <span
+                                        id={`cohort-visibility-${cohort._id}`}
+                                        className="text-sm font-medium text-gray-700 dark:text-gray-200 group-hover:text-gray-900 dark:group-hover:text-white transition-colors"
+                                    >
+                                        {cohort.name}
+                                    </span>
                                 </div>
                                 <div className="flex items-center gap-3">
                                     <span className={cn(
@@ -140,6 +145,7 @@ const NetworkVisibilityCard = () => {
                                         {cohort.visibility ? 'Public' : 'Private'}
                                     </span>
                                     <Switch
+                                        aria-labelledby={`cohort-visibility-${cohort._id}`}
                                         checked={cohort.visibility}
                                         onCheckedChange={(checked) => {
                                             setPendingCohort(cohort);

--- a/src/vertex/components/features/home/network-visibility-card.tsx
+++ b/src/vertex/components/features/home/network-visibility-card.tsx
@@ -58,7 +58,6 @@ const NetworkVisibilityCard = () => {
 
     const allPublic = cohorts.length > 0 && cohorts.every((c) => c.visibility === true);
     const allPrivate = cohorts.length > 0 && cohorts.every((c) => c.visibility === false);
-    const isMixed = !allPublic && !allPrivate;
 
     const handleRunningUpdate = async () => {
         if (!pendingCohort) return;

--- a/src/vertex/components/features/home/network-visibility-card.tsx
+++ b/src/vertex/components/features/home/network-visibility-card.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Globe, Lock } from 'lucide-react';
+import { Globe, Lock, Shield } from 'lucide-react';
 import { Switch } from '@/components/ui/switch';
 import { useCohorts, useGroupCohorts } from '@/core/hooks/useCohorts';
 import { cohorts as cohortsApi } from '@/core/apis/cohorts';
@@ -18,6 +18,7 @@ const NetworkVisibilityCard = () => {
     const router = useRouter();
     const [isDialogOpen, setIsDialogOpen] = useState(false);
     const [targetVisibility, setTargetVisibility] = useState<boolean>(false);
+    const [pendingCohort, setPendingCohort] = useState<any>(null);
     const [isUpdating, setIsUpdating] = useState(false);
 
     const { activeGroup, isExternalOrg } = useUserContext();
@@ -54,41 +55,19 @@ const NetworkVisibilityCard = () => {
         return null; // Don't show card if no cohorts to manage
     }
 
-    // Determine current implied global state.
-    // Default to: if all are public -> ON (Public). Else -> OFF (Private).
     const allPublic = cohorts.length > 0 && cohorts.every((c) => c.visibility === true);
-
-    // Local state for the switch
-    const isChecked = allPublic;
-
-    const handleToggle = (checked: boolean) => {
-        setTargetVisibility(checked);
-        setIsDialogOpen(true);
-    };
+    const allPrivate = cohorts.length > 0 && cohorts.every((c) => c.visibility === false);
+    const isMixed = !allPublic && !allPrivate;
 
     const handleRunningUpdate = async () => {
+        if (!pendingCohort) return;
+        
         setIsUpdating(true);
         try {
-            const cohortsToUpdate = cohorts.filter(c => c.visibility !== targetVisibility);
-
-            if (cohortsToUpdate.length === 0) {
-                ReusableToast({
-                    message: `All cohorts are already ${targetVisibility ? 'Public' : 'Private'}`,
-                    type: 'INFO',
-                });
-                setIsDialogOpen(false);
-                setIsUpdating(false);
-                return;
-            }
-
-            await Promise.all(
-                cohortsToUpdate.map((cohort) =>
-                    cohortsApi.updateCohortDetailsApi(cohort._id, { visibility: targetVisibility })
-                )
-            );
+            await cohortsApi.updateCohortDetailsApi(pendingCohort._id, { visibility: targetVisibility });
 
             ReusableToast({
-                message: `Successfully set ${cohortsToUpdate.length} cohorts to ${targetVisibility ? 'Public' : 'Private'}`,
+                message: `Successfully set ${pendingCohort.name} to ${targetVisibility ? 'Public' : 'Private'}`,
                 type: 'SUCCESS',
             });
 
@@ -103,6 +82,7 @@ const NetworkVisibilityCard = () => {
         } finally {
             setIsUpdating(false);
             setIsDialogOpen(false);
+            setPendingCohort(null);
         }
     };
 
@@ -110,59 +90,77 @@ const NetworkVisibilityCard = () => {
         return null;
     }
 
-    // UI States
-    const isPrivate = !isChecked; // State A
-
     return (
         <>
             <div className="pt-2">
                 <div className="flex flex-col md:flex-row gap-6 justify-between items-start md:items-center">
                     <div className="flex gap-4">
                         <div className={cn(
-                            "w-12 h-12 rounded-full flex items-center justify-center shrink-0",
-                            isPrivate ? "bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-400" : "bg-green-100 text-green-600 dark:bg-green-900/30 dark:text-green-400"
+                            "w-12 h-12 rounded-full flex items-center justify-center shrink-0 transition-colors duration-300",
+                            allPublic ? "bg-green-100 text-green-600 dark:bg-green-900/30 dark:text-green-400" : 
+                            allPrivate ? "bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-400" :
+                            "bg-amber-100 text-amber-600 dark:bg-amber-900/30 dark:text-amber-400"
                         )}>
-                            {isPrivate ? <Lock className="w-6 h-6" /> : <Globe className="w-6 h-6" />}
+                            {allPublic ? <Globe className="w-6 h-6" /> : 
+                             allPrivate ? <Lock className="w-6 h-6" /> : 
+                             <Shield className="w-6 h-6" />}
                         </div>
                         <div>
-                            <h3 className="text-base font-semibold text-gray-900 dark:text-gray-100">
-                                {isPrivate ? "Your devices are Private" : "Your devices are Public"}
+                            <h3 className="text-base font-semibold text-gray-900 dark:text-gray-100 transition-all">
+                                {allPublic ? "Your devices are Public" : 
+                                 allPrivate ? "Your devices are Private" : 
+                                 "Mixed Device Visibility"}
                             </h3>
                             <p className="text-sm text-gray-500 dark:text-gray-400 mt-1 max-w-xl">
-                                {isPrivate
-                                    ? "Your devices are hidden from the public. Data is visible only in your account."
-                                    : "Your devices are visible to anyone on the AirQo Map. You are contributing to open data."
-                                }
+                                {allPublic ? "Your devices are visible to anyone on the AirQo Map. You are contributing to open data." :
+                                 allPrivate ? "Your devices are hidden from the public. Data is visible only in your account." :
+                                 "Some of your cohorts are public while others are private. Manage each cohort below."}
                             </p>
                         </div>
                     </div>
+                </div>
 
-                    <div className="flex items-center gap-2 shrink-0">
-                        <span className={cn(
-                            "text-sm font-medium",
-                            isPrivate ? "text-gray-900 dark:text-gray-100" : "text-gray-500 dark:text-gray-400"
-                        )}>
-                            Private
-                        </span>
-                        <Switch
-                            checked={isChecked}
-                            onCheckedChange={handleToggle}
-                            className="data-[state=checked]:bg-green-500"
-                        />
-                        <span className={cn(
-                            "text-sm font-medium",
-                            !isPrivate ? "text-gray-900 dark:text-gray-100" : "text-gray-500 dark:text-gray-400"
-                        )}>
-                            Public
-                        </span>
+                <div className="mt-8 space-y-3">
+                    <h4 className="text-[10px] font-bold text-gray-400 uppercase tracking-[0.1em] mb-3 px-1">Manage Cohorts Visibility</h4>
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                        {cohorts.map((cohort) => (
+                            <div key={cohort._id} className="flex items-center justify-between p-4 rounded-xl border border-gray-100 dark:border-gray-800 bg-gray-50/30 dark:bg-gray-800/20 hover:border-gray-200 dark:hover:border-gray-700 transition-all duration-200 group">
+                                <div className="flex items-center gap-3">
+                                    <div className={cn(
+                                        "w-2 h-2 rounded-full transition-all duration-300",
+                                        cohort.visibility ? "bg-green-500 shadow-[0_0_8px_rgba(34,197,94,0.4)]" : "bg-gray-300"
+                                    )} />
+                                    <span className="text-sm font-medium text-gray-700 dark:text-gray-200 group-hover:text-gray-900 dark:group-hover:text-white transition-colors">{cohort.name}</span>
+                                </div>
+                                <div className="flex items-center gap-3">
+                                    <span className={cn(
+                                        "text-[10px] font-bold uppercase tracking-wider transition-colors",
+                                        cohort.visibility ? "text-green-600 dark:text-green-400" : "text-gray-400"
+                                    )}>
+                                        {cohort.visibility ? 'Public' : 'Private'}
+                                    </span>
+                                    <Switch
+                                        checked={cohort.visibility}
+                                        onCheckedChange={(checked) => {
+                                            setPendingCohort(cohort);
+                                            setTargetVisibility(checked);
+                                            setIsDialogOpen(true);
+                                        }}
+                                        className="data-[state=checked]:bg-green-500"
+                                    />
+                                </div>
+                            </div>
+                        ))}
                     </div>
                 </div>
-                <div className="border-t border-t-gray-200 dark:border-t-gray-600 mt-6 flex justify-start -mx-6 px-6 pt-1">
+
+                <div className="border-t border-t-gray-100 dark:border-t-gray-800 mt-8 flex justify-start -mx-6 px-6 pt-2">
                     <ReusableButton
                         variant="text"
                         onClick={() => router.push('/cohorts')}
+                        className="text-primary hover:bg-primary/5"
                     >
-                        View Cohorts
+                        View All Cohorts Details
                     </ReusableButton>
                 </div>
             </div>
@@ -170,7 +168,7 @@ const NetworkVisibilityCard = () => {
             <ReusableDialog
                 isOpen={isDialogOpen}
                 onClose={() => !isUpdating && setIsDialogOpen(false)}
-                title={targetVisibility ? "Make all devices public?" : "Make all devices private?"}
+                title={targetVisibility ? `Make "${pendingCohort?.name}" public?` : `Make "${pendingCohort?.name}" private?`}
                 size="md"
                 customFooter={
                     <div className="flex items-center justify-end gap-3 w-full px-6 py-4 border-t border-gray-200 dark:border-gray-700">
@@ -195,8 +193,8 @@ const NetworkVisibilityCard = () => {
                 <div className="space-y-4 py-2">
                     <p className="text-gray-600 dark:text-gray-300">
                         {targetVisibility
-                            ? "You are about to make your devices visible on the public AirQo Map. This means anyone can see your air quality readings."
-                            : "You are about to make your devices private. Your data will only be visible to your organization and will not appear on the public map."
+                            ? `You are about to make the devices in "${pendingCohort?.name}" visible on the public AirQo Map. This means anyone can see the air quality readings for these devices.`
+                            : `You are about to make "${pendingCohort?.name}" private. Data from these devices will only be visible to your organization and will not appear on the public map.`
                         }
                     </p>
                 </div>
@@ -206,3 +204,4 @@ const NetworkVisibilityCard = () => {
 };
 
 export default NetworkVisibilityCard;
+

--- a/src/vertex/components/features/home/network-visibility-card.tsx
+++ b/src/vertex/components/features/home/network-visibility-card.tsx
@@ -12,13 +12,14 @@ import { usePermissions } from '@/core/hooks/usePermissions';
 import { cn } from '@/lib/utils';
 import { useRouter } from 'next/navigation';
 import { useUserContext } from '@/core/hooks/useUserContext';
+import { Cohort } from '@/app/types/cohorts';
 
 const NetworkVisibilityCard = () => {
     const queryClient = useQueryClient();
     const router = useRouter();
     const [isDialogOpen, setIsDialogOpen] = useState(false);
     const [targetVisibility, setTargetVisibility] = useState<boolean>(false);
-    const [pendingCohort, setPendingCohort] = useState<any>(null);
+    const [pendingCohort, setPendingCohort] = useState<Cohort | null>(null);
     const [isUpdating, setIsUpdating] = useState(false);
 
     const { activeGroup, isExternalOrg } = useUserContext();
@@ -109,12 +110,12 @@ const NetworkVisibilityCard = () => {
                             <h3 className="text-base font-semibold text-gray-900 dark:text-gray-100 transition-all">
                                 {allPublic ? "Your devices are Public" : 
                                  allPrivate ? "Your devices are Private" : 
-                                 "Mixed Device Visibility"}
+                                 "Custom Visibility Settings"}
                             </h3>
                             <p className="text-sm text-gray-500 dark:text-gray-400 mt-1 max-w-xl">
                                 {allPublic ? "Your devices are visible to anyone on the AirQo Map. You are contributing to open data." :
                                  allPrivate ? "Your devices are hidden from the public. Data is visible only in your account." :
-                                 "Some of your cohorts are public while others are private. Manage each cohort below."}
+                                 "Visibility settings are customized per cohort. Manage each cohort below."}
                             </p>
                         </div>
                     </div>
@@ -204,4 +205,5 @@ const NetworkVisibilityCard = () => {
 };
 
 export default NetworkVisibilityCard;
+
 

--- a/src/vertex/components/features/sites/create-site-form.tsx
+++ b/src/vertex/components/features/sites/create-site-form.tsx
@@ -60,9 +60,10 @@ type SiteFormValues = z.infer<typeof siteFormSchema>;
 
 interface CreateSiteFormProps {
   disabled?: boolean;
+  basePath?: string;
 }
 
-export function CreateSiteForm({ disabled = false }: CreateSiteFormProps) {
+export function CreateSiteForm({ disabled = false, basePath = "/admin/sites" }: CreateSiteFormProps) {
   const [open, setOpen] = useState(false);
   const router = useRouter();
   const [inputMode, setInputMode] = useState<"siteName" | "coordinates">("coordinates");
@@ -98,7 +99,7 @@ export function CreateSiteForm({ disabled = false }: CreateSiteFormProps) {
         onSuccess: (data) => {
           handleClose();
           if (data?.site?._id) {
-            router.push(`/admin/sites/${data.site._id}`);
+            router.push(`${basePath}/${data.site._id}`);
           }
         },
       }

--- a/src/vertex/components/features/sites/create-site-form.tsx
+++ b/src/vertex/components/features/sites/create-site-form.tsx
@@ -104,7 +104,7 @@ export function CreateSiteForm({ disabled = false, basePath = "/admin/sites" }: 
         },
       }
     );
-  }, [createSite, activeGroup?.grp_title, handleClose, router]);
+  }, [createSite, activeGroup?.grp_title, handleClose, router, basePath]);
 
   const handleCoordinateChange = useCallback((lat: string, lng: string) => {
     form.setValue("latitude", lat, { shouldValidate: true });

--- a/src/vertex/components/features/sites/site-information-card.tsx
+++ b/src/vertex/components/features/sites/site-information-card.tsx
@@ -67,10 +67,15 @@ export const SiteInformationCard: React.FC<SiteInformationCardProps> = ({ site, 
                 <span className="font-mono text-sm truncate max-w-[150px] sm:max-w-none">{site._id}</span>
                 <ReusableButton
                   variant="text"
-                  onClick={() => {
+                  onClick={async () => {
                     if (site._id) {
-                      navigator.clipboard.writeText(site._id);
-                      ReusableToast({ message: "Copied", type: "SUCCESS" });
+                      try {
+                        await navigator.clipboard.writeText(site._id);
+                        ReusableToast({ message: "Copied", type: "SUCCESS" });
+                      } catch (error) {
+                        console.error("Failed to copy:", error);
+                        ReusableToast({ message: "Failed to copy", type: "ERROR" });
+                      }
                     }
                   }}
                   className="p-1 h-auto hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full"

--- a/src/vertex/components/features/sites/site-information-card.tsx
+++ b/src/vertex/components/features/sites/site-information-card.tsx
@@ -8,8 +8,9 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { AqEdit01 } from "@airqo/icons-react";
+import { AqEdit01, AqCopy01 } from "@airqo/icons-react";
 import ReusableButton from "@/components/shared/button/ReusableButton";
+import ReusableToast from "@/components/shared/toast/ReusableToast";
 import {
   badgeColorClasses,
   formatDisplayDate,
@@ -59,7 +60,26 @@ export const SiteInformationCard: React.FC<SiteInformationCardProps> = ({ site, 
           <DetailItem label="Sub County" value={site.sub_county} />
           <DetailItem label="District" value={site.district} />
           <DetailItem label="Region" value={site.region} />
-          <DetailItem label="Altitude" value={`${site.altitude} m`} />
+          <DetailItem 
+            label="Site ID" 
+            value={
+              <div className="flex items-center gap-2">
+                <span className="font-mono text-sm truncate max-w-[150px] sm:max-w-none">{site._id}</span>
+                <ReusableButton
+                  variant="text"
+                  onClick={() => {
+                    if (site._id) {
+                      navigator.clipboard.writeText(site._id);
+                      ReusableToast({ message: "Copied", type: "SUCCESS" });
+                    }
+                  }}
+                  className="p-1 h-auto hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full"
+                  Icon={AqCopy01}
+                />
+              </div>
+            } 
+          />
+          <DetailItem label="Altitude" value={<span className="font-mono">{site.altitude} m</span>} />
           <DetailItem label="Nearest Road" value={site.distance_to_nearest_road != null ? `${site.distance_to_nearest_road.toFixed(2)} m` : "N/A"} />
           <div>
             <div className="text-xs text-muted-foreground uppercase font-medium tracking-wide mb-1">Status</div>

--- a/src/vertex/components/features/sites/sites-list-table.tsx
+++ b/src/vertex/components/features/sites/sites-list-table.tsx
@@ -17,6 +17,7 @@ interface SitesTableProps {
   multiSelect?: boolean;
   onSelectedSitesChange?: (selectedSites: Site[]) => void;
   className?: string;
+  basePath?: string;
 }
 
 type TableSite = TableItem<unknown>;
@@ -27,6 +28,7 @@ export default function SitesTable({
   multiSelect = false,
   onSelectedSitesChange,
   className,
+  basePath = "/admin/sites",
 }: SitesTableProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -52,7 +54,7 @@ export default function SitesTable({
   const handleSiteClick = (item: unknown) => {
     const site = item as Site;
     if (onSiteClick) onSiteClick(site);
-    else if (site._id) router.push(`/admin/sites/${site._id}`);
+    else if (site._id) router.push(`${basePath}/${site._id}`);
   };
 
   const handleSelectedItemsChange = (selectedIds: (string | number)[]) => {

--- a/src/vertex/components/layout/secondary-sidebar.tsx
+++ b/src/vertex/components/layout/secondary-sidebar.tsx
@@ -147,16 +147,6 @@ const SecondarySidebar: React.FC<SecondarySidebarProps> = ({
                   />
                   <NavItem
                     item={{
-                      href: ROUTE_LINKS.ORG_SITES,
-                      icon: AqMarkerPin01,
-                      label: 'Sites',
-                      disabled: !contextPermissions.canViewSites,
-                    }}
-                    isCollapsed={isCollapsed}
-                    onClick={onNavigate}
-                  />
-                  <NavItem
-                    item={{
                       href: ROUTE_LINKS.ORG_REGISTER_DEVICE,
                       icon: AqPackagePlus,
                       label: 'Claim Device',

--- a/src/vertex/components/layout/secondary-sidebar.tsx
+++ b/src/vertex/components/layout/secondary-sidebar.tsx
@@ -147,6 +147,16 @@ const SecondarySidebar: React.FC<SecondarySidebarProps> = ({
                   />
                   <NavItem
                     item={{
+                      href: ROUTE_LINKS.ORG_SITES,
+                      icon: AqMarkerPin01,
+                      label: 'Sites',
+                      disabled: !contextPermissions.canViewSites,
+                    }}
+                    isCollapsed={isCollapsed}
+                    onClick={onNavigate}
+                  />
+                  <NavItem
+                    item={{
                       href: ROUTE_LINKS.ORG_REGISTER_DEVICE,
                       icon: AqPackagePlus,
                       label: 'Claim Device',
@@ -190,6 +200,16 @@ const SecondarySidebar: React.FC<SecondarySidebarProps> = ({
                       icon: AqMonitor,
                       label: 'Assets',
                       disabled: !contextPermissions.canViewDevices,
+                    }}
+                    isCollapsed={isCollapsed}
+                    onClick={onNavigate}
+                  />
+                  <NavItem
+                    item={{
+                      href: ROUTE_LINKS.ORG_SITES,
+                      icon: AqMarkerPin01,
+                      label: 'Sites',
+                      disabled: !contextPermissions.canViewSites,
                     }}
                     isCollapsed={isCollapsed}
                     onClick={onNavigate}

--- a/src/vertex/components/layout/secondary-sidebar.tsx
+++ b/src/vertex/components/layout/secondary-sidebar.tsx
@@ -198,7 +198,7 @@ const SecondarySidebar: React.FC<SecondarySidebarProps> = ({
                     item={{
                       href: ROUTE_LINKS.ORG_ASSETS,
                       icon: AqMonitor,
-                      label: 'Assets',
+                      label: 'Devices',
                       disabled: !contextPermissions.canViewDevices,
                     }}
                     isCollapsed={isCollapsed}

--- a/src/vertex/core/constants/devices.ts
+++ b/src/vertex/core/constants/devices.ts
@@ -1,6 +1,6 @@
 export const DEVICE_CATEGORIES = [
   { value: "lowcost", label: "Low Cost" },
-  { value: "bam", label: "BAM" },
+  { value: "bam", label: "Reference Monitor" },
   { value: "gas", label: "Gas" },
 ] as const;
 

--- a/src/vertex/core/hooks/useContextAwareRouting.ts
+++ b/src/vertex/core/hooks/useContextAwareRouting.ts
@@ -6,6 +6,8 @@ import { ROUTE_LINKS } from '@/core/routes';
 // Map routes to sidebar config properties
 const routeToSidebarConfig: Record<string, keyof SidebarConfig> = {
   [ROUTE_LINKS.SITES]: 'showSites',
+  [ROUTE_LINKS.ORG_SITES]: 'showSites',
+  [ROUTE_LINKS.SITE_DETAILS]: 'showSites',
   '/user-management': 'showUserManagement',
   '/access-control': 'showAccessControl',
   [ROUTE_LINKS.MY_DEVICES]: 'showMyDevices',
@@ -26,39 +28,20 @@ export const useContextAwareRouting = () => {
   const initializedRef = useRef(false);
 
   useEffect(() => {
-    // Don't run routing logic until the user context is fully initialized.
     if (!userContext) {
       return;
     }
 
-    if(!initializedRef.current) {
-      initializedRef.current = true;
-      previousContextRef.current = userContext;
-      return;
-    }
-
-    // Check if context actually changed
-    if (previousContextRef.current === userContext) {
-      return;
-    }
-
-    // Update previous context
-    previousContextRef.current = userContext;
-
     const sidebarConfig = getSidebarConfig();
-    
-    // Check if current route is accessible in new context
+
     const isRouteAccessible = (route: string): boolean => {
-      // Dashboard is always accessible
       if (route === ROUTE_LINKS.HOME) return true;
       
-      // Check if route maps to a sidebar config property
       const configKey = routeToSidebarConfig[route];
       if (configKey) {
         return sidebarConfig[configKey] === true;
       }
       
-      // For dynamic routes, check the base path
       const basePath = route.split('/')[1];
       const baseRoute = `/${basePath}`;
       const baseConfigKey = routeToSidebarConfig[baseRoute];
@@ -66,14 +49,23 @@ export const useContextAwareRouting = () => {
         return sidebarConfig[baseConfigKey] === true;
       }
       
-      // Default to accessible if not explicitly mapped
       return true;
     };
 
-    // If current route is not accessible, redirect to dashboard
-    if (!isRouteAccessible(pathname)) {
-      // logger.debug('Context-aware redirect', { from: pathname, to: '/home', userContext, sidebarConfig })
-      router.push(ROUTE_LINKS.HOME);
+    const contextChanged = initializedRef.current && previousContextRef.current !== userContext;
+
+    // Always check route on first load; also check when context changes
+    if (!initializedRef.current || contextChanged) {
+      initializedRef.current = true;
+      previousContextRef.current = userContext;
+
+      if (!isRouteAccessible(pathname)) {
+        router.push(ROUTE_LINKS.HOME);
+      }
+      return;
     }
+
+    // Same context, no action needed
+    previousContextRef.current = userContext;
   }, [userContext, pathname, getSidebarConfig, router]);
 }; 

--- a/src/vertex/core/hooks/useContextAwareRouting.ts
+++ b/src/vertex/core/hooks/useContextAwareRouting.ts
@@ -52,20 +52,15 @@ export const useContextAwareRouting = () => {
       return true;
     };
 
-    const contextChanged = initializedRef.current && previousContextRef.current !== userContext;
+    const contextChanged =
+      initializedRef.current && previousContextRef.current !== userContext;
+    initializedRef.current = true;
+    previousContextRef.current = userContext;
 
-    // Always check route on first load; also check when context changes
-    if (!initializedRef.current || contextChanged) {
-      initializedRef.current = true;
-      previousContextRef.current = userContext;
-
-      if (!isRouteAccessible(pathname)) {
-        router.push(ROUTE_LINKS.HOME);
-      }
+    // Enforce access on every pathname or context change
+    if (!isRouteAccessible(pathname)) {
+      router.replace(ROUTE_LINKS.HOME);
       return;
     }
-
-    // Same context, no action needed
-    previousContextRef.current = userContext;
   }, [userContext, pathname, getSidebarConfig, router]);
 }; 

--- a/src/vertex/core/hooks/useSites.ts
+++ b/src/vertex/core/hooks/useSites.ts
@@ -55,17 +55,12 @@ export const useSiteActivitiesInfinite = (siteId: string) => {
 };
 
 export const useSites = (options: SiteListingOptions = {}) => {
-  const { userDetails, isExternalOrg, activeGroup } = useUserContext();
+  const activeGroup = useAppSelector((state) => state.user.activeGroup);
   const isAirQoGroup = activeGroup?.grp_title === "airqo";
 
   const { data: groupCohortIds, isLoading: isLoadingCohorts } = useGroupCohorts(activeGroup?._id, {
-    enabled: isExternalOrg && !!activeGroup?._id,
+    enabled: !isAirQoGroup && !!activeGroup?._id,
   });
-
-  const cohortIds = useMemo(() => {
-    if (isExternalOrg) return groupCohortIds || [];
-    return userDetails?.cohort_ids || [];
-  }, [isExternalOrg, groupCohortIds, userDetails?.cohort_ids]);
 
   const { page = 1, limit = 100, search, sortBy, order, network } = options;
   const safePage = Math.max(1, page);
@@ -75,7 +70,7 @@ export const useSites = (options: SiteListingOptions = {}) => {
   const queryParams = useMemo(() => ({ page, limit, search, sortBy, order, status: options.status }), [page, limit, search, sortBy, order, options.status]);
   
   const sitesQuery = useQuery<SitesSummaryResponse, AxiosError<ErrorResponse>>({
-    queryKey: ["sites", network, activeGroup?.grp_title, queryParams, cohortIds],
+    queryKey: ["sites", network, activeGroup?.grp_title, queryParams],
     queryFn: async ({ signal }: QueryFunctionContext) => {
       if (isAirQoGroup) {
         const params: GetSitesSummaryParams = {
@@ -97,31 +92,12 @@ export const useSites = (options: SiteListingOptions = {}) => {
         return sites.getSitesSummary(params, signal);
       }
 
-      if (cohortIds.length === 0 && !isLoadingCohorts) {
-        // If we have no cohorts and we're not loading, return empty result
-        return { 
-          success: true, 
-          message: "No sites found for the current cohorts", 
-          sites: [], 
-          meta: { 
-            total: 0,
-            totalResults: 0,
-            totalPages: 0, 
-            page: 1, 
-            limit: safeLimit,
-            skip: 0,
-            detailLevel: "summary",
-            usedCache: false
-          } 
-        } as SitesSummaryResponse;
-      }
-
-      if (cohortIds.length === 0 && isLoadingCohorts) {
-         throw new Error("Cohort IDs are loading...");
+      if (!groupCohortIds) {
+        throw new Error("Cohort IDs are not available yet.");
       }
 
       return sites.getSitesByCohorts({
-        cohort_ids: cohortIds,
+        cohort_ids: groupCohortIds,
         limit: safeLimit,
         skip,
         ...(search && { search }),
@@ -130,7 +106,7 @@ export const useSites = (options: SiteListingOptions = {}) => {
         ...(network && { network }),
       }, signal);
     },
-    enabled: !!activeGroup?.grp_title && (isAirQoGroup || (!isLoadingCohorts)),
+    enabled: !!activeGroup?.grp_title && (isAirQoGroup || (!!groupCohortIds && groupCohortIds.length > 0)),
     staleTime: 300_000,
     refetchOnWindowFocus: false,
   });

--- a/src/vertex/core/hooks/useSites.ts
+++ b/src/vertex/core/hooks/useSites.ts
@@ -11,6 +11,7 @@ import { DeviceActivitiesResponse } from "../apis/devices";
 
 import { useGroupCohorts } from "./useCohorts";
 import { useAppSelector } from "../redux/hooks";
+import { useUserContext } from "./useUserContext";
 import { useMemo } from "react";
 import ReusableToast from "@/components/shared/toast/ReusableToast";
 import { AxiosError } from "axios";
@@ -54,12 +55,17 @@ export const useSiteActivitiesInfinite = (siteId: string) => {
 };
 
 export const useSites = (options: SiteListingOptions = {}) => {
-  const activeGroup = useAppSelector((state) => state.user.activeGroup);
+  const { userDetails, isExternalOrg, activeGroup } = useUserContext();
   const isAirQoGroup = activeGroup?.grp_title === "airqo";
 
   const { data: groupCohortIds, isLoading: isLoadingCohorts } = useGroupCohorts(activeGroup?._id, {
-    enabled: !isAirQoGroup && !!activeGroup?._id,
+    enabled: isExternalOrg && !!activeGroup?._id,
   });
+
+  const cohortIds = useMemo(() => {
+    if (isExternalOrg) return groupCohortIds || [];
+    return userDetails?.cohort_ids || [];
+  }, [isExternalOrg, groupCohortIds, userDetails?.cohort_ids]);
 
   const { page = 1, limit = 100, search, sortBy, order, network } = options;
   const safePage = Math.max(1, page);
@@ -69,7 +75,7 @@ export const useSites = (options: SiteListingOptions = {}) => {
   const queryParams = useMemo(() => ({ page, limit, search, sortBy, order, status: options.status }), [page, limit, search, sortBy, order, options.status]);
   
   const sitesQuery = useQuery<SitesSummaryResponse, AxiosError<ErrorResponse>>({
-    queryKey: ["sites", network, activeGroup?.grp_title, queryParams],
+    queryKey: ["sites", network, activeGroup?.grp_title, queryParams, cohortIds],
     queryFn: async ({ signal }: QueryFunctionContext) => {
       if (isAirQoGroup) {
         const params: GetSitesSummaryParams = {
@@ -91,12 +97,31 @@ export const useSites = (options: SiteListingOptions = {}) => {
         return sites.getSitesSummary(params, signal);
       }
 
-      if (!groupCohortIds) {
-        throw new Error("Cohort IDs are not available yet.");
+      if (cohortIds.length === 0 && !isLoadingCohorts) {
+        // If we have no cohorts and we're not loading, return empty result
+        return { 
+          success: true, 
+          message: "No sites found for the current cohorts", 
+          sites: [], 
+          meta: { 
+            total: 0,
+            totalResults: 0,
+            totalPages: 0, 
+            page: 1, 
+            limit: safeLimit,
+            skip: 0,
+            detailLevel: "summary",
+            usedCache: false
+          } 
+        } as SitesSummaryResponse;
+      }
+
+      if (cohortIds.length === 0 && isLoadingCohorts) {
+         throw new Error("Cohort IDs are loading...");
       }
 
       return sites.getSitesByCohorts({
-        cohort_ids: groupCohortIds,
+        cohort_ids: cohortIds,
         limit: safeLimit,
         skip,
         ...(search && { search }),
@@ -105,7 +130,7 @@ export const useSites = (options: SiteListingOptions = {}) => {
         ...(network && { network }),
       }, signal);
     },
-    enabled: !!activeGroup?.grp_title && (isAirQoGroup || (!!groupCohortIds && groupCohortIds.length > 0)),
+    enabled: !!activeGroup?.grp_title && (isAirQoGroup || (!isLoadingCohorts)),
     staleTime: 300_000,
     refetchOnWindowFocus: false,
   });

--- a/src/vertex/core/hooks/useUserContext.ts
+++ b/src/vertex/core/hooks/useUserContext.ts
@@ -155,7 +155,7 @@ export const useUserContext = (): UserContextState => {
         return {
           title: 'My Monitors',
           showNetworkMap: false,
-          showSites: false, // Permission based
+          showSites: canViewSites, // Permission based
           showGrids: canViewSites,
           showCohorts: canViewDevices,
           showUserManagement: canViewUserManagement,

--- a/src/vertex/core/hooks/useUserContext.ts
+++ b/src/vertex/core/hooks/useUserContext.ts
@@ -172,7 +172,7 @@ export const useUserContext = (): UserContextState => {
         return {
           title: activeGroup?.grp_title || 'Organization',
           showNetworkMap: false,
-          showSites: false,
+          showSites: canViewSites,
           showGrids: false,
           showCohorts: false,
           showUserManagement: canViewUserManagement,

--- a/src/vertex/core/hooks/useUserContext.ts
+++ b/src/vertex/core/hooks/useUserContext.ts
@@ -155,7 +155,7 @@ export const useUserContext = (): UserContextState => {
         return {
           title: 'My Monitors',
           showNetworkMap: false,
-          showSites: canViewSites, // Permission based
+          showSites: false, // Permission based
           showGrids: canViewSites,
           showCohorts: canViewDevices,
           showUserManagement: canViewUserManagement,

--- a/src/vertex/core/routes.ts
+++ b/src/vertex/core/routes.ts
@@ -11,4 +11,6 @@ export const ROUTE_LINKS = {
   ORG_ASSETS: '/devices/overview',
   ORG_REGISTER_DEVICE: '/devices/claim',
   DEVICE_COHORTS: '/cohorts',
+  ORG_SITES: '/sites/overview',
+  SITE_DETAILS: '/sites',
 };


### PR DESCRIPTION
## Overview
This PR introduces two major feature sets aimed at improving asset management and privacy controls for organizations: **Granular Cohort Visibility** and a new **Sites Overview Module**. These changes transition site management from an admin-only feature to a core organizational tool while providing finer control over device privacy.

## Key Changes

### 🔐 Granular Cohort Visibility Control
- **Per-Cohort Privacy**: Replaced the global organization-wide visibility toggle with individual switches for each cohort.
- **Mixed-State UI**: Introduced "Custom Visibility Settings" with a Shield icon to clearly communicate when an organization has both public and private cohorts.
- **Guarded Interactions**: Every privacy change is now protected by a confirmation dialog identifying the specific cohort and its impact.

### 📍 Centralized Sites Management
- **New Sites Overview**: Introduced a dedicated `/sites/overview` page for standard users and organizations to manage their monitoring sites.
- **User-Facing Details**: Created a new site details view (`/sites/[id]`) that mirrors the rich administrative interface, including telemetry and mobile app settings.
- **Scoped Data Fetching**: Enhanced the `useSites` data hook to automatically resolve cohort-based visibility, ensuring users only manage sites they own.

### 🚀 Navigation & UX Improvements
- **Contextual Site Routing**: The "View site details" button in device cards now intelligently routes users to either the Admin or User site view based on their current context.
- **Sidebar Refresh**: Added a "Sites" section to the sidebar and renamed "Assets" to "Devices" for a more intuitive navigation structure.
- **Developer Utilities**: Added a copy-to-clipboard feature for Site IDs to facilitate easier referencing during configuration tasks.

## Technical Notes
- **Refactored Components**: `SitesTable` and `CreateSiteForm` now support a `basePath` prop for multi-context usage.
- **Standardized Data Handling**: Site ID resolution now uses nested objects, ensuring consistency across the platform.
- **Contextual Hooks**: `useSites` and `useSiteStatistics` have been updated to intelligently handle personal vs. organization cohort scoping.

## Verification Results
- [x] Verified individual cohort visibility toggles with confirmation workflows.
- [x] Tested contextual navigation between admin and user site detail views.
- [x] Confirmed scoped data fetching for personal and organization site lists.


#### Screenshots (optional)
<img width="1920" height="886" alt="image" src="https://github.com/user-attachments/assets/05657b9d-3191-4f2a-b27c-1e2f4bc840f7" />
<img width="960" height="444" alt="image" src="https://github.com/user-attachments/assets/0de46c3b-8e4f-4683-bb1f-77ea192ef2e4" />
<img width="1514" height="443" alt="image" src="https://github.com/user-attachments/assets/f6bfbdc7-6881-4b57-9b14-3924f9ccf57f" />
<img width="1488" height="415" alt="image" src="https://github.com/user-attachments/assets/e122517a-c65a-469b-add9-923826ff7bc3" />
<img width="1494" height="414" alt="image" src="https://github.com/user-attachments/assets/bcf4028e-1f4f-4988-b8d2-479484b72187" />
<img width="244" height="314" alt="image" src="https://github.com/user-attachments/assets/16a7b672-8c8f-4441-997e-5c04f0165c9e" />
<img width="557" height="641" alt="image" src="https://github.com/user-attachments/assets/427ffa45-54f7-495c-a7d7-863913341f77" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sites overview and per-site detail pages with metadata refresh, device table, and inline edit dialogs
  * Copy-to-clipboard Site ID
  * Per-cohort network visibility controls (replaces bulk toggle)

* **Refactor**
  * Device location actions now navigate to site details
  * Sites components support configurable base paths and scoped site fetching
  * Sidebar label changed: "Assets" → "Devices"
  * Device category label: "BAM" → "Reference Monitor"
<!-- end of auto-generated comment: release notes by coderabbit.ai -->