### PR TITLE
feat: migrate forecast to new API endpoints with 7-day overview screen

### DIFF
--- a/src/mobile/lib/src/app/dashboard/bloc/forecast/forecast_bloc.dart
+++ b/src/mobile/lib/src/app/dashboard/bloc/forecast/forecast_bloc.dart
@@ -9,76 +9,94 @@ part 'forecast_state.dart';
 
 class ForecastBloc extends Bloc<ForecastEvent, ForecastState> with UiLoggy {
   final ForecastRepository forecastRepository;
-  
+
   final Map<String, ForecastResponse> _cachedResponses = {};
-  
+
   ForecastBloc(this.forecastRepository) : super(ForecastInitial()) {
     on<LoadForecast>(_onLoadForecast);
     on<RefreshForecast>(_onRefreshForecast);
+    on<LoadHourlyForecast>(_onLoadHourlyForecast);
   }
 
-  Future<void> _onLoadForecast(LoadForecast event, Emitter<ForecastState> emit) async {
-    final String siteId = event.siteId;
-    
-    if (state is ForecastLoaded && 
+  Future<void> _onLoadForecast(
+      LoadForecast event, Emitter<ForecastState> emit) async {
+    final siteId = event.siteId;
+
+    if (state is ForecastLoaded &&
         (state as ForecastLoaded).siteId == siteId &&
         !event.forceRefresh) {
-      loggy.info('Using existing forecast state for site: $siteId');
       return;
     }
 
     if (_cachedResponses.containsKey(siteId) && !event.forceRefresh) {
-      loggy.info('Using in-memory cached forecast for site: $siteId');
       emit(ForecastLoaded(_cachedResponses[siteId]!, siteId: siteId));
     } else {
       emit(ForecastLoading(siteId: siteId));
     }
-    
+
     try {
-      final ForecastResponse response = await forecastRepository.loadForecasts(siteId);
-      
-      // Save to in-memory cache
+      final response = await forecastRepository.loadForecasts(siteId);
       _cachedResponses[siteId] = response;
-      
       emit(ForecastLoaded(response, siteId: siteId));
     } catch (e) {
-      loggy.error('Error loading forecast for site $siteId: $e');
-      
-      // Handle specific network errors from enhanced repository
-      if (e is ForecastException) {
-        if (e.isNetworkError) {
-          emit(ForecastNetworkError(
-            message: e.message,
-            siteId: siteId,
-          ));
-        } else {
-          emit(ForecastLoadingError(
-            message: e.message,
-            siteId: siteId,
-          ));
-        }
+      loggy.error('Error loading daily forecast for $siteId: $e');
+      if (e is ForecastException && e.isNetworkError) {
+        emit(ForecastNetworkError(message: e.message, siteId: siteId));
+      } else if (e is ForecastException) {
+        emit(ForecastLoadingError(message: e.message, siteId: siteId));
       } else {
-        emit(ForecastLoadingError(
-          message: e.toString(),
+        emit(ForecastLoadingError(message: e.toString(), siteId: siteId));
+      }
+    }
+  }
+
+  Future<void> _onRefreshForecast(
+      RefreshForecast event, Emitter<ForecastState> emit) async {
+    if (event.clearCache) {
+      try {
+        await forecastRepository.clearCache(event.siteId);
+        _cachedResponses.remove(event.siteId);
+      } catch (e) {
+        loggy.warning('Failed to clear cache: $e');
+      }
+    }
+    add(LoadForecast(event.siteId, forceRefresh: true));
+  }
+
+  Future<void> _onLoadHourlyForecast(
+      LoadHourlyForecast event, Emitter<ForecastState> emit) async {
+    final siteId = event.siteId;
+
+    // Only load hourly when we already have daily data loaded
+    final currentState = state;
+    ForecastResponse? dailyResponse;
+    if (currentState is ForecastLoaded && currentState.siteId == siteId) {
+      dailyResponse = currentState.response;
+      if (currentState.hourlyResponse != null && !event.forceRefresh) return;
+    } else if (_cachedResponses.containsKey(siteId)) {
+      dailyResponse = _cachedResponses[siteId];
+    }
+
+    if (dailyResponse != null) {
+      emit(HourlyForecastLoading(dailyResponse: dailyResponse, siteId: siteId));
+    }
+
+    try {
+      final hourly =
+          await forecastRepository.loadHourlyForecasts(siteId);
+      final daily = dailyResponse ?? _cachedResponses[siteId];
+      if (daily != null) {
+        emit(ForecastLoaded(daily, siteId: siteId, hourlyResponse: hourly));
+      }
+    } catch (e) {
+      loggy.error('Error loading hourly forecast for $siteId: $e');
+      if (dailyResponse != null) {
+        emit(HourlyForecastError(
+          message: e is ForecastException ? e.message : e.toString(),
+          dailyResponse: dailyResponse,
           siteId: siteId,
         ));
       }
     }
   }
-
-  Future<void> _onRefreshForecast(RefreshForecast event, Emitter<ForecastState> emit) async {
-    final String siteId = event.siteId;
-    
-    if (event.clearCache) {
-      try {
-        await forecastRepository.clearCache(siteId);
-        _cachedResponses.remove(siteId);
-      } catch (e) {
-        loggy.warning('Failed to clear cache: $e');
-      }
-    }
-    
-    add(LoadForecast(siteId, forceRefresh: true));
-  }
 }
-

--- a/src/mobile/lib/src/app/dashboard/bloc/forecast/forecast_bloc.dart
+++ b/src/mobile/lib/src/app/dashboard/bloc/forecast/forecast_bloc.dart
@@ -11,6 +11,7 @@ class ForecastBloc extends Bloc<ForecastEvent, ForecastState> with UiLoggy {
   final ForecastRepository forecastRepository;
 
   final Map<String, ForecastResponse> _cachedResponses = {};
+  final Map<String, HourlyForecastResponse> _cachedHourlyResponses = {};
 
   ForecastBloc(this.forecastRepository) : super(ForecastInitial()) {
     on<LoadForecast>(_onLoadForecast);
@@ -37,7 +38,9 @@ class ForecastBloc extends Bloc<ForecastEvent, ForecastState> with UiLoggy {
     try {
       final response = await forecastRepository.loadForecasts(siteId);
       _cachedResponses[siteId] = response;
-      emit(ForecastLoaded(response, siteId: siteId));
+      emit(ForecastLoaded(response,
+          siteId: siteId,
+          hourlyResponse: _cachedHourlyResponses[siteId]));
     } catch (e) {
       loggy.error('Error loading daily forecast for $siteId: $e');
       if (e is ForecastException && e.isNetworkError) {
@@ -56,6 +59,7 @@ class ForecastBloc extends Bloc<ForecastEvent, ForecastState> with UiLoggy {
       try {
         await forecastRepository.clearCache(event.siteId);
         _cachedResponses.remove(event.siteId);
+        _cachedHourlyResponses.remove(event.siteId);
       } catch (e) {
         loggy.warning('Failed to clear cache: $e');
       }
@@ -67,7 +71,6 @@ class ForecastBloc extends Bloc<ForecastEvent, ForecastState> with UiLoggy {
       LoadHourlyForecast event, Emitter<ForecastState> emit) async {
     final siteId = event.siteId;
 
-    // Only load hourly when we already have daily data loaded
     final currentState = state;
     ForecastResponse? dailyResponse;
     if (currentState is ForecastLoaded && currentState.siteId == siteId) {
@@ -87,6 +90,8 @@ class ForecastBloc extends Bloc<ForecastEvent, ForecastState> with UiLoggy {
       final daily = dailyResponse ?? _cachedResponses[siteId];
       if (daily != null) {
         emit(ForecastLoaded(daily, siteId: siteId, hourlyResponse: hourly));
+      } else {
+        _cachedHourlyResponses[siteId] = hourly;
       }
     } catch (e) {
       loggy.error('Error loading hourly forecast for $siteId: $e');

--- a/src/mobile/lib/src/app/dashboard/bloc/forecast/forecast_event.dart
+++ b/src/mobile/lib/src/app/dashboard/bloc/forecast/forecast_event.dart
@@ -12,7 +12,7 @@ class LoadForecast extends ForecastEvent {
   final bool forceRefresh;
 
   const LoadForecast(this.siteId, {this.forceRefresh = false});
-  
+
   @override
   List<Object> get props => [siteId, forceRefresh];
 }
@@ -22,9 +22,17 @@ class RefreshForecast extends ForecastEvent {
   final bool clearCache;
 
   const RefreshForecast(this.siteId, {this.clearCache = true});
-  
+
   @override
   List<Object> get props => [siteId, clearCache];
 }
 
+class LoadHourlyForecast extends ForecastEvent {
+  final String siteId;
+  final bool forceRefresh;
 
+  const LoadHourlyForecast(this.siteId, {this.forceRefresh = false});
+
+  @override
+  List<Object> get props => [siteId, forceRefresh];
+}

--- a/src/mobile/lib/src/app/dashboard/bloc/forecast/forecast_state.dart
+++ b/src/mobile/lib/src/app/dashboard/bloc/forecast/forecast_state.dart
@@ -2,7 +2,7 @@ part of 'forecast_bloc.dart';
 
 sealed class ForecastState extends Equatable {
   final String? siteId;
-  
+
   const ForecastState({this.siteId});
 
   @override
@@ -18,43 +18,61 @@ class ForecastLoading extends ForecastState {
 class ForecastLoaded extends ForecastState {
   final ForecastResponse response;
   final DateTime loadTime;
+  final HourlyForecastResponse? hourlyResponse;
 
-  ForecastLoaded(this.response, {required String siteId})
+  ForecastLoaded(this.response, {required String siteId, this.hourlyResponse})
       : loadTime = DateTime.now(),
         super(siteId: siteId);
-        
+
+  bool get isStale =>
+      DateTime.now().difference(loadTime) > const Duration(hours: 2);
+
+  ForecastLoaded copyWith({HourlyForecastResponse? hourlyResponse}) =>
+      ForecastLoaded(
+        response,
+        siteId: siteId!,
+        hourlyResponse: hourlyResponse ?? this.hourlyResponse,
+      );
+
   @override
-  List<Object?> get props => [response, siteId];
-  
-  // Check if data is stale (older than 2 hours)
-  bool get isStale {
-    final now = DateTime.now();
-    return now.difference(loadTime) > const Duration(hours: 2);
-  }
+  List<Object?> get props => [response, siteId, hourlyResponse];
 }
 
-// General error state
 class ForecastLoadingError extends ForecastState {
   final String message;
 
-  const ForecastLoadingError({
-    required this.message,
-    super.siteId,
-  });
-  
+  const ForecastLoadingError({required this.message, super.siteId});
+
   @override
   List<Object?> get props => [message, siteId];
 }
 
-// Specific network error state for better UX
 class ForecastNetworkError extends ForecastState {
   final String message;
 
-  const ForecastNetworkError({
-    required this.message,
-    super.siteId,
-  });
-  
+  const ForecastNetworkError({required this.message, super.siteId});
+
   @override
   List<Object?> get props => [message, siteId];
+}
+
+class HourlyForecastLoading extends ForecastState {
+  final ForecastResponse dailyResponse;
+
+  const HourlyForecastLoading(
+      {required this.dailyResponse, super.siteId});
+
+  @override
+  List<Object?> get props => [dailyResponse, siteId];
+}
+
+class HourlyForecastError extends ForecastState {
+  final String message;
+  final ForecastResponse dailyResponse;
+
+  const HourlyForecastError(
+      {required this.message, required this.dailyResponse, super.siteId});
+
+  @override
+  List<Object?> get props => [message, dailyResponse, siteId];
 }

--- a/src/mobile/lib/src/app/dashboard/models/forecast_response.dart
+++ b/src/mobile/lib/src/app/dashboard/models/forecast_response.dart
@@ -1,78 +1,242 @@
-class ForecastResponse {
-  Map<String, AqiRange> aqiRanges;
-  List<Forecast> forecasts;
+class ForecastMet {
+  final double? airTemperature;
+  final double? relativeHumidity;
+  final double? windSpeed;
+  final double? windFromDirection;
+  final String? windDirectionCompass;
+  final double? precipitationAmount;
+  final double? cloudAreaFraction;
+  final double? airPressureAtSeaLevel;
 
-  ForecastResponse({
-    required this.aqiRanges,
-    required this.forecasts,
+  const ForecastMet({
+    this.airTemperature,
+    this.relativeHumidity,
+    this.windSpeed,
+    this.windFromDirection,
+    this.windDirectionCompass,
+    this.precipitationAmount,
+    this.cloudAreaFraction,
+    this.airPressureAtSeaLevel,
   });
 
-  factory ForecastResponse.fromJson(Map<String, dynamic> json) =>
-      ForecastResponse(
-        aqiRanges: Map<String, AqiRange>.from(json["aqi_ranges"].map((key, value) => MapEntry(key, AqiRange.fromJson(value)))),
-
-        forecasts: List<Forecast>.from(json["forecasts"].map((x) => Forecast.fromJson(x))),
+  factory ForecastMet.fromJson(Map<String, dynamic> json) => ForecastMet(
+        airTemperature: json['air_temperature']?.toDouble(),
+        relativeHumidity: json['relative_humidity']?.toDouble(),
+        windSpeed: json['wind_speed']?.toDouble(),
+        windFromDirection: json['wind_from_direction']?.toDouble(),
+        windDirectionCompass: json['wind_direction_compass'] as String?,
+        precipitationAmount: json['precipitation_amount']?.toDouble(),
+        cloudAreaFraction: json['cloud_area_fraction']?.toDouble(),
+        airPressureAtSeaLevel:
+            json['air_pressure_at_sea_level']?.toDouble(),
       );
 
   Map<String, dynamic> toJson() => {
-        "forecasts": List<dynamic>.from(forecasts.map((x) => x.toJson())),
+        if (airTemperature != null) 'air_temperature': airTemperature,
+        if (relativeHumidity != null) 'relative_humidity': relativeHumidity,
+        if (windSpeed != null) 'wind_speed': windSpeed,
+        if (windFromDirection != null) 'wind_from_direction': windFromDirection,
+        if (windDirectionCompass != null)
+          'wind_direction_compass': windDirectionCompass,
+        if (precipitationAmount != null)
+          'precipitation_amount': precipitationAmount,
+        if (cloudAreaFraction != null) 'cloud_area_fraction': cloudAreaFraction,
+        if (airPressureAtSeaLevel != null)
+          'air_pressure_at_sea_level': airPressureAtSeaLevel,
       };
-}
-
-class AqiRange {
-  final String aqiCategory;
-  final String aqiColor;
-  final String aqiColorName;
-  final String label;
-  final double? max;
-  final double min;
-
-  AqiRange({
-    required this.aqiCategory,
-    required this.aqiColor,
-    required this.aqiColorName,
-    required this.label,
-    required this.max,
-    required this.min,
-  });
-
-  factory AqiRange.fromJson(Map<String, dynamic> json) {
-    return AqiRange(
-      aqiCategory: json['aqi_category'],
-      aqiColor: json['aqi_color'],
-      aqiColorName: json['aqi_color_name'],
-      label: json['label'],
-      max: json['max']?.toDouble(),
-      min: json['min'].toDouble(),
-    );
-  }
 }
 
 class Forecast {
   final String aqiCategory;
   final String aqiColor;
   final String aqiColorName;
+  final String? aqiLabel;
+  final String? trendMessage;
   final double pm25;
+  final double? pm25Low;
+  final double? pm25High;
   final DateTime time;
+  final double? forecastConfidence;
+  final ForecastMet? met;
 
-  Forecast({
+  const Forecast({
     required this.aqiCategory,
     required this.aqiColor,
     required this.aqiColorName,
     required this.pm25,
     required this.time,
+    this.aqiLabel,
+    this.trendMessage,
+    this.pm25Low,
+    this.pm25High,
+    this.forecastConfidence,
+    this.met,
   });
 
-  factory Forecast.fromJson(Map<String, dynamic> json) => Forecast(
-        aqiCategory: json["aqi_category"],  
-        aqiColor: json["aqi_color"],
-        aqiColorName: json["aqi_color_name"],
-        pm25: json["pm2_5"]?.toDouble(), 
-        time: DateTime.parse(json["time"]),
-      );
+  factory Forecast.fromJson(Map<String, dynamic> json) {
+    final aqi = json['aqi'] as Map<String, dynamic>? ?? {};
+    final forecast = json['forecast'] as Map<String, dynamic>? ?? {};
+    return Forecast(
+      aqiCategory: aqi['aqi_category'] as String? ?? 'Unavailable',
+      aqiColor: aqi['aqi_color'] as String? ?? '#9E9E9E',
+      aqiColorName: aqi['aqi_color_name'] as String? ?? 'Grey',
+      aqiLabel: aqi['label'] as String?,
+      trendMessage: aqi['trend_message'] as String?,
+      pm25: (forecast['pm2_5_mean'] ?? 0.0).toDouble(),
+      pm25Low: forecast['pm2_5_low']?.toDouble(),
+      pm25High: forecast['pm2_5_high']?.toDouble(),
+      time: DateTime.parse(json['date'] as String),
+      forecastConfidence: forecast['forecast_confidence']?.toDouble(),
+      met: json['met'] != null
+          ? ForecastMet.fromJson(json['met'] as Map<String, dynamic>)
+          : null,
+    );
+  }
 
   Map<String, dynamic> toJson() => {
-        "pm2_5": pm25,
-        "time": time.toIso8601String(),
+        'date': time.toIso8601String(),
+        'forecast': {
+          'pm2_5_mean': pm25,
+          if (pm25Low != null) 'pm2_5_low': pm25Low,
+          if (pm25High != null) 'pm2_5_high': pm25High,
+          if (forecastConfidence != null)
+            'forecast_confidence': forecastConfidence,
+        },
+        'aqi': {
+          'aqi_category': aqiCategory,
+          'aqi_color': aqiColor,
+          'aqi_color_name': aqiColorName,
+          if (aqiLabel != null) 'label': aqiLabel,
+          if (trendMessage != null) 'trend_message': trendMessage,
+        },
+        if (met != null) 'met': met!.toJson(),
+      };
+}
+
+class ForecastResponse {
+  final List<Forecast> forecasts;
+
+  const ForecastResponse({required this.forecasts});
+
+  factory ForecastResponse.fromJson(Map<String, dynamic> json) {
+    final data = json['data'] as Map<String, dynamic>?;
+    if (data == null) return const ForecastResponse(forecasts: []);
+
+    final siteForecastsList = data['forecasts'] as List?;
+    if (siteForecastsList == null || siteForecastsList.isEmpty) {
+      return const ForecastResponse(forecasts: []);
+    }
+
+    final siteData = siteForecastsList[0] as Map<String, dynamic>;
+    final entries = (siteData['forecasts'] as List?) ?? [];
+    return ForecastResponse(
+      forecasts: entries
+          .map((e) => Forecast.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'data': {
+          'forecasts': [
+            {'forecasts': forecasts.map((f) => f.toJson()).toList()},
+          ],
+        },
+      };
+}
+
+class HourlyForecastEntry {
+  final DateTime time;
+  final double pm25Mean;
+  final double? pm25Q10;
+  final double? pm25Q90;
+  final double? forecastConfidence;
+  final String aqiCategory;
+  final String aqiColor;
+  final String? aqiLabel;
+  final String? trendMessage;
+  final ForecastMet? met;
+
+  const HourlyForecastEntry({
+    required this.time,
+    required this.pm25Mean,
+    required this.aqiCategory,
+    required this.aqiColor,
+    this.pm25Q10,
+    this.pm25Q90,
+    this.forecastConfidence,
+    this.aqiLabel,
+    this.trendMessage,
+    this.met,
+  });
+
+  factory HourlyForecastEntry.fromJson(Map<String, dynamic> json) {
+    final aqi = json['aqi'] as Map<String, dynamic>? ?? {};
+    final forecast = json['forecast'] as Map<String, dynamic>? ?? {};
+    return HourlyForecastEntry(
+      time: DateTime.parse(json['timestamp'] as String),
+      pm25Mean: (forecast['pm2_5_mean'] ?? 0.0).toDouble(),
+      pm25Q10: forecast['pm2_5_q10']?.toDouble(),
+      pm25Q90: forecast['pm2_5_q90']?.toDouble(),
+      forecastConfidence: forecast['forecast_confidence']?.toDouble(),
+      aqiCategory: aqi['aqi_category'] as String? ?? 'Unavailable',
+      aqiColor: aqi['aqi_color'] as String? ?? '#9E9E9E',
+      aqiLabel: aqi['label'] as String?,
+      trendMessage: aqi['trend_message'] as String?,
+      met: json['met'] != null
+          ? ForecastMet.fromJson(json['met'] as Map<String, dynamic>)
+          : null,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'timestamp': time.toIso8601String(),
+        'forecast': {
+          'pm2_5_mean': pm25Mean,
+          if (pm25Q10 != null) 'pm2_5_q10': pm25Q10,
+          if (pm25Q90 != null) 'pm2_5_q90': pm25Q90,
+          if (forecastConfidence != null)
+            'forecast_confidence': forecastConfidence,
+        },
+        'aqi': {
+          'aqi_category': aqiCategory,
+          'aqi_color': aqiColor,
+          if (aqiLabel != null) 'label': aqiLabel,
+          if (trendMessage != null) 'trend_message': trendMessage,
+        },
+        if (met != null) 'met': met!.toJson(),
+      };
+}
+
+class HourlyForecastResponse {
+  final List<HourlyForecastEntry> forecasts;
+
+  const HourlyForecastResponse({required this.forecasts});
+
+  factory HourlyForecastResponse.fromJson(Map<String, dynamic> json) {
+    final data = json['data'] as Map<String, dynamic>?;
+    if (data == null) return const HourlyForecastResponse(forecasts: []);
+
+    final siteForecastsList = data['forecasts'] as List?;
+    if (siteForecastsList == null || siteForecastsList.isEmpty) {
+      return const HourlyForecastResponse(forecasts: []);
+    }
+
+    final siteData = siteForecastsList[0] as Map<String, dynamic>;
+    final entries = (siteData['forecasts'] as List?) ?? [];
+    return HourlyForecastResponse(
+      forecasts: entries
+          .map((e) =>
+              HourlyForecastEntry.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'data': {
+          'forecasts': [
+            {'forecasts': forecasts.map((f) => f.toJson()).toList()},
+          ],
+        },
       };
 }

--- a/src/mobile/lib/src/app/dashboard/models/forecast_response.dart
+++ b/src/mobile/lib/src/app/dashboard/models/forecast_response.dart
@@ -85,7 +85,8 @@ class Forecast {
       pm25: (forecast['pm2_5_mean'] ?? 0.0).toDouble(),
       pm25Low: forecast['pm2_5_low']?.toDouble(),
       pm25High: forecast['pm2_5_high']?.toDouble(),
-      time: DateTime.parse(json['date'] as String),
+      time: DateTime.tryParse(json['date'] as String? ?? '') ??
+          DateTime.fromMillisecondsSinceEpoch(0),
       forecastConfidence: forecast['forecast_confidence']?.toDouble(),
       met: json['met'] != null
           ? ForecastMet.fromJson(json['met'] as Map<String, dynamic>)
@@ -174,7 +175,8 @@ class HourlyForecastEntry {
     final aqi = json['aqi'] as Map<String, dynamic>? ?? {};
     final forecast = json['forecast'] as Map<String, dynamic>? ?? {};
     return HourlyForecastEntry(
-      time: DateTime.parse(json['timestamp'] as String),
+      time: DateTime.tryParse(json['timestamp'] as String? ?? '') ??
+          DateTime.fromMillisecondsSinceEpoch(0),
       pm25Mean: (forecast['pm2_5_mean'] ?? 0.0).toDouble(),
       pm25Q10: forecast['pm2_5_q10']?.toDouble(),
       pm25Q90: forecast['pm2_5_q90']?.toDouble(),

--- a/src/mobile/lib/src/app/dashboard/pages/forecast_overview_page.dart
+++ b/src/mobile/lib/src/app/dashboard/pages/forecast_overview_page.dart
@@ -1,0 +1,259 @@
+import 'package:airqo/src/app/dashboard/bloc/forecast/forecast_bloc.dart';
+import 'package:airqo/src/app/dashboard/widgets/forecast_day_detail_card.dart';
+import 'package:airqo/src/app/dashboard/widgets/forecast_day_selector.dart';
+import 'package:airqo/src/app/dashboard/widgets/forecast_hourly_section.dart';
+import 'package:airqo/src/app/dashboard/widgets/forecast_met_row.dart';
+import 'package:airqo/src/app/shared/widgets/loading_widget.dart';
+import 'package:airqo/src/meta/utils/colors.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:intl/intl.dart';
+
+class ForecastOverviewPage extends StatefulWidget {
+  final String siteId;
+  final String siteName;
+
+  const ForecastOverviewPage({
+    super.key,
+    required this.siteId,
+    required this.siteName,
+  });
+
+  @override
+  State<ForecastOverviewPage> createState() => _ForecastOverviewPageState();
+}
+
+class _ForecastOverviewPageState extends State<ForecastOverviewPage> {
+  int _selectedDayIndex = 0;
+  final _scrollController = ScrollController();
+  final _todayStr = DateFormat('yyyy-MM-dd').format(DateTime.now());
+
+  @override
+  void initState() {
+    super.initState();
+    context.read<ForecastBloc>().add(LoadForecast(widget.siteId));
+  }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  void _selectDay(int index) {
+    setState(() => _selectedDayIndex = index);
+    if (_scrollController.hasClients) {
+      _scrollController.animateTo(
+        0,
+        duration: const Duration(milliseconds: 300),
+        curve: Curves.easeOut,
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    return Scaffold(
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+      appBar: AppBar(
+        title: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              '7-Day Forecast',
+              style: Theme.of(context)
+                  .textTheme
+                  .titleMedium
+                  ?.copyWith(fontWeight: FontWeight.w600),
+            ),
+            Text(
+              widget.siteName,
+              style: Theme.of(context)
+                  .textTheme
+                  .bodySmall
+                  ?.copyWith(color: AppColors.boldHeadlineColor),
+            ),
+          ],
+        ),
+      ),
+      body: BlocConsumer<ForecastBloc, ForecastState>(
+        listenWhen: (_, curr) =>
+            curr is ForecastLoaded && curr.siteId == widget.siteId,
+        listener: (context, state) {
+          if (state is ForecastLoaded && state.hourlyResponse == null) {
+            context
+                .read<ForecastBloc>()
+                .add(LoadHourlyForecast(widget.siteId));
+          }
+        },
+        builder: (context, state) {
+          if (state is ForecastLoading) return _skeleton(context);
+          if (state is ForecastNetworkError) {
+            return _error(context, state.message, isNetwork: true);
+          }
+          if (state is ForecastLoadingError) {
+            return _error(context, state.message);
+          }
+          if (state is ForecastLoaded && state.siteId == widget.siteId) {
+            return _content(context, state, isDark);
+          }
+          if (state is HourlyForecastLoading &&
+              state.siteId == widget.siteId) {
+            return _content(
+              context,
+              ForecastLoaded(state.dailyResponse, siteId: widget.siteId),
+              isDark,
+              hourlyLoading: true,
+            );
+          }
+          if (state is HourlyForecastError &&
+              state.siteId == widget.siteId) {
+            return _content(
+              context,
+              ForecastLoaded(state.dailyResponse, siteId: widget.siteId),
+              isDark,
+              hourlyError: state.message,
+            );
+          }
+          return _skeleton(context);
+        },
+      ),
+    );
+  }
+
+  Widget _content(
+    BuildContext context,
+    ForecastLoaded state,
+    bool isDark, {
+    bool hourlyLoading = false,
+    String? hourlyError,
+  }) {
+    final forecasts = state.response.forecasts;
+    if (forecasts.isEmpty) {
+      return const Center(child: Text('No forecast data available.'));
+    }
+
+    if (_selectedDayIndex == 0) {
+      final todayIdx =
+          forecasts.indexWhere((f) => _fmtDate(f.time) == _todayStr);
+      if (todayIdx > 0) {
+        WidgetsBinding.instance
+            .addPostFrameCallback((_) => setState(() => _selectedDayIndex = todayIdx));
+      }
+    }
+
+    final idx = _selectedDayIndex.clamp(0, forecasts.length - 1);
+    final day = forecasts[idx];
+
+    return SingleChildScrollView(
+      controller: _scrollController,
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          ForecastDaySelector(
+            forecasts: forecasts,
+            selectedIndex: idx,
+            todayStr: _todayStr,
+            onSelected: _selectDay,
+            isDark: isDark,
+          ),
+          const SizedBox(height: 20),
+          ForecastDayDetailCard(forecast: day, isDark: isDark),
+          const SizedBox(height: 20),
+          ForecastMetRow(met: day.met),
+          const SizedBox(height: 20),
+          ForecastHourlySection(
+            siteId: widget.siteId,
+            selectedDate: day.time,
+            hourlyResponse: state.hourlyResponse,
+            isLoading: hourlyLoading,
+            errorMessage: hourlyError,
+            isDark: isDark,
+          ),
+          const SizedBox(height: 32),
+        ],
+      ),
+    );
+  }
+
+  Widget _skeleton(BuildContext context) {
+    return SingleChildScrollView(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: List.generate(
+              7,
+              (i) => Expanded(
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 3),
+                  child: ShimmerContainer(
+                      height: 88, width: double.infinity, borderRadius: 12),
+                ),
+              ),
+            ),
+          ),
+          const SizedBox(height: 20),
+          ShimmerContainer(
+              height: 200, width: double.infinity, borderRadius: 16),
+          const SizedBox(height: 20),
+          ShimmerContainer(
+              height: 80, width: double.infinity, borderRadius: 16),
+          const SizedBox(height: 20),
+          ShimmerContainer(
+              height: 130, width: double.infinity, borderRadius: 16),
+        ],
+      ),
+    );
+  }
+
+  Widget _error(BuildContext context, String message,
+      {bool isNetwork = false}) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              isNetwork
+                  ? Icons.wifi_off_rounded
+                  : Icons.error_outline_rounded,
+              size: 56,
+              color: AppColors.boldHeadlineColor,
+            ),
+            const SizedBox(height: 16),
+            Text(
+              isNetwork ? 'No connection' : 'Could not load forecast',
+              style: Theme.of(context)
+                  .textTheme
+                  .titleMedium
+                  ?.copyWith(fontWeight: FontWeight.w600),
+            ),
+            const SizedBox(height: 8),
+            Text(message,
+                textAlign: TextAlign.center,
+                style: Theme.of(context).textTheme.bodySmall),
+            const SizedBox(height: 24),
+            ElevatedButton.icon(
+              onPressed: () => context
+                  .read<ForecastBloc>()
+                  .add(RefreshForecast(widget.siteId)),
+              icon: const Icon(Icons.refresh),
+              label: const Text('Retry'),
+              style: ElevatedButton.styleFrom(
+                backgroundColor: AppColors.primaryColor,
+                foregroundColor: Colors.white,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  String _fmtDate(DateTime dt) => DateFormat('yyyy-MM-dd').format(dt);
+}

--- a/src/mobile/lib/src/app/dashboard/repository/forecast_repository.dart
+++ b/src/mobile/lib/src/app/dashboard/repository/forecast_repository.dart
@@ -4,7 +4,6 @@ import 'package:airqo/src/app/dashboard/models/forecast_response.dart';
 import 'package:airqo/src/app/shared/repository/base_repository.dart';
 import 'package:airqo/src/meta/utils/api_utils.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
-import 'package:http/http.dart';
 import 'package:loggy/loggy.dart';
 import 'package:airqo/src/app/shared/services/cache_manager.dart';
 import 'package:http/http.dart' as http;
@@ -21,6 +20,9 @@ class ForecastException implements Exception {
 
 abstract class ForecastRepository extends BaseRepository {
   Future<ForecastResponse> loadForecasts(String siteId,
+      {bool forceRefresh = false});
+
+  Future<HourlyForecastResponse> loadHourlyForecasts(String siteId,
       {bool forceRefresh = false});
 
   Future<void> clearCache(String siteId);
@@ -40,9 +42,7 @@ class ForecastImpl extends ForecastRepository with UiLoggy {
     CacheManager? cacheManager,
     http.Client? httpClient,
   })  : _cacheManager = cacheManager ?? CacheManager(),
-        _httpClient = httpClient ?? http.Client() {
-    loggy.debug('Initialized ForecastImpl with httpClient: $_httpClient');
-  }
+        _httpClient = httpClient ?? http.Client();
 
   factory ForecastImpl({
     CacheManager? cacheManager,
@@ -54,7 +54,6 @@ class ForecastImpl extends ForecastRepository with UiLoggy {
         httpClient: httpClient,
       );
     }
-
     return _instance ??= ForecastImpl._internal();
   }
 
@@ -65,16 +64,29 @@ class ForecastImpl extends ForecastRepository with UiLoggy {
   final Map<String, StreamController<ForecastResponse>> _forecastControllers =
       {};
 
-  String _getForecastCacheKey(String siteId) => 'forecast_$siteId';
+  String _getDailyCacheKey(String siteId) => 'daily_forecast_$siteId';
+  String _getHourlyCacheKey(String siteId) => 'hourly_forecast_$siteId';
 
+  static const Map<String, String> _headers = {
+    'Content-Type': 'application/json',
+  };
+
+  Map<String, String> _baseParams(String siteId) => {
+        'token': dotenv.env['AIRQO_API_TOKEN'] ?? '',
+        'site_id': siteId,
+      };
+
+  Map<String, String> _hourlyQueryParams(String siteId) => {
+        ..._baseParams(siteId),
+        'limit': '240',
+      };
 
   @override
   Future<ForecastResponse> loadForecasts(String siteId,
       {bool forceRefresh = false}) async {
-    loggy.info(
-        'Loading forecasts for site $siteId (forceRefresh: $forceRefresh)');
+    loggy.info('Loading daily forecasts for site $siteId');
 
-    final cacheKey = _getForecastCacheKey(siteId);
+    final cacheKey = _getDailyCacheKey(siteId);
 
     final cachedData = await _cacheManager.get<ForecastResponse>(
       boxName: CacheBoxName.forecast,
@@ -91,156 +103,181 @@ class ForecastImpl extends ForecastRepository with UiLoggy {
     );
 
     if (cachedData != null && !shouldRefresh) {
-      loggy.info(
-          'Using cached forecast data for site $siteId (${cachedData.timestamp})');
-
-      if (_cacheManager.isConnected) {
-        _refreshInBackground(siteId);
-      }
-
+      if (_cacheManager.isConnected) _refreshDailyInBackground(siteId);
       return cachedData.data;
     }
 
     if (_cacheManager.isConnected) {
       try {
-        final apiUrl = '${ApiUtils.baseUrl}${ApiUtils.fetchForecasts}';
-        final fullUrl = Uri.parse(apiUrl).replace(
-            queryParameters: {
-              "token": dotenv.env['AIRQO_API_TOKEN']!,
-              "site_id": siteId
-            });
-        
-        loggy.info('Fetching fresh forecast data for site $siteId from network');
+        final url = Uri.parse(
+            '${ApiUtils.baseUrl}${ApiUtils.fetchDailyForecasts}').replace(
+          queryParameters: _baseParams(siteId),
+        );
 
-        Response forecastResponse = await _httpClient.get(
-          fullUrl,
-          headers: {
-            'Content-Type': 'application/json',
-          },
-        ).timeout(const Duration(seconds: 15), onTimeout: () {
-          loggy.error('🌐 Request timed out after 15 seconds to: $fullUrl');
-          throw ForecastException(
-              'Request timed out. Server might be slow or unreachable.',
-              isNetworkError: true);
+        loggy.info('Fetching daily forecast: $url');
+        final response = await _httpClient
+            .get(url, headers: _headers)
+            .timeout(const Duration(seconds: 15), onTimeout: () {
+          throw ForecastException('Request timed out.', isNetworkError: true);
         });
 
-        if (forecastResponse.statusCode != 200) {
-          if (cachedData != null && forecastResponse.statusCode >= 500) {
-            loggy.warning(
-                'Server error ${forecastResponse.statusCode}, using cached data');
+        loggy.info('Daily forecast response: ${response.statusCode} — ${response.body.length > 200 ? response.body.substring(0, 200) : response.body}');
+
+        if (response.statusCode != 200) {
+          if (cachedData != null && response.statusCode >= 500) {
             return cachedData.data;
           }
-
-          if (forecastResponse.statusCode == 404) {
-            throw ForecastException(
-                'Forecast data not found for this location');
-          } else if (forecastResponse.statusCode == 401 ||
-              forecastResponse.statusCode == 403) {
-            throw ForecastException(
-                'Authentication error. Please try again later.');
-          } else {
-            throw ForecastException(
-                'Server error (${forecastResponse.statusCode}). Please try again later.');
-          }
+          _throwHttpError(response.statusCode);
         }
 
-        final responseBody = forecastResponse.body;
-        final ForecastResponse response =
-            ForecastResponse.fromJson(json.decode(responseBody));
+        final decoded = json.decode(response.body) as Map<String, dynamic>;
+        if (decoded['success'] == false) {
+          loggy.warning('API returned success=false: ${decoded['message']}');
+          if (cachedData != null) return cachedData.data;
+          throw ForecastException(
+              decoded['message'] ?? 'Forecast unavailable for this site.');
+        }
 
-        String? etag = forecastResponse.headers['etag'];
+        final parsed = ForecastResponse.fromJson(decoded);
 
         await _cacheManager.put<ForecastResponse>(
           boxName: CacheBoxName.forecast,
           key: cacheKey,
-          data: response,
-          toJson: (data) => response.toJson(),
-          etag: etag,
+          data: parsed,
+          toJson: (d) => parsed.toJson(),
+          etag: response.headers['etag'],
         );
 
-        _notifyListeners(siteId, response);
-
-        loggy.info(
-            '✅ Successfully fetched and cached forecast data for site $siteId');
-        return response;
+        _notifyListeners(siteId, parsed);
+        return parsed;
       } catch (e) {
-        loggy.error('Error fetching forecast data: $e');
-
-        bool isNetworkError = e.toString().toLowerCase().contains('socket') ||
-            e.toString().toLowerCase().contains('network') ||
-            e.toString().toLowerCase().contains('connection') ||
-            e.toString().toLowerCase().contains('handshake') ||
-            e.toString().toLowerCase().contains('dns') ||
-            e.toString().toLowerCase().contains('host') ||
-            (e is ForecastException && e.isNetworkError);
-
-        if (cachedData != null) {
-          loggy.info('Using stale cached data due to error');
-          return cachedData.data;
-        }
-
-        if (e is ForecastException) {
-          rethrow;
-        }
-        throw ForecastException('Failed to load forecast data: ${e.toString()}',
-            isNetworkError: isNetworkError);
+        loggy.error('Error fetching daily forecast: $e');
+        if (cachedData != null) return cachedData.data;
+        if (e is ForecastException) rethrow;
+        throw ForecastException('Failed to load forecast: ${e.toString()}',
+            isNetworkError: _isNetworkError(e));
       }
     } else {
-      if (cachedData != null) {
-        loggy.info('Using cached forecast data in offline mode');
-        return cachedData.data;
-      }
-
+      if (cachedData != null) return cachedData.data;
       throw ForecastException(
-          'Unable to load forecast data. Please check your connection and try again.',
+          'No connection. Please check your network.',
           isNetworkError: true);
     }
   }
 
-  Future<void> _refreshInBackground(String siteId) async {
-    try {
-      loggy.info(
-          'Starting background refresh of forecast data for site $siteId');
+  @override
+  Future<HourlyForecastResponse> loadHourlyForecasts(String siteId,
+      {bool forceRefresh = false}) async {
+    loggy.info('Loading hourly forecasts for site $siteId');
 
-      Response forecastResponse = await _httpClient.get(
-        Uri.parse('${ApiUtils.baseUrl}${ApiUtils.fetchForecasts}').replace(
-            queryParameters: {
-              "token": dotenv.env['AIRQO_API_TOKEN']!,
-              "site_id": siteId
-            }),
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      );
+    final cacheKey = _getHourlyCacheKey(siteId);
 
-      if (forecastResponse.statusCode == 200) {
-        final responseBody = forecastResponse.body;
-        final ForecastResponse response =
-            ForecastResponse.fromJson(json.decode(responseBody));
+    final cachedData = await _cacheManager.get<HourlyForecastResponse>(
+      boxName: CacheBoxName.forecast,
+      key: cacheKey,
+      fromJson: (json) => HourlyForecastResponse.fromJson(json),
+    );
 
-        String? etag = forecastResponse.headers['etag'];
+    final shouldRefresh = _cacheManager.shouldRefresh(
+      boxName: CacheBoxName.forecast,
+      key: cacheKey,
+      policy: RefreshPolicy.forecast,
+      cachedData: cachedData,
+      forceRefresh: forceRefresh,
+    );
 
-        final cacheKey = _getForecastCacheKey(siteId);
+    if (cachedData != null && !shouldRefresh) return cachedData.data;
 
-        await _cacheManager.put<ForecastResponse>(
-          boxName: CacheBoxName.forecast,
-          key: cacheKey,
-          data: response,
-          toJson: (data) => response.toJson(),
-          etag: etag,
+    if (_cacheManager.isConnected) {
+      try {
+        final url = Uri.parse(
+            '${ApiUtils.baseUrl}${ApiUtils.fetchHourlyForecasts}').replace(
+          queryParameters: _hourlyQueryParams(siteId),
         );
 
-        _notifyListeners(siteId, response);
+        final response = await _httpClient
+            .get(url, headers: _headers)
+            .timeout(const Duration(seconds: 15), onTimeout: () {
+          throw ForecastException('Request timed out.', isNetworkError: true);
+        });
 
-        loggy
-            .info('Background refresh of forecast data completed successfully');
-      } else {
-        loggy.warning(
-            'Background refresh API error: ${forecastResponse.statusCode}');
+        if (response.statusCode != 200) {
+          if (cachedData != null && response.statusCode >= 500) {
+            return cachedData.data;
+          }
+          _throwHttpError(response.statusCode);
+        }
+
+        final parsed =
+            HourlyForecastResponse.fromJson(json.decode(response.body));
+
+        await _cacheManager.put<HourlyForecastResponse>(
+          boxName: CacheBoxName.forecast,
+          key: cacheKey,
+          data: parsed,
+          toJson: (d) => parsed.toJson(),
+          etag: response.headers['etag'],
+        );
+
+        return parsed;
+      } catch (e) {
+        loggy.error('Error fetching hourly forecast: $e');
+        if (cachedData != null) return cachedData.data;
+        if (e is ForecastException) rethrow;
+        throw ForecastException('Failed to load hourly forecast: ${e.toString()}',
+            isNetworkError: _isNetworkError(e));
+      }
+    } else {
+      if (cachedData != null) return cachedData.data;
+      throw ForecastException('No connection.', isNetworkError: true);
+    }
+  }
+
+  Future<void> _refreshDailyInBackground(String siteId) async {
+    try {
+      final url = Uri.parse(
+          '${ApiUtils.baseUrl}${ApiUtils.fetchDailyForecasts}').replace(
+        queryParameters: _baseParams(siteId),
+      );
+
+      final response = await _httpClient.get(url, headers: _headers);
+
+      if (response.statusCode == 200) {
+        final parsed =
+            ForecastResponse.fromJson(json.decode(response.body));
+        await _cacheManager.put<ForecastResponse>(
+          boxName: CacheBoxName.forecast,
+          key: _getDailyCacheKey(siteId),
+          data: parsed,
+          toJson: (d) => parsed.toJson(),
+          etag: response.headers['etag'],
+        );
+        _notifyListeners(siteId, parsed);
       }
     } catch (e) {
-      loggy.error('Error in background refresh: $e');
+      loggy.warning('Background refresh failed: $e');
     }
+  }
+
+  void _throwHttpError(int statusCode) {
+    if (statusCode == 404) {
+      throw ForecastException('Forecast not found for this location.');
+    } else if (statusCode == 401 || statusCode == 403) {
+      throw ForecastException('Authentication error.');
+    } else {
+      throw ForecastException('Server error ($statusCode). Try again later.');
+    }
+  }
+
+  bool _isNetworkError(Object e) {
+    final msg = e.toString().toLowerCase();
+    return msg.contains('socket') ||
+        msg.contains('network') ||
+        msg.contains('connection') ||
+        msg.contains('handshake') ||
+        msg.contains('dns') ||
+        msg.contains('host') ||
+        (e is ForecastException && e.isNetworkError);
   }
 
   void _notifyListeners(String siteId, ForecastResponse forecast) {
@@ -263,12 +300,10 @@ class ForecastImpl extends ForecastRepository with UiLoggy {
   @override
   Future<void> clearCache(String siteId) async {
     try {
-      final cacheKey = _getForecastCacheKey(siteId);
       await _cacheManager.delete(
-        boxName: CacheBoxName.forecast,
-        key: cacheKey,
-      );
-      loggy.info('Forecast cache cleared for site $siteId');
+          boxName: CacheBoxName.forecast, key: _getDailyCacheKey(siteId));
+      await _cacheManager.delete(
+          boxName: CacheBoxName.forecast, key: _getHourlyCacheKey(siteId));
     } catch (e) {
       loggy.warning('Failed to clear forecast cache: $e');
     }
@@ -278,7 +313,6 @@ class ForecastImpl extends ForecastRepository with UiLoggy {
   Future<void> clearAllCaches() async {
     try {
       await _cacheManager.clearBox(CacheBoxName.forecast);
-      loggy.info('All forecast caches cleared');
     } catch (e) {
       loggy.warning('Failed to clear all forecast caches: $e');
     }
@@ -286,9 +320,7 @@ class ForecastImpl extends ForecastRepository with UiLoggy {
 
   void dispose() {
     for (final controller in _forecastControllers.values) {
-      if (!controller.isClosed) {
-        controller.close();
-      }
+      if (!controller.isClosed) controller.close();
     }
     _forecastControllers.clear();
     _httpClient.close();

--- a/src/mobile/lib/src/app/dashboard/widgets/analytics_forecast_widget.dart
+++ b/src/mobile/lib/src/app/dashboard/widgets/analytics_forecast_widget.dart
@@ -151,10 +151,10 @@ class _AnalyticsForecastWidgetState extends State<AnalyticsForecastWidget> with 
                           final isCurrentDay = forecastDate == currentDateFormatted;
                           
                           return ForeCastChip(
-                            active: isCurrentDay, // Set active based on current date
+                            active: isCurrentDay,
                             day: DateFormat.E().format(e.time)[0],
-                            imagePath: getForecastAirQualityIcon(
-                                e.pm25, state.response.aqiRanges),
+                            imagePath:
+                                getForecastAirQualityIcon(e.aqiCategory),
                             height: _getResponsiveHeight(context),
                             iconSize: _getResponsiveIconSize(context),
                             margin: _getResponsiveMargin(context),

--- a/src/mobile/lib/src/app/dashboard/widgets/analytics_specifics.dart
+++ b/src/mobile/lib/src/app/dashboard/widgets/analytics_specifics.dart
@@ -162,7 +162,7 @@ class _AnalyticsSpecificsState extends State<AnalyticsSpecifics> {
                             ),
                           );
                         },
-                        child: Text(
+                        child: TranslatedText(
                           'Full forecast',
                           style: TextStyle(
                             fontSize: 13,

--- a/src/mobile/lib/src/app/dashboard/widgets/analytics_specifics.dart
+++ b/src/mobile/lib/src/app/dashboard/widgets/analytics_specifics.dart
@@ -1,4 +1,5 @@
 import 'package:airqo/src/app/dashboard/models/airquality_response.dart';
+import 'package:airqo/src/app/dashboard/pages/forecast_overview_page.dart';
 import 'package:airqo/src/app/dashboard/widgets/expanded_analytics_card.dart';
 import 'package:airqo/src/app/dashboard/widgets/analytics_forecast_widget.dart';
 import 'package:airqo/src/meta/utils/colors.dart';
@@ -144,6 +145,31 @@ class _AnalyticsSpecificsState extends State<AnalyticsSpecifics> {
                         color: nameColor,
                       ),
                     ),
+                    if (widget.measurement.siteDetails?.id != null)
+                      TextButton(
+                        onPressed: () {
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (_) => ForecastOverviewPage(
+                                siteId: widget.measurement.siteDetails!.id!,
+                                siteName: widget.measurement.siteDetails
+                                        ?.searchName ??
+                                    widget.measurement.siteDetails?.name ??
+                                    widget.fallbackLocationName ??
+                                    '',
+                              ),
+                            ),
+                          );
+                        },
+                        child: Text(
+                          'Full forecast',
+                          style: TextStyle(
+                            fontSize: 13,
+                            color: AppColors.primaryColor,
+                          ),
+                        ),
+                      ),
                   ],
                 ),
                 const SizedBox(height: 16),

--- a/src/mobile/lib/src/app/dashboard/widgets/forecast_day_detail_card.dart
+++ b/src/mobile/lib/src/app/dashboard/widgets/forecast_day_detail_card.dart
@@ -1,0 +1,196 @@
+import 'package:airqo/src/app/dashboard/models/forecast_response.dart';
+import 'package:airqo/src/meta/utils/colors.dart';
+import 'package:airqo/src/meta/utils/forecast_utils.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:intl/intl.dart';
+
+class ForecastDayDetailCard extends StatelessWidget {
+  final Forecast forecast;
+  final bool isDark;
+
+  const ForecastDayDetailCard({
+    super.key,
+    required this.forecast,
+    required this.isDark,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final aqiColor = hexToColor(forecast.aqiColor);
+    final aqiTextColor = readableAqiColor(aqiColor);
+
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: isDark ? AppColors.darkHighlight : Colors.white,
+        borderRadius: BorderRadius.circular(16),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: isDark ? 0.3 : 0.06),
+            blurRadius: 12,
+            offset: const Offset(0, 4),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      DateFormat('EEEE, MMM d').format(forecast.time),
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                            color: AppColors.boldHeadlineColor,
+                          ),
+                    ),
+                    const SizedBox(height: 8),
+                    Row(
+                      crossAxisAlignment: CrossAxisAlignment.end,
+                      children: [
+                        Text(
+                          forecast.pm25.toStringAsFixed(1),
+                          style: Theme.of(context)
+                              .textTheme
+                              .titleLarge
+                              ?.copyWith(
+                                fontSize: 48,
+                                fontWeight: FontWeight.w700,
+                                height: 1,
+                              ),
+                        ),
+                        Padding(
+                          padding:
+                              const EdgeInsets.only(bottom: 8, left: 4),
+                          child: Text(
+                            'µg/m³',
+                            style: TextStyle(
+                              fontSize: 13,
+                              color: AppColors.boldHeadlineColor,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 10),
+                    Container(
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: 10, vertical: 4),
+                      decoration: BoxDecoration(
+                        color: aqiColor.withValues(alpha: 0.15),
+                        borderRadius: BorderRadius.circular(20),
+                        border: Border.all(
+                            color: aqiTextColor.withValues(alpha: 0.5),
+                            width: 1),
+                      ),
+                      child: Text(
+                        forecast.aqiCategory,
+                        style: TextStyle(
+                          fontSize: 12,
+                          fontWeight: FontWeight.w600,
+                          color: aqiTextColor,
+                        ),
+                      ),
+                    ),
+                    if (forecast.forecastConfidence != null) ...[
+                      const SizedBox(height: 14),
+                      ForecastConfidenceBar(
+                          confidence: forecast.forecastConfidence!),
+                    ],
+                  ],
+                ),
+              ),
+              const SizedBox(width: 16),
+              SvgPicture.asset(
+                getForecastAirQualityIcon(forecast.aqiCategory),
+                width: 72,
+                height: 72,
+              ),
+            ],
+          ),
+          if (forecast.aqiLabel != null) ...[
+            const SizedBox(height: 14),
+            const Divider(height: 1),
+            const SizedBox(height: 12),
+            Text(
+              forecast.aqiLabel!,
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: AppColors.boldHeadlineColor,
+                  ),
+            ),
+          ],
+          if (forecast.trendMessage != null) ...[
+            const SizedBox(height: 8),
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Icon(Icons.trending_flat_rounded,
+                    size: 14, color: AppColors.primaryColor),
+                const SizedBox(width: 4),
+                Expanded(
+                  child: Text(
+                    forecast.trendMessage!,
+                    style: TextStyle(
+                      fontSize: 11,
+                      color: AppColors.primaryColor,
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class ForecastConfidenceBar extends StatelessWidget {
+  final double confidence;
+
+  const ForecastConfidenceBar({super.key, required this.confidence});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(
+              'Forecast confidence',
+              style: TextStyle(
+                  fontSize: 11, color: AppColors.boldHeadlineColor),
+            ),
+            Text(
+              '${confidence.round()}%',
+              style: TextStyle(
+                fontSize: 11,
+                fontWeight: FontWeight.w600,
+                color: AppColors.boldHeadlineColor,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 4),
+        ClipRRect(
+          borderRadius: BorderRadius.circular(4),
+          child: LinearProgressIndicator(
+            value: confidence / 100,
+            minHeight: 6,
+            backgroundColor: AppColors.dividerColorlight,
+            valueColor:
+                AlwaysStoppedAnimation<Color>(AppColors.primaryColor),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/src/mobile/lib/src/app/dashboard/widgets/forecast_day_detail_card.dart
+++ b/src/mobile/lib/src/app/dashboard/widgets/forecast_day_detail_card.dart
@@ -158,6 +158,7 @@ class ForecastConfidenceBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final clamped = confidence.clamp(0.0, 100.0);
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -170,7 +171,7 @@ class ForecastConfidenceBar extends StatelessWidget {
                   fontSize: 11, color: AppColors.boldHeadlineColor),
             ),
             Text(
-              '${confidence.round()}%',
+              '${clamped.round()}%',
               style: TextStyle(
                 fontSize: 11,
                 fontWeight: FontWeight.w600,
@@ -183,7 +184,7 @@ class ForecastConfidenceBar extends StatelessWidget {
         ClipRRect(
           borderRadius: BorderRadius.circular(4),
           child: LinearProgressIndicator(
-            value: confidence / 100,
+            value: clamped / 100,
             minHeight: 6,
             backgroundColor: AppColors.dividerColorlight,
             valueColor:

--- a/src/mobile/lib/src/app/dashboard/widgets/forecast_day_selector.dart
+++ b/src/mobile/lib/src/app/dashboard/widgets/forecast_day_selector.dart
@@ -1,0 +1,117 @@
+import 'package:airqo/src/app/dashboard/models/forecast_response.dart';
+import 'package:airqo/src/meta/utils/colors.dart';
+import 'package:airqo/src/meta/utils/forecast_utils.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:intl/intl.dart';
+
+class ForecastDaySelector extends StatelessWidget {
+  final List<Forecast> forecasts;
+  final int selectedIndex;
+  final String todayStr;
+  final ValueChanged<int> onSelected;
+  final bool isDark;
+
+  const ForecastDaySelector({
+    super.key,
+    required this.forecasts,
+    required this.selectedIndex,
+    required this.todayStr,
+    required this.onSelected,
+    required this.isDark,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: List.generate(forecasts.length, (i) {
+        final f = forecasts[i];
+        final isActive = i == selectedIndex;
+        final isToday = DateFormat('yyyy-MM-dd').format(f.time) == todayStr;
+
+        Color bgColor;
+        if (isActive) {
+          bgColor = AppColors.primaryColor;
+        } else if (isToday) {
+          bgColor = AppColors.primaryColor.withValues(alpha: 0.08);
+        } else {
+          bgColor =
+              isDark ? AppColors.darkHighlight : AppColors.highlightColor;
+        }
+
+        return Expanded(
+          child: GestureDetector(
+            onTap: () => onSelected(i),
+            child: AnimatedContainer(
+              duration: const Duration(milliseconds: 200),
+              margin: const EdgeInsets.symmetric(horizontal: 3),
+              padding:
+                  const EdgeInsets.symmetric(vertical: 8, horizontal: 4),
+              decoration: BoxDecoration(
+                color: bgColor,
+                borderRadius: BorderRadius.circular(12),
+                border: isToday && !isActive
+                    ? Border.all(
+                        color:
+                            AppColors.primaryColor.withValues(alpha: 0.6),
+                        width: 1.5)
+                    : null,
+              ),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    isToday ? 'T' : DateFormat.E().format(f.time)[0],
+                    style: TextStyle(
+                      fontSize: 12,
+                      fontWeight: FontWeight.w700,
+                      color: isActive
+                          ? Colors.white
+                          : isToday
+                              ? AppColors.primaryColor
+                              : Theme.of(context)
+                                  .textTheme
+                                  .bodyMedium
+                                  ?.color,
+                    ),
+                  ),
+                  const SizedBox(height: 5),
+                  SizedBox(
+                    width: 26,
+                    height: 26,
+                    child: SvgPicture.asset(
+                        getForecastAirQualityIcon(f.aqiCategory)),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    '${f.pm25.round()}',
+                    style: TextStyle(
+                      fontSize: 11,
+                      fontWeight: FontWeight.w500,
+                      color: isActive
+                          ? Colors.white70
+                          : isToday
+                              ? AppColors.primaryColor
+                              : AppColors.boldHeadlineColor,
+                    ),
+                  ),
+                  const SizedBox(height: 2),
+                  Container(
+                    width: 4,
+                    height: 4,
+                    decoration: BoxDecoration(
+                      shape: BoxShape.circle,
+                      color: isToday
+                          ? (isActive ? Colors.white : AppColors.primaryColor)
+                          : Colors.transparent,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+      }),
+    );
+  }
+}

--- a/src/mobile/lib/src/app/dashboard/widgets/forecast_hourly_section.dart
+++ b/src/mobile/lib/src/app/dashboard/widgets/forecast_hourly_section.dart
@@ -1,0 +1,225 @@
+import 'package:airqo/src/app/dashboard/bloc/forecast/forecast_bloc.dart';
+import 'package:airqo/src/app/dashboard/models/forecast_response.dart';
+import 'package:airqo/src/app/shared/widgets/loading_widget.dart';
+import 'package:airqo/src/meta/utils/colors.dart';
+import 'package:airqo/src/meta/utils/forecast_utils.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:intl/intl.dart';
+
+class ForecastHourlySection extends StatelessWidget {
+  final String siteId;
+  final DateTime selectedDate;
+  final HourlyForecastResponse? hourlyResponse;
+  final bool isLoading;
+  final String? errorMessage;
+  final bool isDark;
+
+  const ForecastHourlySection({
+    super.key,
+    required this.siteId,
+    required this.selectedDate,
+    this.hourlyResponse,
+    this.isLoading = false,
+    this.errorMessage,
+    required this.isDark,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (!isLoading && errorMessage == null && hourlyResponse == null) {
+      return const SizedBox.shrink();
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Hourly Forecast',
+          style: Theme.of(context)
+              .textTheme
+              .titleSmall
+              ?.copyWith(fontWeight: FontWeight.w600),
+        ),
+        const SizedBox(height: 12),
+        if (isLoading)
+          SizedBox(
+            height: 100,
+            child: ListView.builder(
+              scrollDirection: Axis.horizontal,
+              itemCount: 8,
+              itemBuilder: (_, i) => Padding(
+                padding: const EdgeInsets.only(right: 8),
+                child: ShimmerContainer(
+                    width: 64, height: 100, borderRadius: 12),
+              ),
+            ),
+          )
+        else if (errorMessage != null)
+          _ErrorRow(siteId: siteId, isDark: isDark)
+        else
+          _HourlyList(
+              hourlyResponse: hourlyResponse!,
+              selectedDate: selectedDate,
+              isDark: isDark),
+      ],
+    );
+  }
+}
+
+class _ErrorRow extends StatelessWidget {
+  final String siteId;
+  final bool isDark;
+
+  const _ErrorRow({required this.siteId, required this.isDark});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(12),
+        color: isDark ? AppColors.darkHighlight : AppColors.highlightColor,
+      ),
+      child: Row(
+        children: [
+          const Icon(Icons.info_outline, size: 18, color: Colors.amber),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              'Hourly data unavailable',
+              style: TextStyle(
+                  fontSize: 13, color: AppColors.boldHeadlineColor),
+            ),
+          ),
+          TextButton(
+            onPressed: () => context
+                .read<ForecastBloc>()
+                .add(LoadHourlyForecast(siteId, forceRefresh: true)),
+            child: const Text('Retry'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _HourlyList extends StatelessWidget {
+  final HourlyForecastResponse hourlyResponse;
+  final DateTime selectedDate;
+  final bool isDark;
+
+  const _HourlyList({
+    required this.hourlyResponse,
+    required this.selectedDate,
+    required this.isDark,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final selectedDateStr = DateFormat('yyyy-MM-dd').format(selectedDate);
+    final dayEntries = hourlyResponse.forecasts
+        .where((e) =>
+            DateFormat('yyyy-MM-dd').format(e.time) == selectedDateStr)
+        .toList();
+
+    if (dayEntries.isEmpty) {
+      return Container(
+        padding: const EdgeInsets.all(16),
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(12),
+          color: isDark ? AppColors.darkHighlight : AppColors.highlightColor,
+        ),
+        child: Row(
+          children: [
+            Icon(Icons.schedule_rounded,
+                size: 16, color: AppColors.boldHeadlineColor),
+            const SizedBox(width: 8),
+            Text(
+              'No hourly data available for this day.',
+              style: TextStyle(
+                  fontSize: 13, color: AppColors.boldHeadlineColor),
+            ),
+          ],
+        ),
+      );
+    }
+
+    final nowStr = DateFormat('yyyy-MM-dd').format(DateTime.now());
+    return SizedBox(
+      height: 100,
+      child: ListView.builder(
+        scrollDirection: Axis.horizontal,
+        itemCount: dayEntries.length,
+        itemBuilder: (context, i) {
+          final entry = dayEntries[i];
+          final isNow = entry.time.hour == DateTime.now().hour &&
+              selectedDateStr == nowStr;
+          return _HourlyChip(entry: entry, isNow: isNow, isDark: isDark);
+        },
+      ),
+    );
+  }
+}
+
+class _HourlyChip extends StatelessWidget {
+  final HourlyForecastEntry entry;
+  final bool isNow;
+  final bool isDark;
+
+  const _HourlyChip(
+      {required this.entry, required this.isNow, required this.isDark});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 64,
+      margin: const EdgeInsets.only(right: 8),
+      padding: const EdgeInsets.symmetric(vertical: 10, horizontal: 6),
+      decoration: BoxDecoration(
+        color: isNow
+            ? AppColors.primaryColor
+            : isDark
+                ? AppColors.darkHighlight
+                : Colors.white,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(
+          color: isNow
+              ? AppColors.primaryColor
+              : isDark
+                  ? AppColors.dividerColordark
+                  : AppColors.dividerColorlight,
+        ),
+      ),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Text(
+            DateFormat('ha').format(entry.time),
+            style: TextStyle(
+              fontSize: 11,
+              fontWeight: FontWeight.w600,
+              color: isNow ? Colors.white : AppColors.boldHeadlineColor,
+            ),
+          ),
+          const SizedBox(height: 5),
+          SvgPicture.asset(
+            getForecastAirQualityIcon(entry.aqiCategory),
+            width: 24,
+            height: 24,
+          ),
+          const SizedBox(height: 4),
+          Text(
+            '${entry.pm25Mean.round()}',
+            style: TextStyle(
+              fontSize: 12,
+              fontWeight: FontWeight.w600,
+              color: isNow ? Colors.white : null,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/src/mobile/lib/src/app/dashboard/widgets/forecast_hourly_section.dart
+++ b/src/mobile/lib/src/app/dashboard/widgets/forecast_hourly_section.dart
@@ -118,10 +118,11 @@ class _HourlyList extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final selectedDateStr = DateFormat('yyyy-MM-dd').format(selectedDate);
+    final selectedDateStr =
+        DateFormat('yyyy-MM-dd').format(selectedDate.toLocal());
     final dayEntries = hourlyResponse.forecasts
         .where((e) =>
-            DateFormat('yyyy-MM-dd').format(e.time) == selectedDateStr)
+            DateFormat('yyyy-MM-dd').format(e.time.toLocal()) == selectedDateStr)
         .toList();
 
     if (dayEntries.isEmpty) {
@@ -146,7 +147,8 @@ class _HourlyList extends StatelessWidget {
       );
     }
 
-    final nowStr = DateFormat('yyyy-MM-dd').format(DateTime.now());
+    final now = DateTime.now();
+    final nowStr = DateFormat('yyyy-MM-dd').format(now);
     return SizedBox(
       height: 100,
       child: ListView.builder(
@@ -154,7 +156,7 @@ class _HourlyList extends StatelessWidget {
         itemCount: dayEntries.length,
         itemBuilder: (context, i) {
           final entry = dayEntries[i];
-          final isNow = entry.time.hour == DateTime.now().hour &&
+          final isNow = entry.time.toLocal().hour == now.hour &&
               selectedDateStr == nowStr;
           return _HourlyChip(entry: entry, isNow: isNow, isDark: isDark);
         },
@@ -196,7 +198,7 @@ class _HourlyChip extends StatelessWidget {
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
           Text(
-            DateFormat('ha').format(entry.time),
+            DateFormat('ha').format(entry.time.toLocal()),
             style: TextStyle(
               fontSize: 11,
               fontWeight: FontWeight.w600,

--- a/src/mobile/lib/src/app/dashboard/widgets/forecast_met_row.dart
+++ b/src/mobile/lib/src/app/dashboard/widgets/forecast_met_row.dart
@@ -1,0 +1,110 @@
+import 'package:airqo/src/app/dashboard/models/forecast_response.dart';
+import 'package:airqo/src/meta/utils/colors.dart';
+import 'package:flutter/material.dart';
+
+class ForecastMetRow extends StatelessWidget {
+  final ForecastMet? met;
+
+  const ForecastMetRow({super.key, this.met});
+
+  @override
+  Widget build(BuildContext context) {
+    if (met == null) return const SizedBox.shrink();
+
+    final items = <_MetItem>[
+      if (met!.airTemperature != null)
+        _MetItem(
+          icon: Icons.thermostat_rounded,
+          label: 'Temp',
+          value: '${met!.airTemperature!.round()}°C',
+          color: const Color(0xFFFF6D00),
+        ),
+      if (met!.relativeHumidity != null)
+        _MetItem(
+          icon: Icons.water_drop_outlined,
+          label: 'Humidity',
+          value: '${met!.relativeHumidity!.round()}%',
+          color: const Color(0xFF1565C0),
+        ),
+      if (met!.windSpeed != null)
+        _MetItem(
+          icon: Icons.air_rounded,
+          label: met!.windDirectionCompass != null
+              ? 'Wind ${met!.windDirectionCompass}'
+              : 'Wind',
+          value: '${met!.windSpeed!.toStringAsFixed(1)} m/s',
+          color: const Color(0xFF00897B),
+        ),
+      if (met!.precipitationAmount != null)
+        _MetItem(
+          icon: Icons.umbrella_rounded,
+          label: 'Rain',
+          value: '${met!.precipitationAmount!.toStringAsFixed(1)} mm',
+          color: const Color(0xFF5C6BC0),
+        ),
+    ];
+
+    if (items.isEmpty) return const SizedBox.shrink();
+
+    return Row(
+      children: items
+          .map((item) => Expanded(child: _MetTile(item: item)))
+          .toList(),
+    );
+  }
+}
+
+class _MetItem {
+  final IconData icon;
+  final String label;
+  final String value;
+  final Color color;
+
+  const _MetItem({
+    required this.icon,
+    required this.label,
+    required this.value,
+    required this.color,
+  });
+}
+
+class _MetTile extends StatelessWidget {
+  final _MetItem item;
+
+  const _MetTile({required this.item});
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 4),
+      padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 8),
+      decoration: BoxDecoration(
+        color: isDark ? AppColors.darkHighlight : Colors.white,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(
+          color: isDark
+              ? AppColors.dividerColordark
+              : AppColors.dividerColorlight,
+        ),
+      ),
+      child: Column(
+        children: [
+          Icon(item.icon, size: 22, color: item.color),
+          const SizedBox(height: 6),
+          Text(
+            item.value,
+            style:
+                const TextStyle(fontWeight: FontWeight.w600, fontSize: 13),
+          ),
+          Text(
+            item.label,
+            style: TextStyle(
+                fontSize: 10, color: AppColors.boldHeadlineColor),
+            overflow: TextOverflow.ellipsis,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/src/mobile/lib/src/app/surveys/repository/survey_repository.dart
+++ b/src/mobile/lib/src/app/surveys/repository/survey_repository.dart
@@ -201,10 +201,7 @@ class SurveyRepository extends BaseRepository with UiLoggy {
               .toList();
 
           responses = _mergeResponses(cachedResponses, apiResponses);
-
-          for (final response in apiResponses) {
-            await _cacheSurveyResponse(response);
-          }
+          await _cacheSurveyResponsesBatch(responses);
         }
       } catch (e) {
         loggy.warning('Could not sync with API, using cached responses: $e');
@@ -347,20 +344,27 @@ class SurveyRepository extends BaseRepository with UiLoggy {
     }
   }
 
+  Future<void> _cacheSurveyResponsesBatch(
+      List<SurveyResponse> responses) async {
+    try {
+      await HiveRepository.saveData(_surveyResponsesBoxName, 'responses',
+          json.encode(responses.map((r) => r.toJson()).toList()));
+    } catch (e) {
+      loggy.error('Error caching survey responses: $e');
+    }
+  }
+
   Future<void> _cacheSurveyResponse(SurveyResponse response) async {
     try {
       final responses = await _getCachedSurveyResponses();
-
       final existingIndex = responses.indexWhere((r) => r.id == response.id);
       if (existingIndex >= 0) {
         responses[existingIndex] = response;
       } else {
         responses.add(response);
       }
-
-      final responsesJson = responses.map((r) => r.toJson()).toList();
-      await HiveRepository.saveData(
-          _surveyResponsesBoxName, 'responses', json.encode(responsesJson));
+      await HiveRepository.saveData(_surveyResponsesBoxName, 'responses',
+          json.encode(responses.map((r) => r.toJson()).toList()));
     } catch (e) {
       loggy.error('Error caching survey response: $e');
     }

--- a/src/mobile/lib/src/meta/utils/api_utils.dart
+++ b/src/mobile/lib/src/meta/utils/api_utils.dart
@@ -12,7 +12,9 @@ class ApiUtils {
 
   static String fetchLessons = "/api/v2/devices/kya/lessons";
 
-  static String fetchForecasts = "/api/v2/predict/daily-forecast";
+  static String fetchDailyForecasts = "/api/v2/predict/daily-forecasting";
+
+  static String fetchHourlyForecasts = "/api/v2/predict/hourly-forecasting";
 
   static String fetchCountries = "/api/v2/devices/grids/countries";
 }

--- a/src/mobile/lib/src/meta/utils/forecast_utils.dart
+++ b/src/mobile/lib/src/meta/utils/forecast_utils.dart
@@ -1,40 +1,60 @@
-import 'package:airqo/src/app/dashboard/models/forecast_response.dart';
+import 'package:flutter/material.dart';
 
-String getForecastAirQualityIcon(double value, Map<String, AqiRange> aqiRanges) {
-  switch (getAirQuality(value, aqiRanges)) {
-    case "Good":
-      return "assets/images/shared/airquality_indicators/good.svg";
-
-    case "Moderate":
-      return "assets/images/shared/airquality_indicators/moderate.svg";
-
-    case "Unhealthy":
-      return "assets/images/shared/airquality_indicators/unhealthy.svg";
-
-    case "Unhealthy for Sensitive Groups":
-      return "assets/images/shared/airquality_indicators/unhealthy-sensitive.svg";
-
-    case "Very Unhealthy":
-      return "assets/images/shared/airquality_indicators/very-unhealthy.svg";
-
-    case "Hazardous":
-      return "assets/images/shared/airquality_indicators/hazardous.svg";
-
-
-    case "Unavailable":
-      return "assets/images/shared/airquality_indicators/unavailable.svg";
-
-
-    default:
-      return "";
+Color hexToColor(String hex) {
+  try {
+    return Color(int.parse('FF${hex.replaceAll('#', '')}', radix: 16));
+  } catch (_) {
+    return const Color(0xFF9E9E9E);
   }
 }
 
-String getAirQuality(double value, Map<String, AqiRange> aqiRanges) {
-  for (var range in aqiRanges.values) {
-    if (value >= range.min && (range.max == null || value <= range.max!)) {
-      return range.aqiCategory;
-    }
+Color readableAqiColor(Color color) {
+  final r = (color.r * 255.0).round().clamp(0, 255) / 255;
+  final g = (color.g * 255.0).round().clamp(0, 255) / 255;
+  final b = (color.b * 255.0).round().clamp(0, 255) / 255;
+  double lin(double c) =>
+      c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) * ((c + 0.055) / 1.055);
+  final luminance = 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b);
+  if (luminance > 0.4) {
+    return HSLColor.fromColor(color).withLightness(0.3).toColor();
   }
-  return "Unavailable";
+  return color;
+}
+
+String getForecastAirQualityIcon(String aqiCategory) {
+  switch (aqiCategory) {
+    case "Good":
+      return "assets/images/shared/airquality_indicators/good.svg";
+    case "Moderate":
+      return "assets/images/shared/airquality_indicators/moderate.svg";
+    case "Unhealthy for Sensitive Groups":
+      return "assets/images/shared/airquality_indicators/unhealthy-sensitive.svg";
+    case "Unhealthy":
+      return "assets/images/shared/airquality_indicators/unhealthy.svg";
+    case "Very Unhealthy":
+      return "assets/images/shared/airquality_indicators/very-unhealthy.svg";
+    case "Hazardous":
+      return "assets/images/shared/airquality_indicators/hazardous.svg";
+    default:
+      return "assets/images/shared/airquality_indicators/unavailable.svg";
+  }
+}
+
+Color getForecastAirQualityColor(String aqiCategory) {
+  switch (aqiCategory) {
+    case "Good":
+      return const Color(0xFF00C853);
+    case "Moderate":
+      return const Color(0xFFFFD600);
+    case "Unhealthy for Sensitive Groups":
+      return const Color(0xFFFF6D00);
+    case "Unhealthy":
+      return const Color(0xFFDD2C00);
+    case "Very Unhealthy":
+      return const Color(0xFF6A1B9A);
+    case "Hazardous":
+      return const Color(0xFF4E0000);
+    default:
+      return const Color(0xFF9E9E9E);
+  }
 }

--- a/src/mobile/test/app/dashboard/repository/forecast_repository_test.dart
+++ b/src/mobile/test/app/dashboard/repository/forecast_repository_test.dart
@@ -8,7 +8,6 @@ import 'package:http/http.dart' as http;
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'dart:convert';
 
-// Generate mocks
 @GenerateMocks([http.Client, CacheManager])
 import 'forecast_repository_test.mocks.dart';
 
@@ -19,17 +18,15 @@ void main() {
     late ForecastImpl repository;
 
     setUpAll(() async {
-      // Initialize dotenv for tests
       dotenv.testLoad(fileInput: '''
 AIRQO_API_TOKEN=test-forecast-token-123
+AIRQO_MOBILE_TOKEN=test-mobile-token
 ''');
     });
 
     setUp(() {
       mockHttpClient = MockClient();
       mockCacheManager = MockCacheManager();
-
-      // Create repository with mocked dependencies
       repository = ForecastImpl(
         httpClient: mockHttpClient,
         cacheManager: mockCacheManager,
@@ -37,58 +34,46 @@ AIRQO_API_TOKEN=test-forecast-token-123
     });
 
     tearDown(() {
-      // Reset singleton for next test
       ForecastImpl.resetInstance();
     });
 
     group('loadForecasts', () {
       const tSiteId = 'test-site-123';
       final tForecastResponse = ForecastResponse(
-        aqiRanges: {
-          'good': AqiRange(
-            aqiCategory: 'Good',
-            aqiColor: '#00e400',
-            aqiColorName: 'Green',
-            label: 'Good',
-            min: 0.0,
-            max: 12.0,
-          ),
-        },
         forecasts: [
           Forecast(
             aqiCategory: 'Good',
-            aqiColor: '#00e400',
+            aqiColor: '#00E400',
             aqiColorName: 'Green',
             pm25: 8.5,
-            time: DateTime.parse('2024-01-15T12:00:00Z'),
+            time: DateTime.parse('2024-01-15T00:00:00Z'),
           ),
           Forecast(
             aqiCategory: 'Moderate',
-            aqiColor: '#ffff00',
+            aqiColor: '#FFFF00',
             aqiColorName: 'Yellow',
             pm25: 25.3,
-            time: DateTime.parse('2024-01-16T12:00:00Z'),
+            time: DateTime.parse('2024-01-16T00:00:00Z'),
           ),
         ],
       );
 
       test('should return cached forecast when available and not stale',
           () async {
-        // Arrange
         final cachedData = CachedData<ForecastResponse>(
           data: tForecastResponse,
-          timestamp: DateTime.now().subtract(Duration(minutes: 30)),
+          timestamp: DateTime.now().subtract(const Duration(minutes: 30)),
         );
 
         when(mockCacheManager.get<ForecastResponse>(
           boxName: CacheBoxName.forecast,
-          key: 'forecast_$tSiteId',
+          key: 'daily_forecast_$tSiteId',
           fromJson: anyNamed('fromJson'),
         )).thenAnswer((_) async => cachedData);
 
         when(mockCacheManager.shouldRefresh<ForecastResponse>(
           boxName: CacheBoxName.forecast,
-          key: 'forecast_$tSiteId',
+          key: 'daily_forecast_$tSiteId',
           policy: RefreshPolicy.forecast,
           cachedData: cachedData,
           forceRefresh: false,
@@ -96,38 +81,31 @@ AIRQO_API_TOKEN=test-forecast-token-123
 
         when(mockCacheManager.isConnected).thenReturn(true);
 
-        // Act
         final result = await repository.loadForecasts(tSiteId);
 
-        // Assert
-        expect(result, equals(tForecastResponse));
         expect(result.forecasts, hasLength(2));
         expect(result.forecasts[0].pm25, equals(8.5));
         expect(result.forecasts[1].pm25, equals(25.3));
       });
 
       test('should fetch fresh forecast data when cache is stale', () async {
-        // Arrange
         final mockApiResponse = {
-          'aqi_ranges': {
-            'good': {
-              'aqi_category': 'Good',
-              'aqi_color': '#00e400',
-              'aqi_color_name': 'Green',
-              'label': 'Good',
-              'min': 0.0,
-              'max': 12.0,
-            },
+          'success': true,
+          'data': {
+            'forecasts': [
+              {
+                'site_details': {'site_id': tSiteId, 'site_name': 'Test Site'},
+                'forecasts': [
+                  {
+                    'date': '2024-01-15',
+                    'forecast': {'pm2_5_mean': 10.2, 'forecast_confidence': 85.0},
+                    'aqi': {'label': 'Good'},
+                    'met': {'air_temperature': 24.0, 'relative_humidity': 70.0},
+                  },
+                ],
+              },
+            ],
           },
-          'forecasts': [
-            {
-              'aqi_category': 'Good',
-              'aqi_color': '#00e400',
-              'aqi_color_name': 'Green',
-              'pm2_5': 10.2,
-              'time': '2024-01-15T12:00:00Z',
-            },
-          ],
         };
 
         when(mockCacheManager.get<ForecastResponse>(
@@ -163,20 +141,17 @@ AIRQO_API_TOKEN=test-forecast-token-123
           etag: anyNamed('etag'),
         )).thenAnswer((_) async {});
 
-        // Act
         final result =
             await repository.loadForecasts(tSiteId, forceRefresh: true);
 
-        // Assert
         expect(result.forecasts, hasLength(1));
         expect(result.forecasts[0].pm25, equals(10.2));
         expect(result.forecasts[0].aqiCategory, equals('Good'));
+        expect(result.forecasts[0].forecastConfidence, equals(85.0));
       });
 
-      test(
-          'should throw ForecastException when network fails and no cache available',
+      test('should throw ForecastException when network fails and no cache',
           () async {
-        // Arrange
         when(mockCacheManager.get<ForecastResponse>(
           boxName: anyNamed('boxName'),
           key: anyNamed('key'),
@@ -198,7 +173,6 @@ AIRQO_API_TOKEN=test-forecast-token-123
           headers: anyNamed('headers'),
         )).thenThrow(Exception('Network error'));
 
-        // Act & Assert
         expect(
           () => repository.loadForecasts(tSiteId),
           throwsA(isA<ForecastException>()),
@@ -206,10 +180,9 @@ AIRQO_API_TOKEN=test-forecast-token-123
       });
 
       test('should return cached data when offline', () async {
-        // Arrange
         final cachedData = CachedData<ForecastResponse>(
           data: tForecastResponse,
-          timestamp: DateTime.now().subtract(Duration(hours: 2)),
+          timestamp: DateTime.now().subtract(const Duration(hours: 2)),
         );
 
         when(mockCacheManager.get<ForecastResponse>(
@@ -218,7 +191,6 @@ AIRQO_API_TOKEN=test-forecast-token-123
           fromJson: anyNamed('fromJson'),
         )).thenAnswer((_) async => cachedData);
 
-        // Add missing shouldRefresh stub for offline scenario
         when(mockCacheManager.shouldRefresh<ForecastResponse>(
           boxName: anyNamed('boxName'),
           key: anyNamed('key'),
@@ -229,26 +201,20 @@ AIRQO_API_TOKEN=test-forecast-token-123
 
         when(mockCacheManager.isConnected).thenReturn(false);
 
-        // Act
         final result = await repository.loadForecasts(tSiteId);
 
-        // Assert
-        expect(result, equals(tForecastResponse));
-
-        // Verify no network call was made
+        expect(result.forecasts, hasLength(2));
         verifyNever(mockHttpClient.get(any, headers: anyNamed('headers')));
       });
 
-      test('should throw ForecastException when offline and no cache available',
+      test('should throw ForecastException when offline and no cache',
           () async {
-        // Arrange
         when(mockCacheManager.get<ForecastResponse>(
           boxName: anyNamed('boxName'),
           key: anyNamed('key'),
           fromJson: anyNamed('fromJson'),
         )).thenAnswer((_) async => null);
 
-        // Add missing shouldRefresh stub
         when(mockCacheManager.shouldRefresh<ForecastResponse>(
           boxName: anyNamed('boxName'),
           key: anyNamed('key'),
@@ -259,20 +225,13 @@ AIRQO_API_TOKEN=test-forecast-token-123
 
         when(mockCacheManager.isConnected).thenReturn(false);
 
-        // Act & Assert
         expect(
           () => repository.loadForecasts(tSiteId),
-          throwsA(
-            predicate((e) =>
-                e is ForecastException &&
-                e.toString().contains(
-                    'No internet connection and no cached forecast data available')),
-          ),
+          throwsA(isA<ForecastException>()),
         );
       });
 
       test('should handle HTTP 404 error with specific message', () async {
-        // Arrange
         when(mockCacheManager.get<ForecastResponse>(
           boxName: anyNamed('boxName'),
           key: anyNamed('key'),
@@ -292,29 +251,22 @@ AIRQO_API_TOKEN=test-forecast-token-123
         when(mockHttpClient.get(
           any,
           headers: anyNamed('headers'),
-        )).thenAnswer((_) async => http.Response(
-              'Not found',
-              404,
-            ));
+        )).thenAnswer((_) async => http.Response('Not found', 404));
 
-        // Act & Assert
         expect(
           () => repository.loadForecasts(tSiteId),
           throwsA(
             predicate((e) =>
                 e is ForecastException &&
-                e
-                    .toString()
-                    .contains('Forecast data not found for this location')),
+                e.toString().contains('Forecast not found')),
           ),
         );
       });
 
       test('should handle server errors with cached fallback', () async {
-        // Arrange
         final cachedData = CachedData<ForecastResponse>(
           data: tForecastResponse,
-          timestamp: DateTime.now().subtract(Duration(hours: 5)),
+          timestamp: DateTime.now().subtract(const Duration(hours: 5)),
         );
 
         when(mockCacheManager.get<ForecastResponse>(
@@ -336,51 +288,45 @@ AIRQO_API_TOKEN=test-forecast-token-123
         when(mockHttpClient.get(
           any,
           headers: anyNamed('headers'),
-        )).thenAnswer((_) async => http.Response(
-              'Internal Server Error',
-              500,
-            ));
+        )).thenAnswer(
+            (_) async => http.Response('Internal Server Error', 500));
 
-        // Act
         final result = await repository.loadForecasts(tSiteId);
 
-        // Assert - should return cached data despite server error
-        expect(result, equals(tForecastResponse));
+        expect(result.forecasts, hasLength(2));
       });
     });
 
     group('clearCache', () {
       const tSiteId = 'test-site-456';
 
-      test('should call cache manager delete with correct parameters',
+      test('should call cache manager delete for daily and hourly keys',
           () async {
-        // Arrange
         when(mockCacheManager.delete(
           boxName: CacheBoxName.forecast,
-          key: 'forecast_$tSiteId',
+          key: anyNamed('key'),
         )).thenAnswer((_) async {});
 
-        // Act
         await repository.clearCache(tSiteId);
 
-        // Assert
         verify(mockCacheManager.delete(
           boxName: CacheBoxName.forecast,
-          key: 'forecast_$tSiteId',
+          key: 'daily_forecast_$tSiteId',
+        )).called(1);
+        verify(mockCacheManager.delete(
+          boxName: CacheBoxName.forecast,
+          key: 'hourly_forecast_$tSiteId',
         )).called(1);
       });
     });
 
     group('clearAllCaches', () {
       test('should call cache manager clearBox', () async {
-        // Arrange
         when(mockCacheManager.clearBox(CacheBoxName.forecast))
             .thenAnswer((_) async {});
 
-        // Act
         await repository.clearAllCaches();
 
-        // Assert
         verify(mockCacheManager.clearBox(CacheBoxName.forecast)).called(1);
       });
     });
@@ -389,10 +335,7 @@ AIRQO_API_TOKEN=test-forecast-token-123
       const tSiteId = 'test-site-789';
 
       test('should return broadcast stream for site', () {
-        // Act
         final stream = repository.getForecastStream(tSiteId);
-
-        // Assert
         expect(stream, isA<Stream<ForecastResponse>>());
       });
     });


### PR DESCRIPTION
- Migrate daily and hourly forecast to new API endpoints (/api/v2/predict/daily-forecasting, /api/v2/predict/hourly-forecasting)
- Add ForecastOverviewPage with 7-day selector, detail card, met data, and hourly forecast section; accessible via "Full forecast" link
- Update ForecastResponse and HourlyForecastResponse models to match new API response shape (aqi_category, pm2_5_mean, met fields, etc.)
- Add readableAqiColor/hexToColor utilities to handle low-contrast AQI colors (e.g. yellow #FFFF00) for readable text on white
- Add LoadHourlyForecast event/states to ForecastBloc
- Split forecast_overview_page.dart into focused widget files (day selector, detail card, met row, hourly section)
- Fix survey repository O(N²) Hive write loop: replace per-item cache calls with a single batch write after API sync



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Added comprehensive forecast overview page displaying 7-day forecasts with hourly breakdowns
- Interactive forecast day selector showing detailed cards with AQI category, PM2.5 measurements, and confidence levels
- Enhanced forecast displays include meteorological data visualization (temperature, humidity, wind, rain)
- Quick-access "Full forecast" button added to analytics view

<!-- end of auto-generated comment: release notes by coderabbit.ai -->