### PR TITLE
Add default API URL fallback (vertex app)

### DIFF
--- a/src/vertex/lib/envConstants.ts
+++ b/src/vertex/lib/envConstants.ts
@@ -5,17 +5,22 @@
 import { stripTrailingSlash } from './utils';
 
 /**
+ * Gets the default API URL fallback based on the current environment
+ * @returns {string} The default API URL
+ */
+export const getDefaultApiUrl = (): string => {
+  const env = getEnvironment().toLowerCase();
+  if (env === 'production') return 'https://vertex.airqo.net/api/v2';
+  if (env === 'staging') return 'https://staging-vertex.airqo.net/api/v2';
+  return 'http://localhost:3000';
+};
+
+/**
  * Gets the API base URL from environment variables
  * @returns {string} The API base URL
- * @throws {Error} If API_URL is not defined
  */
 export const getApiBaseUrl = (): string => {
-  const apiUrl = process.env.NEXT_PUBLIC_API_URL;
-  
-  if (!apiUrl) {
-    throw new Error('NEXT_PUBLIC_API_URL environment variable is not defined');
-  }
-  
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL || getDefaultApiUrl();
   return stripTrailingSlash(apiUrl);
 };
 

--- a/src/vertex/lib/envConstants.ts
+++ b/src/vertex/lib/envConstants.ts
@@ -158,7 +158,6 @@ export const getEnvConfig = () => {
  */
 export const validateEnvironment = (): boolean => {
   const required = [
-    'NEXT_PUBLIC_API_URL',
     'NEXT_PUBLIC_API_TOKEN',
     'NEXT_PUBLIC_CLOUDINARY_NAME',
     'NEXT_PUBLIC_CLOUDINARY_PRESET',

--- a/src/vertex/vertex.config.ts
+++ b/src/vertex/vertex.config.ts
@@ -1,8 +1,8 @@
 import {
   defaultVertexConfig,
   validateVertexConfig,
-  type VertexConfigInput,
 } from "./core/config/vertex-config";
+import { getDefaultApiUrl } from "./lib/envConstants";
 
 const config: VertexConfigInput = {
   ...defaultVertexConfig,
@@ -17,9 +17,9 @@ const config: VertexConfigInput = {
   },
   api: {
     adapter: "airqo",
-    baseUrl: process.env.NEXT_PUBLIC_API_URL,
+    baseUrl: process.env.NEXT_PUBLIC_API_URL || getDefaultApiUrl(),
     publicMeasurementsBaseUrl:
-      process.env.NEXT_PUBLIC_API_BASE_URL || "https://api.airqo.net",
+      process.env.NEXT_PUBLIC_API_BASE_URL || getDefaultApiUrl(),
   },
   auth: {
     provider: "airqo",

--- a/src/vertex/vertex.config.ts
+++ b/src/vertex/vertex.config.ts
@@ -1,6 +1,7 @@
 import {
   defaultVertexConfig,
   validateVertexConfig,
+  type VertexConfigInput,
 } from "./core/config/vertex-config";
 import { getDefaultApiUrl } from "./lib/envConstants";
 


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

- Introduce getDefaultApiUrl() in envConstants to provide environment-aware default API endpoints (production, staging, localhost). Change getApiBaseUrl() to fall back to this default instead of throwing when NEXT_PUBLIC_API_URL is missing. Update vertex.config to import and use getDefaultApiUrl() for api.baseUrl and publicMeasurementsBaseUrl, ensuring the app has sensible defaults across environments.

#### Status of maturity (all need to be checked before merging):

- [ ] I've tested this locally
- [ ] I consider this code done
- [ ] This change ready to hit production in its current state
- [ ] The title of the PR states what changed and the related issues number (used for the release note).
- [ ] I've included issue number in the "Closes #ISSUE-NUMBER" part of the "[What are the relevant tickets?](#what-are-the-relevant-tickets)" section to [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [ ] I've updated corresponding documentation for the changes in this PR.
- [ ] I have written unit and/or e2e tests for my change(s).

#### How should this be manually tested?

- Please include the steps to be done inorder to setup and test this PR.

#### What are the relevant tickets?

- Closes #<enter issue number here>
- [Jira_card_number]() (If exists)

#### Screenshots (optional)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Application now gracefully handles missing API configuration by automatically selecting appropriate defaults based on the current environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->