### PR TITLE
feat(grids): Replace all toast-based feedback in grid management components

### DIFF
--- a/src/vertex/app/changelog.md
+++ b/src/vertex/app/changelog.md
@@ -12,7 +12,7 @@
 Migrated all toast-based notifications in the Grid Management module to the centralized `InfoBanner` system powered by `useBanner`. Since most grid actions occur inside dialogs, banner scoping was applied to keep errors inline in the active dialog while deferring success banners until the dialog has closed.
 
 <details>
-<summary><strong>Grid Management Banner Migration (7)</strong></summary>
+<summary><strong>Grid Management Banner Migration (4)</strong></summary>
 
 - **Dialog Error Feedback**: `create-grid.tsx`, `edit-grid-details-dialog.tsx`, and `admin-levels-modal.tsx` now use `scoped: true` so validation and action errors remain visible inside the active dialog without closing it.
 - **Post-Dialog Success Feedback**: `create-grid.tsx` and `edit-grid-details-dialog.tsx` now use `scoped: false` with a `setTimeout(100ms)` to allow the dialog to unmount before showing the global success banner.
@@ -22,7 +22,7 @@ Migrated all toast-based notifications in the Grid Management module to the cent
 </details>
 
 <details>
-<summary><strong>Files Updated (6)</strong></summary>
+<summary><strong>Files Updated (7)</strong></summary>
 
 - `src/vertex/components/features/grids/create-grid.tsx` [MODIFIED]
 - `src/vertex/components/features/grids/edit-grid-details-dialog.tsx` [MODIFIED]

--- a/src/vertex/app/changelog.md
+++ b/src/vertex/app/changelog.md
@@ -4,6 +4,38 @@
 
 ---
 
+## Version 1.23.49
+**Released:** May 26, 2026
+
+### Grid Management Banner Migration
+
+Migrated all toast-based notifications in the Grid Management module to the centralized `InfoBanner` system powered by `useBanner`. Since most grid actions occur inside dialogs, banner scoping was applied to keep errors inline in the active dialog while deferring success banners until the dialog has closed.
+
+<details>
+<summary><strong>Grid Management Banner Migration (7)</strong></summary>
+
+- **Dialog Error Feedback**: `create-grid.tsx`, `edit-grid-details-dialog.tsx`, and `admin-levels-modal.tsx` now use `scoped: true` so validation and action errors remain visible inside the active dialog without closing it.
+- **Post-Dialog Success Feedback**: `create-grid.tsx` and `edit-grid-details-dialog.tsx` now use `scoped: false` with a `setTimeout(100ms)` to allow the dialog to unmount before showing the global success banner.
+- **Missing Banner Feedback Added**: `create-admin-level.tsx` now surfaces error feedback that was previously silent.
+- **Copy Feedback Hardened**: `grid-details-card.tsx` and `grid-measurements-api-card.tsx` now use `scoped: false` and handle async copy failures with a fallback error message.
+
+</details>
+
+<details>
+<summary><strong>Files Updated (6)</strong></summary>
+
+- `src/vertex/components/features/grids/create-grid.tsx` [MODIFIED]
+- `src/vertex/components/features/grids/edit-grid-details-dialog.tsx` [MODIFIED]
+- `src/vertex/components/features/grids/admin-levels-modal.tsx` [MODIFIED]
+- `src/vertex/components/features/grids/create-admin-level.tsx` [MODIFIED]
+- `src/vertex/components/features/grids/grid-details-card.tsx` [MODIFIED]
+- `src/vertex/components/features/grids/grid-measurements-api-card.tsx` [MODIFIED]
+- `src/vertex/core/hooks/useGrids.ts` [MODIFIED]
+
+</details>
+
+---
+
 ## Version 1.23.48
 **Released:** May 23, 2026
 

--- a/src/vertex/app/changelog.md
+++ b/src/vertex/app/changelog.md
@@ -16,7 +16,7 @@ Migrated all toast-based notifications in the Grid Management module to the cent
 
 - **Dialog Error Feedback**: `create-grid.tsx`, `edit-grid-details-dialog.tsx`, and `admin-levels-modal.tsx` now use `scoped: true` so validation and action errors remain visible inside the active dialog without closing it.
 - **Post-Dialog Success Feedback**: `create-grid.tsx` and `edit-grid-details-dialog.tsx` now use `scoped: false` with a `setTimeout(100ms)` to allow the dialog to unmount before showing the global success banner.
-- **Missing Banner Feedback Added**: `create-admin-level.tsx` now surfaces error feedback that was previously silent.
+ - **Admin Level Error Feedback Migrated**: `create-admin-level.tsx` now routes existing error feedback through the centralized banner flow instead of the previous toast-based mechanism.
 - **Copy Feedback Hardened**: `grid-details-card.tsx` and `grid-measurements-api-card.tsx` now use `scoped: false` and handle async copy failures with a fallback error message.
 
 </details>

--- a/src/vertex/components/features/grids/admin-levels-modal.tsx
+++ b/src/vertex/components/features/grids/admin-levels-modal.tsx
@@ -18,6 +18,9 @@ export function AdminLevelsModal({ isOpen, onClose }: AdminLevelsModalProps) {
   const { adminLevels, isLoading: isLoadingLevels } = useAdminLevels();
   const { showBanner } = useBanner();
   
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editValue, setEditValue] = useState("");
+
   const { updateAdminLevel, isLoading: isUpdating } = useUpdateAdminLevel({
     onSuccess: (data) => {
       showBanner({
@@ -36,9 +39,6 @@ export function AdminLevelsModal({ isOpen, onClose }: AdminLevelsModalProps) {
       });
     }
   });
-
-  const [editingId, setEditingId] = useState<string | null>(null);
-  const [editValue, setEditValue] = useState("");
 
   const handleCopyId = async (id: string) => {
     try {

--- a/src/vertex/components/features/grids/admin-levels-modal.tsx
+++ b/src/vertex/components/features/grids/admin-levels-modal.tsx
@@ -6,7 +6,8 @@ import ReusableDialog from "@/components/shared/dialog/ReusableDialog";
 import ReusableButton from "@/components/shared/button/ReusableButton";
 import ReusableInputField from "@/components/shared/inputfield/ReusableInputField";
 import { Copy, Edit2, Check, X } from "lucide-react";
-import ReusableToast from "@/components/shared/toast/ReusableToast";
+import { useBanner } from "@/context/banner-context";
+import { getApiErrorMessage } from "@/core/utils/getApiErrorMessage";
 
 interface AdminLevelsModalProps {
   isOpen: boolean;
@@ -15,21 +16,43 @@ interface AdminLevelsModalProps {
 
 export function AdminLevelsModal({ isOpen, onClose }: AdminLevelsModalProps) {
   const { adminLevels, isLoading: isLoadingLevels } = useAdminLevels();
-  const { updateAdminLevel, isLoading: isUpdating } = useUpdateAdminLevel();
+  const { showBanner } = useBanner();
+  
+  const { updateAdminLevel, isLoading: isUpdating } = useUpdateAdminLevel({
+    onSuccess: (data) => {
+      showBanner({
+        message: `Admin level updated to '${data.admin_levels.name}' successfully`,
+        severity: "success",
+        scoped: true,
+      });
+      setEditingId(null);
+      setEditValue("");
+    },
+    onError: (error) => {
+      showBanner({
+        message: `Failed to update admin level: ${getApiErrorMessage(error)}`,
+        severity: "error",
+        scoped: true,
+      });
+    }
+  });
+
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editValue, setEditValue] = useState("");
 
   const handleCopyId = async (id: string) => {
     try {
       await navigator.clipboard.writeText(id);
-      ReusableToast({
+      showBanner({
         message: "ID copied to clipboard",
-        type: "SUCCESS",
+        severity: "success",
+        scoped: true,
       });
     } catch {
-      ReusableToast({
+      showBanner({
         message: "Failed to copy ID",
-        type: "ERROR",
+        severity: "error",
+        scoped: true,
       });
     }
   };
@@ -49,15 +72,7 @@ export function AdminLevelsModal({ isOpen, onClose }: AdminLevelsModalProps) {
     if (!name) {
       return;
     }
-    updateAdminLevel(
-      { levelId, data: { name } },
-      {
-        onSuccess: () => {
-          setEditingId(null);
-          setEditValue("");
-        },
-      }
-    );
+    updateAdminLevel({ levelId, data: { name } });
   };
 
   return (

--- a/src/vertex/components/features/grids/create-admin-level.tsx
+++ b/src/vertex/components/features/grids/create-admin-level.tsx
@@ -19,6 +19,7 @@ import {
 import { AdminLevelsModal } from "./admin-levels-modal";
 import { useBanner } from "@/context/banner-context";
 import { getApiErrorMessage } from "@/core/utils/getApiErrorMessage";
+import { AFTER_DIALOG_CLOSE_MS } from "@/core/constants/ui";
 
 const adminLevelFormSchema = z.object({
   name: z.string().min(2, {
@@ -54,7 +55,7 @@ export function CreateAdminLevel() {
           severity: "success",
           scoped: false,
         });
-      }, 100);
+      }, AFTER_DIALOG_CLOSE_MS);
     },
     onError: (error) => {
       showBanner({

--- a/src/vertex/components/features/grids/create-admin-level.tsx
+++ b/src/vertex/components/features/grids/create-admin-level.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState } from "react";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import * as z from "zod";
@@ -19,7 +19,7 @@ import {
 import { AdminLevelsModal } from "./admin-levels-modal";
 import { useBanner } from "@/context/banner-context";
 import { getApiErrorMessage } from "@/core/utils/getApiErrorMessage";
-import { AFTER_DIALOG_CLOSE_MS } from "@/core/constants/ui";
+import { useDeferredBanner } from "@/core/hooks/useDeferredBanner";
 
 const adminLevelFormSchema = z.object({
   name: z.string().min(2, {
@@ -33,13 +33,7 @@ export function CreateAdminLevel() {
   const [open, setOpen] = useState(false);
   const [viewModalOpen, setViewModalOpen] = useState(false);
   const { showBanner } = useBanner();
-  const bannerTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  useEffect(() => {
-    return () => {
-      if (bannerTimerRef.current) clearTimeout(bannerTimerRef.current);
-    };
-  }, []);
+  const { showDeferredBanner } = useDeferredBanner();
 
   const form = useForm<AdminLevelFormValues>({
     resolver: zodResolver(adminLevelFormSchema),
@@ -56,13 +50,7 @@ export function CreateAdminLevel() {
   const { createAdminLevel, isLoading } = useCreateAdminLevel({
     onSuccess: () => {
       handleClose();
-      bannerTimerRef.current = setTimeout(() => {
-        showBanner({
-          message: "Admin level created successfully",
-          severity: "success",
-          scoped: false,
-        });
-      }, AFTER_DIALOG_CLOSE_MS);
+      showDeferredBanner({ message: "Admin level created successfully", severity: "success", scoped: false });
     },
     onError: (error) => {
       showBanner({

--- a/src/vertex/components/features/grids/create-admin-level.tsx
+++ b/src/vertex/components/features/grids/create-admin-level.tsx
@@ -17,6 +17,8 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { AdminLevelsModal } from "./admin-levels-modal";
+import { useBanner } from "@/context/banner-context";
+import { getApiErrorMessage } from "@/core/utils/getApiErrorMessage";
 
 const adminLevelFormSchema = z.object({
   name: z.string().min(2, {
@@ -29,7 +31,7 @@ type AdminLevelFormValues = z.infer<typeof adminLevelFormSchema>;
 export function CreateAdminLevel() {
   const [open, setOpen] = useState(false);
   const [viewModalOpen, setViewModalOpen] = useState(false);
-  const { createAdminLevel, isLoading } = useCreateAdminLevel();
+  const { showBanner } = useBanner();
 
   const form = useForm<AdminLevelFormValues>({
     resolver: zodResolver(adminLevelFormSchema),
@@ -43,12 +45,28 @@ export function CreateAdminLevel() {
     form.reset();
   };
 
+  const { createAdminLevel, isLoading } = useCreateAdminLevel({
+    onSuccess: () => {
+      handleClose();
+      setTimeout(() => {
+        showBanner({
+          message: "Admin level created successfully",
+          severity: "success",
+          scoped: false,
+        });
+      }, 100);
+    },
+    onError: (error) => {
+      showBanner({
+        message: `Failed to create admin level: ${getApiErrorMessage(error)}`,
+        severity: "error",
+        scoped: true,
+      });
+    },
+  });
+
   const onSubmit = (data: AdminLevelFormValues) => {
-    createAdminLevel(data, {
-      onSuccess: () => {
-        handleClose();
-      },
-    });
+    createAdminLevel(data);
   };
 
   return (

--- a/src/vertex/components/features/grids/create-admin-level.tsx
+++ b/src/vertex/components/features/grids/create-admin-level.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import * as z from "zod";
@@ -33,6 +33,13 @@ export function CreateAdminLevel() {
   const [open, setOpen] = useState(false);
   const [viewModalOpen, setViewModalOpen] = useState(false);
   const { showBanner } = useBanner();
+  const bannerTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (bannerTimerRef.current) clearTimeout(bannerTimerRef.current);
+    };
+  }, []);
 
   const form = useForm<AdminLevelFormValues>({
     resolver: zodResolver(adminLevelFormSchema),
@@ -49,7 +56,7 @@ export function CreateAdminLevel() {
   const { createAdminLevel, isLoading } = useCreateAdminLevel({
     onSuccess: () => {
       handleClose();
-      setTimeout(() => {
+      bannerTimerRef.current = setTimeout(() => {
         showBanner({
           message: "Admin level created successfully",
           severity: "success",

--- a/src/vertex/components/features/grids/create-grid.tsx
+++ b/src/vertex/components/features/grids/create-grid.tsx
@@ -70,6 +70,18 @@ export function CreateGridForm() {
     };
   }, []);
 
+  const { networks, isLoading: isLoadingNetworks } = useNetworks();
+
+  const form = useForm<GridFormValues>({
+    resolver: zodResolver(gridFormSchema),
+    defaultValues: {
+      name: "",
+      administrativeLevel: "",
+      shapefile: '{"type":"","coordinates":[]}',
+      network: "",
+    },
+  });
+
   const handleClose = () => {
     setOpen(false);
     form.reset();
@@ -93,18 +105,6 @@ export function CreateGridForm() {
         scoped: true,
       });
     }
-  });
-
-  const { networks, isLoading: isLoadingNetworks } = useNetworks();
-
-  const form = useForm<GridFormValues>({
-    resolver: zodResolver(gridFormSchema),
-    defaultValues: {
-      name: "",
-      administrativeLevel: "",
-      shapefile: '{"type":"","coordinates":[]}',
-      network: "",
-    },
   });
 
   useEffect(() => {

--- a/src/vertex/components/features/grids/create-grid.tsx
+++ b/src/vertex/components/features/grids/create-grid.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import * as z from "zod";
@@ -62,7 +62,14 @@ export function CreateGridForm() {
   const [open, setOpen] = useState(false);
   const polygon = useAppSelector((state) => state.grids.polygon);
   const { showBanner } = useBanner();
-  
+  const bannerTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (bannerTimerRef.current) clearTimeout(bannerTimerRef.current);
+    };
+  }, []);
+
   const handleClose = () => {
     setOpen(false);
     form.reset();
@@ -71,7 +78,7 @@ export function CreateGridForm() {
   const { createGrid, isLoading } = useCreateGrid({
     onSuccess: () => {
       handleClose();
-      setTimeout(() => {
+      bannerTimerRef.current = setTimeout(() => {
         showBanner({
           message: `New grid added!`,
           severity: "success",

--- a/src/vertex/components/features/grids/create-grid.tsx
+++ b/src/vertex/components/features/grids/create-grid.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState,useEffect } from "react";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import * as z from "zod";

--- a/src/vertex/components/features/grids/create-grid.tsx
+++ b/src/vertex/components/features/grids/create-grid.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState } from "react";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import * as z from "zod";
@@ -17,7 +17,7 @@ import { useNetworks } from "@/core/hooks/useNetworks";
 import ReusableSelectInput from "@/components/shared/select/ReusableSelectInput";
 import { useBanner } from "@/context/banner-context";
 import { getApiErrorMessage } from "@/core/utils/getApiErrorMessage";
-import { AFTER_DIALOG_CLOSE_MS } from "@/core/constants/ui";
+import { useDeferredBanner } from "@/core/hooks/useDeferredBanner";
 
 // Lazy load MiniMap to reduce initial bundle size
 const MiniMap = dynamic(() => import("@/components/features/mini-map/mini-map"), {
@@ -62,13 +62,7 @@ export function CreateGridForm() {
   const [open, setOpen] = useState(false);
   const polygon = useAppSelector((state) => state.grids.polygon);
   const { showBanner } = useBanner();
-  const bannerTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  useEffect(() => {
-    return () => {
-      if (bannerTimerRef.current) clearTimeout(bannerTimerRef.current);
-    };
-  }, []);
+  const { showDeferredBanner } = useDeferredBanner();
 
   const { networks, isLoading: isLoadingNetworks } = useNetworks();
 
@@ -90,13 +84,7 @@ export function CreateGridForm() {
   const { createGrid, isLoading } = useCreateGrid({
     onSuccess: () => {
       handleClose();
-      bannerTimerRef.current = setTimeout(() => {
-        showBanner({
-          message: `New grid added!`,
-          severity: "success",
-          scoped: false,
-        });
-      }, AFTER_DIALOG_CLOSE_MS);
+      showDeferredBanner({ message: `New grid added!`, severity: "success", scoped: false });
     },
     onError: (error) => {
       showBanner({

--- a/src/vertex/components/features/grids/create-grid.tsx
+++ b/src/vertex/components/features/grids/create-grid.tsx
@@ -15,6 +15,8 @@ import ReusableButton from "@/components/shared/button/ReusableButton";
 import ReusableInputField from "@/components/shared/inputfield/ReusableInputField";
 import { useNetworks } from "@/core/hooks/useNetworks";
 import ReusableSelectInput from "@/components/shared/select/ReusableSelectInput";
+import { useBanner } from "@/context/banner-context";
+import { getApiErrorMessage } from "@/core/utils/getApiErrorMessage";
 
 // Lazy load MiniMap to reduce initial bundle size
 const MiniMap = dynamic(() => import("@/components/features/mini-map/mini-map"), {
@@ -58,7 +60,33 @@ type GridFormValues = z.infer<typeof gridFormSchema>;
 export function CreateGridForm() {
   const [open, setOpen] = useState(false);
   const polygon = useAppSelector((state) => state.grids.polygon);
-  const { createGrid, isLoading } = useCreateGrid();
+  const { showBanner } = useBanner();
+  
+  const handleClose = () => {
+    setOpen(false);
+    form.reset();
+  };
+
+  const { createGrid, isLoading } = useCreateGrid({
+    onSuccess: () => {
+      handleClose();
+      setTimeout(() => {
+        showBanner({
+          message: `New grid added!`,
+          severity: "success",
+          scoped: false,
+        });
+      }, 100);
+    },
+    onError: (error) => {
+      showBanner({
+        message: `Failed to create grid: ${getApiErrorMessage(error)}`,
+        severity: "error",
+        scoped: true,
+      });
+    }
+  });
+
   const { networks, isLoading: isLoadingNetworks } = useNetworks();
 
   const form = useForm<GridFormValues>({
@@ -79,11 +107,6 @@ export function CreateGridForm() {
     }
   }, [polygon, form]);
 
-  const handleClose = () => {
-    setOpen(false);
-    form.reset();
-  };
-
   const onSubmit = (data: GridFormValues) => {
     const gridData = {
       name: data.name,
@@ -92,11 +115,7 @@ export function CreateGridForm() {
       network: data.network,
     };
 
-    createGrid(gridData, {
-      onSuccess: () => {
-        handleClose();
-      },
-    });
+    createGrid(gridData);
   };
 
   return (

--- a/src/vertex/components/features/grids/create-grid.tsx
+++ b/src/vertex/components/features/grids/create-grid.tsx
@@ -17,6 +17,7 @@ import { useNetworks } from "@/core/hooks/useNetworks";
 import ReusableSelectInput from "@/components/shared/select/ReusableSelectInput";
 import { useBanner } from "@/context/banner-context";
 import { getApiErrorMessage } from "@/core/utils/getApiErrorMessage";
+import { AFTER_DIALOG_CLOSE_MS } from "@/core/constants/ui";
 
 // Lazy load MiniMap to reduce initial bundle size
 const MiniMap = dynamic(() => import("@/components/features/mini-map/mini-map"), {
@@ -76,7 +77,7 @@ export function CreateGridForm() {
           severity: "success",
           scoped: false,
         });
-      }, 100);
+      }, AFTER_DIALOG_CLOSE_MS);
     },
     onError: (error) => {
       showBanner({

--- a/src/vertex/components/features/grids/edit-grid-details-dialog.tsx
+++ b/src/vertex/components/features/grids/edit-grid-details-dialog.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useState } from "react";
 import ReusableDialog from "@/components/shared/dialog/ReusableDialog";
 import ReusableInputField from "@/components/shared/inputfield/ReusableInputField";
 import ReusableSelectInput from "@/components/shared/select/ReusableSelectInput";
@@ -8,7 +8,7 @@ import { PERMISSIONS } from "@/core/permissions/constants";
 import { Grid } from "@/app/types/grids";
 import { useBanner } from "@/context/banner-context";
 import { getApiErrorMessage } from "@/core/utils/getApiErrorMessage";
-import { AFTER_DIALOG_CLOSE_MS } from "@/core/constants/ui";
+import { useDeferredBanner } from "@/core/hooks/useDeferredBanner";
 
 interface EditGridDetailsDialogProps {
     open: boolean;
@@ -23,24 +23,12 @@ const EditGridDetailsDialog: React.FC<EditGridDetailsDialogProps> = ({
 }) => {
     const [form, setForm] = useState({ name: "", visibility: false, admin_level: "" });
     const { showBanner } = useBanner();
-    const bannerTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-    useEffect(() => {
-        return () => {
-            if (bannerTimerRef.current) clearTimeout(bannerTimerRef.current);
-        };
-    }, []);
+    const { showDeferredBanner } = useDeferredBanner();
 
     const { updateGridDetails, isLoading } = useUpdateGridDetails(grid._id, {
         onSuccess: () => {
             onClose();
-            bannerTimerRef.current = setTimeout(() => {
-                showBanner({
-                    message: "Grid details updated successfully",
-                    severity: "success",
-                    scoped: false,
-                });
-            }, AFTER_DIALOG_CLOSE_MS);
+            showDeferredBanner({ message: "Grid details updated successfully", severity: "success", scoped: false });
         },
         onError: (error) => {
             showBanner({

--- a/src/vertex/components/features/grids/edit-grid-details-dialog.tsx
+++ b/src/vertex/components/features/grids/edit-grid-details-dialog.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import ReusableDialog from "@/components/shared/dialog/ReusableDialog";
 import ReusableInputField from "@/components/shared/inputfield/ReusableInputField";
 import ReusableSelectInput from "@/components/shared/select/ReusableSelectInput";
@@ -23,11 +23,18 @@ const EditGridDetailsDialog: React.FC<EditGridDetailsDialogProps> = ({
 }) => {
     const [form, setForm] = useState({ name: "", visibility: false, admin_level: "" });
     const { showBanner } = useBanner();
-    
+    const bannerTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    useEffect(() => {
+        return () => {
+            if (bannerTimerRef.current) clearTimeout(bannerTimerRef.current);
+        };
+    }, []);
+
     const { updateGridDetails, isLoading } = useUpdateGridDetails(grid._id, {
         onSuccess: () => {
             onClose();
-            setTimeout(() => {
+            bannerTimerRef.current = setTimeout(() => {
                 showBanner({
                     message: "Grid details updated successfully",
                     severity: "success",

--- a/src/vertex/components/features/grids/edit-grid-details-dialog.tsx
+++ b/src/vertex/components/features/grids/edit-grid-details-dialog.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import ReusableDialog from "@/components/shared/dialog/ReusableDialog";
 import ReusableInputField from "@/components/shared/inputfield/ReusableInputField";
 import ReusableSelectInput from "@/components/shared/select/ReusableSelectInput";

--- a/src/vertex/components/features/grids/edit-grid-details-dialog.tsx
+++ b/src/vertex/components/features/grids/edit-grid-details-dialog.tsx
@@ -6,6 +6,8 @@ import { useUpdateGridDetails } from "@/core/hooks/useGrids";
 import { usePermission } from "@/core/hooks/usePermissions";
 import { PERMISSIONS } from "@/core/permissions/constants";
 import { Grid } from "@/app/types/grids";
+import { useBanner } from "@/context/banner-context";
+import { getApiErrorMessage } from "@/core/utils/getApiErrorMessage";
 
 interface EditGridDetailsDialogProps {
     open: boolean;
@@ -19,7 +21,28 @@ const EditGridDetailsDialog: React.FC<EditGridDetailsDialogProps> = ({
     onClose,
 }) => {
     const [form, setForm] = useState({ name: "", visibility: false, admin_level: "" });
-    const { updateGridDetails, isLoading } = useUpdateGridDetails(grid._id);
+    const { showBanner } = useBanner();
+    
+    const { updateGridDetails, isLoading } = useUpdateGridDetails(grid._id, {
+        onSuccess: () => {
+            onClose();
+            setTimeout(() => {
+                showBanner({
+                    message: "Grid details updated successfully",
+                    severity: "success",
+                    scoped: false,
+                });
+            }, 100);
+        },
+        onError: (error) => {
+            showBanner({
+                message: `Failed to update grid: ${getApiErrorMessage(error)}`,
+                severity: "error",
+                scoped: true,
+            });
+        }
+    });
+
     const canUpdate = usePermission(PERMISSIONS.SITE.UPDATE);
 
     useEffect(() => {
@@ -39,6 +62,11 @@ const EditGridDetailsDialog: React.FC<EditGridDetailsDialogProps> = ({
         const trimmedAdminLevel = form.admin_level.trim();
         
         if (trimmedName.length === 0 || trimmedAdminLevel.length === 0) {
+            showBanner({
+                severity: "error",
+                message: "Grid Name and Admin Level cannot be empty.",
+                scoped: true,
+            });
             return;
         }
 
@@ -55,10 +83,9 @@ const EditGridDetailsDialog: React.FC<EditGridDetailsDialogProps> = ({
         if (form.visibility !== grid.visibility) updates.visibility = form.visibility;
 
         try {
-            await updateGridDetails(updates);
-            onClose();
+            updateGridDetails(updates);
         } catch {
-            return
+            return;
         }
     };
 

--- a/src/vertex/components/features/grids/edit-grid-details-dialog.tsx
+++ b/src/vertex/components/features/grids/edit-grid-details-dialog.tsx
@@ -83,7 +83,7 @@ const EditGridDetailsDialog: React.FC<EditGridDetailsDialogProps> = ({
         if (form.visibility !== grid.visibility) updates.visibility = form.visibility;
 
         try {
-            updateGridDetails(updates);
+            await updateGridDetails(updates);
         } catch {
             return;
         }

--- a/src/vertex/components/features/grids/edit-grid-details-dialog.tsx
+++ b/src/vertex/components/features/grids/edit-grid-details-dialog.tsx
@@ -8,6 +8,7 @@ import { PERMISSIONS } from "@/core/permissions/constants";
 import { Grid } from "@/app/types/grids";
 import { useBanner } from "@/context/banner-context";
 import { getApiErrorMessage } from "@/core/utils/getApiErrorMessage";
+import { AFTER_DIALOG_CLOSE_MS } from "@/core/constants/ui";
 
 interface EditGridDetailsDialogProps {
     open: boolean;
@@ -32,7 +33,7 @@ const EditGridDetailsDialog: React.FC<EditGridDetailsDialogProps> = ({
                     severity: "success",
                     scoped: false,
                 });
-            }, 100);
+            }, AFTER_DIALOG_CLOSE_MS);
         },
         onError: (error) => {
             showBanner({

--- a/src/vertex/components/features/grids/grid-details-card.tsx
+++ b/src/vertex/components/features/grids/grid-details-card.tsx
@@ -5,8 +5,8 @@ import { Badge } from "@/components/ui/badge";
 import { Loader2 } from "lucide-react";
 import ReusableButton from "@/components/shared/button/ReusableButton";
 import { AqCopy01, AqEdit01 } from "@airqo/icons-react";
-import ReusableToast from "@/components/shared/toast/ReusableToast";
 import { Grid } from "@/app/types/grids";
+import { useBanner } from "@/context/banner-context";
 
 interface GridDetailsCardProps {
     grid: Grid;
@@ -15,14 +15,19 @@ interface GridDetailsCardProps {
 }
 
 const GridDetailsCard: React.FC<GridDetailsCardProps> = ({ grid, onEdit, loading }) => {
+    const { showBanner } = useBanner();
+
     if (loading) {
         return <Card className="w-full rounded-lg flex flex-col justify-between items-center p-8"><Loader2 className="w-6 h-6 animate-spin" /></Card>;
     }
 
-    const handleCopy = (text: string) => {
-        if (text) {
-            navigator.clipboard.writeText(text);
-            ReusableToast({ message: "Copied to clipboard", type: "SUCCESS" });
+    const handleCopy = async (text: string) => {
+        if (!text) return;
+        try {
+            await navigator.clipboard.writeText(text);
+            showBanner({ message: "Copied to clipboard", severity: "success", scoped: false });
+        } catch {
+            showBanner({ message: "Failed to copy to clipboard", severity: "error", scoped: false });
         }
     };
 

--- a/src/vertex/components/features/grids/grid-measurements-api-card.tsx
+++ b/src/vertex/components/features/grids/grid-measurements-api-card.tsx
@@ -22,18 +22,7 @@ const GridMeasurementsApiCard: React.FC<GridMeasurementsApiCardProps> = ({ grid,
     const handleCopy = async (text: string) => {
         if (!text) return;
         try {
-            if (navigator?.clipboard?.writeText) {
-                await navigator.clipboard.writeText(text);
-            } else {
-                const el = document.createElement("textarea");
-                el.value = text;
-                el.style.position = "fixed";
-                el.style.opacity = "0";
-                document.body.appendChild(el);
-                el.select();
-                document.execCommand("copy");
-                document.body.removeChild(el);
-            }
+            await navigator.clipboard.writeText(text);
             showBanner({ message: "API URL copied!", severity: "success", scoped: false });
         } catch {
             showBanner({ message: "Failed to copy to clipboard", severity: "error", scoped: false });

--- a/src/vertex/components/features/grids/grid-measurements-api-card.tsx
+++ b/src/vertex/components/features/grids/grid-measurements-api-card.tsx
@@ -4,8 +4,8 @@ import { Card } from "@/components/ui/card";
 import { Loader2 } from "lucide-react";
 import ReusableButton from "@/components/shared/button/ReusableButton";
 import { AqCopy01 } from "@airqo/icons-react";
-import ReusableToast from "@/components/shared/toast/ReusableToast";
 import { Grid } from "@/app/types/grids";
+import { useBanner } from "@/context/banner-context";
 
 interface GridMeasurementsApiCardProps {
     grid: Grid;
@@ -13,6 +13,8 @@ interface GridMeasurementsApiCardProps {
 }
 
 const GridMeasurementsApiCard: React.FC<GridMeasurementsApiCardProps> = ({ grid, loading }) => {
+    const { showBanner } = useBanner();
+
     if (loading) {
         return <Card className="w-full rounded-lg flex flex-col justify-between items-center p-8"><Loader2 className="w-6 h-6 animate-spin" /></Card>;
     }
@@ -32,9 +34,9 @@ const GridMeasurementsApiCard: React.FC<GridMeasurementsApiCardProps> = ({ grid,
                 document.execCommand("copy");
                 document.body.removeChild(el);
             }
-            ReusableToast({ message: "API URL copied!", type: "SUCCESS" });
+            showBanner({ message: "API URL copied!", severity: "success", scoped: false });
         } catch {
-            ReusableToast({ message: "Failed to copy to clipboard", type: "ERROR" });
+            showBanner({ message: "Failed to copy to clipboard", severity: "error", scoped: false });
         }
     };
 

--- a/src/vertex/context/banner-context.tsx
+++ b/src/vertex/context/banner-context.tsx
@@ -15,7 +15,7 @@ interface BannerState {
   isScoped: boolean;
 }
 
-type ShowBannerOptions = BannerDisplayProps & { scoped?: boolean };
+export type ShowBannerOptions = BannerDisplayProps & { scoped?: boolean };
 
 interface BannerContextValue {
   state: BannerState;

--- a/src/vertex/core/constants/ui.ts
+++ b/src/vertex/core/constants/ui.ts
@@ -1,0 +1,5 @@
+/**
+ * Delay (ms) before showing a global banner after a dialog closes.
+ * Allows the dialog's unmount cleanup (which clears scoped banners) to complete first.
+ */
+export const AFTER_DIALOG_CLOSE_MS = 100;

--- a/src/vertex/core/hooks/useDeferredBanner.ts
+++ b/src/vertex/core/hooks/useDeferredBanner.ts
@@ -13,6 +13,7 @@ export const useDeferredBanner = () => {
   }, []);
 
   const showDeferredBanner = (options: ShowBannerOptions) => {
+    if (timerRef.current) clearTimeout(timerRef.current);
     timerRef.current = setTimeout(() => {
       showBanner(options);
     }, AFTER_DIALOG_CLOSE_MS);

--- a/src/vertex/core/hooks/useDeferredBanner.ts
+++ b/src/vertex/core/hooks/useDeferredBanner.ts
@@ -1,0 +1,22 @@
+import { useEffect, useRef } from 'react';
+import { useBanner, type ShowBannerOptions } from '@/context/banner-context';
+import { AFTER_DIALOG_CLOSE_MS } from '@/core/constants/ui';
+
+export const useDeferredBanner = () => {
+  const { showBanner } = useBanner();
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  const showDeferredBanner = (options: ShowBannerOptions) => {
+    timerRef.current = setTimeout(() => {
+      showBanner(options);
+    }, AFTER_DIALOG_CLOSE_MS);
+  };
+
+  return { showDeferredBanner };
+};

--- a/src/vertex/core/hooks/useGrids.ts
+++ b/src/vertex/core/hooks/useGrids.ts
@@ -9,8 +9,7 @@ import { CreateGrid, Grid, GridsSummaryResponse } from "@/app/types/grids";
 import { setError, setGrids } from "../redux/slices/gridsSlice";
 import { useDispatch } from "react-redux";
 import React from "react";
-import ReusableToast from "@/components/shared/toast/ReusableToast";
-import { getApiErrorMessage } from "../utils/getApiErrorMessage";
+
 
 interface ErrorResponse {
   message: string;
@@ -95,8 +94,13 @@ export const useGridDetails = (gridId: string) => {
   };
 };
 
+interface UseUpdateGridDetailsOptions {
+  onSuccess?: (data: Grid) => void;
+  onError?: (error: AxiosError<ErrorResponse>) => void;
+}
+
 // Hook to update grid details
-export const useUpdateGridDetails = (gridId: string) => {
+export const useUpdateGridDetails = (gridId: string, options?: UseUpdateGridDetailsOptions) => {
   const queryClient = useQueryClient();
   const {
     mutateAsync: updateGridDetails,
@@ -105,81 +109,62 @@ export const useUpdateGridDetails = (gridId: string) => {
   } = useMutation<Grid, AxiosError<ErrorResponse>, { name?: string; visibility?: boolean; admin_level?: string }>({
     mutationFn: (updatedFields: { name?: string; visibility?: boolean; admin_level?: string }) =>
       grids.updateGridDetailsApi(gridId, updatedFields),
-    onSuccess: () => {
-      ReusableToast({
-        message: "Grid details updated successfully",
-        type: "SUCCESS",
-      });
+    onSuccess: (data) => {
       queryClient.invalidateQueries({ queryKey: ["gridDetails", gridId] });
       queryClient.invalidateQueries({ queryKey: ["grids"] });
+      options?.onSuccess?.(data);
     },
     onError: (error: AxiosError<ErrorResponse>) => {
-      ReusableToast({
-        message: `Failed to update grid: ${getApiErrorMessage(error)}`,
-        type: "ERROR",
-      });
+      options?.onError?.(error);
     },
   });
 
-  return {
-    updateGridDetails,
-    isLoading,
-    error,
-  };
+  return { updateGridDetails, isLoading, error };
 };
 
+interface UseCreateGridOptions {
+  onSuccess?: (data: Grid) => void;
+  onError?: (error: AxiosError<ErrorResponse>) => void;
+}
+
 // Hook to create a new grid
-export const useCreateGrid = () => {
+export const useCreateGrid = (options?: UseCreateGridOptions) => {
   const queryClient = useQueryClient();
   const { mutate: createGrid, isPending: isLoading, error } = useMutation<Grid, AxiosError<ErrorResponse>, CreateGrid>({
     mutationFn: async (newGrid: CreateGrid) =>
       await grids.createGridApi(newGrid),
     onSuccess: (data) => {
-      ReusableToast({
-        message: `New grid added!`,
-        type: "SUCCESS",
-      });
       queryClient.invalidateQueries({ queryKey: ["grids"] });
+      options?.onSuccess?.(data);
     },
     onError: (error: AxiosError<ErrorResponse>) => {
-      ReusableToast({
-        message: `Failed to create grid: ${getApiErrorMessage(error)}`,
-        type: "ERROR",
-      });
+      options?.onError?.(error);
     },
   });
 
-  return {
-    createGrid,
-    isLoading,
-    error,
-  };
+  return { createGrid, isLoading, error };
 };
 
-export const useCreateAdminLevel = () => {
+interface UseCreateAdminLevelOptions {
+  onSuccess?: (data: AdminLevelResponse) => void;
+  onError?: (error: AxiosError<ErrorResponse>) => void;
+}
+
+export const useCreateAdminLevel = (options?: UseCreateAdminLevelOptions) => {
   const queryClient = useQueryClient();
   const { mutate: createAdminLevel, isPending: isLoading, error } = useMutation<AdminLevelResponse, AxiosError<ErrorResponse>, { name: string }>({
     mutationFn: (data: { name: string }) => grids.createAdminLevelApi(data),
     onSuccess: (data) => {
-      ReusableToast({
-        message: `Admin level '${data.admin_levels.name}' created successfully`,
-        type: "SUCCESS",
-      });
       queryClient.invalidateQueries({ queryKey: ["admin-levels"] });
+      options?.onSuccess?.(data);
     },
     onError: (error: AxiosError<ErrorResponse>) => {
-      ReusableToast({
-        message: `Failed to create admin level: ${getApiErrorMessage(error)}`,
-        type: "ERROR",
-      });
+      options?.onError?.(error);
+    
     },
   });
 
-  return {
-    createAdminLevel,
-    isLoading,
-    error,
-  };
+  return { createAdminLevel, isLoading, error };
 };
 
 export const useAdminLevels = () => {
@@ -196,28 +181,23 @@ export const useAdminLevels = () => {
   };
 };
 
-export const useUpdateAdminLevel = () => {
+interface UseUpdateAdminLevelOptions {
+  onSuccess?: (data: AdminLevelResponse) => void;
+  onError?: (error: AxiosError<ErrorResponse>) => void;
+}
+
+export const useUpdateAdminLevel = (options?: UseUpdateAdminLevelOptions) => {
   const queryClient = useQueryClient();
   const { mutate: updateAdminLevel, isPending: isLoading, error } = useMutation<AdminLevelResponse, AxiosError<ErrorResponse>, { levelId: string; data: { name: string } }>({
     mutationFn: ({ levelId, data }) => grids.updateAdminLevelApi(levelId, data),
     onSuccess: (data) => {
-      ReusableToast({
-        message: `Admin level updated to '${data.admin_levels.name}' successfully`,
-        type: "SUCCESS",
-      });
       queryClient.invalidateQueries({ queryKey: ["admin-levels"] });
+      options?.onSuccess?.(data);
     },
     onError: (error: AxiosError<ErrorResponse>) => {
-      ReusableToast({
-        message: `Failed to update admin level: ${getApiErrorMessage(error)}`,
-        type: "ERROR",
-      });
+      options?.onError?.(error);
     },
   });
 
-  return {
-    updateAdminLevel,
-    isLoading,
-    error,
-  };
+  return { updateAdminLevel, isLoading, error };
 };

--- a/src/vertex/core/utils/getApiErrorMessage.ts
+++ b/src/vertex/core/utils/getApiErrorMessage.ts
@@ -16,7 +16,7 @@ interface ErrorWithData extends Error {
 const HTML_PATTERN = /<\/?[a-z][\s\S]*>/i;
 const GENERIC_ERROR = 'An unexpected error occurred. Please try again.';
 
-const sanitize = (msg: string): string => (HTML_PATTERN.test(msg) ? GENERIC_ERROR : msg);
+const fallbackIfHtml = (msg: string): string => (HTML_PATTERN.test(msg) ? GENERIC_ERROR : msg);
 
 const getMessageFromApiData = (data: ApiErrorResponse | string): string | null => {
     if (typeof data === 'string') {
@@ -69,19 +69,19 @@ export const getApiErrorMessage = (error: unknown): string => {
 
         if (error.response?.data) {
             const message = getMessageFromApiData(error.response.data as ApiErrorResponse | string);
-            if (message) return sanitize(message);
+            if (message) return fallbackIfHtml(message);
         }
     }
 
     // 5. Fetch/custom errors with preserved backend payload: Object.assign(new Error(...), { data })
     if (error instanceof Error && 'data' in error) {
         const message = getMessageFromApiData((error as ErrorWithData).data ?? {});
-        if (message) return sanitize(message);
+        if (message) return fallbackIfHtml(message);
     }
 
     // 6. Fallback to standard Error message
     if (error instanceof Error) {
-        return sanitize(error.message);
+        return fallbackIfHtml(error.message);
     }
 
     // 7. Generic fallback

--- a/src/vertex/core/utils/getApiErrorMessage.ts
+++ b/src/vertex/core/utils/getApiErrorMessage.ts
@@ -15,7 +15,9 @@ interface ErrorWithData extends Error {
 
 const getMessageFromApiData = (data: ApiErrorResponse | string): string | null => {
     if (typeof data === 'string') {
-        return data;
+        return /<\/?[a-z][\s\S]*>/i.test(data)
+            ? 'An unexpected error occurred. Please try again.'
+            : data;
     }
 
     // 1. Nested validation errors: { "errors": { "field": { "msg": "..." } } } OR { "errors": { "field": "..." } }

--- a/src/vertex/core/utils/getApiErrorMessage.ts
+++ b/src/vertex/core/utils/getApiErrorMessage.ts
@@ -13,11 +13,14 @@ interface ErrorWithData extends Error {
     data?: ApiErrorResponse | string;
 }
 
+const HTML_PATTERN = /<\/?[a-z][\s\S]*>/i;
+const GENERIC_ERROR = 'An unexpected error occurred. Please try again.';
+
+const sanitize = (msg: string): string => (HTML_PATTERN.test(msg) ? GENERIC_ERROR : msg);
+
 const getMessageFromApiData = (data: ApiErrorResponse | string): string | null => {
     if (typeof data === 'string') {
-        return /<\/?[a-z][\s\S]*>/i.test(data)
-            ? 'An unexpected error occurred. Please try again.'
-            : data;
+        return data;
     }
 
     // 1. Nested validation errors: { "errors": { "field": { "msg": "..." } } } OR { "errors": { "field": "..." } }
@@ -66,19 +69,19 @@ export const getApiErrorMessage = (error: unknown): string => {
 
         if (error.response?.data) {
             const message = getMessageFromApiData(error.response.data as ApiErrorResponse | string);
-            if (message) return message;
+            if (message) return sanitize(message);
         }
     }
 
     // 5. Fetch/custom errors with preserved backend payload: Object.assign(new Error(...), { data })
     if (error instanceof Error && 'data' in error) {
         const message = getMessageFromApiData((error as ErrorWithData).data ?? {});
-        if (message) return message;
+        if (message) return sanitize(message);
     }
 
     // 6. Fallback to standard Error message
     if (error instanceof Error) {
-        return error.message;
+        return sanitize(error.message);
     }
 
     // 7. Generic fallback

--- a/src/vertex/core/utils/getApiErrorMessage.ts
+++ b/src/vertex/core/utils/getApiErrorMessage.ts
@@ -16,7 +16,10 @@ interface ErrorWithData extends Error {
 const HTML_PATTERN = /<\/?[a-z][\s\S]*>/i;
 const GENERIC_ERROR = 'An unexpected error occurred. Please try again.';
 
-const fallbackIfHtml = (msg: string): string => (HTML_PATTERN.test(msg) ? GENERIC_ERROR : msg);
+const fallbackIfHtml = (msg: string): string => {
+    const trimmed = msg.trim();
+    return !trimmed || HTML_PATTERN.test(trimmed) ? GENERIC_ERROR : trimmed;
+};
 
 const getMessageFromApiData = (data: ApiErrorResponse | string): string | null => {
     if (typeof data === 'string') {
@@ -85,5 +88,5 @@ export const getApiErrorMessage = (error: unknown): string => {
     }
 
     // 7. Generic fallback
-    return 'An unexpected error occurred. Please try again.';
+    return GENERIC_ERROR;
 };


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

Migrates all toast-based notifications in the Grid Management module to the
centralized InfoBanner system (`useBanner` hook). Since most grid management
actions occur inside dialogs, banner scoping has been carefully applied:

- **`scoped: true`** — error banners rendered inside the active dialog's
  built-in `BannerSlot` (dialog stays open on error).
- **`scoped: false` + `setTimeout(100ms)`** — success banners shown after a
  dialog closes, giving the dialog time to unmount before the global banner
  renders.

**Files changed:**

- `src/vertex/core/hooks/useGrids.ts` — Confirmed hooks already used the
  callback options pattern with no toast calls. Minor cleanup only.
- `src/vertex/components/features/grids/create-grid.tsx` — Replaced toast
  with `useBanner`; success `scoped: false`, error `scoped: true`.
- `src/vertex/components/features/grids/edit-grid-details-dialog.tsx` —
  Replaced toast with `useBanner`; same scoping pattern.
- `src/vertex/components/features/grids/admin-levels-modal.tsx` — Replaced
  toast with `useBanner`; all actions `scoped: true` (dialog stays open).
- `src/vertex/components/features/grids/create-admin-level.tsx` — Added
  missing banner feedback (previously silent on error).
- `src/vertex/components/features/grids/grid-details-card.tsx` — Copy action
  uses `scoped: false`; hardened with `async/await` and error fallback.
- `src/vertex/components/features/grids/grid-measurements-api-card.tsx` —
  Copy actions use `scoped: false`.

**Known limitations:**
- The Create Grid flow was not fully tested locally because the polygon map
  (`MiniMap`) does not render in the current development environment.
- The shapefile copy button inside Create Grid still uses a toast — it is
  triggered internally by `ReusableInputField`'s `showCopyButton` prop, which
  is outside the scope of this PR.
- When updating an admin level name, the server returns:
  `unexpected field(s): name — only 'description' may be updated`.
  This is a pre-existing API mismatch, not introduced by this PR.
  Screenshots attached.

---

#### Status of maturity (all need to be checked before merging):

- [x] I've tested this locally
- [x] I consider this code done
- [x] This change ready to hit production in its current state
- [x] The title of the PR states what changed and the related issues number (used for the release note).
- [x] I've included issue number in the "Closes #3494" part of the "[What are the relevant tickets?](#3494)" section to [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [ ] I've updated corresponding documentation for the changes in this PR.
- [ ] I have written unit and/or e2e tests for my change(s).

---

#### How should this be manually tested?

1. Navigate to the **Grids** page.
2. **Edit Grid Details (success)** — open the edit dialog, change the grid
   name or visibility and save. Confirm a success banner appears at the top
   of the page after the dialog closes.
3. **Edit Grid Details (error)** — submit with an empty name field. Confirm an
   error banner appears inside the dialog.
4. **Create Admin Level (error)** — submit a name that already exists (409).
   Confirm an error banner appears inside the dialog.
5. **Admin Levels — copy ID** — hover over a row and click the copy icon.
   Confirm a global success banner appears.
6. **Admin Levels — rename** — edit a level name and save. *(Note: currently
   returns a server-side parameter error — see Known Limitations above.)*
7. **Grid Details card — copy Grid ID** — click the copy icon. Confirm a
   global success banner appears.
8. **Grid Measurements API card — copy URL** — click either copy button.
   Confirm a global success banner appears.

---

#### What are the relevant tickets?

- Closes #3494


#### Screenshots (optional)

<!-- Add screenshots showing the admin level update server error here -->
<img width="1366" height="768" alt="gird7" src="https://github.com/user-attachments/assets/2432d4b9-bdfa-4a75-87ab-c78ac4dbcbc3" />
<img width="1366" height="768" alt="grid1" src="https://github.com/user-attachments/assets/d35a2971-ae0b-48d9-8ab4-714a7937e8a0" />
<img width="1366" height="768" alt="grid2" src="https://github.com/user-attachments/assets/f7e65f88-ebdf-40af-9c81-1fa4bda6e941" />
<img width="1366" height="768" alt="grid3" src="https://github.com/user-attachments/assets/a5f08de6-9ec2-43b8-b163-3ef81b7300cd" />
<img width="1366" height="768" alt="grid4" src="https://github.com/user-attachments/assets/a4caed19-ce3f-4d3f-a5de-7024ff0540de" />
<img width="1366" height="768" alt="grid6" src="https://github.com/user-attachments/assets/cc1c845e-1457-4288-b0b4-4f5275574a2e" />
<img width="1366" height="768" alt="grid7" src="https://github.com/user-attachments/assets/d4781f7e-8f44-43f6-bdbd-5ade834c19cd" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Migrated grid/admin-level notifications from toasts to the unified banner system for consistent success/error feedback.
  * Deferred success banners briefly after dialogs close to ensure proper UI cleanup.
* **Bug Fixes**
  * Sanitized API error messages to avoid malformed output and improved scoped dialog error displays.
  * Clipboard copy actions now surface success/failure via banners.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/airqo-platform/AirQo-frontend/pull/3534?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->