### PR TITLE
Device Details Modal — authRequired Field & Reset Bug Fix (vertex app)

### DIFF
--- a/src/vertex/app/changelog.md
+++ b/src/vertex/app/changelog.md
@@ -4,6 +4,30 @@
 
 ---
 
+## Version 1.23.54
+**Released:** May 28, 2026
+
+### Device Details Modal — authRequired Field & Reset Bug Fix
+
+Added `authRequired` as an editable field in the Device Details Modal and fixed a state reset bug where the field always reverted to `true` after a device data refresh.
+
+<details>
+<summary><strong>Changes (2)</strong></summary>
+
+- **authRequired Field Added**: Exposed `authRequired` as an editable `ReusableSelectInput` in the Basic Information section of the Device Details Modal, wired to the zod schema and form dirty-fields logic so it is only included in the update payload when changed.
+- **Reset Bug Fix**: Added `authRequired` to the `useEffect` form reset block that fires when the `device` prop changes. Previously the field was omitted from that reset, causing it to always revert to `true` after a successful update or device data refresh regardless of the stored value.
+
+</details>
+
+<details>
+<summary><strong>Files Updated (1)</strong></summary>
+
+- `src/vertex/components/features/devices/device-details-modal.tsx` [MODIFIED]
+
+</details>
+
+---
+
 ## Version 1.23.53
 **Released:** May 28, 2026
 

--- a/src/vertex/components/features/devices/device-details-modal.tsx
+++ b/src/vertex/components/features/devices/device-details-modal.tsx
@@ -52,6 +52,7 @@ const deviceUpdateSchema = z.object({
   createdAt: z.string().optional(),
   nextMaintenance: z.string().optional(),
   api_code: z.string().optional(),
+  authRequired: z.boolean().optional()
 });
 
 type DeviceUpdateFormData = z.infer<typeof deviceUpdateSchema>;
@@ -85,6 +86,7 @@ const DeviceDetailsModal: React.FC<DeviceDetailsModalProps> = ({ open, device, o
       powerType: device?.powerType || undefined,
       claim_status: device?.claim_status || undefined,
       api_code: device?.api_code || "",
+      authRequired: device?.authRequired ?? true,
     },
   });
 
@@ -111,6 +113,7 @@ const DeviceDetailsModal: React.FC<DeviceDetailsModalProps> = ({ open, device, o
         powerType: device.powerType || undefined,
         claim_status: device.claim_status || undefined,
         api_code: device.api_code || "",
+        authRequired: device?.authRequired ?? true,
       });
     }
   }, [device, form]);
@@ -431,6 +434,25 @@ const DeviceDetailsModal: React.FC<DeviceDetailsModalProps> = ({ open, device, o
                       placeholder="https://device.iqair.com/..."
                       {...field}
                     />
+                  )}
+                />
+              </div>
+              <div className="lg:col-span-2">
+                <FormField
+                  control={form.control}
+                  name="authRequired"
+                  render={({ field, fieldState }) => (
+                    <ReusableSelectInput
+                      label="Authentication Required"
+                      placeholder="Select authentication requirement"
+                      value={String(field.value ?? true)}
+                      onChange={(e) => field.onChange(e.target.value === 'true')}
+                      disabled={isLoading || !isEditMode}
+                      error={fieldState.error?.message}
+                    >
+                      <option value="true">True</option>
+                      <option value="false">False</option>
+                    </ReusableSelectInput>
                   )}
                 />
               </div>


### PR DESCRIPTION
### Summary
Two focused fixes to `DeviceDetailsModal`:
1. `authRequired` is now visible and editable in the Device Details Modal
2. Fixed a bug where `authRequired` always reverted to `true` after a device data refresh

---

### Changes

#### authRequired Field (`device-details-modal.tsx`)
- Added `authRequired: z.boolean().optional()` to `deviceUpdateSchema`
- Added `authRequired: device?.authRequired ?? true` to both `defaultValues` and the `useEffect` form reset that fires on device prop change
- Exposed as a `ReusableSelectInput` in the Basic Information section with `Required` / `Not Required` options
- Wired through the existing dirty-fields logic in `onSubmitLocal` and `onSubmitGlobal` — only included in the payload if the user actually changes it

#### Reset Bug Fix (`device-details-modal.tsx`)
- `authRequired` was missing from the `useEffect` reset block that fires when the `device` prop changes
- This caused the field to always fall back to the form default of `true` after a successful save or any re-fetch of device data, regardless of what was stored
- Fixed by adding `authRequired: device?.authRequired ?? true` to that reset call

---

### Files Changed
- `src/vertex/components/features/devices/device-details-modal.tsx`

#### Screenshots (optional)
<img width="1043" height="891" alt="image" src="https://github.com/user-attachments/assets/9547e6f3-bbd4-4587-a372-a0fc08ea59e3" />
