### PR TITLE
Bump next-auth session cookie to v2

### DIFF
--- a/src/vertex/app/api/auth/[...nextauth]/options.ts
+++ b/src/vertex/app/api/auth/[...nextauth]/options.ts
@@ -288,8 +288,8 @@ export const options: NextAuthOptions = {
   cookies: {
     sessionToken: {
       name: isProduction
-        ? '__Secure-next-auth.session-token'
-        : 'next-auth.session-token',
+        ? '__Secure-next-auth.session-token-v2'
+        : 'next-auth.session-token-v2',
       options: cookieOptions,
     },
   },

--- a/src/vertex/middleware.ts
+++ b/src/vertex/middleware.ts
@@ -3,8 +3,8 @@ import { NextResponse } from "next/server";
 
 const isProduction = process.env.NODE_ENV === "production";
 const sessionCookieName = isProduction
-  ? "__Secure-next-auth.session-token"
-  : "next-auth.session-token";
+  ? "__Secure-next-auth.session-token-v2"
+  : "next-auth.session-token-v2";
 
 export default withAuth(
   function middleware(req) {


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

- Rename NextAuth session cookie to include a -v2 suffix in both the NextAuth options and middleware (src/vertex/app/api/auth/[...nextauth]/options.ts and src/vertex/middleware.ts). This rotates the cookie name for production and development to avoid collisions and enable migration to the new cookie version.

#### Status of maturity (all need to be checked before merging):

- [ ] I've tested this locally
- [ ] I consider this code done
- [ ] This change ready to hit production in its current state
- [ ] The title of the PR states what changed and the related issues number (used for the release note).
- [ ] I've included issue number in the "Closes #ISSUE-NUMBER" part of the "[What are the relevant tickets?](#what-are-the-relevant-tickets)" section to [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [ ] I've updated corresponding documentation for the changes in this PR.
- [ ] I have written unit and/or e2e tests for my change(s).

#### How should this be manually tested?

- Please include the steps to be done inorder to setup and test this PR.

#### What are the relevant tickets?

- Closes #<enter issue number here>
- [Jira_card_number]() (If exists)

#### Screenshots (optional)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated authentication session configuration with improved cookie handling to enhance security and reliability across production and non-production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->