### PR TITLE
fix(api): gracefully handle canceled requests in secure API interceptor (Vertex app)

### DIFF
--- a/src/vertex/app/changelog.md
+++ b/src/vertex/app/changelog.md
@@ -4,6 +4,29 @@
 
 ---
 
+## Version 1.23.40
+**Released:** May 16, 2026
+
+### Graceful Handling of Canceled API Requests
+
+Fixed a false-positive production error alert caused by React Query's `AbortSignal` cancellations being treated as genuine API failures in the Axios response interceptor.
+
+<details>
+<summary><strong>Bug Fixes (1)</strong></summary>
+
+- **Canceled Request False-Positives**: Added an early-return guard using `axios.isCancel()` and `instanceof CanceledError` at the top of the `secureApiProxyClient` response error interceptor. Requests canceled by React Query's `AbortSignal` (e.g. on component unmount during navigation) are now silently passed through without triggering `logger.error`, token cache invalidation, or the `auth-token-expired` event — all of which were previously firing incorrectly for benign client-side aborts.
+
+</details>
+
+<details>
+<summary><strong>Files Modified (1)</strong></summary>
+
+- `src/vertex/core/utils/secureApiProxyClient.ts` [MODIFIED]
+
+</details>
+
+---
+
 ## Version 1.23.39
 **Released:** May 07, 2026
 

--- a/src/vertex/core/utils/secureApiProxyClient.ts
+++ b/src/vertex/core/utils/secureApiProxyClient.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosInstance, InternalAxiosRequestConfig, AxiosHeaders } from 'axios';
+import axios, { AxiosInstance, InternalAxiosRequestConfig, AxiosHeaders, CanceledError } from 'axios';
 import { getSession } from 'next-auth/react';
 import { getApiToken } from '@/lib/envConstants';
 import logger from '@/lib/logger';
@@ -132,6 +132,10 @@ const createSecureApiClient = (): AxiosInstance => {
       return response;
     },
     (error) => {
+      if (axios.isCancel(error) || error instanceof CanceledError) {
+        return Promise.reject(error);
+      }
+
       const status = error.response?.status;
       const url = error.config?.url;
       const authType = (error.config?.headers?.['x-auth-type'] || 'jwt').toString().toLowerCase();


### PR DESCRIPTION
### Problem
When users navigated away from a page mid-fetch, React Query would abort the in-flight request via `AbortSignal`. This cancellation was being caught by the Axios response interceptor in `secureApiProxyClient.ts` and incorrectly treated as a hard API failure, resulting in:

- **False-positive `ERROR [production]` alerts** logged to the monitoring channel with `message: "canceled"` and `authType: "jwt"` — making it appear as an auth failure when it was a normal client-side abort.
- **Spurious side effects** — the `auth-token-expired` custom event and `tokenCache.clear()` could be triggered on what was simply a navigation-driven cancellation.

### Root Cause
The interceptor's error handler had no guard for `CanceledError`, so every aborted request fell through to the full error-handling pipeline (`logger.error`, auth event dispatch, token cache invalidation).

### Fix
Added an early-return guard at the top of the response error interceptor using both `axios.isCancel()` and `instanceof CanceledError` to cover all cancellation patterns (cancel tokens and `AbortSignal`):

```ts
if (axios.isCancel(error) || error instanceof CanceledError) {
  return Promise.reject(error);
}
```

Cancellations are re-rejected (not swallowed) so React Query can still process them internally — it already suppresses `CanceledError` from triggering query error states or `onError` callbacks, preventing any UI crash.

### What This Fixes
| Issue | Resolution |
|---|---|
| False-positive `ERROR [production]` Slack alerts | ✅ No longer logged |
| Spurious `auth-token-expired` event dispatch | ✅ Guard exits before reaching that code |
| Token cache incorrectly cleared | ✅ Guard exits before `tokenCache.clear()` |
| UI crash / query entering error state | ✅ Already handled by React Query; fix ensures no side effects interfere |

### Files Changed
- `core/utils/secureApiProxyClient.ts`
