### PR TITLE
feat(vertex): move Change email button inside session indicator box

### DIFF
--- a/src/vertex/app/login/page.tsx
+++ b/src/vertex/app/login/page.tsx
@@ -23,7 +23,7 @@ import { getLastActiveModule } from "@/core/utils/userPreferences";
 import { VERTEX_DESKTOP_DOWNLOADS } from "@/core/constants/app-downloads";
 // import GoogleAuthSection from "@/components/features/auth/google-auth-section";
 import { motion, AnimatePresence } from "framer-motion";
-import { ChevronLeft } from "lucide-react";
+
 
 const loginSchema = z.object({
   userName: z.string().email({ message: "Please enter a valid email address" }),
@@ -278,7 +278,15 @@ export default function LoginPage() {
                         transition={{ duration: 0.2 }}
                         className="space-y-5"
                       >
-                        <div className="flex flex-col space-y-1">
+                       <div className="rounded-lg bg-muted/50 p-3 flex items-center justify-between">
+                          <div className="flex flex-col min-w-0">
+                            <span className="text-xs text-muted-foreground">
+                              Signing in as
+                            </span>
+                            <span className="text-sm font-semibold truncate">
+                              {form.getValues('userName')}
+                            </span>
+                          </div>
                           <button
                             type="button"
                             disabled={isLoading}
@@ -287,15 +295,10 @@ export default function LoginPage() {
                               form.clearErrors('password');
                               setStep('email');
                             }}
-                            className="flex items-center text-sm font-medium text-muted-foreground hover:text-foreground transition-colors w-fit -ml-1 mb-2 disabled:opacity-50 disabled:cursor-not-allowed"
+                            className="text-xs font-medium text-primary border border-primary/40 rounded-md px-2.5 py-1 hover:bg-primary/10 active:bg-primary/20 transition-colors ml-3 shrink-0 disabled:opacity-50 disabled:cursor-not-allowed"
                           >
-                            <ChevronLeft className="h-4 w-4 mr-0.5" />
                             Change email
                           </button>
-                          <div className="rounded-lg bg-muted/50 p-3 flex flex-col">
-                            <span className="text-xs text-muted-foreground">Signing in as</span>
-                            <span className="text-sm font-semibold truncate">{form.getValues('userName')}</span>
-                          </div>
                         </div>
 
                         <FormField


### PR DESCRIPTION
#### Summary of Changes.

- This PR moves the "Change email" action inside the "Signing in as" component on the Vertex user account view, so the email-related controls are visually grouped together as one logical unit.

Motivation: Previously, "Change email" sat outside the "Signing in as" box, creating a disconnected user experience for an action that semantically belongs with the email being displayed.

No new dependencies are required.

#### Status of maturity (all need to be checked before merging):

- [x] I've tested this locally
- [x] I consider this code done
- [x] This change ready to hit production in its current state
- [x] The title of the PR states what changed and the related issues number (used for the release note).
- [x] I've included issue number in the "Closes #3447" part of the "[What are the relevant tickets?](#what-are-the-relevant-tickets)" section to [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [ ] I've updated corresponding documentation for the changes in this PR.
- [ ] I have written unit and/or e2e tests for my change(s).

#### How should this be manually tested?

1. Pull this branch and run `npm install` in `src/vertex`.
2. Run `npm run dev` and open `http://localhost:3000`.
3. Go to the `http://localhost:3000` in your broswer.
4. Verify that "Change email" now appears inside the "Signing in as" component rather than outside it.


#### What are the relevant tickets?

- Closes #3447


#### Screenshots (optional)
 **Before:**
<img width="1366" height="768" alt="before" src="https://github.com/user-attachments/assets/f3ab3993-bcb5-441c-bef2-f53e95fdbbb6" />

 **After:**
<img width="1366" height="768" alt="after" src="https://github.com/user-attachments/assets/9d423a18-7434-44e2-b1b3-1ff434bdebc2" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the login interface on the password step with an improved layout. The "Signing in as" section now displays horizontally with refreshed styling for the "Change email" option, enhancing usability while maintaining full functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/airqo-platform/AirQo-frontend/pull/3473)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->