### PR TITLE
fix(firmware): prevent mixed content error on upload

### DIFF
--- a/src/beacon/services/firmware.service.ts
+++ b/src/beacon/services/firmware.service.ts
@@ -74,7 +74,7 @@ class FirmwareService {
       if (params?.limit !== undefined) queryParams.append('limit', params.limit.toString());
       if (params?.firmware_type) queryParams.append('firmware_type', params.firmware_type);
 
-      const endpoint = this.getEndpoint('/firmware');
+      const endpoint = this.getEndpoint('/firmware/');
       const response = await axios.get(
         `${this.baseUrl}${endpoint}?${queryParams.toString()}`,
         this.getAxiosConfig()


### PR DESCRIPTION
Remove trailing slash from firmware upload endpoint to prevent HTTP 307 redirects to HTTP URLs, which caused a mixed content block in the browser.

#### Summary of Changes (What does this PR do?)

- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

#### Status of maturity (all need to be checked before merging):

- [ ] I've tested this locally
- [ ] I consider this code done
- [ ] This change ready to hit production in its current state
- [ ] The title of the PR states what changed and the related issues number (used for the release note).
- [ ] I've included issue number in the "Closes #ISSUE-NUMBER" part of the "[What are the relevant tickets?](#what-are-the-relevant-tickets)" section to [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [ ] I've updated corresponding documentation for the changes in this PR.
- [ ] I have written unit and/or e2e tests for my change(s).

#### How should this be manually tested?

- Please include the steps to be done inorder to setup and test this PR.

#### What are the relevant tickets?

- Closes #<enter issue number here>
- [Jira_card_number]() (If exists)

#### Screenshots (optional)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed firmware data retrieval to properly handle firmware list queries with query parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->