### PR TITLE
Vertex: Device tagging, original cohort tracing, map stability & UI refinements

### DIFF
--- a/src/vertex/app/changelog.md
+++ b/src/vertex/app/changelog.md
@@ -54,7 +54,7 @@ Introduced a comprehensive device tagging system, added original cohort tracing 
 </details>
 
 <details>
-<summary><strong>Files Modified (15)</strong></summary>
+<summary><strong>Files Modified (18)</strong></summary>
 
 - `src/vertex/app/types/devices.ts` [MODIFIED]
 - `src/vertex/app/types/cohorts.ts` [MODIFIED]

--- a/src/vertex/app/changelog.md
+++ b/src/vertex/app/changelog.md
@@ -4,6 +4,61 @@
 
 ---
 
+## Version 1.23.39
+**Released:** May 07, 2026
+
+### Device Tagging, Map Stability & UI Refinements
+
+Introduced a comprehensive device tagging system for better organization, overhauled the MiniMap component for industrial-grade stability, and enhanced device status visualization.
+
+<details>
+<summary><strong>Device Tagging System (4)</strong></summary>
+
+- **Custom & Default Tagging**: Integrated a new tagging system across all device creation and import flows. Users can select from standard tags (e.g., `lowcost`, `mobile`) or create their own custom labels.
+- **Enhanced Device Tables**: Added a "Tags" column to all device listing tables, displaying attributes as color-coded badges for immediate scannability.
+- **In-Place Tag Management**: Updated the Device Details Card to allow operators to view and edit tags directly without leaving the page.
+- **Flexible Data Entry**: Leveraged a new `MultiSelectCombobox` with custom creation support to ensure tagging is both guided and flexible.
+
+</details>
+
+<details>
+<summary><strong>Mapbox Stability & Speed (4)</strong></summary>
+
+- **Industrial-Grade Map Loading**: Refactored the `MiniMap` component to use a `useRef` architecture and `on('load')` synchronization, eliminating intermittent "blank map" issues in Dialogs and Tabs.
+- **Auto-Resize Engine**: Integrated a `ResizeObserver` that automatically recalibrates the map canvas whenever its container's dimensions change, ensuring perfect rendering in dynamic layouts.
+- **Next.js Speed Optimizations**: Implemented `preconnect` resource hints for Mapbox domains to pre-warm connections, significantly reducing map initialization time.
+- **Style Upgrade**: Migrated to Mapbox `streets-v12` for improved vector tile parsing performance and visual clarity.
+
+</details>
+
+<details>
+<summary><strong>UI/UX Improvements (2)</strong></summary>
+
+- **Empty State Visualization**: Redesigned the Device Category Card to handle non-deployed states with a centered `AqPuzzlePiece02` icon and helpful instructional text.
+- **Hardenened UI Components**: Upgraded the `MultiSelectCombobox` with strict property guarding and safety checks to prevent runtime crashes when handling undefined data states.
+
+</details>
+
+<details>
+<summary><strong>Files Created/Modified (12)</strong></summary>
+
+- `src/vertex/core/constants/devices.ts` [MODIFIED]
+- `src/vertex/core/apis/devices.ts` [MODIFIED]
+- `src/vertex/core/hooks/useDevices.ts` [MODIFIED]
+- `src/vertex/components/features/devices/create-device-modal.tsx` [MODIFIED]
+- `src/vertex/components/features/devices/import-device-modal.tsx` [MODIFIED]
+- `src/vertex/components/features/devices/device-details-card.tsx` [MODIFIED]
+- `src/vertex/components/features/devices/utils/table-columns.tsx` [MODIFIED]
+- `src/vertex/components/features/devices/device-category-card.tsx` [MODIFIED]
+- `src/vertex/components/features/mini-map/mini-map.tsx` [MODIFIED]
+- `src/vertex/components/ui/multi-select.tsx` [MODIFIED]
+- `src/vertex/app/layout.tsx` [MODIFIED]
+- `src/vertex/app/changelog.md` [MODIFIED]
+
+</details>
+
+---
+
 ## Version 1.23.38
 **Released:** May 05, 2026
 

--- a/src/vertex/app/changelog.md
+++ b/src/vertex/app/changelog.md
@@ -7,53 +7,73 @@
 ## Version 1.23.39
 **Released:** May 07, 2026
 
-### Device Tagging, Map Stability & UI Refinements
+### Device Tagging, Original Cohort Visibility, Map Stability & UI Refinements
 
-Introduced a comprehensive device tagging system for better organization, overhauled the MiniMap component for industrial-grade stability, and enhanced device status visualization.
+Introduced a comprehensive device tagging system, added original cohort tracing for duplicates, overhauled the MiniMap for reliability and performance, and improved device status visualization.
 
 <details>
 <summary><strong>Device Tagging System (4)</strong></summary>
 
-- **Custom & Default Tagging**: Integrated a new tagging system across all device creation and import flows. Users can select from standard tags (e.g., `lowcost`, `mobile`) or create their own custom labels.
-- **Enhanced Device Tables**: Added a "Tags" column to all device listing tables, displaying attributes as color-coded badges for immediate scannability.
-- **In-Place Tag Management**: Updated the Device Details Card to allow operators to view and edit tags directly without leaving the page.
-- **Flexible Data Entry**: Leveraged a new `MultiSelectCombobox` with custom creation support to ensure tagging is both guided and flexible.
+- **Custom & Default Tagging**: Integrated a new tagging system across all device creation and import flows (`create-device-modal`, `import-device-modal`). Users can select from standard tags (e.g., `lowcost`, `mobile`, `inlab`) or create their own custom labels.
+- **Tags Column in Device Tables**: Added a "Tags" column to the device list table (`table-columns.tsx`), displaying tags as color-coded badges. Updated `Device` type in `app/types/devices.ts` to include the optional `tags` field.
+- **In-Place Tag Management**: Updated the Device Details Card to display current tags as badges and allow operators to edit them via a dialog — without leaving the page.
+- **API & Hook Updates**: Extended `createDevice` and `importDevice` in `core/apis/devices.ts` and `core/hooks/useDevices.ts` to accept and forward an optional `tags` array, omitting the field if empty.
 
 </details>
 
 <details>
-<summary><strong>Mapbox Stability & Speed (4)</strong></summary>
+<summary><strong>Cohort Improvements (1)</strong></summary>
 
-- **Industrial-Grade Map Loading**: Refactored the `MiniMap` component to use a `useRef` architecture and `on('load')` synchronization, eliminating intermittent "blank map" issues in Dialogs and Tabs.
-- **Auto-Resize Engine**: Integrated a `ResizeObserver` that automatically recalibrates the map canvas whenever its container's dimensions change, ensuring perfect rendering in dynamic layouts.
-- **Next.js Speed Optimizations**: Implemented `preconnect` resource hints for Mapbox domains to pre-warm connections, significantly reducing map initialization time.
-- **Style Upgrade**: Migrated to Mapbox `streets-v12` for improved vector tile parsing performance and visual clarity.
+- **Original Cohort Tracing**: Updated `cohort-detail-card.tsx` to display an `InfoBanner` linking to the original cohort when a duplicate is detected. Added `useOriginalCohort` hook and corresponding API (`core/apis/cohorts.ts`, `core/hooks/useCohorts.ts`) with `originalCohort` field added to `app/types/cohorts.ts`.
+
+</details>
+
+<details>
+<summary><strong>Mapbox Stability & Speed (3)</strong></summary>
+
+- **Reliable Map Loading**: Refactored `MiniMap` to use `useRef` for the map instance with an initialization guard, and deferred all controls/marker setup to inside the `map.on('load')` callback — fixing intermittent "blank map" issues in Dialogs and Tabs.
+- **Auto-Resize Support**: Integrated a `ResizeObserver` that calls `map.resize()` whenever the container dimensions change, ensuring correct canvas sizing in dynamic layouts.
+- **Next.js Preconnect Hints**: Added `<link rel="preconnect">` for `api.mapbox.com` and `events.mapbox.com` in `app/layout.tsx`, and upgraded the map style to `streets-v12`.
 
 </details>
 
 <details>
 <summary><strong>UI/UX Improvements (2)</strong></summary>
 
-- **Empty State Visualization**: Redesigned the Device Category Card to handle non-deployed states with a centered `AqPuzzlePiece02` icon and helpful instructional text.
-- **Hardenened UI Components**: Upgraded the `MultiSelectCombobox` with strict property guarding and safety checks to prevent runtime crashes when handling undefined data states.
+- **Device Category Empty State**: Redesigned `device-category-card.tsx` to show a centered `AqPuzzlePiece02` icon with the message "Device not deployed. You will see deployment category here" when `deployment_category` is absent. The info tooltip and category hierarchy are hidden in this state.
+- **Hardened MultiSelectCombobox**: Added default values for `options` and `value` props and a safety check for `value.length` to prevent runtime crashes from undefined prop values.
 
 </details>
 
 <details>
-<summary><strong>Files Created/Modified (12)</strong></summary>
+<summary><strong>Other Changes (2)</strong></summary>
 
+- **Grid Success Message**: Updated the grid creation success message copy in `core/hooks/useGrids.ts`.
+- **Temporarily Disabled Google Login**: Google sign-in was temporarily disabled in `app/login/page.tsx` while the feature is being stabilized.
+
+</details>
+
+<details>
+<summary><strong>Files Modified (15)</strong></summary>
+
+- `src/vertex/app/types/devices.ts` [MODIFIED]
+- `src/vertex/app/types/cohorts.ts` [MODIFIED]
+- `src/vertex/app/layout.tsx` [MODIFIED]
+- `src/vertex/app/login/page.tsx` [MODIFIED]
 - `src/vertex/core/constants/devices.ts` [MODIFIED]
 - `src/vertex/core/apis/devices.ts` [MODIFIED]
+- `src/vertex/core/apis/cohorts.ts` [MODIFIED]
 - `src/vertex/core/hooks/useDevices.ts` [MODIFIED]
+- `src/vertex/core/hooks/useCohorts.ts` [MODIFIED]
+- `src/vertex/core/hooks/useGrids.ts` [MODIFIED]
 - `src/vertex/components/features/devices/create-device-modal.tsx` [MODIFIED]
 - `src/vertex/components/features/devices/import-device-modal.tsx` [MODIFIED]
 - `src/vertex/components/features/devices/device-details-card.tsx` [MODIFIED]
-- `src/vertex/components/features/devices/utils/table-columns.tsx` [MODIFIED]
 - `src/vertex/components/features/devices/device-category-card.tsx` [MODIFIED]
+- `src/vertex/components/features/devices/utils/table-columns.tsx` [MODIFIED]
+- `src/vertex/components/features/cohorts/cohort-detail-card.tsx` [MODIFIED]
 - `src/vertex/components/features/mini-map/mini-map.tsx` [MODIFIED]
 - `src/vertex/components/ui/multi-select.tsx` [MODIFIED]
-- `src/vertex/app/layout.tsx` [MODIFIED]
-- `src/vertex/app/changelog.md` [MODIFIED]
 
 </details>
 

--- a/src/vertex/app/layout.tsx
+++ b/src/vertex/app/layout.tsx
@@ -74,6 +74,10 @@ export default async function RootLayout({
 
   return (
     <html lang="en" className={inter.className}>
+      <head>
+        <link rel="preconnect" href="https://api.mapbox.com" />
+        <link rel="preconnect" href="https://events.mapbox.com" />
+      </head>
       <ClientLayout session={session}>{children}</ClientLayout>
     </html>
   );

--- a/src/vertex/app/login/page.tsx
+++ b/src/vertex/app/login/page.tsx
@@ -21,7 +21,7 @@ import {
 } from "@/core/redux/slices/userSlice";
 import { getLastActiveModule } from "@/core/utils/userPreferences";
 import { VERTEX_DESKTOP_DOWNLOADS } from "@/core/constants/app-downloads";
-import GoogleAuthSection from "@/components/features/auth/google-auth-section";
+// import GoogleAuthSection from "@/components/features/auth/google-auth-section";
 import { motion, AnimatePresence } from "framer-motion";
 import { ChevronLeft } from "lucide-react";
 
@@ -220,13 +220,13 @@ export default function LoginPage() {
             </div>
 
             <div className="flex flex-col">
-              {step === 'email' && (
+              {/* {step === 'email' && (
                 <GoogleAuthSection
                   disabled={isLoading}
                   className="mb-6"
                   callbackUrl={callbackUrl}
                 />
-              )}
+              )} */}
 
               <Form {...form}>
                 <form

--- a/src/vertex/app/types/cohorts.ts
+++ b/src/vertex/app/types/cohorts.ts
@@ -30,6 +30,12 @@ export interface GroupCohortsResponse {
   data: string[];
 }
 
+export interface OriginalCohortResponse {
+  success: boolean;
+  message: string;
+  original_cohort: Cohort;
+}
+
 interface Grid {
     _id: string;
     visibility: boolean;

--- a/src/vertex/app/types/devices.ts
+++ b/src/vertex/app/types/devices.ts
@@ -147,6 +147,7 @@ export interface Device {
   lastActive?: string;
   lastRawData?: string;
   rawOnlineStatus?: boolean;
+  tags?: string[];
 }
 
 export interface PaginationMeta {

--- a/src/vertex/components/features/cohorts/cohort-detail-card.tsx
+++ b/src/vertex/components/features/cohorts/cohort-detail-card.tsx
@@ -37,7 +37,9 @@ const CohortDetailsCard: React.FC<CohortDetailsCardProps> = ({
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const pathname = usePathname();
   const isAdminPath = pathname.startsWith("/admin");
-  const isDuplicate = cohort_tags?.includes("duplicate");
+  const isDuplicate = (cohort_tags ?? []).some(
+    (tag) => tag.toLowerCase() === "duplicate"
+  );
 
   const { mutate: updateCohort, isPending } = useUpdateCohortDetails();
   const { data: originalData } = useOriginalCohort(id, { enabled: !!isDuplicate });

--- a/src/vertex/components/features/cohorts/cohort-detail-card.tsx
+++ b/src/vertex/components/features/cohorts/cohort-detail-card.tsx
@@ -5,11 +5,14 @@ import { AqCopy01, AqEdit01 } from "@airqo/icons-react";
 import ReusableToast from "@/components/shared/toast/ReusableToast";
 import { Switch } from "@/components/ui/switch";
 import { useEffect, useState } from "react";
-import { useUpdateCohortDetails } from "@/core/hooks/useCohorts";
+import { useUpdateCohortDetails, useOriginalCohort } from "@/core/hooks/useCohorts";
 import ReusableDialog from "@/components/shared/dialog/ReusableDialog";
 import { Badge } from "@/components/ui/badge";
 import { MultiSelectCombobox } from "@/components/ui/multi-select";
 import { DEFAULT_COHORT_TAGS } from "@/core/constants/devices";
+import { usePathname } from "next/navigation";
+import Link from "next/link";
+import { InfoBanner } from "@/components/ui/banner";
 
 interface CohortDetailsCardProps {
   name: string;
@@ -32,8 +35,13 @@ const CohortDetailsCard: React.FC<CohortDetailsCardProps> = ({
   const [isTagsDialogOpen, setIsTagsDialogOpen] = useState(false);
   const [targetVisibility, setTargetVisibility] = useState<boolean>(false);
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
+  const pathname = usePathname();
+  const isAdminPath = pathname.startsWith("/admin");
+  const isDuplicate = cohort_tags?.includes("duplicate");
 
   const { mutate: updateCohort, isPending } = useUpdateCohortDetails();
+  const { data: originalData } = useOriginalCohort(id, { enabled: !!isDuplicate });
+  const originalCohort = isDuplicate && originalData?.success ? originalData.original_cohort : null;
 
   useEffect(() => {
     setSelectedTags(cohort_tags ?? []);
@@ -181,6 +189,23 @@ const CohortDetailsCard: React.FC<CohortDetailsCardProps> = ({
               </div>
             </div>
           </div>
+
+          {originalCohort && (
+            <InfoBanner
+              className="mt-4"
+              message={
+                <>
+                  This cohort is a duplicate. The original cohort is{" "}
+                  <Link
+                    href={isAdminPath ? `/admin/cohorts/${originalCohort._id}` : `/cohorts/${originalCohort._id}`}
+                    className="font-semibold underline hover:text-blue-800 dark:hover:text-blue-200"
+                  >
+                    {originalCohort.name}
+                  </Link>
+                </>
+              }
+            />
+          )}
         </div>
       </Card>
 

--- a/src/vertex/components/features/devices/create-device-modal.tsx
+++ b/src/vertex/components/features/devices/create-device-modal.tsx
@@ -7,6 +7,9 @@ import { useAppSelector } from "@/core/redux/hooks";
 import { DEVICE_CATEGORIES } from "@/core/constants/devices";
 import ReusableInputField from "@/components/shared/inputfield/ReusableInputField";
 import ReusableSelectInput from "@/components/shared/select/ReusableSelectInput";
+import { MultiSelectCombobox } from "@/components/ui/multi-select";
+import { DEFAULT_DEVICE_TAGS } from "@/core/constants/devices";
+import { Label } from "@/components/ui/label";
 
 interface CreateDeviceModalProps {
   open: boolean;
@@ -23,6 +26,7 @@ const CreateDeviceModal: React.FC<CreateDeviceModalProps> = ({
     long_name: "",
     category: "",
     description: "",
+    tags: [] as string[],
   });
 
   const [errors, setErrors] = useState<Record<string, string>>({});
@@ -62,6 +66,7 @@ const CreateDeviceModal: React.FC<CreateDeviceModalProps> = ({
         category: formData.category,
         description: formData.description.trim() || undefined,
         network: effectiveNetworkName,
+        tags: formData.tags,
       });
 
       // Reset form and close modal
@@ -69,6 +74,7 @@ const CreateDeviceModal: React.FC<CreateDeviceModalProps> = ({
         long_name: "",
         category: "",
         description: "",
+        tags: [],
       });
       setErrors({});
       onOpenChange(false);
@@ -103,6 +109,7 @@ const CreateDeviceModal: React.FC<CreateDeviceModalProps> = ({
         long_name: "",
         category: "",
         description: "",
+        tags: [],
       });
       setErrors({});
     }
@@ -167,6 +174,16 @@ const CreateDeviceModal: React.FC<CreateDeviceModalProps> = ({
           placeholder="Enter device description"
           rows={3}
         />
+        <div className="space-y-2">
+          <Label className="text-sm font-medium">Tags (Optional)</Label>
+          <MultiSelectCombobox
+            options={DEFAULT_DEVICE_TAGS}
+            placeholder="Select or create tags..."
+            value={formData.tags}
+            onValueChange={(tags) => setFormData((prev) => ({ ...prev, tags }))}
+            allowCreate={true}
+          />
+        </div>
       </div>
     </ReusableDialog>
   );

--- a/src/vertex/components/features/devices/device-category-card.tsx
+++ b/src/vertex/components/features/devices/device-category-card.tsx
@@ -9,6 +9,7 @@ import {
     TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { Device } from "@/app/types/devices";
+import { AqPuzzlePiece02 } from "@airqo/icons-react";
 
 interface DeviceCategoryCardProps {
     device: Device;
@@ -16,41 +17,54 @@ interface DeviceCategoryCardProps {
 
 const DeviceCategoryCard: React.FC<DeviceCategoryCardProps> = ({ device }) => {
     const categories = device.device_categories;
+    const isDeployed = !!categories?.deployment_category;
 
     if (!categories) return null;
 
-    const Icon = categories.deployment_category?.toLowerCase().includes('mobile') ? Car : MapPin;
+    const Icon = isDeployed
+        ? (categories.deployment_category?.toLowerCase().includes('mobile') ? Car : MapPin)
+        : AqPuzzlePiece02;
 
     return (
-        <Card className="w-full rounded-lg overflow-hidden relative">
+        <Card className="w-full rounded-lg overflow-hidden relative min-h-[140px] flex items-center justify-center">
             <TooltipProvider>
                 {/* --- Info Icon Tooltip --- */}
-                <Tooltip>
-                    <TooltipTrigger asChild>
-                        <button
-                            className="absolute top-2 right-2 p-1 text-muted-foreground hover:text-foreground"
-                            aria-label="View category details"
-                            type="button"
-                        >
-                            <Info className="w-4 h-4" />
-                        </button>
-                    </TooltipTrigger>
-                    <TooltipContent className="max-w-xs" side="bottom">
-                        <p className="text-sm font-medium mb-1">Mount Type</p>
-                        <p className="text-xs">{categories.category_relationships.note}</p>
-                    </TooltipContent>
-                </Tooltip>
+                {isDeployed && (
+                    <Tooltip>
+                        <TooltipTrigger asChild>
+                            <button
+                                className="absolute top-2 right-2 p-1 text-muted-foreground hover:text-foreground"
+                                aria-label="View category details"
+                                type="button"
+                            >
+                                <Info className="w-4 h-4" />
+                            </button>
+                        </TooltipTrigger>
+                        <TooltipContent className="max-w-xs" side="bottom">
+                            <p className="text-sm font-medium mb-1">Mount Type</p>
+                            <p className="text-xs">{categories.category_relationships?.note}</p>
+                        </TooltipContent>
+                    </Tooltip>
+                )}
 
-                <div className="flex flex-col pt-6 px-6 pb-6 space-y-4">
+                <div className="flex flex-col p-6 space-y-4 w-full">
                     <div className="flex flex-col items-center text-center cursor-default">
-                        <div className="flex items-center gap-1.5 text-lg font-semibold text-blue-700">
-                            <Icon className="w-5 h-5" />
-                            <span className="capitalize">{categories.deployment_category} Device</span>
+                        <div className={`flex items-center gap-1.5 font-semibold ${isDeployed ? 'text-lg text-blue-700' : 'text-sm text-gray-500 flex-col gap-3'}`}>
+                            <Icon className={isDeployed ? "w-5 h-5" : "w-12 h-12 text-gray-400"} />
+                            {isDeployed ? (
+                                <span className="capitalize">{categories.deployment_category} Device</span>
+                            ) : (
+                                <span className="max-w-[200px] leading-relaxed font-normal">
+                                    Device not deployed. You will see deployment category here
+                                </span>
+                            )}
                         </div>
 
-                        <div className="text-sm text-muted-foreground mt-1">
-                            {categories.category_hierarchy.find(h => h.category === categories.deployment_category)?.description || 'Deployment Category'}
-                        </div>
+                        {isDeployed && (
+                            <div className="text-sm text-muted-foreground mt-1">
+                                {categories.category_hierarchy?.find(h => h.category === categories.deployment_category)?.description || 'Deployment Category'}
+                            </div>
+                        )}
                     </div>
                 </div>
             </TooltipProvider>

--- a/src/vertex/components/features/devices/device-details-card.tsx
+++ b/src/vertex/components/features/devices/device-details-card.tsx
@@ -1,8 +1,13 @@
 import { Card } from "@/components/ui/card";
-import { useDeviceDetails } from "@/core/hooks/useDevices";
+import { useDeviceDetails, useUpdateDeviceLocal } from "@/core/hooks/useDevices";
 import { Loader2 } from "lucide-react";
-import React from "react";
+import React, { useState, useEffect } from "react";
 import ReusableButton from "@/components/shared/button/ReusableButton";
+import { Badge } from "@/components/ui/badge";
+import { AqEdit01 } from "@airqo/icons-react";
+import ReusableDialog from "@/components/shared/dialog/ReusableDialog";
+import { MultiSelectCombobox } from "@/components/ui/multi-select";
+import { DEFAULT_DEVICE_TAGS } from "@/core/constants/devices";
 
 interface DeviceDetailsCardProps {
   deviceId: string;
@@ -12,6 +17,26 @@ interface DeviceDetailsCardProps {
 const DeviceDetailsCard: React.FC<DeviceDetailsCardProps> = ({ deviceId, onShowDetailsModal }) => {
   const { data: deviceResponse, isLoading, error } = useDeviceDetails(deviceId);
   const device = deviceResponse?.data;
+  const [isTagsDialogOpen, setIsTagsDialogOpen] = useState(false);
+  const [selectedTags, setSelectedTags] = useState<string[]>([]);
+  const { mutate: updateDevice, isPending } = useUpdateDeviceLocal();
+
+  useEffect(() => {
+    if (device?.tags) {
+      setSelectedTags(device.tags);
+    }
+  }, [device?.tags]);
+
+  const handleConfirmTagsUpdate = () => {
+    updateDevice(
+      { deviceId, deviceData: { tags: selectedTags } },
+      {
+        onSuccess: () => {
+          setIsTagsDialogOpen(false);
+        },
+      }
+    );
+  };
 
   if (isLoading) {
     return <Card className="w-full rounded-lg flex flex-col justify-between items-center p-8"><Loader2 className="w-6 h-6 animate-spin" /></Card>;
@@ -24,17 +49,46 @@ const DeviceDetailsCard: React.FC<DeviceDetailsCardProps> = ({ deviceId, onShowD
     <Card className="w-full rounded-lg flex flex-col justify-between">
       <div className="px-3 py-2 flex flex-col gap-4">
         <h2 className="text-lg font-semibold">Device Details</h2>
-        <div>
-          <div className="text-xs text-muted-foreground uppercase font-medium tracking-wide mb-1">Device Name</div>
-          <div className="text-base font-normal break-all">{device.long_name || device.name}</div>
-        </div>
-        <div>
-          <div className="text-xs text-muted-foreground uppercase font-medium tracking-wide mb-1">Deployment Status</div>
-          <span className={`inline-block text-base font-mono break-all capitalize px-2 py-1 rounded-md ${device.status === "deployed" ? "text-green-600 bg-green-100" : "text-red-600 bg-red-100"}`}>{device.status}</span>
-        </div>
-        <div>
-          <div className="text-xs text-muted-foreground uppercase font-medium tracking-wide mb-1">Sensor Manufacturer</div>
-          <div className="text-base font-normal break-all">{device.network || 'N/A'}</div>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <div className="text-xs text-muted-foreground uppercase font-medium tracking-wide mb-1">Device Name</div>
+            <div className="text-base font-normal break-all">{device.long_name || device.name}</div>
+          </div>
+          <div>
+            <div className="flex items-center gap-2 mb-1">
+              <div className="text-xs text-muted-foreground uppercase font-medium tracking-wide">
+                Tags
+              </div>
+              <ReusableButton
+                variant="text"
+                onClick={() => setIsTagsDialogOpen(true)}
+                className="p-0.5 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full h-fit w-fit"
+                Icon={AqEdit01}
+                aria-label="Edit tags"
+              />
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {device.tags && device.tags.length > 0 ? (
+                device.tags.map((tag) => (
+                  <Badge key={tag} variant="secondary" className="font-normal capitalize">
+                    {tag}
+                  </Badge>
+                ))
+              ) : (
+                <span className="text-base font-normal text-muted-foreground">
+                  None
+                </span>
+              )}
+            </div>
+          </div>
+          <div>
+            <div className="text-xs text-muted-foreground uppercase font-medium tracking-wide mb-1">Deployment Status</div>
+            <span className={`inline-block text-base font-mono break-all capitalize px-2 py-1 rounded-md ${device.status === "deployed" ? "text-green-600 bg-green-100" : "text-red-600 bg-red-100"}`}>{device.status}</span>
+          </div>
+          <div>
+            <div className="text-xs text-muted-foreground uppercase font-medium tracking-wide mb-1">Sensor Manufacturer</div>
+            <div className="text-base font-normal break-all">{device.network || 'N/A'}</div>
+          </div>
         </div>
       </div>
       <div className="border-t px-2 flex justify-end">
@@ -42,6 +96,43 @@ const DeviceDetailsCard: React.FC<DeviceDetailsCardProps> = ({ deviceId, onShowD
           View more details
         </ReusableButton>
       </div>
+
+      <ReusableDialog
+        isOpen={isTagsDialogOpen}
+        onClose={() => !isPending && setIsTagsDialogOpen(false)}
+        title="Edit Device Tags"
+        size="md"
+        customFooter={
+          <div className="flex items-center justify-end gap-3 w-full px-6 py-4 border-t border-gray-200 dark:border-gray-700">
+            <ReusableButton
+              variant="outlined"
+              onClick={() => setIsTagsDialogOpen(false)}
+              disabled={isPending}
+            >
+              Cancel
+            </ReusableButton>
+            <ReusableButton
+              onClick={handleConfirmTagsUpdate}
+              disabled={isPending}
+              variant="filled"
+              className="bg-blue-600 hover:bg-blue-700"
+            >
+              {isPending ? "Updating..." : "Save Changes"}
+            </ReusableButton>
+          </div>
+        }
+      >
+        <div className="space-y-4 py-4 px-1">
+          <MultiSelectCombobox
+            options={DEFAULT_DEVICE_TAGS}
+            placeholder="Select or create tags..."
+            emptyMessage="No tags found."
+            value={selectedTags}
+            onValueChange={setSelectedTags}
+            allowCreate={true}
+          />
+        </div>
+      </ReusableDialog>
     </Card>
   );
 };

--- a/src/vertex/components/features/devices/device-details-card.tsx
+++ b/src/vertex/components/features/devices/device-details-card.tsx
@@ -22,9 +22,7 @@ const DeviceDetailsCard: React.FC<DeviceDetailsCardProps> = ({ deviceId, onShowD
   const { mutate: updateDevice, isPending } = useUpdateDeviceLocal();
 
   useEffect(() => {
-    if (device?.tags) {
-      setSelectedTags(device.tags);
-    }
+    setSelectedTags(device?.tags ?? []);
   }, [device?.tags]);
 
   const handleConfirmTagsUpdate = () => {

--- a/src/vertex/components/features/devices/import-device-modal.tsx
+++ b/src/vertex/components/features/devices/import-device-modal.tsx
@@ -14,6 +14,9 @@ import { useAppSelector } from "@/core/redux/hooks";
 import { usePathname } from "next/navigation";
 import logger from "@/lib/logger";
 import { NetworkRequestDialog } from "../networks/network-request-dialog";
+import { MultiSelectCombobox } from "@/components/ui/multi-select";
+import { DEFAULT_DEVICE_TAGS } from "@/core/constants/devices";
+import { Label } from "@/components/ui/label";
 
 interface ImportDeviceModalProps {
   open: boolean;
@@ -36,6 +39,7 @@ const ImportDeviceModal: React.FC<ImportDeviceModalProps> = ({
     writeKey: "",
     readKey: "",
     api_code: "",
+    tags: [] as string[],
   });
 
   const [showMore, setShowMore] = useState(false);
@@ -148,6 +152,7 @@ const ImportDeviceModal: React.FC<ImportDeviceModalProps> = ({
         writeKey: "",
         readKey: "",
         api_code: "",
+        tags: [],
       });
       setErrors({});
       setShowMore(false);
@@ -268,6 +273,16 @@ const ImportDeviceModal: React.FC<ImportDeviceModalProps> = ({
           placeholder="Enter device description"
           rows={3}
         />
+        <div className="space-y-2">
+          <Label className="text-sm font-medium">Tags (Optional)</Label>
+          <MultiSelectCombobox
+            options={DEFAULT_DEVICE_TAGS}
+            placeholder="Select or create tags..."
+            value={formData.tags}
+            onValueChange={(tags) => setFormData((prev) => ({ ...prev, tags }))}
+            allowCreate={true}
+          />
+        </div>
 
         {showMore && (
           <div className="space-y-4 pt-2 border-t">

--- a/src/vertex/components/features/devices/utils/table-columns.tsx
+++ b/src/vertex/components/features/devices/utils/table-columns.tsx
@@ -153,9 +153,9 @@ export const getColumns = (
         }
         return (
           <div className="flex flex-wrap gap-1 max-w-[200px]">
-            {tags.map((tag) => (
+            {tags.map((tag, index) => (
               <span
-                key={tag}
+                key={`${tag}-${index}`}
                 className="bg-blue-100 text-blue-800 text-[10px] font-medium px-2 py-0.5 rounded-full truncate capitalize"
               >
                 {tag}

--- a/src/vertex/components/features/devices/utils/table-columns.tsx
+++ b/src/vertex/components/features/devices/utils/table-columns.tsx
@@ -143,6 +143,28 @@ export const getColumns = (
         return !isNaN(num) ? num.toFixed(6) : "-";
       },
     },
+    {
+      key: "tags",
+      label: "Tags",
+      render: (value) => {
+        const tags = value as string[] | undefined;
+        if (!tags || tags.length === 0) {
+          return <span className="text-muted-foreground">-</span>;
+        }
+        return (
+          <div className="flex flex-wrap gap-1 max-w-[200px]">
+            {tags.map((tag) => (
+              <span
+                key={tag}
+                className="bg-blue-100 text-blue-800 text-[10px] font-medium px-2 py-0.5 rounded-full truncate capitalize"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        );
+      },
+    },
   ];
 
   if (isInternalView) {

--- a/src/vertex/components/features/mini-map/mini-map.tsx
+++ b/src/vertex/components/features/mini-map/mini-map.tsx
@@ -104,9 +104,10 @@ function MiniMap({
   scrollZoom = true,
   height = 'h-72',
 }: MiniMapProps) {
-  const [mapInstance, setMapInstance] = useState<mapboxgl.Map | null>(null);
+  const mapRef = useRef<mapboxgl.Map | null>(null);
   const mapContainerRef = useRef<HTMLDivElement | null>(null);
   const markerRef = useRef<mapboxgl.Marker | null>(null);
+  const drawRef = useRef<MapboxDraw | null>(null);
   const [isGeocoding, setIsGeocoding] = useState(false);
   const dispatch = useDispatch();
 
@@ -144,7 +145,7 @@ function MiniMap({
   }, [onCoordinateChange, onSiteNameChange, customSiteName]);
 
   useEffect(() => {
-    if (!mapContainerRef.current || !mapboxgl.accessToken) return;
+    if (!mapContainerRef.current || !mapboxgl.accessToken || mapRef.current) return;
 
     const latNum = latitude?.trim() === '' ? NaN : Number(latitude);
     const lngNum = longitude?.trim() === '' ? NaN : Number(longitude);
@@ -153,82 +154,102 @@ function MiniMap({
 
     const map = new mapboxgl.Map({
       container: mapContainerRef.current,
-      style: 'mapbox://styles/mapbox/streets-v11',
+      style: 'mapbox://styles/mapbox/streets-v12',
       center: currentCenter,
       zoom: zoom,
       scrollZoom: scrollZoom,
+      trackResize: true,
     });
 
-    map.addControl(new mapboxgl.NavigationControl());
+    mapRef.current = map;
 
-    if (mapMode === 'marker') {
-      markerRef.current = new mapboxgl.Marker({ draggable: true })
-        .setLngLat(currentCenter)
-        .addTo(map);
+    map.on('load', () => {
+      if (!mapRef.current) return;
 
-      markerRef.current.on('dragend', () => {
-        const lngLat = markerRef.current?.getLngLat();
-        if (lngLat) {
-          handleCoordinateUpdate(lngLat.lat, lngLat.lng);
-        }
-      });
+      map.addControl(new mapboxgl.NavigationControl());
 
-      map.on('click', (event) => {
-        const { lng, lat } = event.lngLat;
-        markerRef.current?.setLngLat([lng, lat]);
-        handleCoordinateUpdate(lat, lng);
-      });
-    } else if (mapMode === 'polygon') {
-      const draw = new MapboxDraw({
-        displayControlsDefault: false,
-        controls: {
-          polygon: true,
-          trash: true,
-        },
-        defaultMode: 'draw_polygon',
-      });
-      map.addControl(draw);
+      if (mapMode === 'marker') {
+        markerRef.current = new mapboxgl.Marker({ draggable: true })
+          .setLngLat(currentCenter)
+          .addTo(map);
 
-      const updateArea = () => {
-        const data = draw.getAll();
-        if (data.features.length > 1) {
-          const idsToDelete = data.features.slice(0, -1).map((f: { id?: string | number }) => f.id as string);
-          draw.delete(idsToDelete);
-          return;
-        }
-
-        if (data.features.length > 0) {
-          const feature = data.features[0];
-          const geometry = feature.geometry as GeoJSON.Polygon | GeoJSON.MultiPolygon;
-          if (geometry.type === 'Polygon') {
-            const transformed = geometry.coordinates.map(ring =>
-              ring.map(([lng, lat]) => [lat, lng] as [number, number])
-            );
-            dispatch(setPolygon({ type: 'Polygon', coordinates: transformed }));
-          } else if (geometry.type === 'MultiPolygon') {
-            const transformed = geometry.coordinates.map(polygon =>
-              polygon.map(ring => ring.map(([lng, lat]) => [lat, lng] as [number, number]))
-            );
-            dispatch(setPolygon({ type: 'MultiPolygon', coordinates: transformed }));
+        markerRef.current.on('dragend', () => {
+          const lngLat = markerRef.current?.getLngLat();
+          if (lngLat) {
+            handleCoordinateUpdate(lngLat.lat, lngLat.lng);
           }
-        } else {
-          dispatch(setPolygon({ type: "Polygon", coordinates: null }));
-        }
-      };
+        });
 
-      map.on('draw.create', updateArea);
-      map.on('draw.update', updateArea);
-      map.on('draw.delete', updateArea);
-    }
+        map.on('click', (event) => {
+          const { lng, lat } = event.lngLat;
+          markerRef.current?.setLngLat([lng, lat]);
+          handleCoordinateUpdate(lat, lng);
+        });
+      } else if (mapMode === 'polygon') {
+        const draw = new MapboxDraw({
+          displayControlsDefault: false,
+          controls: {
+            polygon: true,
+            trash: true,
+          },
+          defaultMode: 'draw_polygon',
+        });
+        drawRef.current = draw;
+        map.addControl(draw);
 
-    setMapInstance(map);
+        const updateArea = () => {
+          const data = draw.getAll();
+          if (data.features.length > 1) {
+            const idsToDelete = data.features.slice(0, -1).map((f: { id?: string | number }) => f.id as string);
+            draw.delete(idsToDelete);
+            return;
+          }
+
+          if (data.features.length > 0) {
+            const feature = data.features[0];
+            const geometry = feature.geometry as GeoJSON.Polygon | GeoJSON.MultiPolygon;
+            if (geometry.type === 'Polygon') {
+              const transformed = geometry.coordinates.map(ring =>
+                ring.map(([lng, lat]) => [lat, lng] as [number, number])
+              );
+              dispatch(setPolygon({ type: 'Polygon', coordinates: transformed }));
+            } else if (geometry.type === 'MultiPolygon') {
+              const transformed = geometry.coordinates.map(polygon =>
+                polygon.map(ring => ring.map(([lng, lat]) => [lat, lng] as [number, number]))
+              );
+              dispatch(setPolygon({ type: 'MultiPolygon', coordinates: transformed }));
+            }
+          } else {
+            dispatch(setPolygon({ type: "Polygon", coordinates: null }));
+          }
+        };
+
+        map.on('draw.create', updateArea);
+        map.on('draw.update', updateArea);
+        map.on('draw.delete', updateArea);
+      }
+    });
+
+    // ResizeObserver to handle container size changes (e.g. inside Dialogs/Tabs)
+    const resizeObserver = new ResizeObserver(() => {
+      map.resize();
+    });
+    resizeObserver.observe(mapContainerRef.current);
 
     return () => {
+      resizeObserver.disconnect();
       if (markerRef.current) {
         markerRef.current.remove();
         markerRef.current = null;
       }
-      map.remove();
+      if (drawRef.current && mapRef.current) {
+        mapRef.current.removeControl(drawRef.current as any);
+        drawRef.current = null;
+      }
+      if (mapRef.current) {
+        mapRef.current.remove();
+        mapRef.current = null;
+      }
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [mapMode]);
@@ -237,11 +258,11 @@ function MiniMap({
     if (mapMode !== 'marker') return;
     const latNum = latitude?.trim() === '' ? NaN : Number(latitude);
     const lngNum = longitude?.trim() === '' ? NaN : Number(longitude);
-    if (markerRef.current && mapInstance && Number.isFinite(latNum) && Number.isFinite(lngNum)) {
+    if (markerRef.current && mapRef.current && Number.isFinite(latNum) && Number.isFinite(lngNum)) {
       markerRef.current.setLngLat([lngNum, latNum]);
-      mapInstance.setCenter([lngNum, latNum]);
+      mapRef.current.setCenter([lngNum, latNum]);
     }
-  }, [latitude, longitude, mapInstance, mapMode]);
+  }, [latitude, longitude, mapMode]);
 
   return (
     <div className="space-y-4">

--- a/src/vertex/components/features/mini-map/mini-map.tsx
+++ b/src/vertex/components/features/mini-map/mini-map.tsx
@@ -243,7 +243,7 @@ function MiniMap({
         markerRef.current = null;
       }
       if (drawRef.current && mapRef.current) {
-        mapRef.current.removeControl(drawRef.current as any);
+        mapRef.current.removeControl(drawRef.current as unknown as mapboxgl.IControl);
         drawRef.current = null;
       }
       if (mapRef.current) {

--- a/src/vertex/components/ui/multi-select.tsx
+++ b/src/vertex/components/ui/multi-select.tsx
@@ -36,9 +36,9 @@ interface MultiSelectComboboxProps {
 }
 
 export function MultiSelectCombobox({
-  options,
+  options = [],
   placeholder = "Select tags...",
-  value,
+  value = [],
   onValueChange,
   allowCreate = true,
   searchValue: controlledSearchValue,
@@ -119,7 +119,7 @@ export function MultiSelectCombobox({
           className="w-full justify-between h-auto min-h-[40px] flex-wrap bg-transparent"
         >
           <div className="flex flex-wrap gap-1">
-            {value.length === 0 ? (
+            {!value || value.length === 0 ? (
               <span className="text-muted-foreground">{placeholder}</span>
             ) : (
               value.map((val) => {

--- a/src/vertex/core/apis/cohorts.ts
+++ b/src/vertex/core/apis/cohorts.ts
@@ -1,4 +1,4 @@
-import { Cohort, CohortsSummaryResponse, GroupCohortsResponse } from "@/app/types/cohorts";
+import { Cohort, CohortsSummaryResponse, GroupCohortsResponse, OriginalCohortResponse } from "@/app/types/cohorts";
 import createSecureApiClient from "../utils/secureApiProxyClient";
 
 export interface GetCohortsSummaryParams {
@@ -219,6 +219,17 @@ export const cohorts = {
         errors?: { message: string };
         cohort?: { name: string };
       };
+    } catch (error) {
+      throw error;
+    }
+  },
+  getOriginalCohortApi: async (cohortId: string): Promise<OriginalCohortResponse> => {
+    try {
+      const response = await createSecureApiClient().get(
+        `/devices/cohorts/${cohortId}/original`,
+        { headers: { 'X-Auth-Type': 'JWT' } }
+      );
+      return response.data;
     } catch (error) {
       throw error;
     }

--- a/src/vertex/core/apis/cohorts.ts
+++ b/src/vertex/core/apis/cohorts.ts
@@ -225,6 +225,9 @@ export const cohorts = {
   },
   getOriginalCohortApi: async (cohortId: string): Promise<OriginalCohortResponse> => {
     try {
+      if (!cohortId?.trim()) {
+        throw new Error('Cohort ID is required');
+      }
       const response = await createSecureApiClient().get(
         `/devices/cohorts/${cohortId}/original`,
         { headers: { 'X-Auth-Type': 'JWT' } }

--- a/src/vertex/core/apis/devices.ts
+++ b/src/vertex/core/apis/devices.ts
@@ -415,6 +415,7 @@ export const devices = {
     category: string;
     description?: string;
     network: string;
+    tags?: string[];
   }): Promise<DeviceCreationResponse> => {
     try {
       const response = await jwtApiClient.post(
@@ -440,6 +441,7 @@ export const devices = {
     api_code?: string;
     cohort_id?: string;
     user_id: string;
+    tags?: string[];
   }): Promise<DeviceCreationResponse> => {
     try {
       const response = await jwtApiClient.post(

--- a/src/vertex/core/constants/devices.ts
+++ b/src/vertex/core/constants/devices.ts
@@ -18,5 +18,6 @@ export const DEFAULT_COHORT_TAGS = [
   { value: "organizational", label: "organizational" },
   { value: "individual", label: "individual" },
   { value: "hardware", label: "hardware" },
-  { value: "misc", label: "misc" },
+  { value: "inlab", label: "inlab"},
+  { value: "misc", label: "misc" }
 ]

--- a/src/vertex/core/constants/devices.ts
+++ b/src/vertex/core/constants/devices.ts
@@ -21,3 +21,14 @@ export const DEFAULT_COHORT_TAGS = [
   { value: "inlab", label: "inlab"},
   { value: "misc", label: "misc" }
 ]
+
+export const DEFAULT_DEVICE_TAGS = [
+  { value: "urban", label: "urban" },
+  { value: "rural", label: "rural" },
+  { value: "industrial", label: "industrial" },
+  { value: "residential", label: "residential" },
+  { value: "commercial", label: "commercial" },
+  { value: "inlab", label: "inlab" },
+  { value: "reference-station", label: "reference-station" },
+  { value: "pilot", label: "pilot" }
+]

--- a/src/vertex/core/hooks/useCohorts.ts
+++ b/src/vertex/core/hooks/useCohorts.ts
@@ -10,6 +10,7 @@ import { AxiosError } from 'axios';
 import {
   CohortsSummaryResponse,
   GroupCohortsResponse,
+  OriginalCohortResponse,
 } from '@/app/types/cohorts';
 
 interface ErrorResponse {
@@ -489,5 +490,19 @@ export const useVerifyCohort = () => {
       if (!cohortId) throw new Error('Cohort ID is required');
       return await cohortsApi.verifyCohortIdApi(cohortId);
     },
+  });
+};
+
+export const useOriginalCohort = (cohortId: string, options: { enabled?: boolean } = {}) => {
+  const { enabled = true } = options;
+  return useQuery({
+    queryKey: ['original-cohort', cohortId],
+    queryFn: async () => {
+      if (!cohortId) throw new Error('Cohort ID is required');
+      return await cohortsApi.getOriginalCohortApi(cohortId);
+    },
+    enabled: !!cohortId && enabled,
+    retry: false,
+    staleTime: 300_000,
   });
 };

--- a/src/vertex/core/hooks/useDevices.ts
+++ b/src/vertex/core/hooks/useDevices.ts
@@ -506,9 +506,17 @@ export const useCreateDevice = () => {
       category: string;
       description?: string;
       network: string;
+      tags?: string[];
     }
   >({
-    mutationFn: devices.createDevice,
+    mutationFn: (variables) => {
+      const { tags, ...rest } = variables;
+      const payload = {
+        ...rest,
+        ...(tags && tags.length > 0 && { tags }),
+      };
+      return devices.createDevice(payload);
+    },
     onSuccess: (data, variables) => {
       ReusableToast({
         message: `${variables.long_name} has been created.`,
@@ -556,9 +564,17 @@ export const useImportDevice = () => {
       api_code?: string;
       cohort_id?: string;
       user_id: string;
+      tags?: string[];
     }
   >({
-    mutationFn: devices.importDevice,
+    mutationFn: (variables) => {
+      const { tags, ...rest } = variables;
+      const payload = {
+        ...rest,
+        ...(tags && tags.length > 0 && { tags }),
+      };
+      return devices.importDevice(payload);
+    },
     onSuccess: (data, variables) => {
       ReusableToast({
         message: `${variables.long_name} has been imported.`,

--- a/src/vertex/core/hooks/useGrids.ts
+++ b/src/vertex/core/hooks/useGrids.ts
@@ -136,7 +136,7 @@ export const useCreateGrid = () => {
       await grids.createGridApi(newGrid),
     onSuccess: (data) => {
       ReusableToast({
-        message: `Grid '${data.name}' created successfully`,
+        message: `New grid added!`,
         type: "SUCCESS",
       });
       queryClient.invalidateQueries({ queryKey: ["grids"] });


### PR DESCRIPTION
### Summary
This PR introduces a device tagging system for improved organization, adds original cohort tracing for duplicate cohorts, hardens the MiniMap for reliable rendering, and improves device status visualization.

---

### Changes

#### 🏷️ Device Tagging
- Added optional `tags` field to the `Device` type
- Integrated `MultiSelectCombobox` with `allowCreate` into `CreateDeviceModal` and `ImportDeviceModal`, supporting both default tags (`lowcost`, `mobile`, `inlab`, etc.) and user-defined custom tags
- Extended `createDevice` and `importDevice` APIs and hooks to forward `tags`, omitting the field if empty
- Added a **Tags** column to the device list table (rendered as badges)
- Added in-place tag viewing and editing to the `DeviceDetailsCard` via a dialog

#### 🔗 Cohort — Original Cohort Tracing
- Added `useOriginalCohort` hook and API method to fetch the source of a duplicate cohort
- `CohortDetailCard` now shows an `InfoBanner` with a link to the original cohort when the `duplicate` tag is detected
- Added `originalCohort` field to cohort types

#### 🗺️ Mapbox Reliability & Performance
- Refactored `MiniMap` to use `useRef` for the map instance with an initialization guard preventing duplicate instances
- Deferred controls, markers, and draw tools to inside `map.on('load')` to prevent race conditions
- Added `ResizeObserver` to auto-call `map.resize()` when the container resizes (fixes blank maps in Dialogs/Tabs)
- Added `<link rel="preconnect">` hints for `api.mapbox.com` and `events.mapbox.com` in the root layout
- Upgraded map style from `streets-v11` → `streets-v12`

#### 🧩 UI Improvements
- `DeviceCategoryCard`: Shows a centered `AqPuzzlePiece02` empty state with instructional text when `deployment_category` is absent; hides hierarchy and tooltip in this state
- `MultiSelectCombobox`: Hardened against `undefined` `value`/`options` props to prevent runtime crashes

#### 🔧 Other
- Updated grid creation success message copy (`useGrids.ts`)
- Added `inlab` to device category constants
- Temporarily disabled Google login while the feature is being stabilized


#### Screenshots (optional)
<img width="1920" height="873" alt="image" src="https://github.com/user-attachments/assets/19826ad6-7ae6-4d89-a1f4-acfd7bd9b5aa" />

<img width="733" height="445" alt="image" src="https://github.com/user-attachments/assets/7e1988d6-79fc-4745-b157-863ea68a730e" />

<img width="1920" height="887" alt="image" src="https://github.com/user-attachments/assets/dc8d0e98-02d1-4834-a60a-5f7f98e293ac" />

<img width="1489" height="803" alt="image" src="https://github.com/user-attachments/assets/89eaf1c0-7713-421f-bde7-653ca6c14d88" />

<img width="1510" height="488" alt="image" src="https://github.com/user-attachments/assets/e6080e05-4387-4499-b5f2-778cd91bad8c" />

<img width="1499" height="614" alt="image" src="https://github.com/user-attachments/assets/8b0acaca-fdc6-48da-9328-9b245a3d39e2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes - Version 1.23.39

* **New Features**
  * Device tagging system: Create, import, view, and edit tags when managing devices
  * Cohort duplicate detection: Original cohort links now displayed for duplicate cohorts

* **UI/UX Improvements**
  * Device category empty state messaging enhanced
  * Multi-select dropdown component stability improved
  * MiniMap resize handling and stability improvements

* **Changes**
  * Google login temporarily disabled on login page
  * Updated grid success notification message

<!-- end of auto-generated comment: release notes by coderabbit.ai -->