### PR TITLE
Gate hCaptcha to staging (vertex)

### DIFF
--- a/src/vertex/app/api/auth/[...nextauth]/options.ts
+++ b/src/vertex/app/api/auth/[...nextauth]/options.ts
@@ -9,7 +9,7 @@ import type {
 } from '@/app/types/users';
 import { getApiErrorMessage } from '@/core/utils/getApiErrorMessage';
 import logger from '@/lib/logger';
-import { getApiBaseUrl } from '@/lib/envConstants';
+import { getApiBaseUrl, isHCaptchaEnabled } from '@/lib/envConstants';
 import { normalizeOAuthAccessToken } from '@/core/auth/oauth-session';
 
 const isProduction = process.env.NODE_ENV === 'production';
@@ -229,8 +229,13 @@ export const options: NextAuthOptions = {
           throw new Error('Username and password are required.');
         }
 
-        const captchaToken = typeof credentials.captchaToken === 'string' ? credentials.captchaToken.trim() : "";
-        if (!captchaToken) {
+        const hcaptchaEnabled = isHCaptchaEnabled();
+        const captchaToken =
+          typeof credentials.captchaToken === 'string'
+            ? credentials.captchaToken.trim()
+            : '';
+
+        if (hcaptchaEnabled && !captchaToken) {
           logger.warn('Authorize call with missing CAPTCHA token.');
           throw new Error('CAPTCHA validation is required.');
         }
@@ -239,7 +244,7 @@ export const options: NextAuthOptions = {
           const loginResponse = (await users.loginWithDetails({
             userName: credentials.userName,
             password: credentials.password,
-            captchaToken: captchaToken,
+            captchaToken: hcaptchaEnabled ? captchaToken : undefined,
           } as LoginCredentials)) as LoginResponse;
 
           if (loginResponse?.token) {

--- a/src/vertex/app/login/page.tsx
+++ b/src/vertex/app/login/page.tsx
@@ -17,6 +17,7 @@ import { HCaptchaWidget, type HCaptchaWidgetHandle } from "@/components/ui/hcapt
 import logger from "@/lib/logger"
 import { getApiErrorMessage } from "@/core/utils/getApiErrorMessage";
 import { useAppDispatch } from "@/core/redux/hooks";
+import { isHCaptchaEnabled } from "@/lib/envConstants";
 import {
   setLoggingOut,
 } from "@/core/redux/slices/userSlice";
@@ -37,6 +38,7 @@ export default function LoginPage() {
   const [step, setStep] = useState<'email' | 'password'>('email');
   const [captchaToken, setCaptchaToken] = useState("");
   const captchaRef = useRef<HCaptchaWidgetHandle>(null);
+  const hcaptchaEnabled = useMemo(() => isHCaptchaEnabled(), []);
   const searchParams = useSearchParams();
   const callbackUrl = useMemo(() => {
     const raw = searchParams.get("callbackUrl");
@@ -123,7 +125,7 @@ export default function LoginPage() {
     if (!isPasswordValid) return;
 
     // If the user didn't provide the captchaToken
-    if (captchaToken === "") {
+    if (hcaptchaEnabled && captchaToken === "") {
        showBanner({
          severity: 'error',
          message: 'Please complete the CAPTCHA before signing in.',
@@ -149,7 +151,7 @@ export default function LoginPage() {
         redirect: false,
         userName: values.userName,
         password: values.password,
-        captchaToken,
+        captchaToken: hcaptchaEnabled ? captchaToken : undefined,
         callbackUrl: redirectUrl,
       });
 
@@ -185,7 +187,7 @@ export default function LoginPage() {
       captchaRef.current?.reset();
       setIsLoading(false);
     }
-  }, [callbackUrl, waitForSession, step, form, showBanner, captchaToken]);
+  }, [callbackUrl, waitForSession, step, form, showBanner, captchaToken, hcaptchaEnabled]);
 
   return (
     <div className="flex min-h-screen lg:h-screen w-full flex-col bg-primary-50 text-foreground">
@@ -345,15 +347,17 @@ export default function LoginPage() {
                             </div>
                           )}
                         />
-                        <HCaptchaWidget
-                          ref={captchaRef}
-                          onVerify={(token) => setCaptchaToken(token)}
-                          onExpire={() => setCaptchaToken("")}
-                        />
+                        {hcaptchaEnabled ? (
+                          <HCaptchaWidget
+                            ref={captchaRef}
+                            onVerify={(token) => setCaptchaToken(token)}
+                            onExpire={() => setCaptchaToken("")}
+                          />
+                        ) : null}
                         <ReusableButton
                           type="submit"
                           className="w-full font-medium bg-primary hover:bg-primary/90"
-                          disabled={isLoading || !captchaToken}
+                          disabled={isLoading || (hcaptchaEnabled && !captchaToken)}
                           loading={isLoading}
                           variant="filled"
                         >

--- a/src/vertex/app/types/users.ts
+++ b/src/vertex/app/types/users.ts
@@ -95,7 +95,7 @@ export interface UserDetailsResponse {
 export interface LoginCredentials {
   userName: string;
   password: string;
-  captchaToken: string;
+  captchaToken?: string;
 }
 
 export interface DecodedToken {

--- a/src/vertex/components/ui/hcaptcha-widget.tsx
+++ b/src/vertex/components/ui/hcaptcha-widget.tsx
@@ -2,7 +2,7 @@
 
 import HCaptcha from "@hcaptcha/react-hcaptcha";
 import { forwardRef, useImperativeHandle, useRef } from "react";
-import { getHCaptchaSiteKey, getEnvironment } from "@/lib/envConstants";
+import { getHCaptchaSiteKey, getEnvironment, isHCaptchaEnabled } from "@/lib/envConstants";
 
 interface HCaptchaWidgetProps {
   onVerify: (token: string) => void;
@@ -22,6 +22,10 @@ export const HCaptchaWidget = forwardRef<HCaptchaWidgetHandle, HCaptchaWidgetPro
     useImperativeHandle(ref, () => ({
       reset: () => captchaRef.current?.resetCaptcha(),
     }));
+
+    if (!isHCaptchaEnabled()) {
+      return null;
+    }
 
     if (!siteKey || siteKey.trim() === "") {
       return (

--- a/src/vertex/lib/envConstants.ts
+++ b/src/vertex/lib/envConstants.ts
@@ -117,6 +117,15 @@ export const getEnvironment = (): string => {
 };
 
 /**
+ * Whether hCaptcha should be enabled for this deployment.
+ *
+ * Requirement: only available on staging (never production).
+ */
+export const isHCaptchaEnabled = (): boolean => {
+  return getEnvironment().toLowerCase() === 'staging';
+};
+
+/**
  * Gets environment configuration
  * @returns {object} Environment configuration object
  */
@@ -124,6 +133,7 @@ export const getEnvConfig = () => {
   return {
     hCaptchaSiteKey: getHCaptchaSiteKey(),
     environment: getEnvironment(),
+    hCaptchaEnabled: isHCaptchaEnabled(),
     apiUrl: process.env.NEXT_PUBLIC_API_URL,
     apiToken: process.env.NEXT_PUBLIC_API_TOKEN,
     analyticsUrl: process.env.NEXT_PUBLIC_ANALYTICS_URL,


### PR DESCRIPTION
## Summary
- Makes hCaptcha available **only on staging** (`NEXT_PUBLIC_ENV=staging`) and **disabled on production**.

## What changed
- Added `isHCaptchaEnabled()` env gate.
- Login flow only renders/enforces hCaptcha when enabled.
- NextAuth credentials authorize only requires/forwards `captchaToken` when enabled.
- `captchaToken` type is now optional.

## How to test
- **Staging-like:** set `NEXT_PUBLIC_ENV=staging` and a valid `NEXT_PUBLIC_HCAPTCHA_SITE_KEY`; confirm login requires captcha.
- **Production-like:** set `NEXT_PUBLIC_ENV=production`; confirm login works without captcha and widget does not render.

## Notes
- Production no longer blocks sign-in on missing captcha token/key.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * CAPTCHA validation is now conditionally enforced based on environment configuration rather than being mandatory
  * Login authentication flow updated to handle optional CAPTCHA verification
  * CAPTCHA widget now conditionally renders based on environment settings
  * Authentication credentials interface updated to support optional CAPTCHA tokens

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/airqo-platform/AirQo-frontend/pull/3529?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->