### PR TITLE
Update cohort management module to use info banners

### DIFF
--- a/src/vertex/app/changelog.md
+++ b/src/vertex/app/changelog.md
@@ -9,16 +9,16 @@
 
 ### Cohort Management Banner Migration
 
-Migrated all toast-based notifications in the Cohort Management module to the centralized `InfoBanner` system powered by `useBanner`. Errors inside dialogs use `scoped: true` to stay inline while the dialog remains open; post-dialog success feedback uses `scoped: false` via the shared `useDeferredBanner` hook to delay display until the dialog has fully unmounted.
+Migrated all toast-based notifications in the Cohort Management module to the centralized `InfoBanner` system powered by `useBanner`. Errors inside dialogs use `scoped: true` to stay inline while the dialog remains open; post-dialog success feedback uses `scoped: false` via the shared `useBannerWithDelay` hook to delay display until the dialog has fully unmounted.
 
 <details>
 <summary><strong>Cohort Management Banner Migration (5)</strong></summary>
 
 - **Hook-Level Callback Pattern**: All mutation hooks in `useCohorts.ts` now accept optional `onSuccess`/`onError` callbacks at initialization rather than per-call `mutate()` arguments, aligning with the reliable pattern established in the grid module.
 - **Dialog Error Feedback**: `create-cohort.tsx`, `edit-cohort-details-modal.tsx`, `device-name-parser.tsx`, and `assign/unassign-cohort-devices.tsx` use `scoped: true` so validation and mutation errors remain visible inside the active dialog without closing it.
-- **Post-Dialog Success Feedback**: `create-cohort.tsx`, `assign-cohort-devices.tsx`, and `unassign-cohort-devices.tsx` use the shared `useDeferredBanner` hook (`scoped: false`) to show global success banners only after the dialog has unmounted.
+- **Post-Dialog Success Feedback**: `create-cohort.tsx`, `assign-cohort-devices.tsx`, and `unassign-cohort-devices.tsx` use the shared `useBannerWithDelay` hook (`scoped: false`) to show global success banners only after the dialog has unmounted.
 - **Detail Card & API Card Feedback**: `cohort-detail-card.tsx` and `cohort-measurements-api-card.tsx` replace toast calls with `useBanner` for copy feedback and action outcomes, keeping feedback in context.
-- **Shared Utilities Adopted**: `useDeferredBanner` hook and `AFTER_DIALOG_CLOSE_MS` constant (merged from the grid branch) are now consumed across the cohort module, removing all local `bannerTimerRef + setTimeout` patterns.
+- **Shared Utilities Adopted**: `useBannerWithDelay` hook and `AFTER_DIALOG_CLOSE_MS` constant (merged from the grid branch) are now consumed across the cohort module, removing all local `bannerTimerRef + setTimeout` patterns.
 
 </details>
 

--- a/src/vertex/app/changelog.md
+++ b/src/vertex/app/changelog.md
@@ -4,6 +4,41 @@
 
 ---
 
+## Version 1.23.51
+**Released:** May 27, 2026
+
+### Cohort Management Banner Migration
+
+Migrated all toast-based notifications in the Cohort Management module to the centralized `InfoBanner` system powered by `useBanner`. Errors inside dialogs use `scoped: true` to stay inline while the dialog remains open; post-dialog success feedback uses `scoped: false` via the shared `useDeferredBanner` hook to delay display until the dialog has fully unmounted.
+
+<details>
+<summary><strong>Cohort Management Banner Migration (5)</strong></summary>
+
+- **Hook-Level Callback Pattern**: All mutation hooks in `useCohorts.ts` now accept optional `onSuccess`/`onError` callbacks at initialization rather than per-call `mutate()` arguments, aligning with the reliable pattern established in the grid module.
+- **Dialog Error Feedback**: `create-cohort.tsx`, `edit-cohort-details-modal.tsx`, `device-name-parser.tsx`, and `assign/unassign-cohort-devices.tsx` use `scoped: true` so validation and mutation errors remain visible inside the active dialog without closing it.
+- **Post-Dialog Success Feedback**: `create-cohort.tsx`, `assign-cohort-devices.tsx`, and `unassign-cohort-devices.tsx` use the shared `useDeferredBanner` hook (`scoped: false`) to show global success banners only after the dialog has unmounted.
+- **Detail Card & API Card Feedback**: `cohort-detail-card.tsx` and `cohort-measurements-api-card.tsx` replace toast calls with `useBanner` for copy feedback and action outcomes, keeping feedback in context.
+- **Shared Utilities Adopted**: `useDeferredBanner` hook and `AFTER_DIALOG_CLOSE_MS` constant (merged from the grid branch) are now consumed across the cohort module, removing all local `bannerTimerRef + setTimeout` patterns.
+
+</details>
+
+<details>
+<summary><strong>Files Updated (9)</strong></summary>
+
+- `src/vertex/core/hooks/useCohorts.ts` [MODIFIED]
+- `src/vertex/components/features/cohorts/create-cohort.tsx` [MODIFIED]
+- `src/vertex/components/features/cohorts/edit-cohort-details-modal.tsx` [MODIFIED]
+- `src/vertex/components/features/cohorts/cohort-detail-card.tsx` [MODIFIED]
+- `src/vertex/components/features/cohorts/cohort-measurements-api-card.tsx` [MODIFIED]
+- `src/vertex/components/features/cohorts/device-name-parser.tsx` [MODIFIED]
+- `src/vertex/components/features/cohorts/assign-cohort-devices.tsx` [MODIFIED]
+- `src/vertex/components/features/cohorts/unassign-cohort-devices.tsx` [MODIFIED]
+- `src/vertex/app/changelog.md` [MODIFIED]
+
+</details>
+
+---
+
 ## Version 1.23.50
 **Released:** May 27, 2026
 

--- a/src/vertex/app/changelog.md
+++ b/src/vertex/app/changelog.md
@@ -7,23 +7,25 @@
 ## Version 1.23.52
 **Released:** May 27, 2026
 
-### Cohort Management Banner Migration
+### Cohort Management Banner Migration & Banner Delay Standardization
 
-Migrated all toast-based notifications in the Cohort Management module to the centralized `InfoBanner` system powered by `useBanner`. Errors inside dialogs use `scoped: true` to stay inline while the dialog remains open; post-dialog success feedback uses `scoped: false` via the shared `useBannerWithDelay` hook to delay display until the dialog has fully unmounted.
+Migrated toast-based cohort notifications and raw `setTimeout` banner patterns in device dialogs to the centralized `InfoBanner` system and the shared `useBannerWithDelay` hook. Errors inside dialogs use `scoped: true` to stay inline while the dialog remains open; post-dialog success feedback uses `scoped: false` so the delayed banner appears only after the dialog has fully unmounted.
 
 <details>
-<summary><strong>Cohort Management Banner Migration (5)</strong></summary>
+<summary><strong>Banner Delay Standardization (7)</strong></summary>
 
+- **Shared Delay Hook Rename**: Renamed the former `useDeferredBanner` hook to `useBannerWithDelay` across cohort, grid, and device consumers to make the hook name reflect the delayed display behavior.
 - **Hook-Level Callback Pattern**: All mutation hooks in `useCohorts.ts` now accept optional `onSuccess`/`onError` callbacks at initialization rather than per-call `mutate()` arguments, aligning with the reliable pattern established in the grid module.
 - **Dialog Error Feedback**: `create-cohort.tsx`, `edit-cohort-details-modal.tsx`, `device-name-parser.tsx`, and `assign/unassign-cohort-devices.tsx` use `scoped: true` so validation and mutation errors remain visible inside the active dialog without closing it.
 - **Post-Dialog Success Feedback**: `create-cohort.tsx`, `assign-cohort-devices.tsx`, and `unassign-cohort-devices.tsx` use the shared `useBannerWithDelay` hook (`scoped: false`) to show global success banners only after the dialog has unmounted.
+- **Device Banner Refactor**: Device modals and dialogs now use `useBannerWithDelay` instead of raw `setTimeout` timer patterns to display delayed success feedback after unmounting.
 - **Detail Card & API Card Feedback**: `cohort-detail-card.tsx` and `cohort-measurements-api-card.tsx` replace toast calls with `useBanner` for copy feedback and action outcomes, keeping feedback in context.
 - **Shared Utilities Adopted**: `useBannerWithDelay` hook and `AFTER_DIALOG_CLOSE_MS` constant (merged from the grid branch) are now consumed across the cohort module, removing all local `bannerTimerRef + setTimeout` patterns.
 
 </details>
 
 <details>
-<summary><strong>Files Updated (9)</strong></summary>
+<summary><strong>Files Updated (19)</strong></summary>
 
 - `src/vertex/core/hooks/useCohorts.ts` [MODIFIED]
 - `src/vertex/components/features/cohorts/create-cohort.tsx` [MODIFIED]
@@ -33,6 +35,16 @@ Migrated all toast-based notifications in the Cohort Management module to the ce
 - `src/vertex/components/features/cohorts/device-name-parser.tsx` [MODIFIED]
 - `src/vertex/components/features/cohorts/assign-cohort-devices.tsx` [MODIFIED]
 - `src/vertex/components/features/cohorts/unassign-cohort-devices.tsx` [MODIFIED]
+- `src/vertex/components/features/grids/create-admin-level.tsx` [MODIFIED]
+- `src/vertex/components/features/grids/create-grid.tsx` [MODIFIED]
+- `src/vertex/components/features/grids/edit-grid-details-dialog.tsx` [MODIFIED]
+- `src/vertex/components/features/devices/add-maintenance-log-modal.tsx` [MODIFIED]
+- `src/vertex/components/features/devices/create-device-modal.tsx` [MODIFIED]
+- `src/vertex/components/features/devices/deploy-device-component.tsx` [MODIFIED]
+- `src/vertex/components/features/devices/device-assignment-modal.tsx` [MODIFIED]
+- `src/vertex/components/features/devices/import-device-modal.tsx` [MODIFIED]
+- `src/vertex/components/features/devices/recall-device-dialog.tsx` [MODIFIED]
+- `src/vertex/core/hooks/useBannerWithDelay.ts` [ADDED]
 - `src/vertex/app/changelog.md` [MODIFIED]
 
 </details>

--- a/src/vertex/components/features/cohorts/assign-cohort-devices.tsx
+++ b/src/vertex/components/features/cohorts/assign-cohort-devices.tsx
@@ -24,6 +24,7 @@ import { Device } from "@/app/types/devices";
 import { useUserContext } from "@/core/hooks/useUserContext";
 import { useBanner } from "@/context/banner-context";
 import { getApiErrorMessage } from "@/core/utils/getApiErrorMessage";
+import { useDeferredBanner } from "@/core/hooks/useDeferredBanner";
 
 interface AssignCohortDevicesDialogProps {
   open: boolean;
@@ -51,6 +52,7 @@ export function AssignCohortDevicesDialog({
 }: AssignCohortDevicesDialogProps) {
   const { isExternalOrg, activeGroup } = useUserContext();
   const { showBanner } = useBanner();
+  const { showDeferredBanner } = useDeferredBanner();
   const [cohortSearch, setCohortSearch] = useState("");
   const [debouncedCohortSearch, setDebouncedCohortSearch] = useState("");
   const [deviceSearch, setDeviceSearch] = useState("");
@@ -106,13 +108,11 @@ export function AssignCohortDevicesDialog({
   });
   const { mutate: assignDevices, isPending: isAssigning } = useAssignDevicesToCohort({
     onSuccess: (variables) => {
-      setTimeout(() => {
-        showBanner({
-          severity: 'success',
-          message: `${variables.deviceIds.length} device(s) assigned to cohort successfully`,
-          scoped: false,
-        });
-      }, 100);
+      showDeferredBanner({
+        severity: 'success',
+        message: `${variables.deviceIds.length} device(s) assigned to cohort successfully`,
+        scoped: false,
+      });
     },
     onError: (error) => {
       showBanner({

--- a/src/vertex/components/features/cohorts/assign-cohort-devices.tsx
+++ b/src/vertex/components/features/cohorts/assign-cohort-devices.tsx
@@ -22,6 +22,8 @@ import { Cohort } from "@/app/types/cohorts";
 import ReusableDialog from "@/components/shared/dialog/ReusableDialog";
 import { Device } from "@/app/types/devices";
 import { useUserContext } from "@/core/hooks/useUserContext";
+import { useBanner } from "@/context/banner-context";
+import { getApiErrorMessage } from "@/core/utils/getApiErrorMessage";
 
 interface AssignCohortDevicesDialogProps {
   open: boolean;
@@ -48,6 +50,7 @@ export function AssignCohortDevicesDialog({
   cohortId,
 }: AssignCohortDevicesDialogProps) {
   const { isExternalOrg, activeGroup } = useUserContext();
+  const { showBanner } = useBanner();
   const [cohortSearch, setCohortSearch] = useState("");
   const [debouncedCohortSearch, setDebouncedCohortSearch] = useState("");
   const [deviceSearch, setDeviceSearch] = useState("");
@@ -101,7 +104,24 @@ export function AssignCohortDevicesDialog({
     enabled: open,
     search: debouncedDeviceSearch,
   });
-  const { mutate: assignDevices, isPending: isAssigning } = useAssignDevicesToCohort();
+  const { mutate: assignDevices, isPending: isAssigning } = useAssignDevicesToCohort({
+    onSuccess: (variables) => {
+      setTimeout(() => {
+        showBanner({
+          severity: 'success',
+          message: `${variables.deviceIds.length} device(s) assigned to cohort successfully`,
+          scoped: false,
+        });
+      }, 100);
+    },
+    onError: (error) => {
+      showBanner({
+        severity: 'error',
+        message: `Failed to assign devices: ${getApiErrorMessage(error)}`,
+        scoped: true,
+      });
+    },
+  });
 
   const [createCohortModalOpen, setCreateCohortModalOpen] = useState(false);
   const [preselectedForCreate, setPreselectedForCreate] = useState<PreselectedDevice[]>([]);

--- a/src/vertex/components/features/cohorts/assign-cohort-devices.tsx
+++ b/src/vertex/components/features/cohorts/assign-cohort-devices.tsx
@@ -24,7 +24,7 @@ import { Device } from "@/app/types/devices";
 import { useUserContext } from "@/core/hooks/useUserContext";
 import { useBanner } from "@/context/banner-context";
 import { getApiErrorMessage } from "@/core/utils/getApiErrorMessage";
-import { useDeferredBanner } from "@/core/hooks/useDeferredBanner";
+import { useBannerWithDelay } from "@/core/hooks/useBannerWithDelay";
 
 interface AssignCohortDevicesDialogProps {
   open: boolean;
@@ -52,7 +52,7 @@ export function AssignCohortDevicesDialog({
 }: AssignCohortDevicesDialogProps) {
   const { isExternalOrg, activeGroup } = useUserContext();
   const { showBanner } = useBanner();
-  const { showDeferredBanner } = useDeferredBanner();
+  const { showBannerWithDelay } = useBannerWithDelay();
   const [cohortSearch, setCohortSearch] = useState("");
   const [debouncedCohortSearch, setDebouncedCohortSearch] = useState("");
   const [deviceSearch, setDeviceSearch] = useState("");
@@ -108,7 +108,7 @@ export function AssignCohortDevicesDialog({
   });
   const { mutate: assignDevices, isPending: isAssigning } = useAssignDevicesToCohort({
     onSuccess: (variables) => {
-      showDeferredBanner({
+      showBannerWithDelay({
         severity: 'success',
         message: `${variables.deviceIds.length} device(s) assigned to cohort successfully`,
         scoped: false,

--- a/src/vertex/components/features/cohorts/cohort-detail-card.tsx
+++ b/src/vertex/components/features/cohorts/cohort-detail-card.tsx
@@ -2,8 +2,9 @@ import { Card } from "@/components/ui/card";
 import { Loader2 } from "lucide-react";
 import ReusableButton from "@/components/shared/button/ReusableButton";
 import { AqCopy01, AqEdit01 } from "@airqo/icons-react";
-import ReusableToast from "@/components/shared/toast/ReusableToast";
 import { Switch } from "@/components/ui/switch";
+import { useBanner } from "@/context/banner-context";
+import { getApiErrorMessage } from "@/core/utils/getApiErrorMessage";
 import { useEffect, useState } from "react";
 import { useUpdateCohortDetails, useOriginalCohort } from "@/core/hooks/useCohorts";
 import ReusableDialog from "@/components/shared/dialog/ReusableDialog";
@@ -41,7 +42,8 @@ const CohortDetailsCard: React.FC<CohortDetailsCardProps> = ({
     (tag) => tag.toLowerCase() === "duplicate"
   );
 
-  const { mutate: updateCohort, isPending } = useUpdateCohortDetails();
+  const { showBanner } = useBanner();
+  const { mutateAsync: updateCohort, isPending } = useUpdateCohortDetails();
   const { data: originalData } = useOriginalCohort(id, { enabled: !!isDuplicate });
   const originalCohort = isDuplicate && originalData?.success ? originalData.original_cohort : null;
 
@@ -54,26 +56,44 @@ const CohortDetailsCard: React.FC<CohortDetailsCardProps> = ({
     setIsVisibilityDialogOpen(true);
   };
 
-  const handleConfirmVisibilityUpdate = () => {
-    updateCohort(
-      { cohortId: id, data: { visibility: targetVisibility } },
-      {
-        onSuccess: () => {
-          setIsVisibilityDialogOpen(false);
-        },
-      }
-    );
+  const handleConfirmVisibilityUpdate = async () => {
+    try {
+      await updateCohort({ cohortId: id, data: { visibility: targetVisibility } });
+      setIsVisibilityDialogOpen(false);
+      setTimeout(() => {
+        showBanner({
+          severity: 'success',
+          message: `Cohort is now ${targetVisibility ? 'public' : 'private'}`,
+          scoped: false,
+        });
+      }, 100);
+    } catch (error) {
+      showBanner({
+        severity: 'error',
+        message: `Failed to update visibility: ${getApiErrorMessage(error)}`,
+        scoped: true,
+      });
+    }
   };
 
-  const handleConfirmTagsUpdate = () => {
-    updateCohort(
-      { cohortId: id, data: { cohort_tags: selectedTags } },
-      {
-        onSuccess: () => {
-          setIsTagsDialogOpen(false);
-        },
-      }
-    );
+  const handleConfirmTagsUpdate = async () => {
+    try {
+      await updateCohort({ cohortId: id, data: { cohort_tags: selectedTags } });
+      setIsTagsDialogOpen(false);
+      setTimeout(() => {
+        showBanner({
+          severity: 'success',
+          message: 'Cohort tags updated successfully',
+          scoped: false,
+        });
+      }, 100);
+    } catch (error) {
+      showBanner({
+        severity: 'error',
+        message: `Failed to update tags: ${getApiErrorMessage(error)}`,
+        scoped: true,
+      });
+    }
   };
 
   if (loading) {
@@ -179,10 +199,13 @@ const CohortDetailsCard: React.FC<CohortDetailsCardProps> = ({
                 </div>
                 <ReusableButton
                   variant="text"
-                  onClick={() => {
-                    if (id) {
-                      navigator.clipboard.writeText(id);
-                      ReusableToast({ message: "Copied", type: "SUCCESS" });
+                  onClick={async () => {
+                    if (!id) return;
+                    try {
+                      await navigator.clipboard.writeText(id);
+                      showBanner({ severity: 'success', message: 'Cohort ID copied to clipboard', scoped: false });
+                    } catch {
+                      showBanner({ severity: 'error', message: 'Failed to copy to clipboard', scoped: false });
                     }
                   }}
                   className="p-1"

--- a/src/vertex/components/features/cohorts/cohort-detail-card.tsx
+++ b/src/vertex/components/features/cohorts/cohort-detail-card.tsx
@@ -5,6 +5,7 @@ import { AqCopy01, AqEdit01 } from "@airqo/icons-react";
 import { Switch } from "@/components/ui/switch";
 import { useBanner } from "@/context/banner-context";
 import { getApiErrorMessage } from "@/core/utils/getApiErrorMessage";
+import { useDeferredBanner } from "@/core/hooks/useDeferredBanner";
 import { useEffect, useState } from "react";
 import { useUpdateCohortDetails, useOriginalCohort } from "@/core/hooks/useCohorts";
 import ReusableDialog from "@/components/shared/dialog/ReusableDialog";
@@ -43,6 +44,7 @@ const CohortDetailsCard: React.FC<CohortDetailsCardProps> = ({
   );
 
   const { showBanner } = useBanner();
+  const { showDeferredBanner } = useDeferredBanner();
   const { mutateAsync: updateCohort, isPending } = useUpdateCohortDetails();
   const { data: originalData } = useOriginalCohort(id, { enabled: !!isDuplicate });
   const originalCohort = isDuplicate && originalData?.success ? originalData.original_cohort : null;
@@ -60,13 +62,11 @@ const CohortDetailsCard: React.FC<CohortDetailsCardProps> = ({
     try {
       await updateCohort({ cohortId: id, data: { visibility: targetVisibility } });
       setIsVisibilityDialogOpen(false);
-      setTimeout(() => {
-        showBanner({
-          severity: 'success',
-          message: `Cohort is now ${targetVisibility ? 'public' : 'private'}`,
-          scoped: false,
-        });
-      }, 100);
+      showDeferredBanner({
+        severity: 'success',
+        message: `Cohort is now ${targetVisibility ? 'public' : 'private'}`,
+        scoped: false,
+      });
     } catch (error) {
       showBanner({
         severity: 'error',
@@ -80,13 +80,11 @@ const CohortDetailsCard: React.FC<CohortDetailsCardProps> = ({
     try {
       await updateCohort({ cohortId: id, data: { cohort_tags: selectedTags } });
       setIsTagsDialogOpen(false);
-      setTimeout(() => {
-        showBanner({
-          severity: 'success',
-          message: 'Cohort tags updated successfully',
-          scoped: false,
-        });
-      }, 100);
+      showDeferredBanner({
+        severity: 'success',
+        message: 'Cohort tags updated successfully',
+        scoped: false,
+      });
     } catch (error) {
       showBanner({
         severity: 'error',

--- a/src/vertex/components/features/cohorts/cohort-detail-card.tsx
+++ b/src/vertex/components/features/cohorts/cohort-detail-card.tsx
@@ -5,7 +5,7 @@ import { AqCopy01, AqEdit01 } from "@airqo/icons-react";
 import { Switch } from "@/components/ui/switch";
 import { useBanner } from "@/context/banner-context";
 import { getApiErrorMessage } from "@/core/utils/getApiErrorMessage";
-import { useDeferredBanner } from "@/core/hooks/useDeferredBanner";
+import { useBannerWithDelay } from "@/core/hooks/useBannerWithDelay";
 import { useEffect, useState } from "react";
 import { useUpdateCohortDetails, useOriginalCohort } from "@/core/hooks/useCohorts";
 import ReusableDialog from "@/components/shared/dialog/ReusableDialog";
@@ -44,7 +44,7 @@ const CohortDetailsCard: React.FC<CohortDetailsCardProps> = ({
   );
 
   const { showBanner } = useBanner();
-  const { showDeferredBanner } = useDeferredBanner();
+  const { showBannerWithDelay } = useBannerWithDelay();
   const { mutateAsync: updateCohort, isPending } = useUpdateCohortDetails();
   const { data: originalData } = useOriginalCohort(id, { enabled: !!isDuplicate });
   const originalCohort = isDuplicate && originalData?.success ? originalData.original_cohort : null;
@@ -62,7 +62,7 @@ const CohortDetailsCard: React.FC<CohortDetailsCardProps> = ({
     try {
       await updateCohort({ cohortId: id, data: { visibility: targetVisibility } });
       setIsVisibilityDialogOpen(false);
-      showDeferredBanner({
+      showBannerWithDelay({
         severity: 'success',
         message: `Cohort is now ${targetVisibility ? 'public' : 'private'}`,
         scoped: false,
@@ -80,7 +80,7 @@ const CohortDetailsCard: React.FC<CohortDetailsCardProps> = ({
     try {
       await updateCohort({ cohortId: id, data: { cohort_tags: selectedTags } });
       setIsTagsDialogOpen(false);
-      showDeferredBanner({
+      showBannerWithDelay({
         severity: 'success',
         message: 'Cohort tags updated successfully',
         scoped: false,

--- a/src/vertex/components/features/cohorts/cohort-measurements-api-card.tsx
+++ b/src/vertex/components/features/cohorts/cohort-measurements-api-card.tsx
@@ -4,13 +4,24 @@ import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Copy } from "lucide-react";
 import React from "react";
-import ReusableToast from "@/components/shared/toast/ReusableToast";
+import { useBanner } from "@/context/banner-context";
 
 interface CohortMeasurementsApiCardProps {
     cohortId: string;
 }
 
 const CohortMeasurementsApiCard: React.FC<CohortMeasurementsApiCardProps> = ({ cohortId }) => {
+    const { showBanner } = useBanner();
+
+    const handleCopy = async (text: string) => {
+        try {
+            await navigator.clipboard.writeText(text);
+            showBanner({ severity: 'success', message: 'API URL copied to clipboard', scoped: false });
+        } catch {
+            showBanner({ severity: 'error', message: 'Failed to copy to clipboard', scoped: false });
+        }
+    };
+
     return (
         <Card className="w-full rounded-lg flex flex-col gap-4 px-3 py-2">
             <h2 className="text-lg font-semibold mb-2">Cohort Measurements API</h2>
@@ -26,14 +37,7 @@ const CohortMeasurementsApiCard: React.FC<CohortMeasurementsApiCardProps> = ({ c
                         size="icon"
                         className="hover:bg-transparent"
                         aria-label="Copy recent cohort measurements API URL"
-                        onClick={async () => {
-                            try {
-                                await navigator.clipboard.writeText(`https://api.airqo.net/api/v2/devices/measurements/cohorts/${cohortId}/recent?token=YOUR_TOKEN`);
-                                ReusableToast({ message: "Copied", type: "SUCCESS" });
-                            } catch {
-                                ReusableToast({ message: "Copy failed", type: "ERROR" });
-                            }
-                        }}
+                        onClick={() => handleCopy(`https://api.airqo.net/api/v2/devices/measurements/cohorts/${cohortId}/recent?token=YOUR_TOKEN`)}
                     >
                         <Copy className="w-4 h-4" />
                     </Button>
@@ -51,14 +55,7 @@ const CohortMeasurementsApiCard: React.FC<CohortMeasurementsApiCardProps> = ({ c
                         size="icon"
                         className="hover:bg-transparent"
                         aria-label="Copy historical cohort measurements API URL"
-                        onClick={async () => {
-                            try {
-                                await navigator.clipboard.writeText(`https://api.airqo.net/api/v2/devices/measurements/cohorts/${cohortId}/historical?token=YOUR_TOKEN`);
-                                ReusableToast({ message: "Copied", type: "SUCCESS" });
-                            } catch {
-                                ReusableToast({ message: "Copy failed", type: "ERROR" });
-                            }
-                        }}
+                        onClick={() => handleCopy(`https://api.airqo.net/api/v2/devices/measurements/cohorts/${cohortId}/historical?token=YOUR_TOKEN`)}
                     >
                         <Copy className="w-4 h-4" />
                     </Button>

--- a/src/vertex/components/features/cohorts/create-cohort.tsx
+++ b/src/vertex/components/features/cohorts/create-cohort.tsx
@@ -11,8 +11,9 @@ import { useCreateCohortWithDevices } from "@/core/hooks/useCohorts";
 import { useNetworks } from "@/core/hooks/useNetworks";
 import ReusableInputField from "@/components/shared/inputfield/ReusableInputField";
 import ReusableSelectInput from "@/components/shared/select/ReusableSelectInput";
-import ReusableToast from "@/components/shared/toast/ReusableToast";
 import { DeviceNameParser } from "./device-name-parser";
+import { useBanner } from "@/context/banner-context";
+import { getApiErrorMessage } from "@/core/utils/getApiErrorMessage";
 import {
   Form,
   FormControl,
@@ -75,6 +76,8 @@ export function CreateCohortDialog({
   onError,
   preselectedDevices = EMPTY_PRESELECTED_DEVICES,
 }: CreateCohortDialogProps) {
+  const { showBanner } = useBanner();
+
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
     defaultValues: {
@@ -154,7 +157,26 @@ export function CreateCohortDialog({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, preselectedDevices]);
 
-  const { mutate: createCohort, isPending } = useCreateCohortWithDevices();
+  const { mutate: createCohort, isPending } = useCreateCohortWithDevices({
+    onSuccess: (response) => {
+      if (response?.cohort) {
+        setCreatedCohort(response.cohort);
+        setStep("success");
+        onSuccess?.(response);
+      } else {
+        onSuccess?.(response);
+        onOpenChange(false);
+      }
+    },
+    onError: (error) => {
+      showBanner({
+        severity: 'error',
+        message: `Failed to create cohort: ${getApiErrorMessage(error)}`,
+        scoped: true,
+      });
+      onError?.(error);
+    },
+  });
 
   const handleCancel = () => {
     if (step === 'form') {
@@ -191,9 +213,10 @@ export function CreateCohortDialog({
       .filter(Boolean) as string[];
 
     if (matchedIds.length === 0) {
-      ReusableToast({
+      showBanner({
+        severity: 'warning',
         message: 'No matching devices found. Please ensure the devices exist in the selected network.',
-        type: 'WARNING',
+        scoped: true,
       });
       return;
     }
@@ -207,9 +230,10 @@ export function CreateCohortDialog({
     const notFoundCount = deviceNames.length - importedCount;
 
     if (notFoundCount > 0) {
-      ReusableToast({
+      showBanner({
+        severity: 'warning',
         message: `Imported ${importedCount} device${importedCount !== 1 ? 's' : ''}. ${notFoundCount} not found.`,
-        type: 'WARNING',
+        scoped: true,
       });
     }
   };
@@ -226,25 +250,7 @@ export function CreateCohortDialog({
     const derivedName = isOrganizational
       ? buildCohortName(values.city || "", values.projectName || "", values.funder)
       : (values.name || "").trim();
-    createCohort(
-      { name: derivedName, network: values.network, deviceIds: values.devices, cohort_tags: values.cohort_tags },
-      {
-        onSuccess: (response) => {
-          if (response?.cohort) {
-            setCreatedCohort(response.cohort);
-            setStep("success");
-            onSuccess?.(response);
-          } else {
-            // Fallback if response structure is unexpected
-            onSuccess?.(response);
-            onOpenChange(false);
-          }
-        },
-        onError: (error) => {
-          onError?.(error);
-        },
-      },
-    );
+    createCohort({ name: derivedName, network: values.network, deviceIds: values.devices, cohort_tags: values.cohort_tags });
   };
 
   const getDialogConfig = () => {

--- a/src/vertex/components/features/cohorts/device-name-parser.tsx
+++ b/src/vertex/components/features/cohorts/device-name-parser.tsx
@@ -3,7 +3,7 @@
 import React, { useRef, useState } from 'react';
 import { FileSpreadsheet } from 'lucide-react';
 import ReusableButton from '@/components/shared/button/ReusableButton';
-import ReusableToast from '@/components/shared/toast/ReusableToast';
+import { useBanner } from '@/context/banner-context';
 import {
     Tooltip,
     TooltipContent,
@@ -152,6 +152,7 @@ export const DeviceNameParser: React.FC<DeviceNameCohortParserProps> = ({
     const [isImporting, setIsImporting] = useState(false);
     const [filePreview, setFilePreview] = useState<ParsedFileData | null>(null);
     const fileInputRef = useRef<HTMLInputElement>(null);
+    const { showBanner } = useBanner();
 
     const handleLinkClick = (e: React.MouseEvent) => {
         e.preventDefault();
@@ -173,16 +174,13 @@ export const DeviceNameParser: React.FC<DeviceNameCohortParserProps> = ({
 
         const fileExtension = file.name.split('.').pop()?.toLowerCase();
         if (!['csv', 'xlsx', 'xls'].includes(fileExtension || '')) {
-            ReusableToast({
-                message: 'Invalid file format. Please upload a CSV or Excel file.',
-                type: 'ERROR',
-            });
+            showBanner({ severity: 'error', message: 'Invalid file format. Please upload a CSV or Excel file.', scoped: true });
             e.target.value = '';
             return;
         }
 
         if (file.size > 5 * 1024 * 1024) {
-            ReusableToast({ message: 'File too large. Maximum size is 5MB.', type: 'ERROR' });
+            showBanner({ severity: 'error', message: 'File too large. Maximum size is 5MB.', scoped: true });
             e.target.value = '';
             return;
         }
@@ -206,18 +204,12 @@ export const DeviceNameParser: React.FC<DeviceNameCohortParserProps> = ({
                             });
                             setFilePreview({ headers, data: parsedData, fileName: file.name });
                         } else {
-                            ReusableToast({
-                                message: 'The file appears to be empty.',
-                                type: 'WARNING',
-                            });
+                            showBanner({ severity: 'warning', message: 'The file appears to be empty.', scoped: true });
                         }
                         setIsImporting(false);
                     },
                     error: (error) => {
-                        ReusableToast({
-                            message: `Error parsing CSV: ${error.message}`,
-                            type: 'ERROR',
-                        });
+                        showBanner({ severity: 'error', message: `Error parsing CSV: ${error.message}`, scoped: true });
                         setIsImporting(false);
                     },
                 });
@@ -237,24 +229,18 @@ export const DeviceNameParser: React.FC<DeviceNameCohortParserProps> = ({
                         });
                         setFilePreview({ headers, data: parsedData, fileName: file.name });
                     } else {
-                        ReusableToast({
-                            message: 'The file appears to be empty.',
-                            type: 'WARNING',
-                        });
+                        showBanner({ severity: 'warning', message: 'The file appears to be empty.', scoped: true });
                     }
                     setIsImporting(false);
                 };
                 reader.onerror = () => {
-                    ReusableToast({ message: 'Error reading Excel file', type: 'ERROR' });
+                    showBanner({ severity: 'error', message: 'Error reading Excel file.', scoped: true });
                     setIsImporting(false);
                 };
                 reader.readAsBinaryString(file);
             }
         } catch {
-            ReusableToast({
-                message: 'Error importing file. Please ensure papaparse and xlsx libraries are installed.',
-                type: 'ERROR',
-            });
+            showBanner({ severity: 'error', message: 'Error importing file. Please try again.', scoped: true });
             setIsImporting(false);
         }
 
@@ -275,10 +261,7 @@ export const DeviceNameParser: React.FC<DeviceNameCohortParserProps> = ({
             .filter((name) => name.length > 0);
 
         if (deviceNames.length === 0) {
-            ReusableToast({
-                message: 'No valid device names found in the selected column',
-                type: 'ERROR',
-            });
+            showBanner({ severity: 'error', message: 'No valid device names found in the selected column.', scoped: true });
             return;
         }
 

--- a/src/vertex/components/features/cohorts/edit-cohort-details-modal.tsx
+++ b/src/vertex/components/features/cohorts/edit-cohort-details-modal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useEffect, useRef, useState } from "react";
-import { useDeferredBanner } from "@/core/hooks/useDeferredBanner";
+import { useBannerWithDelay } from "@/core/hooks/useBannerWithDelay";
 import ReusableDialog from "@/components/shared/dialog/ReusableDialog";
 import ReusableButton from "@/components/shared/button/ReusableButton";
 import ReusableInputField from "@/components/shared/inputfield/ReusableInputField";
@@ -46,7 +46,7 @@ const CohortDetailsModal: React.FC<CohortDetailsModalProps> = ({
         tags: [] as string[],
     });
     const { showBanner } = useBanner();
-    const { showDeferredBanner } = useDeferredBanner();
+    const { showBannerWithDelay } = useBannerWithDelay();
     const updateCohortName = useUpdateCohortName();
     const updateCohortDetails = useUpdateCohortDetails();
     const [showIgnoredTooltip, setShowIgnoredTooltip] = useState({
@@ -127,7 +127,7 @@ const CohortDetailsModal: React.FC<CohortDetailsModalProps> = ({
                 });
             }
             onClose();
-            showDeferredBanner({
+            showBannerWithDelay({
                 severity: 'success',
                 message: 'Cohort details updated successfully',
                 scoped: false,

--- a/src/vertex/components/features/cohorts/edit-cohort-details-modal.tsx
+++ b/src/vertex/components/features/cohorts/edit-cohort-details-modal.tsx
@@ -8,7 +8,8 @@ import { Label } from "@/components/ui/label";
 
 import { useUpdateCohortDetails, useUpdateCohortName } from "@/core/hooks/useCohorts";
 import { PERMISSIONS } from "@/core/permissions/constants";
-import logger from "@/lib/logger";
+import { useBanner } from "@/context/banner-context";
+import { getApiErrorMessage } from "@/core/utils/getApiErrorMessage";
 import { buildCohortName, sanitizeCohortInput, splitCohortName } from "@/core/utils/cohortName";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { MultiSelectCombobox } from "@/components/ui/multi-select";
@@ -43,6 +44,7 @@ const CohortDetailsModal: React.FC<CohortDetailsModalProps> = ({
         updateReason: "",
         tags: [] as string[],
     });
+    const { showBanner } = useBanner();
     const updateCohortName = useUpdateCohortName();
     const updateCohortDetails = useUpdateCohortDetails();
     const [showIgnoredTooltip, setShowIgnoredTooltip] = useState({
@@ -123,8 +125,19 @@ const CohortDetailsModal: React.FC<CohortDetailsModalProps> = ({
                 });
             }
             onClose();
-        } catch {
-            logger.info("Something went wrong")
+            setTimeout(() => {
+                showBanner({
+                    severity: 'success',
+                    message: 'Cohort details updated successfully',
+                    scoped: false,
+                });
+            }, 100);
+        } catch (error) {
+            showBanner({
+                severity: 'error',
+                message: `Failed to update cohort: ${getApiErrorMessage(error)}`,
+                scoped: true,
+            });
         }
     };
 

--- a/src/vertex/components/features/cohorts/edit-cohort-details-modal.tsx
+++ b/src/vertex/components/features/cohorts/edit-cohort-details-modal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useEffect, useRef, useState } from "react";
+import { useDeferredBanner } from "@/core/hooks/useDeferredBanner";
 import ReusableDialog from "@/components/shared/dialog/ReusableDialog";
 import ReusableButton from "@/components/shared/button/ReusableButton";
 import ReusableInputField from "@/components/shared/inputfield/ReusableInputField";
@@ -45,6 +46,7 @@ const CohortDetailsModal: React.FC<CohortDetailsModalProps> = ({
         tags: [] as string[],
     });
     const { showBanner } = useBanner();
+    const { showDeferredBanner } = useDeferredBanner();
     const updateCohortName = useUpdateCohortName();
     const updateCohortDetails = useUpdateCohortDetails();
     const [showIgnoredTooltip, setShowIgnoredTooltip] = useState({
@@ -125,13 +127,11 @@ const CohortDetailsModal: React.FC<CohortDetailsModalProps> = ({
                 });
             }
             onClose();
-            setTimeout(() => {
-                showBanner({
-                    severity: 'success',
-                    message: 'Cohort details updated successfully',
-                    scoped: false,
-                });
-            }, 100);
+            showDeferredBanner({
+                severity: 'success',
+                message: 'Cohort details updated successfully',
+                scoped: false,
+            });
         } catch (error) {
             showBanner({
                 severity: 'error',

--- a/src/vertex/components/features/cohorts/unassign-cohort-devices.tsx
+++ b/src/vertex/components/features/cohorts/unassign-cohort-devices.tsx
@@ -20,6 +20,7 @@ import ReusableDialog from "@/components/shared/dialog/ReusableDialog";
 import { Device } from "@/app/types/devices";
 import { useBanner } from "@/context/banner-context";
 import { getApiErrorMessage } from "@/core/utils/getApiErrorMessage";
+import { useDeferredBanner } from "@/core/hooks/useDeferredBanner";
 
 interface UnassignCohortDevicesDialogProps {
   open: boolean;
@@ -49,15 +50,14 @@ export function UnassignCohortDevicesDialog({
 }: UnassignCohortDevicesDialogProps) {
   const { cohorts } = useCohorts();
   const { showBanner } = useBanner();
+  const { showDeferredBanner } = useDeferredBanner();
   const { mutate: unassignDevices, isPending: isUnassigning } = useUnassignDevicesFromCohort({
     onSuccess: (variables) => {
-      setTimeout(() => {
-        showBanner({
-          severity: 'success',
-          message: `${variables.device_ids.length} device(s) removed from cohort successfully`,
-          scoped: false,
-        });
-      }, 100);
+      showDeferredBanner({
+        severity: 'success',
+        message: `${variables.device_ids.length} device(s) removed from cohort successfully`,
+        scoped: false,
+      });
     },
     onError: (error) => {
       showBanner({

--- a/src/vertex/components/features/cohorts/unassign-cohort-devices.tsx
+++ b/src/vertex/components/features/cohorts/unassign-cohort-devices.tsx
@@ -20,7 +20,7 @@ import ReusableDialog from "@/components/shared/dialog/ReusableDialog";
 import { Device } from "@/app/types/devices";
 import { useBanner } from "@/context/banner-context";
 import { getApiErrorMessage } from "@/core/utils/getApiErrorMessage";
-import { useDeferredBanner } from "@/core/hooks/useDeferredBanner";
+import { useBannerWithDelay } from "@/core/hooks/useBannerWithDelay";
 
 interface UnassignCohortDevicesDialogProps {
   open: boolean;
@@ -50,10 +50,10 @@ export function UnassignCohortDevicesDialog({
 }: UnassignCohortDevicesDialogProps) {
   const { cohorts } = useCohorts();
   const { showBanner } = useBanner();
-  const { showDeferredBanner } = useDeferredBanner();
+  const { showBannerWithDelay } = useBannerWithDelay();
   const { mutate: unassignDevices, isPending: isUnassigning } = useUnassignDevicesFromCohort({
     onSuccess: (variables) => {
-      showDeferredBanner({
+      showBannerWithDelay({
         severity: 'success',
         message: `${variables.device_ids.length} device(s) removed from cohort successfully`,
         scoped: false,

--- a/src/vertex/components/features/cohorts/unassign-cohort-devices.tsx
+++ b/src/vertex/components/features/cohorts/unassign-cohort-devices.tsx
@@ -18,6 +18,8 @@ import { MultiSelectCombobox, Option } from "@/components/ui/multi-select";
 import { Cohort } from "@/app/types/cohorts";
 import ReusableDialog from "@/components/shared/dialog/ReusableDialog";
 import { Device } from "@/app/types/devices";
+import { useBanner } from "@/context/banner-context";
+import { getApiErrorMessage } from "@/core/utils/getApiErrorMessage";
 
 interface UnassignCohortDevicesDialogProps {
   open: boolean;
@@ -46,7 +48,25 @@ export function UnassignCohortDevicesDialog({
   cohortDevices = [],
 }: UnassignCohortDevicesDialogProps) {
   const { cohorts } = useCohorts();
-  const { mutate: unassignDevices, isPending: isUnassigning } = useUnassignDevicesFromCohort();
+  const { showBanner } = useBanner();
+  const { mutate: unassignDevices, isPending: isUnassigning } = useUnassignDevicesFromCohort({
+    onSuccess: (variables) => {
+      setTimeout(() => {
+        showBanner({
+          severity: 'success',
+          message: `${variables.device_ids.length} device(s) removed from cohort successfully`,
+          scoped: false,
+        });
+      }, 100);
+    },
+    onError: (error) => {
+      showBanner({
+        severity: 'error',
+        message: `Failed to remove devices: ${getApiErrorMessage(error)}`,
+        scoped: true,
+      });
+    },
+  });
 
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),

--- a/src/vertex/components/features/devices/add-maintenance-log-modal.tsx
+++ b/src/vertex/components/features/devices/add-maintenance-log-modal.tsx
@@ -10,6 +10,7 @@ import { MultiSelectCombobox } from "@/components/ui/multi-select";
 import { Switch } from "@/components/ui/switch";
 import ReusableDialog from "@/components/shared/dialog/ReusableDialog";
 import { useBanner } from "@/context/banner-context";
+import { useBannerWithDelay } from "@/core/hooks/useBannerWithDelay";
 import { getApiErrorMessage } from "@/core/utils/getApiErrorMessage";
 
 interface AddMaintenanceLogModalProps {
@@ -53,6 +54,7 @@ const AddMaintenanceLogModal: React.FC<AddMaintenanceLogModalProps> = ({ open, o
 
   const { userDetails } = useUserContext();
   const { showBanner } = useBanner();
+  const { showBannerWithDelay } = useBannerWithDelay();
   const addMaintenanceLog = useAddMaintenanceLog();
 
   // Reset form when modal opens/closes
@@ -85,13 +87,11 @@ const AddMaintenanceLogModal: React.FC<AddMaintenanceLogModalProps> = ({ open, o
 
     try {
       await addMaintenanceLog.mutateAsync({ deviceName, logData });
-      setTimeout(() => {
-        showBanner({
-          severity: 'success',
-          title: 'Success',
-          message: `Maintenance log for ${deviceName} has been added successfully.`,
-          scoped: false
-        });
+      showBannerWithDelay({
+        severity: 'success',
+        title: 'Success',
+        message: `Maintenance log for ${deviceName} has been added successfully.`,
+        scoped: false
       }, 300);
       onOpenChange(false);
     } catch (error) {

--- a/src/vertex/components/features/devices/create-device-modal.tsx
+++ b/src/vertex/components/features/devices/create-device-modal.tsx
@@ -11,6 +11,7 @@ import { MultiSelectCombobox } from "@/components/ui/multi-select";
 import { DEFAULT_DEVICE_TAGS } from "@/core/constants/devices";
 import { Label } from "@/components/ui/label";
 import { useBanner } from "@/context/banner-context";
+import { useBannerWithDelay } from "@/core/hooks/useBannerWithDelay";
 import { getApiErrorMessage } from "@/core/utils/getApiErrorMessage";
 
 interface CreateDeviceModalProps {
@@ -33,6 +34,7 @@ const CreateDeviceModal: React.FC<CreateDeviceModalProps> = ({
 
   const [errors, setErrors] = useState<Record<string, string>>({});
   const { showBanner } = useBanner();
+  const { showBannerWithDelay } = useBannerWithDelay();
   const activeNetwork = useAppSelector((state) => state.user.activeNetwork);
   const createDevice = useCreateDevice();
 
@@ -72,13 +74,11 @@ const CreateDeviceModal: React.FC<CreateDeviceModalProps> = ({
         tags: formData.tags,
       }, {
         onSuccess: (data, variables) => {
-          setTimeout(() => {
-            showBanner({
-              severity: 'success',
-              title: 'Success',
-              message: `${variables.long_name.trim()} has been created successfully.`,
-              scoped: false
-            });
+          showBannerWithDelay({
+            severity: 'success',
+            title: 'Success',
+            message: `${variables.long_name.trim()} has been created successfully.`,
+            scoped: false
           }, 300);
           setFormData({ long_name: "", category: "", description: "", tags: [] });
           setErrors({});

--- a/src/vertex/components/features/devices/deploy-device-component.tsx
+++ b/src/vertex/components/features/devices/deploy-device-component.tsx
@@ -27,6 +27,7 @@ import { useDeviceDetails, useDevices, useDeployDevice } from "@/core/hooks/useD
 import { ComboBox } from "@/components/ui/combobox";
 import { Device, type DevicePreviousSite } from "@/app/types/devices";
 import { useBanner } from "@/context/banner-context";
+import { useBannerWithDelay } from "@/core/hooks/useBannerWithDelay";
 import { getApiErrorMessage } from "@/core/utils/getApiErrorMessage";
 import LocationAutocomplete from "@/components/features/location-autocomplete/LocationAutocomplete";
 import { useNetworks } from "@/core/hooks/useNetworks";
@@ -429,6 +430,7 @@ const DeployDeviceComponent = ({
 }: DeployDeviceComponentProps) => {
   const queryClient = useQueryClient();
   const { showBanner } = useBanner();
+  const { showBannerWithDelay } = useBannerWithDelay();
   const { userScope, userDetails } = useUserContext();
   const { devices: allDevices } = useDevices({ enabled: userScope !== 'personal' });
   const [currentStep, setCurrentStep] = React.useState<number>(0);
@@ -679,13 +681,11 @@ const DeployDeviceComponent = ({
             queryClient.invalidateQueries({ queryKey: ["device-details", prefilledDevice._id] });
           }
 
-          setTimeout(() => {
-            showBanner({
-              severity: 'success',
-              title: 'Success',
-              message: `${deviceData.deviceName} has been deployed successfully.`,
-              scoped: false
-            });
+          showBannerWithDelay({
+            severity: 'success',
+            title: 'Success',
+            message: `${deviceData.deviceName} has been deployed successfully.`,
+            scoped: false
           }, 300);
 
           setDeviceData({

--- a/src/vertex/components/features/devices/device-assignment-modal.tsx
+++ b/src/vertex/components/features/devices/device-assignment-modal.tsx
@@ -14,6 +14,7 @@ import { useAppSelector } from "@/core/redux/hooks";
 import { Device } from "@/app/types/devices";
 import { useAssignDeviceToOrganization } from "@/core/hooks/useDevices";
 import { useBanner } from "@/context/banner-context";
+import { useBannerWithDelay } from "@/core/hooks/useBannerWithDelay";
 import { getApiErrorMessage } from "@/core/utils/getApiErrorMessage";
 import { Label } from "@/components/ui/label";
 import { ComboBox } from "@/components/ui/combobox";
@@ -48,6 +49,7 @@ const DeviceAssignmentModal: React.FC<DeviceAssignmentModalProps> = ({
 
   const assignDevice = useAssignDeviceToOrganization();
   const { showBanner } = useBanner();
+  const { showBannerWithDelay } = useBannerWithDelay();
 
   const handleAssign = async () => {
     if (!selectedOrganization || !selectedDevice || !userDetails?._id) return;
@@ -58,12 +60,10 @@ const DeviceAssignmentModal: React.FC<DeviceAssignmentModalProps> = ({
         organization_id: selectedOrganization,
         user_id: userDetails._id,
       });
-      setTimeout(() => {
-        showBanner({
-          severity: 'success',
-          title: 'Success',
-          message: `${data.device.name} has been assigned successfully.`,
-        });
+      showBannerWithDelay({
+        severity: 'success',
+        title: 'Success',
+        message: `${data.device.name} has been assigned successfully.`,
       }, 300);
       onSuccess();
     } catch (error) {

--- a/src/vertex/components/features/devices/import-device-modal.tsx
+++ b/src/vertex/components/features/devices/import-device-modal.tsx
@@ -15,6 +15,7 @@ import { useAppSelector } from "@/core/redux/hooks";
 import { usePathname } from "next/navigation";
 import logger from "@/lib/logger";
 import { useBanner } from "@/context/banner-context";
+import { useBannerWithDelay } from "@/core/hooks/useBannerWithDelay";
 import { NetworkRequestDialog } from "../networks/network-request-dialog";
 import { MultiSelectCombobox } from "@/components/ui/multi-select";
 import ReusableFileUpload from "@/components/shared/fileupload/ReusableFileUpload";
@@ -71,6 +72,7 @@ const ImportDeviceModal: React.FC<ImportDeviceModalProps> = ({
   const [previewMode, setPreviewMode] = useState(false);
   const [transformedPreview, setTransformedPreview] = useState<Record<string, string | string[] | number | undefined>[]>([]);
   const { showBanner, hideBanner } = useBanner();
+  const { showBannerWithDelay } = useBannerWithDelay();
   const importDevice = useImportDevice();
   const bulkImport = useBulkImportDevices();
   const { networks, isLoading: isLoadingNetworks } = useNetworks();
@@ -311,13 +313,11 @@ const ImportDeviceModal: React.FC<ImportDeviceModalProps> = ({
       {
         onSuccess: (data, variables) => {
           onOpenChange(false);
-          setTimeout(() => {
-            showBanner({
-              severity: 'success',
-              title: 'Success',
-              message: `${variables.long_name.trim()} has been imported successfully.`,
-              scoped: false
-            });
+          showBannerWithDelay({
+            severity: 'success',
+            title: 'Success',
+            message: `${variables.long_name.trim()} has been imported successfully.`,
+            scoped: false
           }, 300);
         },
         onError: (error) => {
@@ -350,13 +350,11 @@ const ImportDeviceModal: React.FC<ImportDeviceModalProps> = ({
         onSuccess: (data) => {
           if (data.failed === 0) {
             onOpenChange(false);
-            setTimeout(() => {
-              showBanner({
-                severity: 'success',
-                title: 'Success',
-                message: `${data.imported} device(s) imported successfully.`,
-                scoped: false,
-              });
+            showBannerWithDelay({
+              severity: 'success',
+              title: 'Success',
+              message: `${data.imported} device(s) imported successfully.`,
+              scoped: false,
             }, 300);
           } else {
             if (data.imported === 0) {

--- a/src/vertex/components/features/devices/recall-device-dialog.tsx
+++ b/src/vertex/components/features/devices/recall-device-dialog.tsx
@@ -6,6 +6,7 @@ import ReusableSelectInput from "@/components/shared/select/ReusableSelectInput"
 import { useRecallDevice } from "@/core/hooks/useDevices";
 import { useUserContext } from "@/core/hooks/useUserContext";
 import { useBanner } from "@/context/banner-context";
+import { useBannerWithDelay } from "@/core/hooks/useBannerWithDelay";
 import { getApiErrorMessage } from "@/core/utils/getApiErrorMessage";
 
 interface RecallDeviceDialogProps {
@@ -30,6 +31,7 @@ export default function RecallDeviceDialog({
   const recallDevice = useRecallDevice();
   const { userDetails } = useUserContext();
   const { showBanner } = useBanner();
+  const { showBannerWithDelay } = useBannerWithDelay();
 
   const handleRecall = async () => {
     if (!recallType || !userDetails?._id) {
@@ -49,13 +51,11 @@ export default function RecallDeviceDialog({
           userName: userDetails.userName,
         },
       });
-      setTimeout(() => {
-        showBanner({
-          severity: 'success',
-          title: 'Success',
-          message: `${deviceDisplayName || deviceName} has been recalled successfully.`,
-          scoped: false
-        });
+      showBannerWithDelay({
+        severity: 'success',
+        title: 'Success',
+        message: `${deviceDisplayName || deviceName} has been recalled successfully.`,
+        scoped: false
       }, 300);
       setRecallType("");
       onOpenChange(false);

--- a/src/vertex/components/features/grids/create-admin-level.tsx
+++ b/src/vertex/components/features/grids/create-admin-level.tsx
@@ -19,7 +19,7 @@ import {
 import { AdminLevelsModal } from "./admin-levels-modal";
 import { useBanner } from "@/context/banner-context";
 import { getApiErrorMessage } from "@/core/utils/getApiErrorMessage";
-import { useDeferredBanner } from "@/core/hooks/useDeferredBanner";
+import { useBannerWithDelay } from "@/core/hooks/useBannerWithDelay";
 
 const adminLevelFormSchema = z.object({
   name: z.string().min(2, {
@@ -33,7 +33,7 @@ export function CreateAdminLevel() {
   const [open, setOpen] = useState(false);
   const [viewModalOpen, setViewModalOpen] = useState(false);
   const { showBanner } = useBanner();
-  const { showDeferredBanner } = useDeferredBanner();
+  const { showBannerWithDelay } = useBannerWithDelay();
 
   const form = useForm<AdminLevelFormValues>({
     resolver: zodResolver(adminLevelFormSchema),
@@ -50,7 +50,7 @@ export function CreateAdminLevel() {
   const { createAdminLevel, isLoading } = useCreateAdminLevel({
     onSuccess: () => {
       handleClose();
-      showDeferredBanner({ message: "Admin level created successfully", severity: "success", scoped: false });
+      showBannerWithDelay({ message: "Admin level created successfully", severity: "success", scoped: false });
     },
     onError: (error) => {
       showBanner({

--- a/src/vertex/components/features/grids/create-grid.tsx
+++ b/src/vertex/components/features/grids/create-grid.tsx
@@ -17,7 +17,7 @@ import { useNetworks } from "@/core/hooks/useNetworks";
 import ReusableSelectInput from "@/components/shared/select/ReusableSelectInput";
 import { useBanner } from "@/context/banner-context";
 import { getApiErrorMessage } from "@/core/utils/getApiErrorMessage";
-import { useDeferredBanner } from "@/core/hooks/useDeferredBanner";
+import { useBannerWithDelay } from "@/core/hooks/useBannerWithDelay";
 
 // Lazy load MiniMap to reduce initial bundle size
 const MiniMap = dynamic(() => import("@/components/features/mini-map/mini-map"), {
@@ -62,7 +62,7 @@ export function CreateGridForm() {
   const [open, setOpen] = useState(false);
   const polygon = useAppSelector((state) => state.grids.polygon);
   const { showBanner } = useBanner();
-  const { showDeferredBanner } = useDeferredBanner();
+  const { showBannerWithDelay } = useBannerWithDelay();
 
   const { networks, isLoading: isLoadingNetworks } = useNetworks();
 
@@ -84,7 +84,7 @@ export function CreateGridForm() {
   const { createGrid, isLoading } = useCreateGrid({
     onSuccess: () => {
       handleClose();
-      showDeferredBanner({ message: `New grid added!`, severity: "success", scoped: false });
+      showBannerWithDelay({ message: `New grid added!`, severity: "success", scoped: false });
     },
     onError: (error) => {
       showBanner({

--- a/src/vertex/components/features/grids/edit-grid-details-dialog.tsx
+++ b/src/vertex/components/features/grids/edit-grid-details-dialog.tsx
@@ -8,7 +8,7 @@ import { PERMISSIONS } from "@/core/permissions/constants";
 import { Grid } from "@/app/types/grids";
 import { useBanner } from "@/context/banner-context";
 import { getApiErrorMessage } from "@/core/utils/getApiErrorMessage";
-import { useDeferredBanner } from "@/core/hooks/useDeferredBanner";
+import { useBannerWithDelay } from "@/core/hooks/useBannerWithDelay";
 
 interface EditGridDetailsDialogProps {
     open: boolean;
@@ -23,12 +23,12 @@ const EditGridDetailsDialog: React.FC<EditGridDetailsDialogProps> = ({
 }) => {
     const [form, setForm] = useState({ name: "", visibility: false, admin_level: "" });
     const { showBanner } = useBanner();
-    const { showDeferredBanner } = useDeferredBanner();
+    const { showBannerWithDelay } = useBannerWithDelay();
 
     const { updateGridDetails, isLoading } = useUpdateGridDetails(grid._id, {
         onSuccess: () => {
             onClose();
-            showDeferredBanner({ message: "Grid details updated successfully", severity: "success", scoped: false });
+            showBannerWithDelay({ message: "Grid details updated successfully", severity: "success", scoped: false });
         },
         onError: (error) => {
             showBanner({

--- a/src/vertex/core/hooks/useBannerWithDelay.ts
+++ b/src/vertex/core/hooks/useBannerWithDelay.ts
@@ -12,11 +12,11 @@ export const useBannerWithDelay = () => {
     };
   }, []);
 
-  const showBannerWithDelay = (options: ShowBannerOptions) => {
+  const showBannerWithDelay = (options: ShowBannerOptions, delay: number = AFTER_DIALOG_CLOSE_MS) => {
     if (timerRef.current) clearTimeout(timerRef.current);
     timerRef.current = setTimeout(() => {
       showBanner(options);
-    }, AFTER_DIALOG_CLOSE_MS);
+    }, delay);
   };
 
   return { showBannerWithDelay };

--- a/src/vertex/core/hooks/useBannerWithDelay.ts
+++ b/src/vertex/core/hooks/useBannerWithDelay.ts
@@ -2,7 +2,7 @@ import { useEffect, useRef } from 'react';
 import { useBanner, type ShowBannerOptions } from '@/context/banner-context';
 import { AFTER_DIALOG_CLOSE_MS } from '@/core/constants/ui';
 
-export const useDeferredBanner = () => {
+export const useBannerWithDelay = () => {
   const { showBanner } = useBanner();
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -12,12 +12,12 @@ export const useDeferredBanner = () => {
     };
   }, []);
 
-  const showDeferredBanner = (options: ShowBannerOptions) => {
+  const showBannerWithDelay = (options: ShowBannerOptions) => {
     if (timerRef.current) clearTimeout(timerRef.current);
     timerRef.current = setTimeout(() => {
       showBanner(options);
     }, AFTER_DIALOG_CLOSE_MS);
   };
 
-  return { showDeferredBanner };
+  return { showBannerWithDelay };
 };

--- a/src/vertex/core/hooks/useCohorts.ts
+++ b/src/vertex/core/hooks/useCohorts.ts
@@ -4,13 +4,11 @@ import {
   cohorts as cohortsApi,
 } from '../apis/cohorts';
 import { useAppSelector } from '../redux/hooks';
-import ReusableToast from '@/components/shared/toast/ReusableToast';
-import { getApiErrorMessage } from '../utils/getApiErrorMessage';
 import { AxiosError } from 'axios';
 import {
+  Cohort,
   CohortsSummaryResponse,
   GroupCohortsResponse,
-  OriginalCohortResponse,
 } from '@/app/types/cohorts';
 
 interface ErrorResponse {
@@ -145,7 +143,12 @@ export const useCohortDetails = (
   });
 };
 
-export const useUpdateCohortDetails = () => {
+interface UseUpdateCohortDetailsOptions {
+  onSuccess?: () => void;
+  onError?: (error: AxiosError) => void;
+}
+
+export const useUpdateCohortDetails = (options?: UseUpdateCohortDetailsOptions) => {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: ({
@@ -155,28 +158,27 @@ export const useUpdateCohortDetails = () => {
       cohortId: string;
       data: Partial<{ name: string; visibility: boolean; cohort_tags: string[] }>;
     }) => cohortsApi.updateCohortDetailsApi(cohortId, data),
-    onSuccess: (data, variables) => {
-      ReusableToast({
-        message: 'Cohort details updated successfully',
-        type: 'SUCCESS',
-      });
+    onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({
         queryKey: ['cohort-details', variables.cohortId],
       });
       queryClient.invalidateQueries({ queryKey: ['cohorts'] });
       queryClient.invalidateQueries({ queryKey: ['user-cohorts'] });
       queryClient.invalidateQueries({ queryKey: ['groupCohorts'] });
+      options?.onSuccess?.();
     },
-    onError: error => {
-      ReusableToast({
-        message: `Failed to update cohort: ${getApiErrorMessage(error)}`,
-        type: 'ERROR',
-      });
+    onError: (error: AxiosError) => {
+      options?.onError?.(error);
     },
   });
 };
 
-export const useUpdateCohortName = () => {
+interface UseUpdateCohortNameOptions {
+  onSuccess?: () => void;
+  onError?: (error: AxiosError) => void;
+}
+
+export const useUpdateCohortName = (options?: UseUpdateCohortNameOptions) => {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: ({
@@ -193,27 +195,26 @@ export const useUpdateCohortName = () => {
         confirm_update: true,
         update_reason: updateReason,
       }),
-    onSuccess: (data, variables) => {
-      ReusableToast({
-        message: 'Cohort name updated successfully',
-        type: 'SUCCESS',
-      });
+    onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({
         queryKey: ['cohort-details', variables.cohortId],
       });
       queryClient.invalidateQueries({ queryKey: ['cohorts'] });
       queryClient.invalidateQueries({ queryKey: ['user-cohorts'] });
+      options?.onSuccess?.();
     },
-    onError: error => {
-      ReusableToast({
-        message: `Failed to update cohort name: ${getApiErrorMessage(error)}`,
-        type: 'ERROR',
-      });
+    onError: (error: AxiosError) => {
+      options?.onError?.(error);
     },
   });
 };
 
-export const useCreateCohort = () => {
+interface UseCreateCohortOptions {
+    onSuccess?: (data: { success: boolean; message: string; cohort: Cohort }) => void;
+    onError?: (error: AxiosError) => void;
+}
+
+export const useCreateCohort = (options?: UseCreateCohortOptions) => {
     const queryClient = useQueryClient();
     return useMutation({
         mutationFn: async ({
@@ -230,24 +231,23 @@ export const useCreateCohort = () => {
             if (!cohortId) throw new Error('Cohort created but missing id');
             return createResp;
         },
-        onSuccess: (resp, variables) => {
-            ReusableToast({
-                message: `${variables.name} created`,
-                type: 'SUCCESS',
-            });
+        onSuccess: (data) => {
             queryClient.invalidateQueries({ queryKey: ['cohorts'] });
             queryClient.invalidateQueries({ queryKey: ['user-cohorts'] });
+            options?.onSuccess?.(data);
         },
-        onError: error => {
-            ReusableToast({
-                message: `Failed to create cohort: ${getApiErrorMessage(error)}`,
-                type: 'ERROR',
-            });
+        onError: (error: AxiosError) => {
+            options?.onError?.(error);
         },
     });
 }
 
-export const useCreateCohortWithDevices = () => {
+interface UseCreateCohortWithDevicesOptions {
+  onSuccess?: (data: { success: boolean; message: string; cohort: Cohort }) => void;
+  onError?: (error: AxiosError) => void;
+}
+
+export const useCreateCohortWithDevices = (options?: UseCreateCohortWithDevicesOptions) => {
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -270,24 +270,23 @@ export const useCreateCohortWithDevices = () => {
       }
       return createResp;
     },
-    onSuccess: (resp, variables) => {
-      ReusableToast({
-        message: `${variables.name} created`,
-        type: 'SUCCESS',
-      });
+    onSuccess: (data) => {
       queryClient.invalidateQueries({ queryKey: ['cohorts'] });
       queryClient.invalidateQueries({ queryKey: ['user-cohorts'] });
+      options?.onSuccess?.(data);
     },
-    onError: error => {
-      ReusableToast({
-        message: `Failed to create cohort: ${getApiErrorMessage(error)}`,
-        type: 'ERROR',
-      });
+    onError: (error: AxiosError) => {
+      options?.onError?.(error);
     },
   });
 };
 
-export const useCreateCohortFromCohorts = () => {
+interface UseCreateCohortFromCohortsOptions {
+  onSuccess?: (data: { success: boolean; message: string; data: Cohort }) => void;
+  onError?: (error: AxiosError) => void;
+}
+
+export const useCreateCohortFromCohorts = (options?: UseCreateCohortFromCohortsOptions) => {
   const queryClient = useQueryClient();
   const activeNetwork = useAppSelector(state => state.user.activeNetwork);
 
@@ -312,26 +311,25 @@ export const useCreateCohortFromCohorts = () => {
         network,
         cohort_tags,
       }),
-    onSuccess: (data, variables) => {
-      ReusableToast({
-        message: `Cohort '${variables.name}' created successfully.`,
-        type: 'SUCCESS',
-      });
+    onSuccess: (data) => {
       queryClient.invalidateQueries({
         queryKey: ['cohorts', activeNetwork?.net_name],
       });
       queryClient.invalidateQueries({ queryKey: ['user-cohorts'] });
+      options?.onSuccess?.(data);
     },
-    onError: error => {
-      ReusableToast({
-        message: `Failed to create from cohorts: ${getApiErrorMessage(error)}`,
-        type: 'ERROR',
-      });
+    onError: (error: AxiosError) => {
+      options?.onError?.(error);
     },
   });
 };
 
-export const useAssignDevicesToCohort = () => {
+interface UseAssignDevicesToCohortOptions {
+  onSuccess?: (variables: { cohortId: string; deviceIds: string[] }) => void;
+  onError?: (error: AxiosError) => void;
+}
+
+export const useAssignDevicesToCohort = (options?: UseAssignDevicesToCohortOptions) => {
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -347,28 +345,27 @@ export const useAssignDevicesToCohort = () => {
       }
       return cohortsApi.assignDevicesToCohort(cohortId, deviceIds);
     },
-    onSuccess: (data, variables) => {
-      ReusableToast({
-        message: `${variables.deviceIds.length} device(s) assigned to cohort successfully`,
-        type: 'SUCCESS',
-      });
+    onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({ queryKey: ['cohorts'] });
       queryClient.invalidateQueries({ queryKey: ['user-cohorts'] });
       queryClient.invalidateQueries({ queryKey: ['devices'], exact: false });
       queryClient.invalidateQueries({
         queryKey: ['cohort-details', variables.cohortId],
       });
+      options?.onSuccess?.(variables);
     },
-    onError: error => {
-      ReusableToast({
-        message: `Failed to assign devices: ${getApiErrorMessage(error)}`,
-        type: 'ERROR',
-      });
+    onError: (error: AxiosError) => {
+      options?.onError?.(error);
     },
   });
 };
 
-export const useUnassignDevicesFromCohort = () => {
+interface UseUnassignDevicesFromCohortOptions {
+  onSuccess?: (variables: { cohortId: string; device_ids: string[] }) => void;
+  onError?: (error: AxiosError) => void;
+}
+
+export const useUnassignDevicesFromCohort = (options?: UseUnassignDevicesFromCohortOptions) => {
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -384,28 +381,27 @@ export const useUnassignDevicesFromCohort = () => {
       }
       return cohortsApi.unassignDevicesFromCohort({ cohortId, device_ids });
     },
-    onSuccess: (data, variables) => {
-      ReusableToast({
-        message: `${variables.device_ids.length} device(s) unassigned from cohort successfully`,
-        type: 'SUCCESS',
-      });
+    onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({ queryKey: ['cohorts'] });
       queryClient.invalidateQueries({ queryKey: ['user-cohorts'] });
       queryClient.invalidateQueries({ queryKey: ['devices'], exact: false });
       queryClient.invalidateQueries({
         queryKey: ['cohort-details', variables.cohortId],
       });
+      options?.onSuccess?.(variables);
     },
-    onError: error => {
-      ReusableToast({
-        message: `Failed to unassign devices: ${getApiErrorMessage(error)}`,
-        type: 'ERROR',
-      });
+    onError: (error: AxiosError) => {
+      options?.onError?.(error);
     },
   });
 };
 
-export const useAssignCohortsToGroup = () => {
+interface UseAssignCohortsToGroupOptions {
+  onSuccess?: () => void;
+  onError?: (error: AxiosError) => void;
+}
+
+export const useAssignCohortsToGroup = (options?: UseAssignCohortsToGroupOptions) => {
   const queryClient = useQueryClient();
   const activeNetwork = useAppSelector(state => state.user.activeNetwork);
 
@@ -425,7 +421,7 @@ export const useAssignCohortsToGroup = () => {
       }
       return cohortsApi.assignCohortsToGroup(groupId, cohortIds);
     },
-    onSuccess: (data, variables) => {
+    onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: ['cohorts', activeNetwork?.net_name],
       });
@@ -433,17 +429,20 @@ export const useAssignCohortsToGroup = () => {
       queryClient.invalidateQueries({ queryKey: ['deviceCount'] });
       queryClient.invalidateQueries({ queryKey: ['devices'] });
       queryClient.invalidateQueries({ queryKey: ['myDevices'] });
+      options?.onSuccess?.();
     },
-    onError: error => {
-      ReusableToast({
-        message: `Failed to assign cohorts to organization: ${getApiErrorMessage(error)}`,
-        type: 'ERROR',
-      });
+    onError: (error: AxiosError) => {
+      options?.onError?.(error);
     },
   });
 };
 
-export const useAssignCohortsToUser = () => {
+interface UseAssignCohortsToUserOptions {
+  onSuccess?: (variables: { userId: string; cohortIds: string[] }) => void;
+  onError?: (error: AxiosError) => void;
+}
+
+export const useAssignCohortsToUser = (options?: UseAssignCohortsToUserOptions) => {
   const queryClient = useQueryClient();
   const activeNetwork = useAppSelector(state => state.user.activeNetwork);
 
@@ -474,12 +473,10 @@ export const useAssignCohortsToUser = () => {
         queryKey: ['myDevices'],
       });
       queryClient.invalidateQueries({ queryKey: ['user-cohorts'] });
+      options?.onSuccess?.(variables);
     },
-    onError: error => {
-      ReusableToast({
-        message: `Failed to assign cohorts: ${getApiErrorMessage(error)}`,
-        type: 'ERROR',
-      });
+    onError: (error: AxiosError) => {
+      options?.onError?.(error);
     },
   });
 };

--- a/src/vertex/core/hooks/useCohorts.ts
+++ b/src/vertex/core/hooks/useCohorts.ts
@@ -3,7 +3,6 @@ import {
   GetCohortsSummaryParams,
   cohorts as cohortsApi,
 } from '../apis/cohorts';
-import { useAppSelector } from '../redux/hooks';
 import { AxiosError } from 'axios';
 import {
   Cohort,
@@ -288,7 +287,6 @@ interface UseCreateCohortFromCohortsOptions {
 
 export const useCreateCohortFromCohorts = (options?: UseCreateCohortFromCohortsOptions) => {
   const queryClient = useQueryClient();
-  const activeNetwork = useAppSelector(state => state.user.activeNetwork);
 
   return useMutation({
     mutationFn: ({
@@ -312,9 +310,7 @@ export const useCreateCohortFromCohorts = (options?: UseCreateCohortFromCohortsO
         cohort_tags,
       }),
     onSuccess: (data) => {
-      queryClient.invalidateQueries({
-        queryKey: ['cohorts', activeNetwork?.net_name],
-      });
+      queryClient.invalidateQueries({ queryKey: ['cohorts'] });
       queryClient.invalidateQueries({ queryKey: ['user-cohorts'] });
       options?.onSuccess?.(data);
     },
@@ -403,7 +399,6 @@ interface UseAssignCohortsToGroupOptions {
 
 export const useAssignCohortsToGroup = (options?: UseAssignCohortsToGroupOptions) => {
   const queryClient = useQueryClient();
-  const activeNetwork = useAppSelector(state => state.user.activeNetwork);
 
   return useMutation({
     mutationFn: async ({
@@ -422,9 +417,7 @@ export const useAssignCohortsToGroup = (options?: UseAssignCohortsToGroupOptions
       return cohortsApi.assignCohortsToGroup(groupId, cohortIds);
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: ['cohorts', activeNetwork?.net_name],
-      });
+      queryClient.invalidateQueries({ queryKey: ['cohorts'] });
       queryClient.invalidateQueries({ queryKey: ['groupCohorts'] });
       queryClient.invalidateQueries({ queryKey: ['deviceCount'] });
       queryClient.invalidateQueries({ queryKey: ['devices'] });
@@ -444,7 +437,6 @@ interface UseAssignCohortsToUserOptions {
 
 export const useAssignCohortsToUser = (options?: UseAssignCohortsToUserOptions) => {
   const queryClient = useQueryClient();
-  const activeNetwork = useAppSelector(state => state.user.activeNetwork);
 
   return useMutation({
     mutationFn: async ({
@@ -463,9 +455,7 @@ export const useAssignCohortsToUser = (options?: UseAssignCohortsToUserOptions) 
       return cohortsApi.assignCohortsToUser(userId, cohortIds);
     },
     onSuccess: (_data, variables) => {
-      queryClient.invalidateQueries({
-        queryKey: ['cohorts', activeNetwork?.net_name],
-      });
+      queryClient.invalidateQueries({ queryKey: ['cohorts'] });
       queryClient.invalidateQueries({
         queryKey: ['userDetails', variables.userId],
       });


### PR DESCRIPTION
#### Summary of Changes

Migrates the Cohort Management module from `ReusableToast` to the centralized `InfoBanner` system (`useBanner` hook). All user feedback is now surfaced at the component layer rather than inside hooks, following the architecture established by the Grid Management module refactor.

**Hook changes (`useCohorts.ts`)**
- Removed all `ReusableToast` calls from the hook layer
- Added optional `onSuccess`/`onError` callback options to all mutation hooks: `useCreateCohort`, `useCreateCohortWithDevices`, `useCreateCohortFromCohorts`, `useAssignDevicesToCohort`, `useUnassignDevicesFromCohort`, `useAssignCohortsToGroup`, `useAssignCohortsToUser`, `useUpdateCohortDetails`, `useUpdateCohortName`

**Component changes**
- `cohort-detail-card.tsx` — replaced toasts with scoped/global banners; switched to `mutateAsync` for visibility and tags updates
- `cohort-measurements-api-card.tsx` — replaced toast with `useBanner` for clipboard feedback
- `create-cohort.tsx` — replaced toasts with banners; consolidated `onSuccess`/`onError` to hook-level (removed unreliable per-call callbacks)
- `device-name-parser.tsx` — replaced all toast calls with scoped banners
- `edit-cohort-details-modal.tsx` — replaced toasts with banners; added `setTimeout` success banner pattern after dialog close
- `assign-cohort-devices.tsx` / `unassign-cohort-devices.tsx` — replaced toasts with `useDeferredBanner` for post-close success banners

**Shared utilities used from Grid Management PR**
- `useDeferredBanner` hook — handles timer ref, cleanup on unmount, and `AFTER_DIALOG_CLOSE_MS` delay
- `getApiErrorMessage` — now guards against empty/whitespace and raw HTML error responses

#### Status of maturity

- [x] I've tested this locally
- [x] I consider this code done
- [x] This change ready to hit production in its current state
- [x] The title of the PR states what changed and the related issues number
- [x] I've included the issue number in the "Closes #3492" section
- [x] I've updated corresponding documentation for the changes in this PR
- [ ] I have written unit and/or e2e tests for my change(s)

#### How should this be manually tested?

1. Navigate to the Cohorts section
2. **Create a cohort** — confirm success banner appears globally after the dialog closes; confirm error banner appears inside the dialog on failure
3. **Edit cohort details** (name, visibility, tags) — confirm success banner appears after dialog closes; confirm error banner appears inside dialog on failure
4. **Assign devices to a cohort** — confirm success banner appears after dialog closes
5. **Remove devices from a cohort** — confirm success banner appears after dialog closes
6. **Copy cohort ID and API URLs** — confirm success/error banners appear correctly
7. Navigate away immediately after a successful action — confirm no stale banner appears on the next page


#### What are the relevant tickets?

- Closes #3492

#### Screenshots 
<img width="1366" height="768" alt="coh1" src="https://github.com/user-attachments/assets/a6583184-d476-496c-a67d-a43ddb17445c" />
<img width="1366" height="768" alt="coh2" src="https://github.com/user-attachments/assets/6139c329-3f19-4e09-921f-3778e93b34c6" />
<img width="1366" height="768" alt="coh3" src="https://github.com/user-attachments/assets/42c4af72-4fe5-4452-ba66-e079bb606dba" />
<img width="1366" height="768" alt="coh4" src="https://github.com/user-attachments/assets/4e462889-6551-40ef-8ae3-fdc385e6a0f7" />
<img width="1366" height="768" alt="coh5" src="https://github.com/user-attachments/assets/63c441be-075e-445c-8509-d0ca59868a48" />
<img width="1366" height="768" alt="coh6" src="https://github.com/user-attachments/assets/47074293-01bb-43bf-a67d-c88c9e73c6fb" />
<img width="1366" height="768" alt="coh7" src="https://github.com/user-attachments/assets/616050fa-fe78-4d2b-b50e-9a6c73df964b" />
<img width="1366" height="768" alt="coh8" src="https://github.com/user-attachments/assets/c03afdf8-e167-4255-ac89-360ffc40620b" />
<img width="1366" height="768" alt="coh9" src="https://github.com/user-attachments/assets/50fefa9a-0e34-40f6-be3c-6a44e1fc0bd5" />
<img width="1366" height="768" alt="coh10" src="https://github.com/user-attachments/assets/ba86d066-ff95-4900-9fdd-964845986130" />
<img width="1366" height="768" alt="coh11" src="https://github.com/user-attachments/assets/a9d9a105-5b30-48ff-94d7-a9c15d43c4ca" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Cohort/grid/device flows migrated to a centralized banner notification system for consistent inline feedback.
  * Success/error messages now use banners (scoped for in-dialog errors; unscoped and delayed after dialog close for post-dialog success).
  * Clipboard copy and import flows show banner feedback instead of toasts.
  * Mutation hooks now support caller-provided success/error callbacks to coordinate UI updates.

* **Chore**
  * Added release notes entry documenting the migration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/airqo-platform/AirQo-frontend/pull/3546?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->