### PR TITLE
Update Organizations and Groups module to use info banners

### DIFF
--- a/src/vertex/app/changelog.md
+++ b/src/vertex/app/changelog.md
@@ -3,6 +3,31 @@
 > **Note**: This changelog consolidates all recent improvements, features, and fixes to the AirQo Vertex frontend.
 
 ---
+
+## Version 1.23.57
+**Released:** June 02, 2026
+
+### Organization Picker Banner Migration
+
+Replaced the `ReusableToast` error call in `OrganizationPicker` with the centralized `useBannerWithDelay` hook. The shimmer progress bar dispatch (`setOrganizationSwitching`) was also moved to just before navigation fires so it only appears when the switch is actually proceeding — errors that occur before navigation never trigger the shimmer.
+
+<details>
+<summary><strong>Changes (2)</strong></summary>
+
+- **Error Feedback**: Replaced `ReusableToast` with `showBannerWithDelay` (`scoped: false`) for org switch failures. Using the delayed variant ensures the banner is not cleared by `ReusableDialog`'s `hideBanner` cleanup effect that fires when the modal closes.
+- **Shimmer Timing Fix**: Moved `setOrganizationSwitching({ isSwitching: true })` inside the try block just before navigation so the progress bar only appears when switching is guaranteed to proceed. The catch block no longer needs to reset it.
+
+</details>
+
+<details>
+<summary><strong>Files Updated (1)</strong></summary>
+
+- `src/vertex/components/features/org-picker/organization-picker.tsx` [MODIFIED]
+
+</details>
+
+---
+
 ## Version 1.23.56
 **Released:** May 29, 2026
 

--- a/src/vertex/components/features/org-picker/organization-picker.tsx
+++ b/src/vertex/components/features/org-picker/organization-picker.tsx
@@ -17,7 +17,8 @@ import { UserContext } from "@/core/redux/slices/userSlice";
 import { AqGrid01 } from "@airqo/icons-react";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useRouter, usePathname } from "next/navigation";
-import ReusableToast from "@/components/shared/toast/ReusableToast";
+import { useBanner } from "@/context/banner-context";
+import { useBannerWithDelay } from "@/core/hooks/useBannerWithDelay";
 
 const formatTitle = (title: string) => {
   if (!title) return "";
@@ -32,6 +33,8 @@ const OrganizationPicker: React.FC = () => {
   const userGroups = useAppSelector((state) => state.user.userGroups);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const { isLoading } = useUserContext();
+  const { showBanner } = useBanner();
+  const { showBannerWithDelay } = useBannerWithDelay();
   const { isSwitching } = useAppSelector((state) => state.user.organizationSwitching);
   const pathname = usePathname();
   const lastPathname = useRef(pathname);
@@ -105,8 +108,17 @@ const OrganizationPicker: React.FC = () => {
       } else {
         router.push("/home");
       }
+      showBannerWithDelay({
+        severity: 'success',
+        message: `Switched to ${formatTitle(group.grp_title)}`,
+        scoped: false,
+      });
     } catch {
-      ReusableToast({ message: "Failed to switch organization", type: "ERROR" });
+      showBanner({
+        severity: 'error',
+        message: 'Failed to switch organization. Please try again.',
+        scoped: false,
+      });
       dispatch(setOrganizationSwitching({ isSwitching: false, switchingTo: "" }));
     }
   };

--- a/src/vertex/components/features/org-picker/organization-picker.tsx
+++ b/src/vertex/components/features/org-picker/organization-picker.tsx
@@ -97,11 +97,6 @@ const OrganizationPicker: React.FC = () => {
       } else {
         router.push("/home");
       }
-      showBannerWithDelay({
-        severity: 'success',
-        message: `Switched to ${formatTitle(group.grp_title)}`,
-        scoped: false,
-      });
     } catch {
       showBannerWithDelay({
         severity: 'error',

--- a/src/vertex/components/features/org-picker/organization-picker.tsx
+++ b/src/vertex/components/features/org-picker/organization-picker.tsx
@@ -99,7 +99,7 @@ const OrganizationPicker: React.FC = () => {
       // 4. Update Redux State
       dispatch(setActiveGroup(group));
       dispatch(setUserContext(newContext));
-
+      
       // 5. Trigger Navigation
       if (pathname === "/home") {
         // If already on home, we must clear immediately as pathname won't change

--- a/src/vertex/components/features/org-picker/organization-picker.tsx
+++ b/src/vertex/components/features/org-picker/organization-picker.tsx
@@ -17,7 +17,6 @@ import { UserContext } from "@/core/redux/slices/userSlice";
 import { AqGrid01 } from "@airqo/icons-react";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useRouter, usePathname } from "next/navigation";
-import { useBanner } from "@/context/banner-context";
 import { useBannerWithDelay } from "@/core/hooks/useBannerWithDelay";
 
 const formatTitle = (title: string) => {
@@ -33,7 +32,6 @@ const OrganizationPicker: React.FC = () => {
   const userGroups = useAppSelector((state) => state.user.userGroups);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const { isLoading } = useUserContext();
-  const { showBanner } = useBanner();
   const { showBannerWithDelay } = useBannerWithDelay();
   const { isSwitching } = useAppSelector((state) => state.user.organizationSwitching);
   const pathname = usePathname();
@@ -56,16 +54,8 @@ const OrganizationPicker: React.FC = () => {
   }, [userGroups]);
 
   const handleOrganizationChange = async (group: Group) => {
-    // 1. Instant UI Feedback
     setIsModalOpen(false);
-    // Clear any stale forbidden state from previous context before switching.
     dispatch(clearForbiddenState());
-
-    // 2. Start Background Transition
-    dispatch(setOrganizationSwitching({
-      isSwitching: true,
-      switchingTo: group.grp_title
-    }));
 
     const newContext: UserContext =
       group.grp_title.toLowerCase() === "airqo"
@@ -73,8 +63,7 @@ const OrganizationPicker: React.FC = () => {
         : "external-org";
 
     try {
-      // 3. Optimized Background Cleanup (Non-blocking)
-      // We don't await these to prevent UI blocking
+      // Optimized Background Cleanup (Non-blocking)
       const orgScopedQueryKeys = [
         ["devices"],
         ["myDevices"],
@@ -96,13 +85,13 @@ const OrganizationPicker: React.FC = () => {
         queryClient.removeQueries({ queryKey });
       });
 
-      // 4. Update Redux State
+      // Start shimmer just before navigation fires
+      dispatch(setOrganizationSwitching({ isSwitching: true, switchingTo: group.grp_title }));
+
       dispatch(setActiveGroup(group));
       dispatch(setUserContext(newContext));
-      
-      // 5. Trigger Navigation
+
       if (pathname === "/home") {
-        // If already on home, we must clear immediately as pathname won't change
         dispatch(setOrganizationSwitching({ isSwitching: false, switchingTo: "" }));
         router.refresh();
       } else {
@@ -114,12 +103,11 @@ const OrganizationPicker: React.FC = () => {
         scoped: false,
       });
     } catch {
-      showBanner({
+      showBannerWithDelay({
         severity: 'error',
         message: 'Failed to switch organization. Please try again.',
         scoped: false,
       });
-      dispatch(setOrganizationSwitching({ isSwitching: false, switchingTo: "" }));
     }
   };
 


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

Replaces the ReusableToast call in OrganizationPicker with the centralized InfoBanner system. 

- Some items from this issue were already resolved in PR #3558.

#### Status of maturity (all need to be checked before merging):

- [x] I've tested this locally
- [x] I consider this code done
- [x] This change ready to hit production in its current state
- [x] The title of the PR states what changed and the related issues number (used for the release note).
- [x] I've included issue number in the "Closes #3452" part of the "[What are the relevant tickets?](#what-are-the-relevant-tickets)" section to link the issue.
- [ ] I've updated corresponding documentation for the changes in this PR.
- [ ] I have written unit and/or e2e tests for my change(s).

#### How should this be manually tested?

1. Log in with an account that belongs to multiple organizations.
2. Click the organization picker in the topbar and select a different organization.
3. Success banner removed.
4. To test the error path, temporarily add throw new Error() as the very first line inside the try block in handleOrganizationChange (before removeQueries runs), switch any org, and confirm a red error banner appears after the modal closes.

#### What are the relevant tickets?

- Closes #3452
- 
- Files handled as part of this issue (remaining items resolved in PR #3558):

- `src/vertex/app/(authenticated)/admin/networks/page.tsx`
- `src/vertex/app/(authenticated)/admin/networks/[id]/page.tsx`
- `src/vertex/app/(authenticated)/admin/networks/requests/page.tsx`


#### Screenshots 

<img width="1366" height="768" alt="gp2" src="https://github.com/user-attachments/assets/4cc6f300-9b5e-4f39-8176-82519b34eaa3" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Organization switching now uses centralized banners for errors and success, giving clearer feedback.
  * Progress indicator only appears when navigation proceeds, reducing false loading states and improving reliability during switches.

* **Documentation**
  * Changelog updated with the organization picker banner migration and behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->