### PR TITLE
fix(vertex): add feedback app identifier (#3455)

### DIFF
--- a/src/vertex/components/features/feedback/feedback-launcher.tsx
+++ b/src/vertex/components/features/feedback/feedback-launcher.tsx
@@ -151,6 +151,7 @@ export const FeedbackLauncher: React.FC = () => {
         rating,
         category: mainCategory === 'issue' ? 'bug' : 'feature_request',
         platform: 'web',
+        app: 'vertex',
         metadata: defaultMetadata,
       });
 

--- a/src/vertex/core/apis/feedback.ts
+++ b/src/vertex/core/apis/feedback.ts
@@ -14,6 +14,7 @@ export interface SubmitFeedbackRequest {
   rating: number;
   category: string;
   platform: string;
+  app?: string;
   metadata?: FeedbackSubmissionMetadata;
 }
 


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

- Adds `app: 'vertex'` to Vertex feedback submissions so backend analytics can identify the source application.
- Extends the feedback submission request type with an optional `app` field.
- Keeps the existing `platform: 'web'` field unchanged.

#### Status of maturity (all need to be checked before merging):

- [x] I've tested this locally
- [x] I consider this code done
- [x] This change ready to hit production in its current state
- [x] The title of the PR states what changed and the related issues number (used for the release note).
- [x] I've included issue number in the "Closes #ISSUE-NUMBER" part of the "[What are the relevant tickets?](#what-are-the-relevant-tickets)" section to link the issue.
- [x] I've updated corresponding documentation for the changes in this PR. Documentation impact is covered in this PR; no separate user-facing docs were required for this internal request payload change.
- [ ] I have written unit and/or e2e tests for my change(s). Not added: validated with lint, TypeScript, and production build for this request payload/type change.

#### How should this be manually tested?

- From `src/vertex`, run `npm run lint`.
- From `src/vertex`, run `npx tsc --noEmit`.
- From `src/vertex`, run `npm run build`.
- Submit feedback from Vertex and confirm the request payload includes `app: 'vertex'` while preserving `platform: 'web'`.

#### What are the relevant tickets?

- Closes #3455

#### Screenshots (optional)

N/A
