### PR TITLE
Vertex: Add hourly update info banner

### DIFF
--- a/src/vertex/components/features/devices/online-status-card.tsx
+++ b/src/vertex/components/features/devices/online-status-card.tsx
@@ -201,6 +201,16 @@ const OnlineStatusCard: React.FC<OnlineStatusCardProps> = ({ deviceId }) => {
             </div>
           )}
         </div>
+
+        {/* --- Hourly Update Info Banner --- */}
+        <div className="flex items-start gap-2 bg-amber-50 dark:bg-amber-950/30 border-t border-amber-200 dark:border-amber-800 px-3 py-2">
+          <Info className="w-3.5 h-3.5 text-amber-600 dark:text-amber-400 mt-0.5 shrink-0" />
+          <p className="text-xs text-amber-700 dark:text-amber-400 leading-snug">
+            Statuses are updated on an hourly basis and may not reflect the
+            most recent state of the device.
+          </p>
+        </div>
+        {/* --- End Info Banner --- */}
       </TooltipProvider>
     </Card>
   );

--- a/src/vertex/components/features/devices/online-status-card.tsx
+++ b/src/vertex/components/features/devices/online-status-card.tsx
@@ -204,7 +204,7 @@ const OnlineStatusCard: React.FC<OnlineStatusCardProps> = ({ deviceId }) => {
 
         {/* --- Hourly Update Info Banner --- */}
         <div className="flex items-start gap-2 bg-amber-50 dark:bg-amber-950/30 border-t border-amber-200 dark:border-amber-800 px-3 py-2">
-          <Info className="w-3.5 h-3.5 text-amber-600 dark:text-amber-400 mt-0.5 shrink-0" />
+          <Info className="w-3.5 h-3.5 text-amber-600 dark:text-amber-400 mt-0.5 shrink-0" aria-hidden="true" />
           <p className="text-xs text-amber-700 dark:text-amber-400 leading-snug">
             Statuses are updated on an hourly basis and may not reflect the
             most recent state of the device.


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an informational banner to device status displays indicating that statuses update hourly and may not reflect the most recent state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<img width="494" height="307" alt="image" src="https://github.com/user-attachments/assets/4edec6ac-6fcd-47bd-9867-ad640aade433" />


#### Status of maturity (all need to be checked before merging):

- [ ] I've tested this locally
- [ ] I consider this code done
- [ ] This change ready to hit production in its current state
- [ ] The title of the PR states what changed and the related issues number (used for the release note).
- [ ] I've included issue number in the "Closes #ISSUE-NUMBER" part of the "[What are the relevant tickets?](#what-are-the-relevant-tickets)" section to [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [ ] I've updated corresponding documentation for the changes in this PR.
- [ ] I have written unit and/or e2e tests for my change(s).

#### How should this be manually tested?

- Please include the steps to be done inorder to setup and test this PR.

#### What are the relevant tickets?

- Closes #<enter issue number here>
- [Jira_card_number]() (If exists)


