### PR TITLE
Add reusable feedback prompts and authenticated page title alignment (vertex app)

### DIFF
--- a/src/vertex/app/(authenticated)/admin/cohorts/[id]/page.tsx
+++ b/src/vertex/app/(authenticated)/admin/cohorts/[id]/page.tsx
@@ -14,6 +14,7 @@ import { PERMISSIONS } from "@/core/permissions/constants";
 import ReusableButton from "@/components/shared/button/ReusableButton";
 import { UnassignCohortDevicesDialog } from "@/components/features/cohorts/unassign-cohort-devices";
 import CohortMeasurementsApiCard from "@/components/features/cohorts/cohort-measurements-api-card";
+import { usePageTitle } from "@/context/page-title-context";
 
 // Loading skeleton for content grid
 const ContentGridSkeleton = () => (
@@ -30,6 +31,7 @@ export default function CohortDetailsPage() {
   const cohortId = params?.id as string;
 
   const { data: cohort, isLoading, error } = useCohortDetails(cohortId);
+  usePageTitle({ title: cohort?.name || "Cohort Details", section: "Cohorts" });
   const canUpdateDevice = usePermission(PERMISSIONS.DEVICE.UPDATE);
   const [cohortDetails, setCohortDetails] = useState<{
     name: string;

--- a/src/vertex/app/(authenticated)/admin/cohorts/page.tsx
+++ b/src/vertex/app/(authenticated)/admin/cohorts/page.tsx
@@ -15,6 +15,7 @@ import { AqPlus } from "@airqo/icons-react";
 import { CreateCohortFromSelectionDialog } from "@/components/features/cohorts/create-cohort-from-cohorts";
 import { AssignCohortsToGroupDialog } from "@/components/features/cohorts/assign-cohorts-to-group";
 import { useServerSideTableState } from "@/core/hooks/useServerSideTableState";
+import { usePageTitle } from "@/context/page-title-context";
 
 import { DEFAULT_COHORT_TAGS } from "@/core/constants/devices";
 
@@ -28,6 +29,8 @@ type CohortRow = {
 }
 
 export default function CohortsPage() {
+  usePageTitle({ title: "Cohorts", section: "Administrative Panel" });
+
   const router = useRouter();
   const searchParams = useSearchParams();
   const pathname = usePathname();

--- a/src/vertex/app/(authenticated)/admin/grids/[id]/page.tsx
+++ b/src/vertex/app/(authenticated)/admin/grids/[id]/page.tsx
@@ -13,6 +13,7 @@ import GridMeasurementsApiCard from "@/components/features/grids/grid-measuremen
 import EditGridDetailsDialog from "@/components/features/grids/edit-grid-details-dialog";
 import { PERMISSIONS } from "@/core/permissions/constants";
 import ClientPaginatedSitesTable from "@/components/features/sites/client-paginated-sites-table";
+import { usePageTitle } from "@/context/page-title-context";
 
 const ContentGridSkeleton = () => (
   <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mt-6 items-start">
@@ -28,6 +29,7 @@ export default function GridDetailsPage() {
   const gridId = id.toString();
   const { gridDetails, isLoading, error } = useGridDetails(gridId);
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
+  usePageTitle({ title: gridDetails?.name || "Grid Details", section: "Grids" });
 
   if (error) {
     return (

--- a/src/vertex/app/(authenticated)/admin/networks/[id]/page.tsx
+++ b/src/vertex/app/(authenticated)/admin/networks/[id]/page.tsx
@@ -15,6 +15,7 @@ import ImportDeviceModal from "@/components/features/devices/import-device-modal
 import { useState } from "react";
 import { usePermission } from "@/core/hooks/usePermissions";
 import { NetworkStatsCards } from "@/components/features/networks/NetworkStatsCards";
+import { usePageTitle } from "@/context/page-title-context";
 
 // Loading skeleton for content grid
 const ContentGridSkeleton = () => (
@@ -38,6 +39,10 @@ export default function NetworkDetailsPage() {
     const network = useMemo(() => {
         return networks.find((n) => n._id === networkId);
     }, [networks, networkId]);
+    usePageTitle({
+        title: network?.net_name || "Sensor Manufacturer Details",
+        section: "Sensor Manufacturers",
+    });
 
     const isAirQoNetwork = network?.net_name?.toLowerCase() === "airqo";
 

--- a/src/vertex/app/(authenticated)/admin/shipping/[batchId]/page.tsx
+++ b/src/vertex/app/(authenticated)/admin/shipping/[batchId]/page.tsx
@@ -15,6 +15,7 @@ import ReusableToast from '@/components/shared/toast/ReusableToast';
 import ShippingLabelPrintModal from '@/components/features/shipping/ShippingLabelPrintModal';
 import { useQueryClient } from '@tanstack/react-query';
 import { useState, useCallback } from 'react';
+import { usePageTitle } from '@/context/page-title-context';
 
 type BatchDevice = ShippingStatusDevice & {
     id: string | number;
@@ -30,6 +31,10 @@ const BatchDetailsPage = () => {
     const { data, isLoading, error } = useShippingBatchDetails(batchId);
     const { mutate: generateLabels, isPending: isGenerating, data: labelsData } = useGenerateShippingLabels();
     const [showLabelModal, setShowLabelModal] = useState(false);
+    usePageTitle({
+        title: data?.batch?.batch_name || "Shipping Batch",
+        section: "Shipping",
+    });
 
     const handleGenerateLabels = useCallback((ids: (string | number)[]) => {
         if (!ids || ids.length === 0) {

--- a/src/vertex/app/(authenticated)/admin/sites/[id]/page.tsx
+++ b/src/vertex/app/(authenticated)/admin/sites/[id]/page.tsx
@@ -15,6 +15,7 @@ import { EditSiteDetailsDialog } from "@/components/features/sites/edit-site-det
 import ClientPaginatedDevicesTable from "@/components/features/devices/client-paginated-devices-table";
 import SiteMeasurementsApiCard from "@/components/features/sites/site-measurements-api-card";
 import SiteActivityCard from "@/components/features/sites/site-activity-card";
+import { usePageTitle } from "@/context/page-title-context";
 
 const ContentGridSkeleton = () => (
   <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mt-6 items-start">
@@ -33,6 +34,7 @@ export default function SiteDetailsPage() {
   const [editSection, setEditSection] = useState<"general" | "mobile" | null>(
     null
   );
+  usePageTitle({ title: site?.name || "Site Details", section: "Sites" });
 
   if (error) {
     return (

--- a/src/vertex/app/(authenticated)/admin/sites/page.tsx
+++ b/src/vertex/app/(authenticated)/admin/sites/page.tsx
@@ -3,6 +3,7 @@
 import { RouteGuard } from "@/components/layout/accessConfig/route-guard";
 import SitesTable from "@/components/features/sites/sites-list-table";
 import { SiteStatsCards } from "@/components/features/sites/site-stats-cards";
+import { usePageTitle } from "@/context/page-title-context";
 import dynamic from "next/dynamic";
 
 const CreateSiteForm = dynamic(() =>
@@ -14,6 +15,8 @@ const CreateSiteForm = dynamic(() =>
 );
 
 export default function SitesPage() {
+  usePageTitle({ title: "Sites", section: "Administrative Panel" });
+
   return (
     <RouteGuard permission="SITE_VIEW">
       <div>

--- a/src/vertex/app/(authenticated)/cohorts/[id]/page.tsx
+++ b/src/vertex/app/(authenticated)/cohorts/[id]/page.tsx
@@ -13,6 +13,7 @@ import ReusableButton from "@/components/shared/button/ReusableButton";
 import CohortMeasurementsApiCard from "@/components/features/cohorts/cohort-measurements-api-card";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { ExclamationTriangleIcon } from "@radix-ui/react-icons";
+import { usePageTitle } from "@/context/page-title-context";
 
 const ContentGridSkeleton = () => (
     <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mt-6 items-start">
@@ -28,6 +29,7 @@ export default function CohortDetailsPage() {
     const cohortId = typeof params?.id === "string" ? params.id : "";
 
     const { data: cohort, isLoading, error } = useCohortDetails(cohortId, { enabled: !!cohortId });
+    usePageTitle({ title: cohort?.name || "Cohort Details", section: "Cohorts" });
 
     const [cohortDetails, setCohortDetails] = useState<{
         name: string;

--- a/src/vertex/app/(authenticated)/home/page.tsx
+++ b/src/vertex/app/(authenticated)/home/page.tsx
@@ -58,6 +58,11 @@ const ImportDeviceModal = dynamic(
   { ssr: false }
 );
 
+const LoginFeedbackToast = dynamic(
+  () => import("@/components/features/feedback/login-feedback-toast"),
+  { ssr: false }
+);
+
 const WelcomePage = () => {
   const { data: session } = useSession();
   const { userContext, userScope, hasError, error, isLoading: isLoadingUserContext } = useUserContext();
@@ -220,6 +225,9 @@ const WelcomePage = () => {
         open={isImportModalOpen}
         onOpenChange={setIsImportModalOpen}
       />
+      {userId && (user?.email || user?.userName) && (
+        <LoginFeedbackToast userId={userId} email={(user?.email || user?.userName) as string} />
+      )}
     </div>
   );
 };

--- a/src/vertex/app/(authenticated)/layout.tsx
+++ b/src/vertex/app/(authenticated)/layout.tsx
@@ -4,6 +4,7 @@ import Layout from "@/components/layout/layout";
 import { ForbiddenGuard } from "@/components/layout/accessConfig/forbidden-guard";
 import { useForbiddenHandler } from "@/core/hooks/useForbiddenHandler";
 import { useContextAwareRouting } from "@/core/hooks/useContextAwareRouting";
+import { PageTitleProvider } from "@/context/page-title-context";
 
 export default function AuthenticatedLayout({
   children,
@@ -18,9 +19,11 @@ export default function AuthenticatedLayout({
 
   return (
     <ForbiddenGuard>
-      <Layout>
-        {children}
-      </Layout>
+      <PageTitleProvider>
+        <Layout>
+          {children}
+        </Layout>
+      </PageTitleProvider>
     </ForbiddenGuard>
   );
 }

--- a/src/vertex/app/(authenticated)/sites/[id]/page.tsx
+++ b/src/vertex/app/(authenticated)/sites/[id]/page.tsx
@@ -17,6 +17,7 @@ import SiteMeasurementsApiCard from "@/components/features/sites/site-measuremen
 import SiteActivityCard from "@/components/features/sites/site-activity-card";
 import { RouteGuard } from "@/components/layout/accessConfig/route-guard";
 import { PERMISSIONS } from "@/core/permissions/constants";
+import { usePageTitle } from "@/context/page-title-context";
 
 const ContentGridSkeleton = () => (
   <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mt-6 items-start">
@@ -35,6 +36,7 @@ export default function UserSiteDetailsPage() {
   const [editSection, setEditSection] = useState<"general" | "mobile" | null>(
     null
   );
+  usePageTitle({ title: site?.name || "Site Details", section: "Sites" });
 
   return (
     <RouteGuard permission={PERMISSIONS.SITE.VIEW}>

--- a/src/vertex/app/changelog.md
+++ b/src/vertex/app/changelog.md
@@ -23,10 +23,11 @@ Added a post-login satisfaction feedback flow and extracted its toast UI into a 
 </details>
 
 <details>
-<summary><strong>Reusable Satisfaction Feedback Toast (4)</strong></summary>
+<summary><strong>Reusable Satisfaction Feedback Toast & API (5)</strong></summary>
 
 - **Reusable Component Extraction**: Created `ReusableSatisfactionFeedbackToast` as a shared component for satisfaction-style feedback prompts.
 - **Configurable Copy and Reasons**: Supports custom titles, subtitles, positive/negative labels, reason lists, thank-you copy, show delay, auto-dismiss delay, and submit handlers.
+- **Generic Satisfaction Submission Helper**: Added `feedbackService.submitSatisfactionFeedback` so future feature prompts can submit consistent satisfaction feedback without adding a new API method per feature.
 - **Shared Input Styling**: Uses `ReusableInputField` for the "Other" textarea field to stay aligned with the app's shared form styling.
 - **Thank-You State Polish**: Restored the celebratory emoji in the thank-you state after feedback submission.
 

--- a/src/vertex/app/changelog.md
+++ b/src/vertex/app/changelog.md
@@ -7,9 +7,9 @@
 ## Version 1.23.48
 **Released:** May 23, 2026
 
-### Post-Login Feedback Toast & Cookie Banner Refinements
+### Post-Login Feedback, Page Titles & Cookie Banner Refinements
 
-Added a post-login satisfaction feedback flow and extracted its toast UI into a reusable feedback component that can be reused for future workflows such as site creation feedback. Also refreshed the unauthenticated cookie information banner styling to use shared button primitives.
+Added a post-login satisfaction feedback flow and extracted its toast UI into a reusable feedback component that can be reused for future workflows such as site creation feedback. Also aligned authenticated page titles with the satisfaction banner and refreshed the unauthenticated cookie information banner styling to use shared button primitives.
 
 <details>
 <summary><strong>Post-Login Feedback Flow (5)</strong></summary>
@@ -34,6 +34,17 @@ Added a post-login satisfaction feedback flow and extracted its toast UI into a 
 </details>
 
 <details>
+<summary><strong>Authenticated Page Title Alignment (5)</strong></summary>
+
+- **Shared Page Title Context**: Added a `PageTitleProvider` and `usePageTitle` hook for authenticated pages so visible page headings, browser tab titles, and satisfaction prompts can use the same title source.
+- **Route-Based Defaults**: Added sensible fallback titles for authenticated routes including Home, My Devices, Sites, Cohorts, Sensor Manufacturers, Grids, Shipping, and common detail pages.
+- **Dynamic Entity Titles**: Added title overrides for detail pages so site, cohort, device, grid, sensor manufacturer, and shipping batch pages can display human-readable names instead of IDs.
+- **Satisfaction Banner Alignment**: Updated `PageSatisfactionBanner` to read the shared page title instead of deriving labels from the URL path.
+- **Title Reset Hardening**: Added document-head mutation handling so client-side page titles are restored if Next.js re-applies the root `AirQo Vertex` title after navigation.
+
+</details>
+
+<details>
 <summary><strong>Cookie Info Banner Refinement (1)</strong></summary>
 
 - **Shared Button Migration**: Refactored `CookieInfoBanner` to use `ReusableButton` and refreshed its styling for better consistency with the rest of the Vertex UI.
@@ -41,13 +52,26 @@ Added a post-login satisfaction feedback flow and extracted its toast UI into a 
 </details>
 
 <details>
-<summary><strong>Files Created/Modified (8)</strong></summary>
+<summary><strong>Files Created/Modified (21)</strong></summary>
 
+- `src/vertex/app/(authenticated)/admin/cohorts/[id]/page.tsx` [MODIFIED]
+- `src/vertex/app/(authenticated)/admin/cohorts/page.tsx` [MODIFIED]
+- `src/vertex/app/(authenticated)/admin/grids/[id]/page.tsx` [MODIFIED]
+- `src/vertex/app/(authenticated)/admin/networks/[id]/page.tsx` [MODIFIED]
+- `src/vertex/app/(authenticated)/admin/shipping/[batchId]/page.tsx` [MODIFIED]
+- `src/vertex/app/(authenticated)/admin/sites/[id]/page.tsx` [MODIFIED]
+- `src/vertex/app/(authenticated)/admin/sites/page.tsx` [MODIFIED]
+- `src/vertex/app/(authenticated)/cohorts/[id]/page.tsx` [MODIFIED]
 - `src/vertex/app/(authenticated)/home/page.tsx` [MODIFIED]
+- `src/vertex/app/(authenticated)/layout.tsx` [MODIFIED]
+- `src/vertex/app/(authenticated)/sites/[id]/page.tsx` [MODIFIED]
 - `src/vertex/app/login/page.tsx` [MODIFIED]
+- `src/vertex/components/features/devices/device-details-layout.tsx` [MODIFIED]
 - `src/vertex/components/features/auth/cookie-info-banner.tsx` [MODIFIED]
+- `src/vertex/components/features/feedback/page-satisfaction-banner.tsx` [MODIFIED]
 - `src/vertex/components/features/feedback/login-feedback-toast.tsx` [ADDED/MODIFIED]
 - `src/vertex/components/features/feedback/reusable-satisfaction-feedback-toast.tsx` [ADDED]
+- `src/vertex/context/page-title-context.tsx` [ADDED]
 - `src/vertex/core/apis/feedback.ts` [MODIFIED]
 - `src/vertex/core/utils/sessionManager.ts` [MODIFIED]
 - `src/vertex/core/utils/userPreferences.ts` [MODIFIED]

--- a/src/vertex/app/changelog.md
+++ b/src/vertex/app/changelog.md
@@ -4,6 +4,57 @@
 
 ---
 
+## Version 1.23.48
+**Released:** May 23, 2026
+
+### Post-Login Feedback Toast & Cookie Banner Refinements
+
+Added a post-login satisfaction feedback flow and extracted its toast UI into a reusable feedback component that can be reused for future workflows such as site creation feedback. Also refreshed the unauthenticated cookie information banner styling to use shared button primitives.
+
+<details>
+<summary><strong>Post-Login Feedback Flow (5)</strong></summary>
+
+- **Login Feedback Prompt**: Added `LoginFeedbackToast` on the authenticated home page to ask users how their login experience went shortly after sign-in.
+- **Login Timing Metadata**: Captures login start time from the login flow and submits login duration metadata with feedback payloads.
+- **Suppression Window**: Added local user preference helpers to avoid repeatedly prompting the same user after successful feedback submission.
+- **Structured Negative Feedback**: Added radio-button reason options and an "Other" details field so users can explain poor login experiences without typing from scratch.
+- **Auto-Dismiss Behavior**: Tuned delayed display and auto-dismiss timing so the toast appears after login but disappears if the user does not interact.
+
+</details>
+
+<details>
+<summary><strong>Reusable Satisfaction Feedback Toast (4)</strong></summary>
+
+- **Reusable Component Extraction**: Created `ReusableSatisfactionFeedbackToast` as a shared component for satisfaction-style feedback prompts.
+- **Configurable Copy and Reasons**: Supports custom titles, subtitles, positive/negative labels, reason lists, thank-you copy, show delay, auto-dismiss delay, and submit handlers.
+- **Shared Input Styling**: Uses `ReusableInputField` for the "Other" textarea field to stay aligned with the app's shared form styling.
+- **Thank-You State Polish**: Restored the celebratory emoji in the thank-you state after feedback submission.
+
+</details>
+
+<details>
+<summary><strong>Cookie Info Banner Refinement (1)</strong></summary>
+
+- **Shared Button Migration**: Refactored `CookieInfoBanner` to use `ReusableButton` and refreshed its styling for better consistency with the rest of the Vertex UI.
+
+</details>
+
+<details>
+<summary><strong>Files Created/Modified (8)</strong></summary>
+
+- `src/vertex/app/(authenticated)/home/page.tsx` [MODIFIED]
+- `src/vertex/app/login/page.tsx` [MODIFIED]
+- `src/vertex/components/features/auth/cookie-info-banner.tsx` [MODIFIED]
+- `src/vertex/components/features/feedback/login-feedback-toast.tsx` [ADDED/MODIFIED]
+- `src/vertex/components/features/feedback/reusable-satisfaction-feedback-toast.tsx` [ADDED]
+- `src/vertex/core/apis/feedback.ts` [MODIFIED]
+- `src/vertex/core/utils/sessionManager.ts` [MODIFIED]
+- `src/vertex/core/utils/userPreferences.ts` [MODIFIED]
+
+</details>
+
+---
+
 ## Version 1.23.47
 **Released:** May 21, 2026
 

--- a/src/vertex/app/login/page.tsx
+++ b/src/vertex/app/login/page.tsx
@@ -135,6 +135,12 @@ export default function LoginPage() {
       }
 
     setIsLoading(true);
+    // Record the login start time so the Home page can compute login duration
+    // for the post-login feedback toast. sessionStorage survives the redirect
+    // but is cleared automatically when the tab closes.
+    if (typeof window !== 'undefined') {
+      sessionStorage.setItem('vertex_login_start_ts', String(Date.now()));
+    }
 
     // Read preference BEFORE authentication to avoid timing issues
     const lastModule = getLastActiveModule(values.userName);

--- a/src/vertex/components/features/auth/cookie-info-banner.tsx
+++ b/src/vertex/components/features/auth/cookie-info-banner.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { COOKIE_POLICY_URL } from '@/lib/envConstants';
+import ReusableButton from '@/components/shared/button/ReusableButton';
 
 export function CookieInfoBanner() {
   const [isVisible, setIsVisible] = useState(false);
@@ -24,7 +25,7 @@ export function CookieInfoBanner() {
   }
 
   return (
-    <div className="fixed bottom-0 left-0 right-0 z-[100] bg-[#0066b3] text-white py-3 px-4 shadow">
+    <div className="fixed bottom-0 left-0 right-0 z-[100] bg-primary text-white py-3 px-4 shadow">
       <div className="mx-auto flex max-w-[1200px] flex-col items-center justify-between gap-3 sm:flex-row w-full">
         <p className="m-0 text-center text-sm sm:text-left">
           AirQo uses cookies to deliver and enhance the quality of its services and to analyze traffic.
@@ -38,12 +39,13 @@ export function CookieInfoBanner() {
             Learn more about our cookie policy
           </Link>
         </p>
-        <button
+        <ReusableButton
+          variant="outlined"
           onClick={handleDismiss}
-          className="rounded-md bg-white px-4 py-1 text-sm font-medium text-[#0066b3] transition-colors hover:bg-white/90 active:bg-white/80 cursor-pointer"
+          className="rounded-md bg-white px-4 py-1 text-sm font-medium text-primary transition-colors hover:bg-white/90 active:bg-white/80 hover:text-primary cursor-pointer"
         >
           OK, got it
-        </button>
+        </ReusableButton>
       </div>
     </div>
   );

--- a/src/vertex/components/features/devices/device-details-layout.tsx
+++ b/src/vertex/components/features/devices/device-details-layout.tsx
@@ -21,6 +21,7 @@ import MaintenanceStatusCard from "@/components/features/devices/maintenance-sta
 import DeviceCategoryCard from "@/components/features/devices/device-category-card";
 import DeviceHistoryCard from "@/components/features/devices/device-history-card";
 import { AqArrowLeft, AqSignal02, AqTool01 } from "@airqo/icons-react";
+import { usePageTitle } from "@/context/page-title-context";
 
 const ActionButtonsSkeleton = () => (
     <div className="flex gap-1">
@@ -46,6 +47,10 @@ export default function DeviceDetailsLayout({ deviceId }: DeviceDetailsLayoutPro
     const { data: deviceResponse, isLoading, error } = useDeviceDetails(deviceId);
     const device = (deviceResponse?.data as Device | undefined) ?? undefined;
     const router = useRouter();
+    usePageTitle({
+        title: device?.long_name || device?.name || "Device Details",
+        section: "Devices",
+    });
 
     const deploymentStatus = device?.status || "unknown";
 

--- a/src/vertex/components/features/feedback/login-feedback-toast.tsx
+++ b/src/vertex/components/features/feedback/login-feedback-toast.tsx
@@ -1,14 +1,14 @@
 "use client";
 
 import React, { useEffect, useRef, useState } from "react";
-import { motion, AnimatePresence } from "framer-motion";
-import { ThumbsUp, ThumbsDown } from "lucide-react";
-import { Card, CardContent } from "@/components/ui/card";
-import ReusableButton from "@/components/shared/button/ReusableButton";
 import { feedbackService } from "@/core/apis/feedback";
-import { getLoginFeedbackRecord, setLoginFeedbackRecord } from "@/core/utils/userPreferences";
+import {
+  getLoginFeedbackRecord,
+  setLoginFeedbackRecord,
+} from "@/core/utils/userPreferences";
+import { ReusableSatisfactionFeedbackToast } from "./reusable-satisfaction-feedback-toast";
 
-const NEGATIVE_REASONS = [
+const LOGIN_NEGATIVE_REASONS = [
   "It took too long to load",
   "I had trouble with my password",
   "I got an error message",
@@ -16,227 +16,60 @@ const NEGATIVE_REASONS = [
   "Other",
 ];
 
-type ToastPhase = "idle" | "visible" | "negative-expanded" | "submitting" | "thankyou" | "dismissed";
-
 interface LoginFeedbackToastProps {
   userId: string;
   email: string;
 }
 
-const LoginFeedbackToast: React.FC<LoginFeedbackToastProps> = ({ userId, email }) => {
-  const [phase, setPhase] = useState<ToastPhase>("idle");
-  const [description, setDescription] = useState("");
-  const [otherText, setOtherText] = useState("");
+const LoginFeedbackToast: React.FC<LoginFeedbackToastProps> = ({
+  userId,
+  email,
+}) => {
+  const [shouldAskForFeedback, setShouldAskForFeedback] = useState(false);
   const loginDurationRef = useRef(0);
 
   useEffect(() => {
-    if (!userId) return;
+    if (!userId) {
+      setShouldAskForFeedback(false);
+      return;
+    }
 
-    // Check if we should suppress the prompt
     const record = getLoginFeedbackRecord(userId);
-    if (record && Date.now() < record.expiresAt) return; // Stay idle
+    if (record && Date.now() < record.expiresAt) {
+      setShouldAskForFeedback(false);
+      return;
+    }
 
-    // Compute login duration
-    const loginStartTs = Number(sessionStorage.getItem("vertex_login_start_ts") || 0);
-    loginDurationRef.current = loginStartTs > 0 ? Date.now() - loginStartTs : 0;
-
-    // Show after 3 seconds
-    const showTimer = setTimeout(() => {
-      setPhase((current) => (current === "idle" ? "visible" : current));
-    }, 3000);
-
-    // Auto-dismiss after 30 seconds (3s wait + 30s visibility)
-    // Only dismiss if the user hasn't interacted (still in "visible" phase)
-    const autoTimer = setTimeout(() => {
-      setPhase((current) => (current === "visible" ? "dismissed" : current));
-    }, 33000);
-
-    return () => {
-      clearTimeout(showTimer);
-      clearTimeout(autoTimer);
-    };
+    const loginStartTs = Number(
+      sessionStorage.getItem("vertex_login_start_ts") || 0
+    );
+    loginDurationRef.current =
+      loginStartTs > 0 ? Date.now() - loginStartTs : 0;
+    setShouldAskForFeedback(true);
   }, [userId]);
 
-  const handlePositive = async () => {
-    setPhase("submitting");
-    try {
-      await feedbackService.submitLoginFeedback({
-        email,
-        rating: 5,
-        loginDurationMs: loginDurationRef.current,
-        submittedAt: Date.now(),
-      });
-      setLoginFeedbackRecord(userId);
-    } catch (error) {
-      console.error("Failed to submit positive login feedback", error);
-      // Swallow error, skip localStorage write
-    }
-    showThankYouAndDismiss();
+  const submitLoginFeedback = async (rating: number, description?: string) => {
+    await feedbackService.submitLoginFeedback({
+      email,
+      rating,
+      description,
+      loginDurationMs: loginDurationRef.current,
+      submittedAt: Date.now(),
+    });
+    setLoginFeedbackRecord(userId);
   };
-
-  const handleNegativeSubmit = async () => {
-    setPhase("submitting");
-    try {
-      const finalDescription = description === "Other" 
-        ? `Other: ${otherText.trim()}`
-        : description.trim() || undefined;
-
-      await feedbackService.submitLoginFeedback({
-        email,
-        rating: 1,
-        description: finalDescription,
-        loginDurationMs: loginDurationRef.current,
-        submittedAt: Date.now(),
-      });
-      setLoginFeedbackRecord(userId);
-    } catch (error) {
-      console.error("Failed to submit negative login feedback", error);
-      // Swallow error
-    }
-    showThankYouAndDismiss();
-  };
-
-  const isSubmitDisabled = phase === "submitting" || !description || (description === "Other" && !otherText.trim());
-
-  const showThankYouAndDismiss = () => {
-    setPhase("thankyou");
-    setTimeout(() => {
-      setPhase("dismissed");
-    }, 2000);
-  };
-
-  if (phase === "idle" || phase === "dismissed") return null;
 
   return (
-    <AnimatePresence>
-      <motion.div
-        key="login-feedback-toast"
-        initial={{ y: 24, opacity: 0 }}
-        animate={{ y: 0, opacity: 1 }}
-        exit={{ opacity: 0 }}
-        transition={{ duration: 0.3, ease: "easeOut" }}
-        className="fixed bottom-6 right-6 z-[9999] w-80"
-      >
-        <Card className="rounded-2xl shadow-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 overflow-hidden">
-          <CardContent className="p-5 flex flex-col gap-4">
-            {phase === "thankyou" ? (
-              <div className="flex flex-col items-center justify-center py-4 text-center">
-                <span className="text-xl mb-2">🎉</span>
-                <p className="text-sm font-medium text-gray-900 dark:text-white">
-                  Thank you for your feedback!
-                </p>
-                <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-                  Your input helps us improve Vertex.
-                </p>
-              </div>
-            ) : (
-              <>
-                <div>
-                  <h4 className="text-sm font-semibold text-gray-900 dark:text-white leading-tight mb-1">
-                    How was your login experience?
-                  </h4>
-                  <p className="text-xs text-gray-500 dark:text-gray-400">
-                    Rate us to help improve Vertex
-                  </p>
-                </div>
-
-                <div className="flex items-center gap-3">
-                  <ReusableButton
-                    variant="filled"
-                    className="flex-1 py-2"
-                    onClick={handlePositive}
-                    disabled={phase === "submitting" || phase === "negative-expanded"}
-                    Icon={ThumbsUp}
-                  >
-                    Great
-                  </ReusableButton>
-                  <ReusableButton
-                    variant="outlined"
-                    className={`flex-1 py-2 ${
-                      phase === "negative-expanded" ? "bg-gray-100 dark:bg-gray-700 opacity-50" : ""
-                    }`}
-                    onClick={() => {
-                      if (phase === "visible") setPhase("negative-expanded");
-                    }}
-                    disabled={phase === "submitting"}
-                    Icon={ThumbsDown}
-                  >
-                    Not great
-                  </ReusableButton>
-                </div>
-
-                <AnimatePresence>
-                  {phase === "negative-expanded" && (
-                    <motion.div
-                      initial={{ height: 0, opacity: 0 }}
-                      animate={{ height: "auto", opacity: 1 }}
-                      exit={{ height: 0, opacity: 0 }}
-                      className="overflow-hidden"
-                    >
-                      <div className="pt-3 border-t border-gray-100 dark:border-gray-700 mt-1 flex flex-col gap-3">
-                        <div className="space-y-2 mb-1">
-                          {NEGATIVE_REASONS.map((r) => (
-                            <label
-                              key={r}
-                              className="flex items-center gap-2 cursor-pointer"
-                            >
-                              <input
-                                type="radio"
-                                name="reason"
-                                value={r}
-                                checked={description === r}
-                                onChange={() => {
-                                  setDescription(r);
-                                  if (r !== "Other") setOtherText("");
-                                }}
-                                disabled={phase === "submitting"}
-                                className="h-4 w-4 text-primary accent-primary"
-                              />
-                              <span className="text-sm text-gray-700 dark:text-gray-300">
-                                {r}
-                              </span>
-                            </label>
-                          ))}
-                        </div>
-                        <AnimatePresence>
-                          {description === "Other" && (
-                            <motion.div
-                              initial={{ height: 0, opacity: 0 }}
-                              animate={{ height: "auto", opacity: 1 }}
-                              exit={{ height: 0, opacity: 0 }}
-                              className="overflow-hidden"
-                            >
-                              <textarea
-                                placeholder="Please provide details (required)"
-                                className="w-full text-sm rounded-lg border border-gray-200 dark:border-gray-600 bg-gray-50 dark:bg-gray-900 p-3 outline-none focus:ring-2 focus:ring-primary focus:border-transparent resize-none min-h-[70px] mt-1"
-                                value={otherText}
-                                onChange={(e) => setOtherText(e.target.value)}
-                                disabled={phase === "submitting"}
-                              />
-                            </motion.div>
-                          )}
-                        </AnimatePresence>
-                        <div className="flex gap-2 mt-1">
-                          <ReusableButton
-                            variant="filled"
-                            className="w-full py-2"
-                            onClick={handleNegativeSubmit}
-                            loading={phase === "submitting"}
-                            disabled={isSubmitDisabled}
-                          >
-                            Submit
-                          </ReusableButton>
-                        </div>
-                      </div>
-                    </motion.div>
-                  )}
-                </AnimatePresence>
-              </>
-            )}
-          </CardContent>
-        </Card>
-      </motion.div>
-    </AnimatePresence>
+    <ReusableSatisfactionFeedbackToast
+      enabled={shouldAskForFeedback}
+      resetKey={userId}
+      title="How was your login experience?"
+      subtitle="Rate us to help improve Vertex"
+      negativeReasons={LOGIN_NEGATIVE_REASONS}
+      onPositiveSubmit={() => submitLoginFeedback(5)}
+      onNegativeSubmit={(description) => submitLoginFeedback(1, description)}
+      onDismiss={() => setShouldAskForFeedback(false)}
+    />
   );
 };
 

--- a/src/vertex/components/features/feedback/login-feedback-toast.tsx
+++ b/src/vertex/components/features/feedback/login-feedback-toast.tsx
@@ -7,7 +7,6 @@ import { Card, CardContent } from "@/components/ui/card";
 import ReusableButton from "@/components/shared/button/ReusableButton";
 import { feedbackService } from "@/core/apis/feedback";
 import { getLoginFeedbackRecord, setLoginFeedbackRecord } from "@/core/utils/userPreferences";
-import { openFeedbackDialog } from "./feedback-dialog";
 
 type ToastPhase = "idle" | "visible" | "negative-expanded" | "submitting" | "thankyou" | "dismissed";
 
@@ -82,12 +81,6 @@ const LoginFeedbackToast: React.FC<LoginFeedbackToastProps> = ({ userId, email }
       // Swallow error
     }
     showThankYouAndDismiss();
-  };
-
-  const handleNegativeAddDetails = () => {
-    // Open the comprehensive feedback dialog and dismiss this toast silently
-    openFeedbackDialog();
-    setPhase("dismissed");
   };
 
   const showThankYouAndDismiss = () => {
@@ -176,20 +169,12 @@ const LoginFeedbackToast: React.FC<LoginFeedbackToastProps> = ({ userId, email }
                         <div className="flex gap-2">
                           <ReusableButton
                             variant="filled"
-                            className="flex-1 py-2"
+                            className="w-full py-2"
                             onClick={handleNegativeSubmit}
                             loading={phase === "submitting"}
                             disabled={phase === "submitting"}
                           >
                             Submit
-                          </ReusableButton>
-                          <ReusableButton
-                            variant="outlined"
-                            className="flex-1 py-2"
-                            onClick={handleNegativeAddDetails}
-                            disabled={phase === "submitting"}
-                          >
-                            Add Details
                           </ReusableButton>
                         </div>
                       </div>

--- a/src/vertex/components/features/feedback/login-feedback-toast.tsx
+++ b/src/vertex/components/features/feedback/login-feedback-toast.tsx
@@ -1,0 +1,208 @@
+"use client";
+
+import React, { useEffect, useRef, useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { ThumbsUp, ThumbsDown } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import ReusableButton from "@/components/shared/button/ReusableButton";
+import { feedbackService } from "@/core/apis/feedback";
+import { getLoginFeedbackRecord, setLoginFeedbackRecord } from "@/core/utils/userPreferences";
+import { openFeedbackDialog } from "./feedback-dialog";
+
+type ToastPhase = "idle" | "visible" | "negative-expanded" | "submitting" | "thankyou" | "dismissed";
+
+interface LoginFeedbackToastProps {
+  userId: string;
+  email: string;
+}
+
+const LoginFeedbackToast: React.FC<LoginFeedbackToastProps> = ({ userId, email }) => {
+  const [phase, setPhase] = useState<ToastPhase>("idle");
+  const [description, setDescription] = useState("");
+  const loginDurationRef = useRef(0);
+
+  useEffect(() => {
+    if (!userId) return;
+
+    // Check if we should suppress the prompt
+    const record = getLoginFeedbackRecord(userId);
+    if (record && Date.now() < record.expiresAt) return; // Stay idle
+
+    // Compute login duration
+    const loginStartTs = Number(sessionStorage.getItem("vertex_login_start_ts") || 0);
+    loginDurationRef.current = loginStartTs > 0 ? Date.now() - loginStartTs : 0;
+
+    // Show after 3 seconds
+    const showTimer = setTimeout(() => {
+      setPhase((current) => (current === "idle" ? "visible" : current));
+    }, 3000);
+
+    // Auto-dismiss after 10 minutes (3s wait + 10m visibility)
+    // Only dismiss if the user hasn't interacted (still in "visible" phase)
+    const autoTimer = setTimeout(() => {
+      setPhase((current) => (current === "visible" ? "dismissed" : current));
+    }, 603000);
+
+    return () => {
+      clearTimeout(showTimer);
+      clearTimeout(autoTimer);
+    };
+  }, [userId]);
+
+  const handlePositive = async () => {
+    setPhase("submitting");
+    try {
+      await feedbackService.submitLoginFeedback({
+        email,
+        rating: 5,
+        loginDurationMs: loginDurationRef.current,
+        submittedAt: Date.now(),
+      });
+      setLoginFeedbackRecord(userId);
+    } catch (error) {
+      console.error("Failed to submit positive login feedback", error);
+      // Swallow error, skip localStorage write
+    }
+    showThankYouAndDismiss();
+  };
+
+  const handleNegativeSubmit = async () => {
+    setPhase("submitting");
+    try {
+      await feedbackService.submitLoginFeedback({
+        email,
+        rating: 1,
+        description: description.trim() || undefined,
+        loginDurationMs: loginDurationRef.current,
+        submittedAt: Date.now(),
+      });
+      setLoginFeedbackRecord(userId);
+    } catch (error) {
+      console.error("Failed to submit negative login feedback", error);
+      // Swallow error
+    }
+    showThankYouAndDismiss();
+  };
+
+  const handleNegativeAddDetails = () => {
+    // Open the comprehensive feedback dialog and dismiss this toast silently
+    openFeedbackDialog();
+    setPhase("dismissed");
+  };
+
+  const showThankYouAndDismiss = () => {
+    setPhase("thankyou");
+    setTimeout(() => {
+      setPhase("dismissed");
+    }, 2000);
+  };
+
+  if (phase === "idle" || phase === "dismissed") return null;
+
+  return (
+    <AnimatePresence>
+      <motion.div
+        key="login-feedback-toast"
+        initial={{ y: 24, opacity: 0 }}
+        animate={{ y: 0, opacity: 1 }}
+        exit={{ opacity: 0 }}
+        transition={{ duration: 0.3, ease: "easeOut" }}
+        className="fixed bottom-6 right-6 z-[9999] w-80"
+      >
+        <Card className="rounded-2xl shadow-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 overflow-hidden">
+          <CardContent className="p-5 flex flex-col gap-4">
+            {phase === "thankyou" ? (
+              <div className="flex flex-col items-center justify-center py-4 text-center">
+                <span className="text-xl mb-2">🎉</span>
+                <p className="text-sm font-medium text-gray-900 dark:text-white">
+                  Thank you for your feedback!
+                </p>
+                <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                  Your input helps us improve Vertex.
+                </p>
+              </div>
+            ) : (
+              <>
+                <div>
+                  <h4 className="text-sm font-semibold text-gray-900 dark:text-white leading-tight mb-1">
+                    How was your login experience?
+                  </h4>
+                  <p className="text-xs text-gray-500 dark:text-gray-400">
+                    Rate us to help improve Vertex
+                  </p>
+                </div>
+
+                <div className="flex items-center gap-3">
+                  <ReusableButton
+                    variant="filled"
+                    className="flex-1 py-2"
+                    onClick={handlePositive}
+                    disabled={phase === "submitting" || phase === "negative-expanded"}
+                    Icon={ThumbsUp}
+                  >
+                    Great
+                  </ReusableButton>
+                  <ReusableButton
+                    variant="outlined"
+                    className={`flex-1 py-2 ${
+                      phase === "negative-expanded" ? "bg-gray-100 dark:bg-gray-700 opacity-50" : ""
+                    }`}
+                    onClick={() => {
+                      if (phase === "visible") setPhase("negative-expanded");
+                    }}
+                    disabled={phase === "submitting"}
+                    Icon={ThumbsDown}
+                  >
+                    Not great
+                  </ReusableButton>
+                </div>
+
+                <AnimatePresence>
+                  {phase === "negative-expanded" && (
+                    <motion.div
+                      initial={{ height: 0, opacity: 0 }}
+                      animate={{ height: "auto", opacity: 1 }}
+                      exit={{ height: 0, opacity: 0 }}
+                      className="overflow-hidden"
+                    >
+                      <div className="pt-3 border-t border-gray-100 dark:border-gray-700 mt-1 flex flex-col gap-3">
+                        <textarea
+                          placeholder="Tell us more (optional)"
+                          className="w-full text-sm rounded-lg border border-gray-200 dark:border-gray-600 bg-gray-50 dark:bg-gray-900 p-3 outline-none focus:ring-2 focus:ring-primary focus:border-transparent resize-none min-h-[70px]"
+                          value={description}
+                          onChange={(e) => setDescription(e.target.value)}
+                          disabled={phase === "submitting"}
+                        />
+                        <div className="flex gap-2">
+                          <ReusableButton
+                            variant="filled"
+                            className="flex-1 py-2"
+                            onClick={handleNegativeSubmit}
+                            loading={phase === "submitting"}
+                            disabled={phase === "submitting"}
+                          >
+                            Submit
+                          </ReusableButton>
+                          <ReusableButton
+                            variant="outlined"
+                            className="flex-1 py-2"
+                            onClick={handleNegativeAddDetails}
+                            disabled={phase === "submitting"}
+                          >
+                            Add Details
+                          </ReusableButton>
+                        </div>
+                      </div>
+                    </motion.div>
+                  )}
+                </AnimatePresence>
+              </>
+            )}
+          </CardContent>
+        </Card>
+      </motion.div>
+    </AnimatePresence>
+  );
+};
+
+export default LoginFeedbackToast;

--- a/src/vertex/components/features/feedback/login-feedback-toast.tsx
+++ b/src/vertex/components/features/feedback/login-feedback-toast.tsx
@@ -26,6 +26,7 @@ interface LoginFeedbackToastProps {
 const LoginFeedbackToast: React.FC<LoginFeedbackToastProps> = ({ userId, email }) => {
   const [phase, setPhase] = useState<ToastPhase>("idle");
   const [description, setDescription] = useState("");
+  const [otherText, setOtherText] = useState("");
   const loginDurationRef = useRef(0);
 
   useEffect(() => {
@@ -76,10 +77,14 @@ const LoginFeedbackToast: React.FC<LoginFeedbackToastProps> = ({ userId, email }
   const handleNegativeSubmit = async () => {
     setPhase("submitting");
     try {
+      const finalDescription = description === "Other" 
+        ? `Other: ${otherText.trim()}`
+        : description.trim() || undefined;
+
       await feedbackService.submitLoginFeedback({
         email,
         rating: 1,
-        description: description.trim() || undefined,
+        description: finalDescription,
         loginDurationMs: loginDurationRef.current,
         submittedAt: Date.now(),
       });
@@ -90,6 +95,8 @@ const LoginFeedbackToast: React.FC<LoginFeedbackToastProps> = ({ userId, email }
     }
     showThankYouAndDismiss();
   };
+
+  const isSubmitDisabled = phase === "submitting" || !description || (description === "Other" && !otherText.trim());
 
   const showThankYouAndDismiss = () => {
     setPhase("thankyou");
@@ -178,7 +185,10 @@ const LoginFeedbackToast: React.FC<LoginFeedbackToastProps> = ({ userId, email }
                                 name="reason"
                                 value={r}
                                 checked={description === r}
-                                onChange={() => setDescription(r)}
+                                onChange={() => {
+                                  setDescription(r);
+                                  if (r !== "Other") setOtherText("");
+                                }}
                                 disabled={phase === "submitting"}
                                 className="h-4 w-4 text-primary accent-primary"
                               />
@@ -188,13 +198,31 @@ const LoginFeedbackToast: React.FC<LoginFeedbackToastProps> = ({ userId, email }
                             </label>
                           ))}
                         </div>
-                        <div className="flex gap-2">
+                        <AnimatePresence>
+                          {description === "Other" && (
+                            <motion.div
+                              initial={{ height: 0, opacity: 0 }}
+                              animate={{ height: "auto", opacity: 1 }}
+                              exit={{ height: 0, opacity: 0 }}
+                              className="overflow-hidden"
+                            >
+                              <textarea
+                                placeholder="Please provide details (required)"
+                                className="w-full text-sm rounded-lg border border-gray-200 dark:border-gray-600 bg-gray-50 dark:bg-gray-900 p-3 outline-none focus:ring-2 focus:ring-primary focus:border-transparent resize-none min-h-[70px] mt-1"
+                                value={otherText}
+                                onChange={(e) => setOtherText(e.target.value)}
+                                disabled={phase === "submitting"}
+                              />
+                            </motion.div>
+                          )}
+                        </AnimatePresence>
+                        <div className="flex gap-2 mt-1">
                           <ReusableButton
                             variant="filled"
                             className="w-full py-2"
                             onClick={handleNegativeSubmit}
                             loading={phase === "submitting"}
-                            disabled={phase === "submitting"}
+                            disabled={isSubmitDisabled}
                           >
                             Submit
                           </ReusableButton>

--- a/src/vertex/components/features/feedback/login-feedback-toast.tsx
+++ b/src/vertex/components/features/feedback/login-feedback-toast.tsx
@@ -37,11 +37,11 @@ const LoginFeedbackToast: React.FC<LoginFeedbackToastProps> = ({ userId, email }
       setPhase((current) => (current === "idle" ? "visible" : current));
     }, 3000);
 
-    // Auto-dismiss after 10 minutes (3s wait + 10m visibility)
+    // Auto-dismiss after 30 seconds (3s wait + 30s visibility)
     // Only dismiss if the user hasn't interacted (still in "visible" phase)
     const autoTimer = setTimeout(() => {
       setPhase((current) => (current === "visible" ? "dismissed" : current));
-    }, 603000);
+    }, 33000);
 
     return () => {
       clearTimeout(showTimer);

--- a/src/vertex/components/features/feedback/login-feedback-toast.tsx
+++ b/src/vertex/components/features/feedback/login-feedback-toast.tsx
@@ -8,6 +8,14 @@ import ReusableButton from "@/components/shared/button/ReusableButton";
 import { feedbackService } from "@/core/apis/feedback";
 import { getLoginFeedbackRecord, setLoginFeedbackRecord } from "@/core/utils/userPreferences";
 
+const NEGATIVE_REASONS = [
+  "It took too long to load",
+  "I had trouble with my password",
+  "I got an error message",
+  "The page froze or crashed",
+  "Other",
+];
+
 type ToastPhase = "idle" | "visible" | "negative-expanded" | "submitting" | "thankyou" | "dismissed";
 
 interface LoginFeedbackToastProps {
@@ -159,13 +167,27 @@ const LoginFeedbackToast: React.FC<LoginFeedbackToastProps> = ({ userId, email }
                       className="overflow-hidden"
                     >
                       <div className="pt-3 border-t border-gray-100 dark:border-gray-700 mt-1 flex flex-col gap-3">
-                        <textarea
-                          placeholder="Tell us more (optional)"
-                          className="w-full text-sm rounded-lg border border-gray-200 dark:border-gray-600 bg-gray-50 dark:bg-gray-900 p-3 outline-none focus:ring-2 focus:ring-primary focus:border-transparent resize-none min-h-[70px]"
-                          value={description}
-                          onChange={(e) => setDescription(e.target.value)}
-                          disabled={phase === "submitting"}
-                        />
+                        <div className="space-y-2 mb-1">
+                          {NEGATIVE_REASONS.map((r) => (
+                            <label
+                              key={r}
+                              className="flex items-center gap-2 cursor-pointer"
+                            >
+                              <input
+                                type="radio"
+                                name="reason"
+                                value={r}
+                                checked={description === r}
+                                onChange={() => setDescription(r)}
+                                disabled={phase === "submitting"}
+                                className="h-4 w-4 text-primary accent-primary"
+                              />
+                              <span className="text-sm text-gray-700 dark:text-gray-300">
+                                {r}
+                              </span>
+                            </label>
+                          ))}
+                        </div>
                         <div className="flex gap-2">
                           <ReusableButton
                             variant="filled"

--- a/src/vertex/components/features/feedback/page-satisfaction-banner.tsx
+++ b/src/vertex/components/features/feedback/page-satisfaction-banner.tsx
@@ -11,6 +11,7 @@ import ReusableInputField from '@/components/shared/inputfield/ReusableInputFiel
 import ReusableButton from '@/components/shared/button/ReusableButton';
 import { getApiErrorMessage } from '@/core/utils/getApiErrorMessage';
 import { usePathname } from 'next/navigation';
+import { usePageTitleContext } from '@/context/page-title-context';
 
 const NEGATIVE_REASONS = [
  'Confusing',
@@ -147,16 +148,7 @@ export const PageSatisfactionBanner: React.FC = () => {
  const pathname = usePathname();
  const { userDetails } = useUserContext();
  const { showBanner } = useBanner();
-
- const getPageName = () => {
-  if (!pathname) return 'this page';
-  const parts = pathname.split('/').filter(Boolean);
-  const lastPart = parts[parts.length - 1] || 'home';
-  return lastPart
-   .split('-')
-   .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-   .join(' ');
- };
+ const { title: pageName, section: pageSection } = usePageTitleContext();
 
  const handleSubmitFeedback = async (
   rating: number,
@@ -180,6 +172,8 @@ export const PageSatisfactionBanner: React.FC = () => {
   try {
    const metadata = {
     page: pathname || window.location.pathname,
+    pageTitle: pageName,
+    pageSection,
     reason,
     browser:
      typeof window !== 'undefined'
@@ -190,7 +184,7 @@ export const PageSatisfactionBanner: React.FC = () => {
 
    await feedbackService.submitFeedback({
     email: userEmail,
-    subject: `Page Satisfaction: ${getPageName()}`,
+    subject: `Page Satisfaction: ${pageName}`,
     message: message || `Rating: ${rating}/5, Reason: ${reason}`,
     rating,
     category: 'page_satisfaction',
@@ -220,7 +214,7 @@ export const PageSatisfactionBanner: React.FC = () => {
     <div className="max-w-7xl mx-auto flex flex-col sm:flex-row items-center justify-between gap-4">
      <div className="text-center sm:text-left">
       <h3 className="text-sm font-semibold text-gray-900 dark:text-white">
-       Overall, how satisfied are you with {getPageName()}?
+       Overall, how satisfied are you with {pageName}?
       </h3>
      </div>
 

--- a/src/vertex/components/features/feedback/reusable-satisfaction-feedback-toast.tsx
+++ b/src/vertex/components/features/feedback/reusable-satisfaction-feedback-toast.tsx
@@ -148,6 +148,7 @@ export const ReusableSatisfactionFeedbackToast: React.FC<
           <CardContent className="p-5 flex flex-col gap-4">
             {phase === "thankyou" ? (
               <div className="flex flex-col items-center justify-center py-4 text-center">
+                <span className="text-xl mb-2">🎉</span>
                 <p className="text-sm font-medium text-gray-900 dark:text-white">
                   {thankYouTitle}
                 </p>

--- a/src/vertex/components/features/feedback/reusable-satisfaction-feedback-toast.tsx
+++ b/src/vertex/components/features/feedback/reusable-satisfaction-feedback-toast.tsx
@@ -1,0 +1,278 @@
+"use client";
+
+import React, { useEffect, useRef, useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { ThumbsUp, ThumbsDown } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import ReusableButton from "@/components/shared/button/ReusableButton";
+import ReusableInputField from "@/components/shared/inputfield/ReusableInputField";
+
+type ToastPhase =
+  | "idle"
+  | "visible"
+  | "negative-expanded"
+  | "submitting"
+  | "thankyou"
+  | "dismissed";
+
+interface ReusableSatisfactionFeedbackToastProps {
+  title: string;
+  subtitle?: string;
+  negativeReasons: string[];
+  onPositiveSubmit: () => Promise<void> | void;
+  onNegativeSubmit: (description?: string) => Promise<void> | void;
+  enabled?: boolean;
+  resetKey?: string | number;
+  positiveLabel?: string;
+  negativeLabel?: string;
+  otherReasonLabel?: string;
+  otherPlaceholder?: string;
+  thankYouTitle?: string;
+  thankYouMessage?: string;
+  showDelayMs?: number;
+  autoDismissMs?: number;
+  onDismiss?: () => void;
+  className?: string;
+}
+
+export const ReusableSatisfactionFeedbackToast: React.FC<
+  ReusableSatisfactionFeedbackToastProps
+> = ({
+  title,
+  subtitle = "Rate us to help improve Vertex",
+  negativeReasons,
+  onPositiveSubmit,
+  onNegativeSubmit,
+  enabled = true,
+  resetKey,
+  positiveLabel = "Great",
+  negativeLabel = "Not great",
+  otherReasonLabel = "Other",
+  otherPlaceholder = "Please provide details (required)",
+  thankYouTitle = "Thank you for your feedback!",
+  thankYouMessage = "Your input helps us improve Vertex.",
+  showDelayMs = 3000,
+  autoDismissMs = 30000,
+  onDismiss,
+  className = "fixed bottom-6 right-6 z-[9999] w-80",
+}) => {
+  const [phase, setPhase] = useState<ToastPhase>("idle");
+  const [description, setDescription] = useState("");
+  const [otherText, setOtherText] = useState("");
+  const dismissNotifiedRef = useRef(false);
+
+  useEffect(() => {
+    dismissNotifiedRef.current = false;
+    setDescription("");
+    setOtherText("");
+
+    if (!enabled) {
+      setPhase("idle");
+      return;
+    }
+
+    setPhase("idle");
+
+    const showTimer = setTimeout(() => {
+      setPhase((current) => (current === "idle" ? "visible" : current));
+    }, showDelayMs);
+
+    const autoTimer = setTimeout(() => {
+      setPhase((current) => (current === "visible" ? "dismissed" : current));
+    }, showDelayMs + autoDismissMs);
+
+    return () => {
+      clearTimeout(showTimer);
+      clearTimeout(autoTimer);
+    };
+  }, [autoDismissMs, enabled, resetKey, showDelayMs]);
+
+  useEffect(() => {
+    if (phase !== "dismissed" || dismissNotifiedRef.current) return;
+    dismissNotifiedRef.current = true;
+    onDismiss?.();
+  }, [onDismiss, phase]);
+
+  const showThankYouAndDismiss = () => {
+    setPhase("thankyou");
+    setTimeout(() => {
+      setPhase("dismissed");
+    }, 2000);
+  };
+
+  const handlePositive = async () => {
+    setPhase("submitting");
+    try {
+      await onPositiveSubmit();
+    } catch (error) {
+      console.error("Failed to submit positive satisfaction feedback", error);
+    }
+    showThankYouAndDismiss();
+  };
+
+  const handleNegativeSubmit = async () => {
+    setPhase("submitting");
+    try {
+      const finalDescription =
+        description === otherReasonLabel
+          ? `${otherReasonLabel}: ${otherText.trim()}`
+          : description.trim() || undefined;
+
+      await onNegativeSubmit(finalDescription);
+    } catch (error) {
+      console.error("Failed to submit negative satisfaction feedback", error);
+    }
+    showThankYouAndDismiss();
+  };
+
+  const isOtherReason = description === otherReasonLabel;
+  const isSubmitting = phase === "submitting";
+  const isSubmitDisabled =
+    isSubmitting ||
+    !description ||
+    (isOtherReason && !otherText.trim());
+
+  if (phase === "idle" || phase === "dismissed") return null;
+
+  return (
+    <AnimatePresence>
+      <motion.div
+        key="reusable-satisfaction-feedback-toast"
+        initial={{ y: 24, opacity: 0 }}
+        animate={{ y: 0, opacity: 1 }}
+        exit={{ opacity: 0 }}
+        transition={{ duration: 0.3, ease: "easeOut" }}
+        className={className}
+      >
+        <Card className="rounded-2xl shadow-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 overflow-hidden">
+          <CardContent className="p-5 flex flex-col gap-4">
+            {phase === "thankyou" ? (
+              <div className="flex flex-col items-center justify-center py-4 text-center">
+                <p className="text-sm font-medium text-gray-900 dark:text-white">
+                  {thankYouTitle}
+                </p>
+                {thankYouMessage && (
+                  <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                    {thankYouMessage}
+                  </p>
+                )}
+              </div>
+            ) : (
+              <>
+                <div>
+                  <h4 className="text-sm font-semibold text-gray-900 dark:text-white leading-tight mb-1">
+                    {title}
+                  </h4>
+                  {subtitle && (
+                    <p className="text-xs text-gray-500 dark:text-gray-400">
+                      {subtitle}
+                    </p>
+                  )}
+                </div>
+
+                <div className="flex items-center gap-3">
+                  <ReusableButton
+                    variant="filled"
+                    className="flex-1 py-2"
+                    onClick={handlePositive}
+                    disabled={
+                      phase === "submitting" || phase === "negative-expanded"
+                    }
+                    Icon={ThumbsUp}
+                  >
+                    {positiveLabel}
+                  </ReusableButton>
+                  <ReusableButton
+                    variant="outlined"
+                    className={`flex-1 py-2 ${
+                      phase === "negative-expanded"
+                        ? "bg-gray-100 dark:bg-gray-700 opacity-50"
+                        : ""
+                    }`}
+                    onClick={() => {
+                      if (phase === "visible") setPhase("negative-expanded");
+                    }}
+                    disabled={phase === "submitting"}
+                    Icon={ThumbsDown}
+                  >
+                    {negativeLabel}
+                  </ReusableButton>
+                </div>
+
+                <AnimatePresence>
+                  {phase === "negative-expanded" && (
+                    <motion.div
+                      initial={{ height: 0, opacity: 0 }}
+                      animate={{ height: "auto", opacity: 1 }}
+                      exit={{ height: 0, opacity: 0 }}
+                      className="overflow-hidden"
+                    >
+                      <div className="pt-3 border-t border-gray-100 dark:border-gray-700 mt-1 flex flex-col gap-3">
+                        <div className="space-y-2 mb-1">
+                          {negativeReasons.map((reason) => (
+                            <label
+                              key={reason}
+                              className="flex items-center gap-2 cursor-pointer"
+                            >
+                              <input
+                                type="radio"
+                                name="reason"
+                                value={reason}
+                                checked={description === reason}
+                                onChange={() => {
+                                  setDescription(reason);
+                                  if (reason !== otherReasonLabel) {
+                                    setOtherText("");
+                                  }
+                                }}
+                                disabled={isSubmitting}
+                                className="h-4 w-4 text-primary accent-primary"
+                              />
+                              <span className="text-sm text-gray-700 dark:text-gray-300">
+                                {reason}
+                              </span>
+                            </label>
+                          ))}
+                        </div>
+                        <AnimatePresence>
+                          {isOtherReason && (
+                            <motion.div
+                              initial={{ height: 0, opacity: 0 }}
+                              animate={{ height: "auto", opacity: 1 }}
+                              exit={{ height: 0, opacity: 0 }}
+                              className="overflow-hidden"
+                            >
+                              <ReusableInputField
+                                as="textarea"
+                                placeholder={otherPlaceholder}
+                                className="resize-none min-h-[70px] mt-1"
+                                value={otherText}
+                                onChange={(e) => setOtherText(e.target.value)}
+                                disabled={isSubmitting}
+                              />
+                            </motion.div>
+                          )}
+                        </AnimatePresence>
+                        <div className="flex gap-2 mt-1">
+                          <ReusableButton
+                            variant="filled"
+                            className="w-full py-2"
+                            onClick={handleNegativeSubmit}
+                            loading={isSubmitting}
+                            disabled={isSubmitDisabled}
+                          >
+                            Submit
+                          </ReusableButton>
+                        </div>
+                      </div>
+                    </motion.div>
+                  )}
+                </AnimatePresence>
+              </>
+            )}
+          </CardContent>
+        </Card>
+      </motion.div>
+    </AnimatePresence>
+  );
+};

--- a/src/vertex/context/page-title-context.tsx
+++ b/src/vertex/context/page-title-context.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import { usePathname } from "next/navigation";
+
+const APP_TITLE = "AirQo Vertex";
+
+interface PageTitleValue {
+  title: string;
+  section?: string;
+}
+
+interface PageTitleContextValue extends PageTitleValue {
+  setPageTitle: (value: PageTitleValue) => void;
+  clearPageTitle: () => void;
+}
+
+type PageTitleOverride = PageTitleValue & {
+  pathname: string | null;
+};
+
+const PageTitleContext = createContext<PageTitleContextValue | undefined>(
+  undefined
+);
+
+const titleCase = (value: string) =>
+  value
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+
+const cleanDocumentTitle = () => {
+  if (typeof document === "undefined") return "";
+  return document.title
+    .replace(new RegExp(`\\s*\\|\\s*${APP_TITLE}$`), "")
+    .trim();
+};
+
+const getFallbackTitle = (pathname: string | null): PageTitleValue => {
+  if (!pathname) return { title: "this page" };
+
+  const exactRouteTitles: Record<string, PageTitleValue> = {
+    "/home": { title: "Home" },
+    "/devices/my-devices": { title: "My Devices", section: "Devices" },
+    "/devices/claim": { title: "Claim Device", section: "Devices" },
+    "/devices/overview": { title: "Devices" },
+    "/sites/overview": { title: "Sites" },
+    "/cohorts": { title: "Cohorts" },
+    "/admin/networks": {
+      title: "Sensor Manufacturers",
+      section: "Administrative Panel",
+    },
+    "/admin/networks/requests": {
+      title: "Manufacturer Requests",
+      section: "Administrative Panel",
+    },
+    "/admin/cohorts": { title: "Cohorts", section: "Administrative Panel" },
+    "/admin/sites": { title: "Sites", section: "Administrative Panel" },
+    "/admin/grids": { title: "Grids", section: "Administrative Panel" },
+    "/admin/shipping": { title: "Shipping", section: "Administrative Panel" },
+  };
+
+  if (exactRouteTitles[pathname]) return exactRouteTitles[pathname];
+
+  const dynamicRouteTitles: Array<[RegExp, PageTitleValue]> = [
+    [
+      /^\/admin\/sites\/[^/]+\/devices\/[^/]+$/,
+      { title: "Device Details", section: "Sites" },
+    ],
+    [/^\/admin\/sites\/[^/]+$/, { title: "Site Details", section: "Sites" }],
+    [/^\/sites\/[^/]+$/, { title: "Site Details", section: "Sites" }],
+    [
+      /^\/admin\/cohorts\/[^/]+\/devices\/[^/]+$/,
+      { title: "Device Details", section: "Cohorts" },
+    ],
+    [
+      /^\/admin\/cohorts\/[^/]+$/,
+      { title: "Cohort Details", section: "Cohorts" },
+    ],
+    [/^\/cohorts\/[^/]+$/, { title: "Cohort Details", section: "Cohorts" }],
+    [
+      /^\/admin\/networks\/[^/]+\/devices\/[^/]+$/,
+      { title: "Device Details", section: "Sensor Manufacturers" },
+    ],
+    [
+      /^\/admin\/networks\/[^/]+$/,
+      { title: "Sensor Manufacturer Details", section: "Sensor Manufacturers" },
+    ],
+    [/^\/admin\/grids\/[^/]+$/, { title: "Grid Details", section: "Grids" }],
+    [
+      /^\/admin\/shipping\/[^/]+$/,
+      { title: "Shipping Batch", section: "Shipping" },
+    ],
+    [
+      /^\/devices\/overview\/[^/]+$/,
+      { title: "Device Details", section: "Devices" },
+    ],
+  ];
+
+  const dynamicMatch = dynamicRouteTitles.find(([pattern]) =>
+    pattern.test(pathname)
+  );
+  if (dynamicMatch) return dynamicMatch[1];
+
+  const lastSegment = pathname.split("/").filter(Boolean).pop();
+  const documentTitle = cleanDocumentTitle();
+
+  return {
+    title: documentTitle || (lastSegment ? titleCase(lastSegment) : "this page"),
+  };
+};
+
+const formatBrowserTitle = ({ title, section }: PageTitleValue) => {
+  if (!title || title === "this page") return APP_TITLE;
+  if (section && section !== title) return `${title} | ${section} | ${APP_TITLE}`;
+  return `${title} | ${APP_TITLE}`;
+};
+
+export const PageTitleProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const pathname = usePathname();
+  const [overrideTitle, setOverrideTitle] = useState<PageTitleOverride | null>(
+    null
+  );
+
+  const fallbackTitle = useMemo(() => getFallbackTitle(pathname), [pathname]);
+  const currentTitle =
+    overrideTitle?.pathname === pathname ? overrideTitle : fallbackTitle;
+  const setPageTitle = useCallback(
+    (value: PageTitleValue) => setOverrideTitle({ ...value, pathname }),
+    [pathname]
+  );
+  const clearPageTitle = useCallback(() => setOverrideTitle(null), []);
+
+  useEffect(() => {
+    document.title = formatBrowserTitle(currentTitle);
+  }, [currentTitle]);
+
+  const value = useMemo<PageTitleContextValue>(
+    () => ({
+      ...currentTitle,
+      setPageTitle,
+      clearPageTitle,
+    }),
+    [clearPageTitle, currentTitle, setPageTitle]
+  );
+
+  return (
+    <PageTitleContext.Provider value={value}>
+      {children}
+    </PageTitleContext.Provider>
+  );
+};
+
+export const usePageTitleContext = () => {
+  const context = useContext(PageTitleContext);
+  if (!context) {
+    throw new Error("usePageTitleContext must be used within PageTitleProvider");
+  }
+  return context;
+};
+
+export const usePageTitle = ({ title, section }: PageTitleValue) => {
+  const { setPageTitle, clearPageTitle } = usePageTitleContext();
+
+  useEffect(() => {
+    if (!title) return;
+    setPageTitle({ title, section });
+    return () => clearPageTitle();
+  }, [clearPageTitle, section, setPageTitle, title]);
+};

--- a/src/vertex/context/page-title-context.tsx
+++ b/src/vertex/context/page-title-context.tsx
@@ -142,7 +142,30 @@ export const PageTitleProvider: React.FC<{ children: React.ReactNode }> = ({
   const clearPageTitle = useCallback(() => setOverrideTitle(null), []);
 
   useEffect(() => {
-    document.title = formatBrowserTitle(currentTitle);
+    const expectedTitle = formatBrowserTitle(currentTitle);
+    const applyTitle = () => {
+      if (document.title !== expectedTitle) {
+        document.title = expectedTitle;
+      }
+    };
+
+    applyTitle();
+
+    const timeoutId = window.setTimeout(applyTitle, 0);
+    const animationFrameId = window.requestAnimationFrame(applyTitle);
+
+    const observer = new MutationObserver(applyTitle);
+    observer.observe(document.head, {
+      childList: true,
+      subtree: true,
+      characterData: true,
+    });
+
+    return () => {
+      window.clearTimeout(timeoutId);
+      window.cancelAnimationFrame(animationFrameId);
+      observer.disconnect();
+    };
   }, [currentTitle]);
 
   const value = useMemo<PageTitleContextValue>(

--- a/src/vertex/core/apis/feedback.ts
+++ b/src/vertex/core/apis/feedback.ts
@@ -49,6 +49,48 @@ export class FeedbackService {
       'Failed to submit feedback'
     );
   }
+
+  /**
+   * Submits a quick post-login experience rating.
+   * Maps onto the existing /users/feedback/submit endpoint using
+   * category: 'page_satisfaction' and subject: 'Login Experience'.
+   */
+  async submitLoginFeedback(params: {
+    email: string;
+    rating: number;
+    description?: string;
+    loginDurationMs: number;
+    submittedAt: number;
+  }): Promise<SubmitFeedbackResponse> {
+    const { email, rating, description, loginDurationMs, submittedAt } = params;
+
+    const ratingLabel = rating >= 4 ? 'Positive' : 'Negative';
+    const message = description
+      ? `${ratingLabel}: ${description}`
+      : ratingLabel;
+
+    const metadata: FeedbackSubmissionMetadata = {
+      page: '/home',
+      loginDurationMs: String(loginDurationMs),
+      submittedAt: String(submittedAt),
+      browser:
+        typeof window !== 'undefined'
+          ? navigator.userAgent.slice(0, 80)
+          : 'Unknown',
+      appVersion: process.env.NEXT_PUBLIC_APP_VERSION || '1.0.0',
+    };
+
+    return this.submitFeedback({
+      email,
+      subject: 'Login Experience',
+      message,
+      rating,
+      category: 'page_satisfaction',
+      platform: 'web',
+      app: 'vertex',
+      metadata,
+    });
+  }
 }
 
 export const feedbackService = new FeedbackService();

--- a/src/vertex/core/apis/feedback.ts
+++ b/src/vertex/core/apis/feedback.ts
@@ -22,7 +22,19 @@ export interface SubmitFeedbackRequest {
 export interface SubmitFeedbackResponse {
   success: boolean;
   message: string;
-  feedback?: any;
+  feedback?: unknown;
+}
+
+export interface SubmitSatisfactionFeedbackRequest {
+  email: string;
+  subject: string;
+  rating: number;
+  description?: string;
+  category?: string;
+  page?: string;
+  platform?: string;
+  app?: string;
+  metadata?: FeedbackSubmissionMetadata;
 }
 
 const extractResponseData = <T extends { success?: boolean; message?: string }>(
@@ -50,6 +62,46 @@ export class FeedbackService {
     );
   }
 
+  async submitSatisfactionFeedback(
+    params: SubmitSatisfactionFeedbackRequest
+  ): Promise<SubmitFeedbackResponse> {
+    const {
+      email,
+      subject,
+      rating,
+      description,
+      category = 'page_satisfaction',
+      page,
+      platform = 'web',
+      app = 'vertex',
+      metadata,
+    } = params;
+
+    const ratingLabel = rating >= 4 ? 'Positive' : 'Negative';
+    const message = description
+      ? `${ratingLabel}: ${description}`
+      : ratingLabel;
+
+    return this.submitFeedback({
+      email,
+      subject,
+      message,
+      rating,
+      category,
+      platform,
+      app,
+      metadata: {
+        page,
+        browser:
+          typeof window !== 'undefined'
+            ? navigator.userAgent.slice(0, 80)
+            : 'Unknown',
+        appVersion: process.env.NEXT_PUBLIC_APP_VERSION || '1.0.0',
+        ...metadata,
+      },
+    });
+  }
+
   /**
    * Submits a quick post-login experience rating.
    * Maps onto the existing /users/feedback/submit endpoint using
@@ -64,31 +116,16 @@ export class FeedbackService {
   }): Promise<SubmitFeedbackResponse> {
     const { email, rating, description, loginDurationMs, submittedAt } = params;
 
-    const ratingLabel = rating >= 4 ? 'Positive' : 'Negative';
-    const message = description
-      ? `${ratingLabel}: ${description}`
-      : ratingLabel;
-
-    const metadata: FeedbackSubmissionMetadata = {
-      page: '/home',
-      loginDurationMs: String(loginDurationMs),
-      submittedAt: String(submittedAt),
-      browser:
-        typeof window !== 'undefined'
-          ? navigator.userAgent.slice(0, 80)
-          : 'Unknown',
-      appVersion: process.env.NEXT_PUBLIC_APP_VERSION || '1.0.0',
-    };
-
-    return this.submitFeedback({
+    return this.submitSatisfactionFeedback({
       email,
       subject: 'Login Experience',
-      message,
       rating,
-      category: 'page_satisfaction',
-      platform: 'web',
-      app: 'vertex',
-      metadata,
+      description,
+      page: '/home',
+      metadata: {
+        loginDurationMs: String(loginDurationMs),
+        submittedAt: String(submittedAt),
+      },
     });
   }
 }

--- a/src/vertex/core/utils/sessionManager.ts
+++ b/src/vertex/core/utils/sessionManager.ts
@@ -16,7 +16,8 @@ export const clearSessionData = () => {
       key.startsWith('next-auth') ||
       key === 'vertex_remembered_accounts_v1' ||
       key.startsWith('lastActiveModule') ||
-      key.startsWith('lastActiveGroupId')
+      key.startsWith('lastActiveGroupId') ||
+      key.startsWith('vertex_login_feedback')
     ) {
       continue;
     }

--- a/src/vertex/core/utils/userPreferences.ts
+++ b/src/vertex/core/utils/userPreferences.ts
@@ -35,3 +35,47 @@ export const setLastActiveGroupId = (userId: string, groupId: string) => {
   if (typeof window === 'undefined' || !userId || !groupId) return;
   localStorage.setItem(`${PREFERENCE_KEYS_GROUP.LAST_ACTIVE_GROUP_ID}_${userId}`, groupId);
 };
+
+// ===========================================================
+// Login feedback suppression helpers
+// ===========================================================
+const LOGIN_FEEDBACK_KEY = 'vertex_login_feedback';
+
+export interface LoginFeedbackRecord {
+  submittedAt: number;
+  expiresAt: number;
+}
+
+/**
+ * Returns the stored login-feedback record for a given user, or null if none /
+ * already expired.
+ */
+export const getLoginFeedbackRecord = (userId: string): LoginFeedbackRecord | null => {
+  if (typeof window === 'undefined' || !userId) return null;
+  try {
+    const raw = localStorage.getItem(`${LOGIN_FEEDBACK_KEY}_${userId}`);
+    if (!raw) return null;
+    const record: LoginFeedbackRecord = JSON.parse(raw);
+    if (Date.now() > record.expiresAt) {
+      localStorage.removeItem(`${LOGIN_FEEDBACK_KEY}_${userId}`);
+      return null;
+    }
+    return record;
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Writes a login-feedback suppression record for the given user with a 30-day TTL.
+ * Call this only after a successful rating submission.
+ */
+export const setLoginFeedbackRecord = (userId: string): void => {
+  if (typeof window === 'undefined' || !userId) return;
+  const now = Date.now();
+  const record: LoginFeedbackRecord = {
+    submittedAt: now,
+    expiresAt: now + 30 * 24 * 60 * 60 * 1000, // 30 days
+  };
+  localStorage.setItem(`${LOGIN_FEEDBACK_KEY}_${userId}`, JSON.stringify(record));
+};


### PR DESCRIPTION
## Summary

This PR introduces reusable satisfaction feedback infrastructure, improves the post-login feedback experience, aligns authenticated page titles with the page satisfaction banner, and refines the cookie info banner styling.

## Changes

- Added `ReusableSatisfactionFeedbackToast` for reusable positive/negative satisfaction prompts.
- Refactored `LoginFeedbackToast` to use the reusable toast while keeping login-specific timing, suppression, and submission behavior.
- Added `feedbackService.submitSatisfactionFeedback` as a generic helper for future satisfaction-style feedback flows.
- Updated login feedback to collect structured negative reasons and optional “Other” details.
- Restored the celebratory thank-you state in the reusable feedback toast.
- Replaced the reusable toast textarea with `ReusableInputField`.
- Added `PageTitleProvider` and `usePageTitle` for authenticated page title management.
- Updated `PageSatisfactionBanner` to use the shared page title instead of deriving names from URL paths.
- Added route-based page title defaults for authenticated routes.
- Added dynamic page title overrides for site, cohort, device, grid, sensor manufacturer, and shipping batch detail pages.
- Hardened browser title updates so Next.js title resets do not fall back to `AirQo Vertex`.
- Refactored `CookieInfoBanner` to use `ReusableButton` and updated its styling.
- Updated `app/changelog.md` with the new feedback, page title, and cookie banner changes.

## Verification

- Ran targeted Next lint checks successfully.
- Ran TypeScript check successfully:

```bash
npx tsc --noEmit --pretty false
```

#### Screenshots (optional)

<img width="1919" height="941" alt="image" src="https://github.com/user-attachments/assets/54016280-be13-450c-ac55-dee436c10a2b" />
<img width="1919" height="951" alt="image" src="https://github.com/user-attachments/assets/6e939ce1-c24c-419f-9373-afb2676e83ee" />
<img width="1919" height="953" alt="image" src="https://github.com/user-attachments/assets/c8e3d03d-3aaf-49ad-a036-87140ac7537d" />
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/2e4b9d63-75d4-4877-a0f1-e6d36b0856ce" />
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/47d6a345-8566-40be-9379-5b2ea8b4aea4" />
