### PR TITLE
feat(vertex/devices): migrate Device Management module to InfoBanner

### DIFF
--- a/src/vertex/components/features/devices/add-maintenance-log-modal.tsx
+++ b/src/vertex/components/features/devices/add-maintenance-log-modal.tsx
@@ -9,7 +9,7 @@ import { useUserContext } from "@/core/hooks/useUserContext";
 import { MultiSelectCombobox } from "@/components/ui/multi-select";
 import { Switch } from "@/components/ui/switch";
 import ReusableDialog from "@/components/shared/dialog/ReusableDialog";
-import ReusableToast from "@/components/shared/toast/ReusableToast";
+import { useBanner, BannerSlot } from "@/context/banner-context";
 
 interface AddMaintenanceLogModalProps {
   open: boolean;
@@ -51,6 +51,7 @@ const AddMaintenanceLogModal: React.FC<AddMaintenanceLogModalProps> = ({ open, o
   const [maintenanceType, setMaintenanceType] = useState<"preventive" | "corrective">("preventive");
 
   const { userDetails } = useUserContext();
+  const { showBanner } = useBanner();
   const addMaintenanceLog = useAddMaintenanceLog();
 
   // Reset form when modal opens/closes
@@ -65,7 +66,7 @@ const AddMaintenanceLogModal: React.FC<AddMaintenanceLogModalProps> = ({ open, o
 
   const handleSubmit = async () => {
     if (!date || selectedTags.length === 0) {
-      ReusableToast({message: "Please fill all fields", type:"ERROR"})
+      showBanner({ severity: 'error', message: 'Please fill all required fields', scoped: true });
       return;
     }
 
@@ -104,6 +105,7 @@ const AddMaintenanceLogModal: React.FC<AddMaintenanceLogModalProps> = ({ open, o
       }}
     >
       <div className="space-y-4">
+        <BannerSlot />
         <div className="flex items-center space-x-2">
           <Label>Maintenance Type:</Label>
           <span className={maintenanceType === 'preventive' ? 'font-semibold' : ''}>Preventive</span>

--- a/src/vertex/components/features/devices/create-device-modal.tsx
+++ b/src/vertex/components/features/devices/create-device-modal.tsx
@@ -10,6 +10,7 @@ import ReusableSelectInput from "@/components/shared/select/ReusableSelectInput"
 import { MultiSelectCombobox } from "@/components/ui/multi-select";
 import { DEFAULT_DEVICE_TAGS } from "@/core/constants/devices";
 import { Label } from "@/components/ui/label";
+import { useBanner, BannerSlot } from "@/context/banner-context";
 
 interface CreateDeviceModalProps {
   open: boolean;
@@ -30,6 +31,7 @@ const CreateDeviceModal: React.FC<CreateDeviceModalProps> = ({
   });
 
   const [errors, setErrors] = useState<Record<string, string>>({});
+  const { showBanner } = useBanner();
   const activeNetwork = useAppSelector((state) => state.user.activeNetwork);
   const createDevice = useCreateDevice();
 
@@ -56,7 +58,7 @@ const CreateDeviceModal: React.FC<CreateDeviceModalProps> = ({
     const effectiveNetworkName = networkName || activeNetwork?.net_name;
 
     if (!effectiveNetworkName) {
-      setErrors({ general: "No active Sensor Manufacturer found" });
+      showBanner({ severity: 'error', message: 'No active Sensor Manufacturer found', scoped: true });
       return;
     }
 
@@ -136,11 +138,7 @@ const CreateDeviceModal: React.FC<CreateDeviceModalProps> = ({
       }}
     >
       <div className="space-y-4">
-        {errors.general && (
-          <div className="text-sm text-red-600 bg-red-50 p-2 rounded">
-            {errors.general}
-          </div>
-        )}
+        <BannerSlot />
         <ReusableInputField
           label="Device Name"
           id="long_name"

--- a/src/vertex/components/features/devices/deploy-device-component.tsx
+++ b/src/vertex/components/features/devices/deploy-device-component.tsx
@@ -26,7 +26,7 @@ import { useUserContext } from "@/core/hooks/useUserContext";
 import { useDeviceDetails, useDevices, useDeployDevice } from "@/core/hooks/useDevices";
 import { ComboBox } from "@/components/ui/combobox";
 import { Device, type DevicePreviousSite } from "@/app/types/devices";
-import ReusableToast from "@/components/shared/toast/ReusableToast";
+import { useBanner, BannerSlot } from "@/context/banner-context";
 import LocationAutocomplete from "@/components/features/location-autocomplete/LocationAutocomplete";
 import { useNetworks } from "@/core/hooks/useNetworks";
 const MiniMap = React.lazy(() => import("../mini-map/mini-map"));
@@ -427,6 +427,7 @@ const DeployDeviceComponent = ({
   onDeploymentError
 }: DeployDeviceComponentProps) => {
   const queryClient = useQueryClient();
+  const { showBanner } = useBanner();
   const { userScope, userDetails } = useUserContext();
   const { devices: allDevices } = useDevices({ enabled: userScope !== 'personal' });
   const [currentStep, setCurrentStep] = React.useState<number>(0);
@@ -608,10 +609,7 @@ const DeployDeviceComponent = ({
 
   const handleNext = (): void => {
     if (currentStep === 0 && !validateDeviceDetails()) {
-      ReusableToast({
-        type: "ERROR",
-        message: "Incomplete Details: Please fill in all required device details.",
-      });
+      showBanner({ severity: 'error', message: 'Incomplete Details: Please fill in all required device details.', scoped: true });
       return;
     }
     setCurrentStep((prev) => Math.min(prev + 1, siteSource === 'new' ? 2 : 1));
@@ -642,18 +640,12 @@ const DeployDeviceComponent = ({
 
   const handleDeploy = (): void => {
     if (!userDetails?._id) {
-      ReusableToast({
-        type: "ERROR",
-        message: "User information not available. Please reload the page.",
-      });
+      showBanner({ severity: 'error', message: 'User information not available. Please reload the page.', scoped: true });
       return;
     }
 
     if (siteSource === 'previous' && !deviceData.site_id) {
-      ReusableToast({
-        type: "ERROR",
-        message: "Select a previous site to continue.",
-      });
+      showBanner({ severity: 'error', message: 'Select a previous site to continue.', scoped: true });
       return;
     }
 
@@ -815,6 +807,7 @@ const DeployDeviceComponent = ({
     <div className="flex flex-col md:flex-row h-full">
       {/* Main Steps Column */}
       <div className="flex-1 min-w-0">
+        <BannerSlot />
         {steps.map((step, idx) => (
           <StepCard
             key={step.title}

--- a/src/vertex/components/features/devices/import-device-modal.tsx
+++ b/src/vertex/components/features/devices/import-device-modal.tsx
@@ -17,6 +17,7 @@ import { NetworkRequestDialog } from "../networks/network-request-dialog";
 import { MultiSelectCombobox } from "@/components/ui/multi-select";
 import { DEFAULT_DEVICE_TAGS } from "@/core/constants/devices";
 import { Label } from "@/components/ui/label";
+import { BannerSlot } from "@/context/banner-context";
 
 interface ImportDeviceModalProps {
   open: boolean;
@@ -180,11 +181,7 @@ const ImportDeviceModal: React.FC<ImportDeviceModalProps> = ({
       }}
     >
       <div className="space-y-2">
-        {errors.general && (
-          <div className="text-sm text-red-600 bg-red-50 p-2 rounded">
-            {errors.general}
-          </div>
-        )}
+        <BannerSlot />
 
         <ReusableInputField
           label="Device Name"

--- a/src/vertex/components/features/devices/recall-device-dialog.tsx
+++ b/src/vertex/components/features/devices/recall-device-dialog.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import ReusableDialog from "@/components/shared/dialog/ReusableDialog";
 import ReusableSelectInput from "@/components/shared/select/ReusableSelectInput";
 import { useRecallDevice } from "@/core/hooks/useDevices";
+import { BannerSlot } from "@/context/banner-context";
 import { useUserContext } from "@/core/hooks/useUserContext";
 
 interface RecallDeviceDialogProps {
@@ -78,7 +79,9 @@ export default function RecallDeviceDialog({
         variant: "outline",
       }}
     >
-      <ReusableSelectInput
+      <div className="space-y-4">
+        <BannerSlot />
+        <ReusableSelectInput
         label="Set Recall Type"
         required
         value={recallType}
@@ -87,6 +90,7 @@ export default function RecallDeviceDialog({
       >
         {recallTypes.map((type) => <option key={type.value} value={type.value}>{type.label}</option>)}
       </ReusableSelectInput>
+      </div>
     </ReusableDialog>
   );
 }


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

Replaces `ReusableToast` calls with `useBanner` across device management
components. Error and validation feedback now renders as an InfoBanner
inside the active modal or dialog container instead of a floating toast,
keeping the message in context with the action the user is performing.

No new dependencies required. Depends on the `BannerContext` infrastructure
added in the previous PR.

Changes per component:
- **create-device-modal** — `BannerSlot` added; missing network error now shows as a scoped banner
- **import-device-modal** — `BannerSlot` added for future feedback readiness
- **add-maintenance-log-modal** — validation toast replaced with scoped banner
- **recall-device-dialog** — `BannerSlot` added above the recall type select
- **deploy-device-component** — 3 validation toasts replaced with scoped banners, `BannerSlot` placed at top of steps column

#### Status of maturity (all need to be checked before merging):

- [x] I've tested this locally
- [x] I consider this code done
- [x] This change ready to hit production in its current state
- [x] The title of the PR states what changed and the related issues number (used for the release note).
- [ ] I've included issue number in the "Closes #3451" part of the "[What are the relevant tickets?](#what-are-the-relevant-tickets)" section to [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [ ] I've updated corresponding documentation for the changes in this PR.
- [ ] I have written unit and/or e2e tests for my change(s).

#### How should this be manually tested?

**Deploy Device** (`/devices/overview/[device-id]` → Deploy action)
1. Open the Deploy Device flow
2. Click **Next** without filling required fields  confirm error banner appears at the top of the steps column
3. Fill all fields and attempt deploy without a user session confirm the user info error banner appears
4. Select "Previous site" without picking a site confirm the site selection error banner appears

**Add Maintenance Log** (Device detail page ,Maintenance tab)
1. Open the Add Maintenance Log dialog
2. Click **Save Log** without selecting tags confirm the error banner appears inside the dialog above the form fields
3. Fill all required fields and save — confirm the dialog closes normally

**Create Device** (`/admin/networks/[id]` requires admin access)
1. Open the Add AirQo Device dialog
2. Confirm the layout is intact and no visual regressions

**Import Device** (`/devices/overview` or `/devices/my-devices`)
1. Open the Import Device dialog
2. Confirm the layout is intact and no visual regressions

**Recall Device** (Device detail page → Recall action)
1. Open the Recall Device dialog
2. Confirm the `BannerSlot` area renders cleanly above the recall type select

#### What are the relevant tickets?

- Closes #3451

#### Screenshots (optional)

> Full coverage was not possible for all modals — admin-gated pages
> (Create Device, Recall Device) could not be reached during local testing.

**Deploy Device  validation error banner**
<img width="1366" height="768" alt="Deploy_after" src="https://github.com/user-attachments/assets/969edf1f-1004-488e-b374-a5b7489515c7" />



**Maintenance Log  validation error banner**
<img width="1366" height="768" alt="matainance_banner" src="https://github.com/user-attachments/assets/18208d96-a727-4b1a-8a15-975872a69dd2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized error display across device management modals and dialogs to use the app banner system (renders banner area and shows scoped error banners).
  * Replaced prior in-component error blocks and toast notifications with the unified banner approach for create/import/add-maintenance/deploy/recall flows, improving consistency and visibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/airqo-platform/AirQo-frontend/pull/3490?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->