### PR TITLE
feat(vertex/devices): migrate device management toasts to InfoBanner …

### DIFF
--- a/src/vertex/app/changelog.md
+++ b/src/vertex/app/changelog.md
@@ -4,6 +4,50 @@
 
 ---
 
+## Version 1.23.44
+**Released:** May 19, 2026
+
+### Device Management Scoped Banner Migration & Mutation Callback Cleanup
+
+Migrated feedback notifications from global floating toasts (`ReusableToast`) to context-aware `InfoBanner` components (`useBanner`) inside device management modules to keep alerts inline and centered within their active modal or dialog containers. Refactored React Query hook callbacks to push feedback responsibility to the UI components.
+
+<details>
+<summary><strong>Device Management — Scoped Banner Migration (7)</strong></summary>
+
+- **Create Device Modal**: Integrated `useBanner` for scoped validation and creation alerts. The `showBanner` utility replaces the old inline red error block for missing network errors.
+- **Import Device Modal**: Integrated `useBanner` to surface a previously silent missing user ID warning and errors. Replaced old inline red error alerts and fixed a critical TypeScript compilation error where `importDevice.mutate()` was called with 3 arguments instead of 1-2 by merging the `onSuccess` and `onError` options into a single second argument. Added missing `getApiErrorMessage` import.
+- **Add Maintenance Log Modal**: Replaced `ReusableToast` with scoped `showBanner` for validation errors to align modal design feedback.
+- **Deploy Device Component**: Swapped 3 occurrences of `ReusableToast` with `showBanner` alerts.
+- **Recall Device Dialog**: Added `useBanner` support and shifted all success and error UI notifications from raw hook callbacks directly to try/catch blocks within the component.
+- **Device Details Modal**: Migrated all validation, detail update, and key decryption feedback from floating toasts to `showBanner`. Added local callback overrides to the `updateLocal` and `updateGlobal` mutate invocations.
+- **Device Assignment Modal**: Added `useBanner` with `scoped: false` (since this dialog extends base Radix `Dialog` rather than `ReusableDialog`), keeping assignment feedback in the modal itself instead of hook side-effects.
+
+</details>
+
+<details>
+<summary><strong>Custom Hook & Callback Separation (1)</strong></summary>
+
+- **useDevices Hooks Overhaul**: Removed imperative `ReusableToast` side-effects from `useRecallDevice`, `useUpdateDeviceLocal`, `useUpdateDeviceGlobal`, `useAssignDeviceToOrganization`, and `useDecryptDeviceKeys`. Hooks are now clean, focused solely on API interactions and cache invalidation.
+
+</details>
+
+<details>
+<summary><strong>Files Modified (8)</strong></summary>
+
+- `src/vertex/app/changelog.md` [MODIFIED]
+- `src/vertex/components/features/devices/create-device-modal.tsx` [MODIFIED]
+- `src/vertex/components/features/devices/import-device-modal.tsx` [MODIFIED]
+- `src/vertex/components/features/devices/add-maintenance-log-modal.tsx` [MODIFIED]
+- `src/vertex/components/features/devices/deploy-device-component.tsx` [MODIFIED]
+- `src/vertex/components/features/devices/recall-device-dialog.tsx` [MODIFIED]
+- `src/vertex/components/features/devices/device-details-modal.tsx` [MODIFIED]
+- `src/vertex/components/features/devices/device-assignment-modal.tsx` [MODIFIED]
+- `src/vertex/core/hooks/useDevices.ts` [MODIFIED]
+
+</details>
+
+---
+
 ## Version 1.23.43
 **Released:** May 17, 2026
 

--- a/src/vertex/components/features/devices/add-maintenance-log-modal.tsx
+++ b/src/vertex/components/features/devices/add-maintenance-log-modal.tsx
@@ -85,7 +85,13 @@ const AddMaintenanceLogModal: React.FC<AddMaintenanceLogModalProps> = ({ open, o
 
     try {
       await addMaintenanceLog.mutateAsync({ deviceName, logData });
-      showBanner({ severity: 'success', message: `Maintenance log has been added for ${deviceName}.`, scoped: false });
+      setTimeout(() => {
+        showBanner({
+          severity: 'success',
+          title: 'Success',
+          message: `Maintenance log for ${deviceName} has been added successfully.`,
+        });
+      }, 300);
       onOpenChange(false);
     } catch (error) {
       showBanner({ severity: 'error', message: `Failed to Add Maintenance Log: ${getApiErrorMessage(error)}`, scoped: true });

--- a/src/vertex/components/features/devices/add-maintenance-log-modal.tsx
+++ b/src/vertex/components/features/devices/add-maintenance-log-modal.tsx
@@ -10,6 +10,7 @@ import { MultiSelectCombobox } from "@/components/ui/multi-select";
 import { Switch } from "@/components/ui/switch";
 import ReusableDialog from "@/components/shared/dialog/ReusableDialog";
 import { useBanner } from "@/context/banner-context";
+import { getApiErrorMessage } from "@/core/utils/getApiErrorMessage";
 
 interface AddMaintenanceLogModalProps {
   open: boolean;
@@ -82,8 +83,13 @@ const AddMaintenanceLogModal: React.FC<AddMaintenanceLogModalProps> = ({ open, o
       user_id: userDetails?._id || "",
     };
 
-    await addMaintenanceLog.mutateAsync({ deviceName, logData });
-    onOpenChange(false);
+    try {
+      await addMaintenanceLog.mutateAsync({ deviceName, logData });
+      showBanner({ severity: 'success', message: `Maintenance log has been added for ${deviceName}.`, scoped: false });
+      onOpenChange(false);
+    } catch (error) {
+      showBanner({ severity: 'error', message: `Failed to Add Maintenance Log: ${getApiErrorMessage(error)}`, scoped: true });
+    }
   };
 
   return (

--- a/src/vertex/components/features/devices/add-maintenance-log-modal.tsx
+++ b/src/vertex/components/features/devices/add-maintenance-log-modal.tsx
@@ -9,7 +9,7 @@ import { useUserContext } from "@/core/hooks/useUserContext";
 import { MultiSelectCombobox } from "@/components/ui/multi-select";
 import { Switch } from "@/components/ui/switch";
 import ReusableDialog from "@/components/shared/dialog/ReusableDialog";
-import ReusableToast from "@/components/shared/toast/ReusableToast";
+import { useBanner } from "@/context/banner-context";
 
 interface AddMaintenanceLogModalProps {
   open: boolean;
@@ -51,6 +51,7 @@ const AddMaintenanceLogModal: React.FC<AddMaintenanceLogModalProps> = ({ open, o
   const [maintenanceType, setMaintenanceType] = useState<"preventive" | "corrective">("preventive");
 
   const { userDetails } = useUserContext();
+  const { showBanner } = useBanner();
   const addMaintenanceLog = useAddMaintenanceLog();
 
   // Reset form when modal opens/closes
@@ -65,7 +66,7 @@ const AddMaintenanceLogModal: React.FC<AddMaintenanceLogModalProps> = ({ open, o
 
   const handleSubmit = async () => {
     if (!date || selectedTags.length === 0) {
-      ReusableToast({message: "Please fill all fields", type:"ERROR"})
+      showBanner({ severity: 'error', message: 'Please fill all required fields', scoped: true });
       return;
     }
 

--- a/src/vertex/components/features/devices/add-maintenance-log-modal.tsx
+++ b/src/vertex/components/features/devices/add-maintenance-log-modal.tsx
@@ -90,6 +90,7 @@ const AddMaintenanceLogModal: React.FC<AddMaintenanceLogModalProps> = ({ open, o
           severity: 'success',
           title: 'Success',
           message: `Maintenance log for ${deviceName} has been added successfully.`,
+          scoped: false
         });
       }, 300);
       onOpenChange(false);

--- a/src/vertex/components/features/devices/create-device-modal.tsx
+++ b/src/vertex/components/features/devices/create-device-modal.tsx
@@ -10,6 +10,7 @@ import ReusableSelectInput from "@/components/shared/select/ReusableSelectInput"
 import { MultiSelectCombobox } from "@/components/ui/multi-select";
 import { DEFAULT_DEVICE_TAGS } from "@/core/constants/devices";
 import { Label } from "@/components/ui/label";
+import { useBanner } from "@/context/banner-context";
 
 interface CreateDeviceModalProps {
   open: boolean;
@@ -30,6 +31,7 @@ const CreateDeviceModal: React.FC<CreateDeviceModalProps> = ({
   });
 
   const [errors, setErrors] = useState<Record<string, string>>({});
+  const { showBanner } = useBanner();
   const activeNetwork = useAppSelector((state) => state.user.activeNetwork);
   const createDevice = useCreateDevice();
 
@@ -56,7 +58,7 @@ const CreateDeviceModal: React.FC<CreateDeviceModalProps> = ({
     const effectiveNetworkName = networkName || activeNetwork?.net_name;
 
     if (!effectiveNetworkName) {
-      setErrors({ general: "No active Sensor Manufacturer found" });
+      showBanner({ severity: 'error', message: 'No active Sensor Manufacturer found', scoped: true });
       return;
     }
 
@@ -136,11 +138,6 @@ const CreateDeviceModal: React.FC<CreateDeviceModalProps> = ({
       }}
     >
       <div className="space-y-4">
-        {errors.general && (
-          <div className="text-sm text-red-600 bg-red-50 p-2 rounded">
-            {errors.general}
-          </div>
-        )}
         <ReusableInputField
           label="Device Name"
           id="long_name"

--- a/src/vertex/components/features/devices/create-device-modal.tsx
+++ b/src/vertex/components/features/devices/create-device-modal.tsx
@@ -70,18 +70,24 @@ const CreateDeviceModal: React.FC<CreateDeviceModalProps> = ({
         description: formData.description.trim() || undefined,
         network: effectiveNetworkName,
         tags: formData.tags,
+      }, {
+        onSuccess: (data, variables) => {
+          setTimeout(() => {
+            showBanner({
+              severity: 'success',
+              title: 'Success',
+              message: `${variables.long_name.trim()} has been created successfully.`,
+              scoped: false
+            });
+          }, 300);
+          setFormData({ long_name: "", category: "", description: "", tags: [] });
+          setErrors({});
+          onOpenChange(false);
+        },
+        onError: (error) => {
+          showBanner({ severity: 'error', message: `Creation Failed: ${getApiErrorMessage(error)}`, scoped: true });
+        },
       });
-
-      setTimeout(() => {
-        showBanner({
-          severity: 'success',
-          title: 'Success',
-          message: `${formData.long_name.trim()} has been created successfully.`,
-        });
-      }, 300);
-      setFormData({ long_name: "", category: "", description: "", tags: [] });
-      setErrors({});
-      onOpenChange(false);
     } catch (error) {
       showBanner({ severity: 'error', message: `Creation Failed: ${getApiErrorMessage(error)}`, scoped: true });
     }

--- a/src/vertex/components/features/devices/create-device-modal.tsx
+++ b/src/vertex/components/features/devices/create-device-modal.tsx
@@ -11,6 +11,7 @@ import { MultiSelectCombobox } from "@/components/ui/multi-select";
 import { DEFAULT_DEVICE_TAGS } from "@/core/constants/devices";
 import { Label } from "@/components/ui/label";
 import { useBanner } from "@/context/banner-context";
+import { getApiErrorMessage } from "@/core/utils/getApiErrorMessage";
 
 interface CreateDeviceModalProps {
   open: boolean;
@@ -71,18 +72,12 @@ const CreateDeviceModal: React.FC<CreateDeviceModalProps> = ({
         tags: formData.tags,
       });
 
-      // Reset form and close modal
-      setFormData({
-        long_name: "",
-        category: "",
-        description: "",
-        tags: [],
-      });
+      showBanner({ severity: 'success', message: `${formData.long_name.trim()} has been created.`, scoped: false });
+      setFormData({ long_name: "", category: "", description: "", tags: [] });
       setErrors({});
       onOpenChange(false);
     } catch (error) {
-      // Error handling is done in the hook
-      console.error("Create device failed:", error);
+      showBanner({ severity: 'error', message: `Creation Failed: ${getApiErrorMessage(error)}`, scoped: true });
     }
   };
 

--- a/src/vertex/components/features/devices/create-device-modal.tsx
+++ b/src/vertex/components/features/devices/create-device-modal.tsx
@@ -72,7 +72,13 @@ const CreateDeviceModal: React.FC<CreateDeviceModalProps> = ({
         tags: formData.tags,
       });
 
-      showBanner({ severity: 'success', message: `${formData.long_name.trim()} has been created.`, scoped: false });
+      setTimeout(() => {
+        showBanner({
+          severity: 'success',
+          title: 'Success',
+          message: `${formData.long_name.trim()} has been created successfully.`,
+        });
+      }, 300);
       setFormData({ long_name: "", category: "", description: "", tags: [] });
       setErrors({});
       onOpenChange(false);

--- a/src/vertex/components/features/devices/deploy-device-component.tsx
+++ b/src/vertex/components/features/devices/deploy-device-component.tsx
@@ -27,6 +27,7 @@ import { useDeviceDetails, useDevices, useDeployDevice } from "@/core/hooks/useD
 import { ComboBox } from "@/components/ui/combobox";
 import { Device, type DevicePreviousSite } from "@/app/types/devices";
 import { useBanner } from "@/context/banner-context";
+import { getApiErrorMessage } from "@/core/utils/getApiErrorMessage";
 import LocationAutocomplete from "@/components/features/location-autocomplete/LocationAutocomplete";
 import { useNetworks } from "@/core/hooks/useNetworks";
 const MiniMap = React.lazy(() => import("../mini-map/mini-map"));
@@ -678,7 +679,8 @@ const DeployDeviceComponent = ({
             queryClient.invalidateQueries({ queryKey: ["device-details", prefilledDevice._id] });
           }
 
-          // On successful deployment, reset form fields
+          showBanner({ severity: 'success', message: `${deviceData.deviceName} has been deployed.`, scoped: false });
+
           setDeviceData({
             deviceName: "",
             deployment_date: undefined,
@@ -701,6 +703,22 @@ const DeployDeviceComponent = ({
           if (onClose) onClose();
         },
         onError: (error) => {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const errorData = (error as any)?.response?.data;
+          let errorMessage = getApiErrorMessage(error);
+
+          if (errorData?.failed_deployments?.length > 0) {
+            const failedMessages = errorData.failed_deployments
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              .map((deployment: any) => deployment.error?.message)
+              .filter(Boolean);
+
+            if (failedMessages.length > 0) {
+              errorMessage = failedMessages.join(', ');
+            }
+          }
+
+          showBanner({ severity: 'error', message: `Deployment Failed: ${errorMessage}`, scoped: true });
           onDeploymentError?.(error instanceof Error ? error : new Error("Unknown error"));
         },
       }

--- a/src/vertex/components/features/devices/deploy-device-component.tsx
+++ b/src/vertex/components/features/devices/deploy-device-component.tsx
@@ -684,6 +684,7 @@ const DeployDeviceComponent = ({
               severity: 'success',
               title: 'Success',
               message: `${deviceData.deviceName} has been deployed successfully.`,
+              scoped: false
             });
           }, 300);
 

--- a/src/vertex/components/features/devices/deploy-device-component.tsx
+++ b/src/vertex/components/features/devices/deploy-device-component.tsx
@@ -679,7 +679,13 @@ const DeployDeviceComponent = ({
             queryClient.invalidateQueries({ queryKey: ["device-details", prefilledDevice._id] });
           }
 
-          showBanner({ severity: 'success', message: `${deviceData.deviceName} has been deployed.`, scoped: false });
+          setTimeout(() => {
+            showBanner({
+              severity: 'success',
+              title: 'Success',
+              message: `${deviceData.deviceName} has been deployed successfully.`,
+            });
+          }, 300);
 
           setDeviceData({
             deviceName: "",

--- a/src/vertex/components/features/devices/deploy-device-component.tsx
+++ b/src/vertex/components/features/devices/deploy-device-component.tsx
@@ -26,7 +26,7 @@ import { useUserContext } from "@/core/hooks/useUserContext";
 import { useDeviceDetails, useDevices, useDeployDevice } from "@/core/hooks/useDevices";
 import { ComboBox } from "@/components/ui/combobox";
 import { Device, type DevicePreviousSite } from "@/app/types/devices";
-import ReusableToast from "@/components/shared/toast/ReusableToast";
+import { useBanner } from "@/context/banner-context";
 import LocationAutocomplete from "@/components/features/location-autocomplete/LocationAutocomplete";
 import { useNetworks } from "@/core/hooks/useNetworks";
 const MiniMap = React.lazy(() => import("../mini-map/mini-map"));
@@ -427,6 +427,7 @@ const DeployDeviceComponent = ({
   onDeploymentError
 }: DeployDeviceComponentProps) => {
   const queryClient = useQueryClient();
+  const { showBanner } = useBanner();
   const { userScope, userDetails } = useUserContext();
   const { devices: allDevices } = useDevices({ enabled: userScope !== 'personal' });
   const [currentStep, setCurrentStep] = React.useState<number>(0);
@@ -608,10 +609,7 @@ const DeployDeviceComponent = ({
 
   const handleNext = (): void => {
     if (currentStep === 0 && !validateDeviceDetails()) {
-      ReusableToast({
-        type: "ERROR",
-        message: "Incomplete Details: Please fill in all required device details.",
-      });
+      showBanner({ severity: 'error', message: 'Incomplete Details: Please fill in all required device details.', scoped: true });
       return;
     }
     setCurrentStep((prev) => Math.min(prev + 1, siteSource === 'new' ? 2 : 1));
@@ -642,18 +640,12 @@ const DeployDeviceComponent = ({
 
   const handleDeploy = (): void => {
     if (!userDetails?._id) {
-      ReusableToast({
-        type: "ERROR",
-        message: "User information not available. Please reload the page.",
-      });
+      showBanner({ severity: 'error', message: 'User information not available. Please reload the page.', scoped: true });
       return;
     }
 
     if (siteSource === 'previous' && !deviceData.site_id) {
-      ReusableToast({
-        type: "ERROR",
-        message: "Select a previous site to continue.",
-      });
+      showBanner({ severity: 'error', message: 'Select a previous site to continue.', scoped: true });
       return;
     }
 

--- a/src/vertex/components/features/devices/device-assignment-modal.tsx
+++ b/src/vertex/components/features/devices/device-assignment-modal.tsx
@@ -13,6 +13,8 @@ import { Button } from "@/components/ui/button";
 import { useAppSelector } from "@/core/redux/hooks";
 import { Device } from "@/app/types/devices";
 import { useAssignDeviceToOrganization } from "@/core/hooks/useDevices";
+import { useBanner } from "@/context/banner-context";
+import { getApiErrorMessage } from "@/core/utils/getApiErrorMessage";
 import { Label } from "@/components/ui/label";
 import { ComboBox } from "@/components/ui/combobox";
 import { useRouter } from "next/navigation";
@@ -45,16 +47,22 @@ const DeviceAssignmentModal: React.FC<DeviceAssignmentModalProps> = ({
   const [selectedDevice, setSelectedDevice] = useState("");
 
   const assignDevice = useAssignDeviceToOrganization();
+  const { showBanner } = useBanner();
 
   const handleAssign = async () => {
     if (!selectedOrganization || !selectedDevice || !userDetails?._id) return;
 
-    await assignDevice.mutateAsync({
-      device_name: selectedDevice,
-      organization_id: selectedOrganization,
-      user_id: userDetails._id,
-    });
-    onSuccess();
+    try {
+      const data = await assignDevice.mutateAsync({
+        device_name: selectedDevice,
+        organization_id: selectedOrganization,
+        user_id: userDetails._id,
+      });
+      showBanner({ severity: 'success', message: `${data.device.name} has been assigned to the organization.`, scoped: false });
+      onSuccess();
+    } catch (error) {
+      showBanner({ severity: 'error', message: `Assignment Failed: ${getApiErrorMessage(error)}`, scoped: false });
+    }
   };
 
   const handleClose = () => {

--- a/src/vertex/components/features/devices/device-assignment-modal.tsx
+++ b/src/vertex/components/features/devices/device-assignment-modal.tsx
@@ -58,7 +58,13 @@ const DeviceAssignmentModal: React.FC<DeviceAssignmentModalProps> = ({
         organization_id: selectedOrganization,
         user_id: userDetails._id,
       });
-      showBanner({ severity: 'success', message: `${data.device.name} has been assigned to the organization.`, scoped: false });
+      setTimeout(() => {
+        showBanner({
+          severity: 'success',
+          title: 'Success',
+          message: `${data.device.name} has been assigned successfully.`,
+        });
+      }, 300);
       onSuccess();
     } catch (error) {
       showBanner({ severity: 'error', message: `Assignment Failed: ${getApiErrorMessage(error)}`, scoped: false });

--- a/src/vertex/components/features/devices/device-details-modal.tsx
+++ b/src/vertex/components/features/devices/device-details-modal.tsx
@@ -14,7 +14,8 @@ import ReusableButton from "@/components/shared/button/ReusableButton";
 import ReusableSelectInput from "@/components/shared/select/ReusableSelectInput";
 import ReusableInputField from "@/components/shared/inputfield/ReusableInputField";
 import { AqEdit01 as AqEdit, AqKey01 } from "@airqo/icons-react";
-import ReusableToast from "@/components/shared/toast/ReusableToast";
+import { useBanner } from "@/context/banner-context";
+import { getApiErrorMessage } from "@/core/utils/getApiErrorMessage";
 import logger from "@/lib/logger";
 
 interface DeviceDetailsModalProps {
@@ -60,6 +61,7 @@ const DeviceDetailsModal: React.FC<DeviceDetailsModalProps> = ({ open, device, o
   const updateLocal = useUpdateDeviceLocal();
   const updateGlobal = useUpdateDeviceGlobal();
   const decryptKeys = useDecryptDeviceKeys();
+  const { showBanner } = useBanner();
 
   const form = useForm<DeviceUpdateFormData>({
     resolver: zodResolver(deviceUpdateSchema),
@@ -132,7 +134,7 @@ const DeviceDetailsModal: React.FC<DeviceDetailsModalProps> = ({ open, device, o
 
   const onSubmitLocal = async (data: DeviceUpdateFormData) => {
     if (!device?._id) {
-      ReusableToast({ message: "Cannot update device: missing device ID", type: "WARNING" });
+      showBanner({ severity: 'warning', message: "Cannot update device: missing device ID", scoped: true });
       return;
     }
 
@@ -168,8 +170,12 @@ const DeviceDetailsModal: React.FC<DeviceDetailsModalProps> = ({ open, device, o
       { deviceId: device._id, deviceData: processedData },
       {
         onSuccess: () => {
+          showBanner({ severity: 'success', message: 'Device information has been updated locally.', scoped: true });
           setIsEditMode(false);
           form.reset(data);
+        },
+        onError: (error) => {
+          showBanner({ severity: 'error', message: `Update Failed: ${getApiErrorMessage(error)}`, scoped: true });
         },
       }
     );
@@ -177,7 +183,7 @@ const DeviceDetailsModal: React.FC<DeviceDetailsModalProps> = ({ open, device, o
 
   const onSubmitGlobal = async (data: DeviceUpdateFormData) => {
     if (!device?._id) {
-      ReusableToast({ message: "Cannot update device: missing device ID", type: "WARNING" });
+      showBanner({ severity: 'warning', message: "Cannot update device: missing device ID", scoped: true });
       return;
     }
 
@@ -213,8 +219,12 @@ const DeviceDetailsModal: React.FC<DeviceDetailsModalProps> = ({ open, device, o
       { deviceId: device._id, deviceData: processedData },
       {
         onSuccess: () => {
+          showBanner({ severity: 'success', message: 'Device information has been updated globally.', scoped: true });
           setIsEditMode(false);
           form.reset(data);
+        },
+        onError: (error) => {
+          showBanner({ severity: 'error', message: `Sync Failed: ${getApiErrorMessage(error)}`, scoped: true });
         },
       }
     );
@@ -224,9 +234,9 @@ const DeviceDetailsModal: React.FC<DeviceDetailsModalProps> = ({ open, device, o
     if (valueToCopy !== undefined && valueToCopy !== null) {
       try {
         await navigator.clipboard?.writeText(String(valueToCopy))
-        ReusableToast({ message: "Decrypted Key Copied", type: "SUCCESS" })
+        showBanner({ severity: 'success', message: "Decrypted Key Copied", scoped: true });
       } catch (err) {
-        ReusableToast({ message: `Failed to copy key: ${String(err)}`, type: "ERROR" })
+        showBanner({ severity: 'error', message: `Failed to copy key: ${String(err)}`, scoped: true });
       }
     }
   }
@@ -236,7 +246,7 @@ const DeviceDetailsModal: React.FC<DeviceDetailsModalProps> = ({ open, device, o
     const deviceNumber = device.device_number;
 
     if (!encryptedKey || !deviceNumber) {
-      ReusableToast({ message: `No ${keyType} or device number available for decryption.`, type: "WARNING" });
+      showBanner({ severity: 'warning', message: `No ${keyType} or device number available for decryption.`, scoped: true });
       return;
     }
 
@@ -251,10 +261,11 @@ const DeviceDetailsModal: React.FC<DeviceDetailsModalProps> = ({ open, device, o
       if (response.success && response.decrypted_keys && response.decrypted_keys.length > 0) {
         handleCopy(response.decrypted_keys[0].decrypted_key);
       } else {
-        ReusableToast({ message: "Decryption failed or no key returned.", type: "ERROR" });
+        showBanner({ severity: 'error', message: "Decryption failed or no key returned.", scoped: true });
       }
-    } catch {
-      logger.info("Decryption failed"); // simple log
+    } catch (error) {
+      showBanner({ severity: 'error', message: `Decryption Failed: ${getApiErrorMessage(error)}`, scoped: true });
+      logger.info("Decryption failed");
     }
   };
 

--- a/src/vertex/components/features/devices/import-device-modal.tsx
+++ b/src/vertex/components/features/devices/import-device-modal.tsx
@@ -130,6 +130,7 @@ const ImportDeviceModal: React.FC<ImportDeviceModalProps> = ({
               severity: 'success',
               title: 'Success',
               message: `${variables.long_name.trim()} has been imported successfully.`,
+              scoped: false
             });
           }, 300);
         },

--- a/src/vertex/components/features/devices/import-device-modal.tsx
+++ b/src/vertex/components/features/devices/import-device-modal.tsx
@@ -13,6 +13,7 @@ import { useGroupCohorts } from "@/core/hooks/useCohorts";
 import { useAppSelector } from "@/core/redux/hooks";
 import { usePathname } from "next/navigation";
 import logger from "@/lib/logger";
+import { useBanner } from "@/context/banner-context";
 import { NetworkRequestDialog } from "../networks/network-request-dialog";
 import { MultiSelectCombobox } from "@/components/ui/multi-select";
 import { DEFAULT_DEVICE_TAGS } from "@/core/constants/devices";
@@ -45,6 +46,7 @@ const ImportDeviceModal: React.FC<ImportDeviceModalProps> = ({
   const [showMore, setShowMore] = useState(false);
   const [isRequestDialogOpen, setIsRequestDialogOpen] = useState(false);
   const [errors, setErrors] = useState<Record<string, string>>({});
+  const { showBanner } = useBanner();
   const importDevice = useImportDevice();
   const { networks, isLoading: isLoadingNetworks } = useNetworks();
 
@@ -108,6 +110,7 @@ const ImportDeviceModal: React.FC<ImportDeviceModalProps> = ({
 
     if (!userId) {
       logger.warn("User ID is missing");
+      showBanner({ severity: 'error', message: 'Unable to identify user. Please reload and try again.', scoped: true });
       return;
     }
 
@@ -180,11 +183,6 @@ const ImportDeviceModal: React.FC<ImportDeviceModalProps> = ({
       }}
     >
       <div className="space-y-2">
-        {errors.general && (
-          <div className="text-sm text-red-600 bg-red-50 p-2 rounded">
-            {errors.general}
-          </div>
-        )}
 
         <ReusableInputField
           label="Device Name"

--- a/src/vertex/components/features/devices/import-device-modal.tsx
+++ b/src/vertex/components/features/devices/import-device-modal.tsx
@@ -18,6 +18,8 @@ import { NetworkRequestDialog } from "../networks/network-request-dialog";
 import { MultiSelectCombobox } from "@/components/ui/multi-select";
 import { DEFAULT_DEVICE_TAGS } from "@/core/constants/devices";
 import { Label } from "@/components/ui/label";
+import { getApiErrorMessage } from "@/core/utils/getApiErrorMessage";
+
 
 interface ImportDeviceModalProps {
   open: boolean;
@@ -120,7 +122,21 @@ const ImportDeviceModal: React.FC<ImportDeviceModalProps> = ({
         user_id: userId,
         ...(cohortId && { cohort_id: cohortId }),
       },
-      { onSuccess: () => onOpenChange(false) }
+      {
+        onSuccess: (data, variables) => {
+          onOpenChange(false);
+          setTimeout(() => {
+            showBanner({
+              severity: 'success',
+              title: 'Success',
+              message: `${variables.long_name.trim()} has been imported successfully.`,
+            });
+          }, 300);
+        },
+        onError: (error) => {
+          showBanner({ severity: 'error', message: `Import Failed: ${getApiErrorMessage(error)}`, scoped: true });
+        },
+      }
     );
   };
 

--- a/src/vertex/components/features/devices/recall-device-dialog.tsx
+++ b/src/vertex/components/features/devices/recall-device-dialog.tsx
@@ -5,6 +5,8 @@ import ReusableDialog from "@/components/shared/dialog/ReusableDialog";
 import ReusableSelectInput from "@/components/shared/select/ReusableSelectInput";
 import { useRecallDevice } from "@/core/hooks/useDevices";
 import { useUserContext } from "@/core/hooks/useUserContext";
+import { useBanner } from "@/context/banner-context";
+import { getApiErrorMessage } from "@/core/utils/getApiErrorMessage";
 
 interface RecallDeviceDialogProps {
   open: boolean;
@@ -27,6 +29,7 @@ export default function RecallDeviceDialog({
   const [recallType, setRecallType] = useState<string>("");
   const recallDevice = useRecallDevice();
   const { userDetails } = useUserContext();
+  const { showBanner } = useBanner();
 
   const handleRecall = async () => {
     if (!recallType || !userDetails?._id) {
@@ -47,12 +50,11 @@ export default function RecallDeviceDialog({
         },
       });
 
-      // Reset form and close dialog
+      showBanner({ severity: 'success', message: `${deviceDisplayName || deviceName} has been recalled.`, scoped: true });
       setRecallType("");
       onOpenChange(false);
     } catch (error) {
-      // Error handling is done in the hook
-      console.error("Recall failed:", error);
+      showBanner({ severity: 'error', message: `Recall Failed: ${getApiErrorMessage(error)}`, scoped: true });
     }
   };
 

--- a/src/vertex/components/features/devices/recall-device-dialog.tsx
+++ b/src/vertex/components/features/devices/recall-device-dialog.tsx
@@ -49,8 +49,13 @@ export default function RecallDeviceDialog({
           userName: userDetails.userName,
         },
       });
-
-      showBanner({ severity: 'success', message: `${deviceDisplayName || deviceName} has been recalled.`, scoped: true });
+      setTimeout(() => {
+        showBanner({
+          severity: 'success',
+          title: 'Success',
+          message: `${deviceDisplayName || deviceName} has been recalled successfully.`,
+        });
+      }, 300);
       setRecallType("");
       onOpenChange(false);
     } catch (error) {

--- a/src/vertex/components/features/devices/recall-device-dialog.tsx
+++ b/src/vertex/components/features/devices/recall-device-dialog.tsx
@@ -54,6 +54,7 @@ export default function RecallDeviceDialog({
           severity: 'success',
           title: 'Success',
           message: `${deviceDisplayName || deviceName} has been recalled successfully.`,
+          scoped: false
         });
       }, 300);
       setRecallType("");

--- a/src/vertex/core/hooks/useDevices.ts
+++ b/src/vertex/core/hooks/useDevices.ts
@@ -487,11 +487,7 @@ export const useCreateDevice = () => {
       };
       return devices.createDevice(payload);
     },
-    onSuccess: (data, variables) => {
-      ReusableToast({
-        message: `${variables.long_name} has been created.`,
-        type: 'SUCCESS',
-      });
+    onSuccess: (data) => {
       if (data.created_device && activeGroup?.grp_title) {
         updateDeviceGroup.mutate({
           deviceId: data.created_device._id || '',
@@ -501,12 +497,6 @@ export const useCreateDevice = () => {
       queryClient.invalidateQueries({ queryKey: ['devices'] });
       queryClient.invalidateQueries({ queryKey: ['network-devices'] });
       queryClient.invalidateQueries({ queryKey: ['deviceActivities'] });
-    },
-    onError: error => {
-      ReusableToast({
-        message: `Creation Failed: ${getApiErrorMessage(error)}`,
-        type: 'ERROR',
-      });
     },
   });
 };

--- a/src/vertex/core/hooks/useDevices.ts
+++ b/src/vertex/core/hooks/useDevices.ts
@@ -597,35 +597,11 @@ export const useDeployDevice = () => {
       email?: string;
       userName?: string;
     }) => devices.deployDevice(deviceData),
-    onSuccess: (data, variables) => {
-      ReusableToast({
-        message: `${variables.deviceName} has been deployed.`,
-        type: 'SUCCESS',
-      });
+    onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['devices'] });
       queryClient.invalidateQueries({ queryKey: ['claimedDevices'] });
       queryClient.invalidateQueries({ queryKey: ['myDevices'] });
       queryClient.invalidateQueries({ queryKey: ['deviceActivities'] });
-    },
-    onError: (error: AxiosError<any>) => {
-      let errorMessage = getApiErrorMessage(error);
-      const errorData = error.response?.data as any;
-
-      if (errorData?.failed_deployments?.length > 0) {
-        const failedMessages = errorData.failed_deployments
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          .map((deployment: any) => deployment.error?.message)
-          .filter(Boolean);
-
-        if (failedMessages.length > 0) {
-          errorMessage = failedMessages.join(', ');
-        }
-      }
-
-      ReusableToast({
-        message: `Deployment Failed: ${errorMessage}`,
-        type: 'ERROR',
-      });
     },
   });
 };
@@ -670,20 +646,10 @@ export const useAddMaintenanceLog = () => {
       logData: MaintenanceLogData;
     }) => devices.addMaintenanceLog(deviceName, logData),
     onSuccess: (data, variables) => {
-      ReusableToast({
-        message: `Maintenance log has been added for ${variables.deviceName}.`,
-        type: 'SUCCESS',
-      });
       queryClient.invalidateQueries({ queryKey: ['devices'] });
       queryClient.invalidateQueries({ queryKey: ['device-details'] });
       queryClient.invalidateQueries({ queryKey: ['deviceStatus'] });
       queryClient.invalidateQueries({ queryKey: ['deviceActivities'] });
-    },
-    onError: error => {
-      ReusableToast({
-        message: `Failed to Add Maintenance Log: ${getApiErrorMessage(error)}`,
-        type: 'ERROR',
-      });
     },
   });
 };

--- a/src/vertex/core/hooks/useDevices.ts
+++ b/src/vertex/core/hooks/useDevices.ts
@@ -535,12 +535,7 @@ export const useImportDevice = () => {
       };
       return devices.importDevice(payload);
     },
-    onSuccess: (data, variables) => {
-      ReusableToast({
-        message: `${variables.long_name} has been imported.`,
-        type: 'SUCCESS',
-      });
-
+    onSuccess: () => {
       // Refresh based on active module
       if (isAdminModule) {
         queryClient.invalidateQueries({ queryKey: ['network-devices'] });
@@ -555,13 +550,7 @@ export const useImportDevice = () => {
           queryClient.invalidateQueries({ queryKey: ['deviceActivities'] });
         }
       }
-    },
-    onError: error => {
-      ReusableToast({
-        message: `Import Failed: ${getApiErrorMessage(error)}`,
-        type: 'ERROR',
-      });
-    },
+    }
   });
 };
 

--- a/src/vertex/core/hooks/useDevices.ts
+++ b/src/vertex/core/hooks/useDevices.ts
@@ -349,19 +349,9 @@ export const useAssignDeviceToOrganization = () => {
     DeviceAssignmentRequest
   >({
     mutationFn: devices.assignDeviceToOrganization,
-    onSuccess: data => {
-      ReusableToast({
-        message: `${data.device.name} has been assigned to the organization.`,
-        type: 'SUCCESS',
-      });
+    onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['myDevices'] });
       queryClient.invalidateQueries({ queryKey: ['devices'] });
-    },
-    onError: error => {
-      ReusableToast({
-        message: `Assignment Failed: ${getApiErrorMessage(error)}`,
-        type: 'ERROR',
-      });
     },
   });
 };
@@ -413,20 +403,10 @@ export const useUpdateDeviceLocal = () => {
       deviceData: Partial<Device>;
     }) => devices.updateDeviceLocal(deviceId, deviceData),
     onSuccess: (data, variables) => {
-      ReusableToast({
-        message: 'Device information has been updated locally.',
-        type: 'SUCCESS',
-      });
       queryClient.invalidateQueries({
         queryKey: ['device-details', variables.deviceId],
       });
       queryClient.invalidateQueries({ queryKey: ['devices'] });
-    },
-    onError: (error: AxiosError<ErrorResponse>) => {
-      ReusableToast({
-        message: `Update Failed: ${getApiErrorMessage(error)}`,
-        type: 'ERROR',
-      });
     },
   });
 };
@@ -443,20 +423,10 @@ export const useUpdateDeviceGlobal = () => {
       deviceData: Partial<Device>;
     }) => devices.updateDeviceGlobal(deviceId, deviceData),
     onSuccess: (data, variables) => {
-      ReusableToast({
-        message: 'Device information has been updated globally.',
-        type: 'SUCCESS',
-      });
       queryClient.invalidateQueries({
         queryKey: ['device-details', variables.deviceId],
       });
       queryClient.invalidateQueries({ queryKey: ['devices'] });
-    },
-    onError: (error: AxiosError<ErrorResponse>) => {
-      ReusableToast({
-        message: `Sync Failed: ${getApiErrorMessage(error)}`,
-        type: 'ERROR',
-      });
     },
   });
 };
@@ -680,20 +650,10 @@ export const useRecallDevice = () => {
       };
     }) => devices.recallDevice(deviceName, recallData),
     onSuccess: (data, variables) => {
-      ReusableToast({
-        message: `${variables.deviceName} has been recalled.`,
-        type: 'SUCCESS',
-      });
       queryClient.invalidateQueries({ queryKey: ['devices'] });
       queryClient.invalidateQueries({ queryKey: ['device-details'] });
       queryClient.invalidateQueries({ queryKey: ['myDevices'] });
       queryClient.invalidateQueries({ queryKey: ['deviceActivities'] });
-    },
-    onError: error => {
-      ReusableToast({
-        message: `Recall Failed: ${getApiErrorMessage(error)}`,
-        type: 'ERROR',
-      });
     },
   });
 };
@@ -737,12 +697,6 @@ export const useDecryptDeviceKeys = () => {
     mutationFn: devices.decryptDeviceKeys,
     onSuccess: () => {
       logger.info('Keys decrypted successfully!');
-    },
-    onError: error => {
-      ReusableToast({
-        message: `Decryption Failed: ${getApiErrorMessage(error)}`,
-        type: 'ERROR',
-      });
     },
   });
 };


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

Replaces `ReusableToast` calls with `useBanner` across device management
components. Error and validation feedback now renders as an InfoBanner
inside the active modal or dialog container instead of a floating toast.

No new dependencies required. Depends on the `BannerContext` infrastructure
and the updated `ReusableDialog` from PR #3498.

Changes per component:
- **create-device-modal** — `useBanner` added; `showBanner` replaces old inline red error div for missing network error
- **import-device-modal** — `useBanner` added; `showBanner` surfaces the previously silent missing user ID error; removes old inline red error div
- **add-maintenance-log-modal** — `ReusableToast` replaced with `showBanner` for validation error
- **deploy-device-component** — 3 `ReusableToast` calls replaced with `showBanner`
- **recall-device-dialog** — `useBanner` added; success and error feedback moved from hook callbacks to component try/catch
- **device-details-modal** — `ReusableToast` replaced with `showBanner` for all validation, update, and key decryption feedback; success/error callbacks added to `updateLocal` and `updateGlobal` mutate calls
- **device-assignment-modal** — `useBanner` added with `scoped: false` (uses base `Dialog`, not `ReusableDialog`); assignment success and error feedback moved from hook to component
- **useDevices.ts** — removed `ReusableToast` from `onSuccess`/`onError` in `useRecallDevice`, `useUpdateDeviceLocal`, `useUpdateDeviceGlobal`, `useAssignDeviceToOrganization`, and `useDecryptDeviceKeys`; hooks now only handle API calls and cache invalidation

#### Status of maturity (all need to be checked before merging):

- [x] I've tested this locally
- [x] I consider this code done
- [x] This change ready to hit production in its current state
- [x] The title of the PR states what changed and the related issues number (used for the release note).
- [x] I've included issue number in the "Closes #3451" part of the "[What are the relevant tickets?](#what-are-the-relevant-tickets)" section to [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [ ] I've updated corresponding documentation for the changes in this PR.
- [ ] I have written unit and/or e2e tests for my change(s).

#### How should this be manually tested?

**Deploy Device** (`/devices/overview/[device-id]` → Deploy action)
1. Open the Deploy Device flow
2. Click **Next** without filling required fields — confirm error banner appears inside the dialog
3. Select "Previous site" without picking a site — confirm the site selection error banner appears

**Add Maintenance Log** (Device detail page → Maintenance tab)
1. Open the Add Maintenance Log dialog
2. Click **Save Log** without selecting tags — confirm error banner appears inside the dialog
3. Fill all required fields and save — confirm the dialog closes normally

**Import Device** (`/devices/overview` or `/devices/my-devices`)
1. Open the Import Device dialog and confirm the layout is intact

**Create Device** (`/admin/networks/[id]` — requires admin access)
1. Open the Add AirQo Device dialog and confirm the layout is intact

**Recall Device** (Device detail page → Recall action)
1. Open the Recall Device dialog, select a recall type and submit — confirm success banner appears
2. Submit with network down — confirm error banner appears with API error detail

**Device Details** (Device detail page → Edit)
1. Click Edit, change a field and click **Save Local** — confirm success banner appears inside the dialog
2. Click **Sync Global** — confirm success banner appears
3. Trigger a failure (e.g. network down) — confirm error banner appears with API error detail
4. Click the key icon on Write Key or Read Key — confirm decryption feedback appears as a banner

**Share Device** (`/devices/my-devices` → Share action)
1. Select an organization and device, click **Share Device** — confirm success banner appears at the top of the page
2. Trigger a failure — confirm error banner appears at the top of the page with API error detail

#### What are the relevant tickets?

- Closes #3451

#### Screenshots (optional)

> Full coverage was not possible for all modals — admin-gated pages
> (Create Device, Recall Device) could not be reached during local testing.

**Deploy Device — validation error banner**
<img width="1366" height="768" alt="Deploy_after" src="https://github.com/user-attachments/assets/969edf1f-1004-488e-b374-a5b7489515c7" />

**Maintenance Log — validation error banner**
<img width="1366" height="768" alt="matainance_banner" src="https://github.com/user-attachments/assets/18208d96-a727-4b1a-8a15-975872a69dd2" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Replaced toast alerts with unified inline banner messages across device workflows (create, import, deploy, assign, recall, maintenance, details) for clearer success/error/warning feedback.
  * API errors, missing required fields, clipboard/decrypt results, and auth-related issues now show scoped, formatted banner messages.
  * Success banners are shown consistently (some with short delay), and redundant pop-up notifications have been removed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/airqo-platform/AirQo-frontend/pull/3503?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->