### PR TITLE
Vertex:(Migration)Update Network Management Module to use InfoBanners

### DIFF
--- a/src/vertex/app/(authenticated)/admin/networks/requests/NetworkRequestsClient.tsx
+++ b/src/vertex/app/(authenticated)/admin/networks/requests/NetworkRequestsClient.tsx
@@ -24,7 +24,7 @@ export default function NetworkRequestsClient({ initialRequests }: NetworkReques
   const router = useRouter();
   const [activeTab, setActiveTab] = useState<TabStatus>("pending");
   const [isUpdating, setIsUpdating] = useState(false);
-  const {showBanner} = useBanner();
+  const { showBanner } = useBanner();
   // Action management
   const [selectedRequest, setSelectedRequest] = useState<NetworkCreationRequest | null>(null);
   const [actionType, setActionType] = useState<'approve' | 'deny' | 'review' | null>(null);

--- a/src/vertex/app/(authenticated)/admin/networks/requests/NetworkRequestsClient.tsx
+++ b/src/vertex/app/(authenticated)/admin/networks/requests/NetworkRequestsClient.tsx
@@ -11,8 +11,8 @@ import { NetworkCreationRequest } from "@/core/apis/networks";
 import ReusableDialog from "@/components/shared/dialog/ReusableDialog";
 import ReusableInputField from "@/components/shared/inputfield/ReusableInputField";
 import ReusableButton from "@/components/shared/button/ReusableButton";
-import ReusableToast from "@/components/shared/toast/ReusableToast";
 import { getApiErrorMessage } from "@/core/utils/getApiErrorMessage";
+import { useBanner } from "@/context/banner-context";
 
 type TabStatus = "all" | "pending" | "under_review" | "approved" | "denied";
 
@@ -24,7 +24,7 @@ export default function NetworkRequestsClient({ initialRequests }: NetworkReques
   const router = useRouter();
   const [activeTab, setActiveTab] = useState<TabStatus>("pending");
   const [isUpdating, setIsUpdating] = useState(false);
-  
+  const {showBanner} = useBanner();
   // Action management
   const [selectedRequest, setSelectedRequest] = useState<NetworkCreationRequest | null>(null);
   const [actionType, setActionType] = useState<'approve' | 'deny' | 'review' | null>(null);
@@ -67,18 +67,20 @@ export default function NetworkRequestsClient({ initialRequests }: NetworkReques
         reviewer_notes: notes
       });
 
-      ReusableToast({ 
+      showBanner({ 
         message: response.data.message || 'Status updated successfully', 
-        type: 'SUCCESS' 
+        severity: 'success',
+        scoped: false 
       });
 
       setSelectedRequest(null);
       setActionType(null);
       router.refresh(); // Invalidate server data
     } catch (error: unknown) {
-      ReusableToast({ 
+      showBanner({ 
         message: `Action failed: ${getApiErrorMessage(error)}`, 
-        type: 'ERROR' 
+        severity: 'error',
+        scoped: false  
       });
     } finally {
       setIsUpdating(false);

--- a/src/vertex/app/changelog.md
+++ b/src/vertex/app/changelog.md
@@ -11,22 +11,24 @@
 Migrated user feedback in the network management feature from toast notifications to the banner system. This standardizes notifications across the networks admin area for a consistent feedback experience.
 
 <details>
-<summary><strong>Changes (4)</strong></summary>
+<summary><strong>Changes (5)</strong></summary>
 
 - **Network Requests Actions**: Replaced toast notifications with page-level banners (`scoped: false`) for approve, deny, and review status updates in `NetworkRequestsClient`.
 - **Copy ID Feedback**: Updated the "copy Sensor Manufacturer ID" action in the networks table to show success/error banners (`scoped: false`) instead of toasts.
 - **Create Network Form**: Success feedback now uses `showBannerWithDelay` so the banner appears after the dialog closes (`scoped: false`); error feedback uses an in-dialog banner (`scoped: true`).
 - **Network Request Dialog**: Submission success uses `showBannerWithDelay` (`scoped: true`) and errors use `showBanner` (`scoped: true`), replacing the previous toast calls.
+- **Banner Text Alignment Fix**: Added `text-left` to the `Banner` component's root div so banner text is always left-aligned regardless of any ancestor container that sets `text-center` (e.g. shadcn `DialogHeader`).
 
 </details>
 
 <details>
-<summary><strong>Files Updated (4)</strong></summary>
+<summary><strong>Files Updated (5)</strong></summary>
 
 - `src/vertex/app/(authenticated)/admin/networks/requests/NetworkRequestsClient.tsx` [MODIFIED]
 - `src/vertex/components/features/networks/client-paginated-networks-table.tsx` [MODIFIED]
 - `src/vertex/components/features/networks/create-network-form.tsx` [MODIFIED]
 - `src/vertex/components/features/networks/network-request-dialog.tsx` [MODIFIED]
+- `src/vertex/components/ui/banner.tsx` [MODIFIED]
 
 </details>
 

--- a/src/vertex/app/changelog.md
+++ b/src/vertex/app/changelog.md
@@ -3,6 +3,32 @@
 > **Note**: This changelog consolidates all recent improvements, features, and fixes to the AirQo Vertex frontend.
 
 ---
+## Version 1.23.56
+**Released:** May 29, 2026
+
+### Banner Notifications for Network Management
+
+Migrated user feedback in the network management feature from toast notifications to the banner system. This standardizes notifications across the networks admin area for a consistent feedback experience.
+
+<details>
+<summary><strong>Changes (4)</strong></summary>
+
+- **Network Requests Actions**: Replaced toast notifications with page-level banners (`scoped: false`) for approve, deny, and review status updates in `NetworkRequestsClient`.
+- **Copy ID Feedback**: Updated the "copy Sensor Manufacturer ID" action in the networks table to show success/error banners (`scoped: false`) instead of toasts.
+- **Create Network Form**: Success feedback now uses `showBannerWithDelay` so the banner appears after the dialog closes (`scoped: false`); error feedback uses an in-dialog banner (`scoped: true`).
+- **Network Request Dialog**: Submission success uses `showBannerWithDelay` (`scoped: true`) and errors use `showBanner` (`scoped: true`), replacing the previous toast calls.
+
+</details>
+
+<details>
+<summary><strong>Files Updated (4)</strong></summary>
+
+- `src/vertex/app/(authenticated)/admin/networks/requests/NetworkRequestsClient.tsx` [MODIFIED]
+- `src/vertex/components/features/networks/client-paginated-networks-table.tsx` [MODIFIED]
+- `src/vertex/components/features/networks/create-network-form.tsx` [MODIFIED]
+- `src/vertex/components/features/networks/network-request-dialog.tsx` [MODIFIED]
+
+</details>
 
 ## Version 1.23.55
 **Released:** May 28, 2026

--- a/src/vertex/app/changelog.md
+++ b/src/vertex/app/changelog.md
@@ -16,7 +16,7 @@ Migrated user feedback in the network management feature from toast notification
 - **Network Requests Actions**: Replaced toast notifications with page-level banners (`scoped: false`) for approve, deny, and review status updates in `NetworkRequestsClient`.
 - **Copy ID Feedback**: Updated the "copy Sensor Manufacturer ID" action in the networks table to show success/error banners (`scoped: false`) instead of toasts.
 - **Create Network Form**: Success feedback now uses `showBannerWithDelay` so the banner appears after the dialog closes (`scoped: false`); error feedback uses an in-dialog banner (`scoped: true`).
-- **Network Request Dialog**: Submission success uses `showBannerWithDelay` (`scoped: true`) and errors use `showBanner` (`scoped: true`), replacing the previous toast calls.
+- **Network Request Dialog**: Submission success and errors both use `scoped: true` to render feedback inline inside the dialog via `BannerSlot`; success additionally uses `showBannerWithDelay` to time the display correctly.
 - **Banner Text Alignment Fix**: Added `text-left` to the `Banner` component's root div so banner text is always left-aligned regardless of any ancestor container that sets `text-center` (e.g. shadcn `DialogHeader`).
 
 </details>

--- a/src/vertex/components/features/networks/client-paginated-networks-table.tsx
+++ b/src/vertex/components/features/networks/client-paginated-networks-table.tsx
@@ -26,7 +26,7 @@ export default function ClientPaginatedNetworksTable({
   onNetworkClick,
 }: NetworksTableProps) {
   const router = useRouter();
-  const {showBanner} = useBanner();
+  const { showBanner } = useBanner();
 
   const handleNetworkClick = (item: unknown) => {
     const network = item as Network;
@@ -39,9 +39,9 @@ export default function ClientPaginatedNetworksTable({
     if (text) {
       try {
         await navigator.clipboard.writeText(text);
-        showBanner({ message: "Sensor Manufacturer ID copied", severity:"success",scoped: false });
+        showBanner({ message: "Sensor Manufacturer ID copied", severity: "success", scoped: false });
       } catch {
-        showBanner({ message: "Failed to copy ID", severity: "error", scoped:false });        
+        showBanner({ message: "Failed to copy ID", severity: "error", scoped: false });
       }
     }
   };

--- a/src/vertex/components/features/networks/client-paginated-networks-table.tsx
+++ b/src/vertex/components/features/networks/client-paginated-networks-table.tsx
@@ -41,8 +41,7 @@ export default function ClientPaginatedNetworksTable({
         await navigator.clipboard.writeText(text);
         showBanner({ message: "Sensor Manufacturer ID copied", severity:"success",scoped: false });
       } catch {
-        showBanner({ message: "Failed to copy ID", severity: "error", scoped:false });
-        
+        showBanner({ message: "Failed to copy ID", severity: "error", scoped:false });        
       }
     }
   };

--- a/src/vertex/components/features/networks/client-paginated-networks-table.tsx
+++ b/src/vertex/components/features/networks/client-paginated-networks-table.tsx
@@ -6,7 +6,7 @@ import ReusableTable, {
 import { useRouter } from "next/navigation";
 import { Network } from "@/core/apis/networks";
 import { AqCopy01, AqLinkExternal01 } from "@airqo/icons-react";
-import ReusableToast from "@/components/shared/toast/ReusableToast";
+import { useBanner } from "@/context/banner-context";
 
 interface NetworksTableProps {
   networks: Network[];
@@ -26,6 +26,7 @@ export default function ClientPaginatedNetworksTable({
   onNetworkClick,
 }: NetworksTableProps) {
   const router = useRouter();
+  const {showBanner} = useBanner();
 
   const handleNetworkClick = (item: unknown) => {
     const network = item as Network;
@@ -38,9 +39,10 @@ export default function ClientPaginatedNetworksTable({
     if (text) {
       try {
         await navigator.clipboard.writeText(text);
-        ReusableToast({ message: "Sensor Manufacturer ID copied", type: "SUCCESS" });
+        showBanner({ message: "Sensor Manufacturer ID copied", severity:"success",scoped: false });
       } catch {
-        ReusableToast({ message: "Failed to copy ID", type: "ERROR" });
+        showBanner({ message: "Failed to copy ID", severity: "error", scoped:false });
+        
       }
     }
   };

--- a/src/vertex/components/features/networks/create-network-form.tsx
+++ b/src/vertex/components/features/networks/create-network-form.tsx
@@ -20,8 +20,8 @@ export function CreateNetworkForm() {
     const [open, setOpen] = useState(false);
     const [isPending, setIsPending] = useState(false);
     const queryClient = useQueryClient();
-    const {showBanner} = useBanner();
-    const {showBannerWithDelay} = useBannerWithDelay();
+    const { showBanner } = useBanner();
+    const { showBannerWithDelay } = useBannerWithDelay();
     const form = useForm<NetworkFormValues>({
         resolver: zodResolver(networkFormSchema),
         defaultValues: {
@@ -52,15 +52,15 @@ export function CreateNetworkForm() {
                 });                         
                 queryClient.invalidateQueries({ queryKey: ["networks"] });
                 handleClose();
-                showBannerWithDelay({severity:'success',message:'Sensor Manufacturer created successfully!',scoped:false});
+                showBannerWithDelay({ severity: 'success', message: 'Sensor Manufacturer created successfully!', scoped: false });
             } catch (error: unknown) {
                 const errorMessage = getApiErrorMessage(error);                
-                showBanner({severity:'error',message:errorMessage,scoped:true})
+                showBanner({ severity: 'error', message: errorMessage, scoped: true });
             } finally {
                 setIsPending(false);
             }
         },
-        [handleClose,queryClient,showBanner,showBannerWithDelay]
+        [handleClose, queryClient, showBanner, showBannerWithDelay]
     );
 
     return (

--- a/src/vertex/components/features/networks/create-network-form.tsx
+++ b/src/vertex/components/features/networks/create-network-form.tsx
@@ -20,8 +20,8 @@ export function CreateNetworkForm() {
     const [open, setOpen] = useState(false);
     const [isPending, setIsPending] = useState(false);
     const queryClient = useQueryClient();
-    const {showBanner}=useBanner();
-    const {showBannerWithDelay}=useBannerWithDelay();
+    const {showBanner} = useBanner();
+    const {showBannerWithDelay} = useBannerWithDelay();
     const form = useForm<NetworkFormValues>({
         resolver: zodResolver(networkFormSchema),
         defaultValues: {

--- a/src/vertex/components/features/networks/create-network-form.tsx
+++ b/src/vertex/components/features/networks/create-network-form.tsx
@@ -9,18 +9,19 @@ import { Form, FormField } from "@/components/ui/form";
 import ReusableDialog from "@/components/shared/dialog/ReusableDialog";
 import ReusableInputField from "@/components/shared/inputfield/ReusableInputField";
 import ReusableButton from "@/components/shared/button/ReusableButton";
-import ReusableToast from "@/components/shared/toast/ReusableToast";
 import { AqPlus } from "@airqo/icons-react";
 import { getApiErrorMessage } from "@/core/utils/getApiErrorMessage";
 import ReusableSelectInput from "@/components/shared/select/ReusableSelectInput";
-
+import { useBanner } from "@/context/banner-context";
+import { useBannerWithDelay } from "@/core/hooks/useBannerWithDelay";
 import { networkFormSchema, NetworkFormValues } from "./schema";
 
 export function CreateNetworkForm() {
     const [open, setOpen] = useState(false);
     const [isPending, setIsPending] = useState(false);
     const queryClient = useQueryClient();
-
+    const {showBanner}=useBanner();
+    const {showBannerWithDelay}=useBannerWithDelay();
     const form = useForm<NetworkFormValues>({
         resolver: zodResolver(networkFormSchema),
         defaultValues: {
@@ -48,19 +49,18 @@ export function CreateNetworkForm() {
             try {
                 await axios.post('/api/network', values, {
                     headers: { 'Content-Type': 'application/json' },
-                });
-
-                ReusableToast({ message: 'Sensor Manufacturer created successfully!', type: 'SUCCESS' });
+                });                         
                 queryClient.invalidateQueries({ queryKey: ["networks"] });
                 handleClose();
+                showBannerWithDelay({severity:'success',message:'Sensor Manufacturer created successfully!',scoped:false});
             } catch (error: unknown) {
-                const errorMessage = getApiErrorMessage(error);
-                ReusableToast({ message: errorMessage, type: 'ERROR' });
+                const errorMessage = getApiErrorMessage(error);                
+                showBanner({severity:'error',message:errorMessage,scoped:true})
             } finally {
                 setIsPending(false);
             }
         },
-        [handleClose, queryClient]
+        [handleClose,queryClient,showBanner,showBannerWithDelay]
     );
 
     return (

--- a/src/vertex/components/features/networks/network-request-dialog.tsx
+++ b/src/vertex/components/features/networks/network-request-dialog.tsx
@@ -9,17 +9,20 @@ import ReusableDialog from "@/components/shared/dialog/ReusableDialog";
 import ReusableInputField from "@/components/shared/inputfield/ReusableInputField";
 import { networkRequestSchema, NetworkRequestValues } from "./schema";
 import { useAppSelector } from "@/core/redux/hooks";
-import ReusableToast from "@/components/shared/toast/ReusableToast";
 import { getApiErrorMessage } from "@/core/utils/getApiErrorMessage";
+import { useBanner } from "@/context/banner-context";
+import { useBannerWithDelay } from "@/core/hooks/useBannerWithDelay";
 
 interface NetworkRequestDialogProps {
     open: boolean;
     onOpenChange: (open: boolean) => void;
 }
 
-export function NetworkRequestDialog({ open, onOpenChange }: NetworkRequestDialogProps) {
+export function NetworkRequestDialog({ open,onOpenChange }: NetworkRequestDialogProps) {
     const userDetails = useAppSelector((state) => state.user.userDetails);
     const queryClient = useQueryClient();
+    const {showBanner}=useBanner();
+    const {showBannerWithDelay}=useBannerWithDelay();
 
     const { mutate: submitRequest, isPending } = useMutation({
         mutationFn: async (data: NetworkRequestValues) => {
@@ -37,15 +40,12 @@ export function NetworkRequestDialog({ open, onOpenChange }: NetworkRequestDialo
             }
             return response.json();
         },
-        onSuccess: (resp) => {
-            ReusableToast({
-                message: resp.message || "Your request for a new Sensor Manufacturer has been submitted successfully!",
-                type: "SUCCESS",
-            });
+        onSuccess: (resp) => {            
             queryClient.invalidateQueries({ queryKey: ["network-requests"] });
+            showBannerWithDelay({severity:'success',message:resp.message || "Your request for a new Sensor Manufacturer has been submitted successfully!",scoped:true});
         },
-        onError: (error) => {
-            ReusableToast({ message: getApiErrorMessage(error), type: "ERROR" });
+        onError: (error) => {            
+            showBanner({severity:'error',message:getApiErrorMessage(error),scoped:true})
         },
     });
 

--- a/src/vertex/components/features/networks/network-request-dialog.tsx
+++ b/src/vertex/components/features/networks/network-request-dialog.tsx
@@ -18,11 +18,11 @@ interface NetworkRequestDialogProps {
     onOpenChange: (open: boolean) => void;
 }
 
-export function NetworkRequestDialog({ open,onOpenChange }: NetworkRequestDialogProps) {
+export function NetworkRequestDialog({ open, onOpenChange }: NetworkRequestDialogProps) {
     const userDetails = useAppSelector((state) => state.user.userDetails);
     const queryClient = useQueryClient();
-    const {showBanner}=useBanner();
-    const {showBannerWithDelay}=useBannerWithDelay();
+    const {showBanner} = useBanner();
+    const {showBannerWithDelay} = useBannerWithDelay();
 
     const { mutate: submitRequest, isPending } = useMutation({
         mutationFn: async (data: NetworkRequestValues) => {
@@ -45,7 +45,7 @@ export function NetworkRequestDialog({ open,onOpenChange }: NetworkRequestDialog
             showBannerWithDelay({severity:'success',message:resp.message || "Your request for a new Sensor Manufacturer has been submitted successfully!",scoped:true});
         },
         onError: (error) => {            
-            showBanner({severity:'error',message:getApiErrorMessage(error),scoped:true})
+            showBanner({severity:'error',message:getApiErrorMessage(error),scoped:true});
         },
     });
 

--- a/src/vertex/components/features/networks/network-request-dialog.tsx
+++ b/src/vertex/components/features/networks/network-request-dialog.tsx
@@ -21,8 +21,8 @@ interface NetworkRequestDialogProps {
 export function NetworkRequestDialog({ open, onOpenChange }: NetworkRequestDialogProps) {
     const userDetails = useAppSelector((state) => state.user.userDetails);
     const queryClient = useQueryClient();
-    const {showBanner} = useBanner();
-    const {showBannerWithDelay} = useBannerWithDelay();
+    const { showBanner } = useBanner();
+    const { showBannerWithDelay } = useBannerWithDelay();
 
     const { mutate: submitRequest, isPending } = useMutation({
         mutationFn: async (data: NetworkRequestValues) => {
@@ -42,10 +42,10 @@ export function NetworkRequestDialog({ open, onOpenChange }: NetworkRequestDialo
         },
         onSuccess: (resp) => {            
             queryClient.invalidateQueries({ queryKey: ["network-requests"] });
-            showBannerWithDelay({severity:'success',message:resp.message || "Your request for a new Sensor Manufacturer has been submitted successfully!",scoped:true});
+            showBannerWithDelay({ severity: 'success', message: resp.message || "Your request for a new Sensor Manufacturer has been submitted successfully!", scoped: true });
         },
         onError: (error) => {            
-            showBanner({severity:'error',message:getApiErrorMessage(error),scoped:true});
+            showBanner({ severity: 'error', message: getApiErrorMessage(error), scoped: true });
         },
     });
 

--- a/src/vertex/components/ui/banner.tsx
+++ b/src/vertex/components/ui/banner.tsx
@@ -95,7 +95,7 @@ export const Banner: React.FC<BannerProps> = ({
   return (
     <div
       className={cn(
-        'flex items-start gap-3 rounded-md border shadow-sm',
+        'flex items-start gap-3 rounded-md border shadow-sm text-left',
         paddingClass,
         config.bgColor,
         config.borderColor,


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)
- Migrates the notification system in the network management feature from the toast-based component (`ReusableToast`) to the banner-based system (`useBanner` context and the `useBannerWithDelay` hook).
- Updated the following components to dispatch banners instead of toasts:
  - `NetworkRequestsClient.tsx` – approve / deny / review status updates now show success and error banners (`scoped: false`).
  - `client-paginated-networks-table.tsx` – the "copy Sensor Manufacturer ID" action now shows success/error banners (`scoped: false`).
  - `create-network-form.tsx` – success path uses `showBannerWithDelay` (so the banner appears after the dialog closes, `scoped: false`); error path uses `showBanner` (`scoped: true`).
  - `network-request-dialog.tsx` – `onSuccess` uses `showBannerWithDelay` (`scoped: true`); `onError` uses `showBanner` (`scoped: true`).

#### Status of maturity (all need to be checked before merging):
- [x] I've tested this locally
- [x] I consider this code done
- [x] This change ready to hit production in its current state
- [x] The title of the PR states what changed and the related issues number (used for the release note).
- [x] I've included issue number in the "Closes  #3495"
- [ ] I've updated corresponding documentation for the changes in this PR.
- [ ] I have written unit and/or e2e tests for my change(s).

#### How should this be manually tested?
1. Pull this branch and run the Vertex app locally.
2. Navigate to the **Admin → Networks** area.
3. **Create network form:** Open the "Create Sensor Manufacturer" form, submit valid data, and confirm a success banner appears after the dialog closes. Submit invalid/duplicate data and confirm an error banner appears within the dialog.
4. **Network request dialog:** Submit a new Sensor Manufacturer request and confirm a success banner appears; trigger a failing request and confirm an error banner appears.
5. **Networks table:** Click the copy icon for a Sensor Manufacturer ID and confirm the "Sensor Manufacturer ID copied" success banner shows; simulate a clipboard failure and confirm the error banner shows.
6. **Network requests client:** Approve, deny, and review a request and confirm the success banner appears on success and the error banner appears on failure.
7. Confirm no `ReusableToast` notifications appear anywhere in these flows.

#### What are the relevant tickets?
- Closes #3495

#### Screenshots

<img width="1366" height="768" alt="net1" src="https://github.com/user-attachments/assets/b7f08e6f-a2de-41c3-bc92-d49df0ee5d49" />
<img width="1366" height="768" alt="net2" src="https://github.com/user-attachments/assets/bc1f1bfa-f081-42ee-8992-3d3fa20e0f02" />
<img width="1366" height="768" alt="net3" src="https://github.com/user-attachments/assets/bc17fb7e-ebb6-4d8b-b4cf-49a264320ae7" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Network management now uses a centralized banner system for user feedback; banners support scoped and delayed displays for consistent notifications.
* **Documentation**
  * Added changelog entry for Version 1.23.56 (May 29, 2026).
* **UI**
  * Banner content alignment adjusted to left-aligned for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->