### PR TITLE
Implement context aware global banner

### DIFF
--- a/src/vertex/app/providers.tsx
+++ b/src/vertex/app/providers.tsx
@@ -10,6 +10,7 @@ import { ThemeProvider } from "@/components/theme-provider";
 import SessionLoadingState from "@/components/layout/loading/session-loading";
 import { QueryProvider } from "@/core/providers/query-provider";
 import { runClientCacheMaintenance } from "@/core/utils/clientCache";
+import { BannerProvider, GlobalBannerContainer } from "@/context/banner-context";
 
 const NetworkStatusBanner = dynamic(
   () => import('@/components/features/network-status-banner'),
@@ -46,7 +47,10 @@ export default function Providers({ children, session }: { children: React.React
               enableSystem={false}
               disableTransitionOnChange
             >
-              {children}
+              <BannerProvider>
+                <GlobalBannerContainer />
+                {children}
+              </BannerProvider>
             </ThemeProvider>
             {process.env.NODE_ENV !== "production" && (
               <ReactQueryDevtools initialIsOpen={false} />

--- a/src/vertex/context/banner-context.tsx
+++ b/src/vertex/context/banner-context.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import React, { createContext, useContext, useState, useCallback } from 'react';
+import { Banner, type BannerProps, type BannerSeverity } from '@/components/ui/banner';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface BannerState {
+  severity: BannerSeverity;
+  message?: React.ReactNode;
+  title?: React.ReactNode;
+  isVisible: boolean;
+  isScoped: boolean;
+}
+
+type ShowBannerOptions = Omit<BannerProps, 'dismissible' | 'onDismiss'> & {
+  scoped?: boolean;
+};
+
+interface BannerContextValue {
+  state: BannerState;
+  showBanner: (options: ShowBannerOptions) => void;
+  hideBanner: () => void;
+}
+
+// ============================================================================
+// Context
+// ============================================================================
+
+const BannerContext = createContext<BannerContextValue | null>(null);
+
+const DEFAULT_STATE: BannerState = {
+  severity: 'info',
+  isVisible: false,
+  isScoped: false,
+};
+
+// ============================================================================
+// Provider
+// ============================================================================
+
+export function BannerProvider({ children }: { children: React.ReactNode }) {
+  const [state, setState] = useState<BannerState>(DEFAULT_STATE);
+
+  const showBanner = useCallback((options: ShowBannerOptions) => {
+    const { scoped = false, severity, message, title } = options;
+    setState({ severity, message, title, isVisible: true, isScoped: scoped });
+  }, []);
+
+  const hideBanner = useCallback(() => {
+    setState(DEFAULT_STATE);
+  }, []);
+
+  return (
+    <BannerContext.Provider value={{ state, showBanner, hideBanner }}>
+      {children}
+    </BannerContext.Provider>
+  );
+}
+
+// ============================================================================
+// Hook
+// ============================================================================
+
+export function useBanner() {
+  const ctx = useContext(BannerContext);
+  if (!ctx) throw new Error('useBanner must be used within a BannerProvider');
+  return {
+    showBanner: ctx.showBanner,
+    hideBanner: ctx.hideBanner,
+    BannerSlot,
+  };
+}
+
+// ============================================================================
+// BannerSlot — drop inside any Dialog or Page to receive scoped banners
+// ============================================================================
+
+export function BannerSlot() {
+  const ctx = useContext(BannerContext);
+  if (!ctx) return null;
+
+  const { state, hideBanner } = ctx;
+  if (!state.isVisible || !state.isScoped) return null;
+
+  return (
+    <Banner
+      severity={state.severity}
+      title={state.title}
+      message={state.message}
+      dismissible
+      onDismiss={hideBanner}
+      className="rounded-none border-x-0 border-t-0"
+    />
+  );
+}
+
+// ============================================================================
+// GlobalBannerContainer — lives in the root layout, handles non-scoped banners
+// ============================================================================
+
+export function GlobalBannerContainer() {
+  const ctx = useContext(BannerContext);
+  if (!ctx) return null;
+
+  const { state, hideBanner } = ctx;
+  if (!state.isVisible || state.isScoped) return null;
+
+  return (
+    <div className="px-4 pt-3">
+      <Banner
+        severity={state.severity}
+        title={state.title}
+        message={state.message}
+        dismissible
+        onDismiss={hideBanner}
+      />
+    </div>
+  );
+}

--- a/src/vertex/context/banner-context.tsx
+++ b/src/vertex/context/banner-context.tsx
@@ -1,23 +1,21 @@
 'use client';
 
 import React, { createContext, useContext, useState, useCallback } from 'react';
-import { Banner, type BannerProps, type BannerSeverity } from '@/components/ui/banner';
+import { Banner, type BannerProps } from '@/components/ui/banner';
 
 // ============================================================================
 // Types
 // ============================================================================
 
+type BannerDisplayProps = Omit<BannerProps, 'dismissible' | 'onDismiss'>;
+
 interface BannerState {
-  severity: BannerSeverity;
-  message?: React.ReactNode;
-  title?: React.ReactNode;
+  bannerProps: BannerDisplayProps;
   isVisible: boolean;
   isScoped: boolean;
 }
 
-type ShowBannerOptions = Omit<BannerProps, 'dismissible' | 'onDismiss'> & {
-  scoped?: boolean;
-};
+type ShowBannerOptions = BannerDisplayProps & { scoped?: boolean };
 
 interface BannerContextValue {
   state: BannerState;
@@ -32,7 +30,7 @@ interface BannerContextValue {
 const BannerContext = createContext<BannerContextValue | null>(null);
 
 const DEFAULT_STATE: BannerState = {
-  severity: 'info',
+  bannerProps: { severity: 'info' },
   isVisible: false,
   isScoped: false,
 };
@@ -45,8 +43,8 @@ export function BannerProvider({ children }: { children: React.ReactNode }) {
   const [state, setState] = useState<BannerState>(DEFAULT_STATE);
 
   const showBanner = useCallback((options: ShowBannerOptions) => {
-    const { scoped = false, severity, message, title } = options;
-    setState({ severity, message, title, isVisible: true, isScoped: scoped });
+    const { scoped = false, ...bannerProps } = options;
+    setState({ bannerProps, isVisible: true, isScoped: scoped });
   }, []);
 
   const hideBanner = useCallback(() => {
@@ -87,9 +85,7 @@ export function BannerSlot() {
 
   return (
     <Banner
-      severity={state.severity}
-      title={state.title}
-      message={state.message}
+      {...state.bannerProps}
       dismissible
       onDismiss={hideBanner}
       className="rounded-none border-x-0 border-t-0"
@@ -111,9 +107,7 @@ export function GlobalBannerContainer() {
   return (
     <div className="px-4 pt-3">
       <Banner
-        severity={state.severity}
-        title={state.title}
-        message={state.message}
+        {...state.bannerProps}
         dismissible
         onDismiss={hideBanner}
       />


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

- Adds centralized banner notification infrastructure to replace floating toasts. Built a `BannerContext`, `useBanner` hook, `BannerSlot` and `GlobalBannerContainer`. The login page is the first test wrong password now shows an error banner inside the card, this was just for demonstration login page.tsx still uses the old Toast. No new dependencies, the `Banner` component was already there.

#### Status of maturity (all need to be checked before merging):

- [x] I've tested this locally
- [x] I consider this code done
- [x] This change ready to hit production in its current state
- [x] The title of the PR states what changed and the related issues number (used for the release note).
- [ ] I've included issue number in the "Closes #3449 " part of the "[What are the relevant tickets?](#what-are-the-relevant-tickets)" section to [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [ ] I've updated corresponding documentation for the changes in this PR.
- [ ] I have written unit and/or e2e tests for my change(s).

#### How should this be manually tested?
-Navigate to `src/vertex/context/banner-context.tsx`.
-This exports banner context provider.
-Navigate to `src/vertex/app/providers.tsx`.
-The provider is wrapped around the component tree.

#### What are the relevant tickets?

- Closes #3449


#### Screenshots 
### Expected output after banner implementation
<img width="1366" height="768" alt="after_banner" src="https://github.com/user-attachments/assets/94fef5ff-33b9-47a4-a2d3-996ed71ac471" />






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a flexible banner notification system with scoped (page/dialog) and global (application-wide) banners for improved user communication.
  * Banners support severity, titles, messages and dismiss controls for better user control.
  * Integrated global banner rendering into the app's provider tree so global notifications appear consistently across the UI.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/airqo-platform/AirQo-frontend/pull/3481?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->