### PR TITLE
Pull Key Vault secrets into vertex .env

### DIFF
--- a/.github/workflows/deploy-frontend-to-azureprod.yml
+++ b/.github/workflows/deploy-frontend-to-azureprod.yml
@@ -170,9 +170,8 @@ jobs:
           az keyvault secret show \
             --vault-name ${{ env.KEYVAULT }} \
             --name prod-env-next-platform \
-            --query value -o tsv > secrets.json
-
-          jq -r 'to_entries | .[] | "\(.key)=\(.value|tojson)"' secrets.json > src/platform/.env        
+            --query value -o tsv | \
+          jq -r 'to_entries | .[] | "\(.key)=\(.value|tojson)"' > src/platform/.env        
 
       - name: Build and Push Docker Image
         run: |
@@ -216,9 +215,8 @@ jobs:
           az keyvault secret show \
             --vault-name ${{ env.KEYVAULT }} \
             --name prod-env-vertex \
-            --query value -o tsv > secrets.json
-
-          jq -r 'to_entries | .[] | "\(.key)=\(.value|tojson)"' secrets.json > src/vertex/.env        
+            --query value -o tsv | \
+          jq -r 'to_entries | .[] | "\(.key)=\(.value|tojson)"' > src/vertex/.env        
 
       - name: Build and Push Docker Image
         run: |

--- a/.github/workflows/deploy-frontend-to-azureprod.yml
+++ b/.github/workflows/deploy-frontend-to-azureprod.yml
@@ -211,6 +211,15 @@ jobs:
       - name: ACR Login
         run: az acr login --name ${{ env.ACR_NAME }}
 
+      - name: Pull secrets from Key Vault
+        run: |
+          az keyvault secret show \
+            --vault-name ${{ env.KEYVAULT }} \
+            --name prod-env-vertex \
+            --query value -o tsv > secrets.json
+
+          jq -r 'to_entries | .[] | "\(.key)=\(.value|tojson)"' secrets.json > src/vertex/.env        
+
       - name: Build and Push Docker Image
         run: |
           cd src/vertex/

--- a/.github/workflows/deploy-frontend-to-azurestaging.yml
+++ b/.github/workflows/deploy-frontend-to-azurestaging.yml
@@ -280,6 +280,15 @@ jobs:
       - name: ACR Login
         run: az acr login --name ${{ env.ACR_NAME }}
 
+      - name: Pull secrets from Key Vault
+        run: |
+          az keyvault secret show \
+            --vault-name ${{ env.KEYVAULT }} \
+            --name sta-env-vertex \
+            --query value -o tsv > secrets.json
+
+          jq -r 'to_entries | .[] | "\(.key)=\(.value|tojson)"' secrets.json > src/vertex/.env        
+
       - name: Build and Push Docker Image
         run: |
           cd src/vertex/

--- a/.github/workflows/deploy-frontend-to-azurestaging.yml
+++ b/.github/workflows/deploy-frontend-to-azurestaging.yml
@@ -238,9 +238,8 @@ jobs:
           az keyvault secret show \
             --vault-name ${{ env.KEYVAULT }} \
             --name sta-env-next-platform \
-            --query value -o tsv > secrets.json
-
-          jq -r 'to_entries | .[] | "\(.key)=\(.value|tojson)"' secrets.json > src/platform/.env        
+            --query value -o tsv | \
+          jq -r 'to_entries | .[] | "\(.key)=\(.value|tojson)"' > src/platform/.env        
 
       - name: Build and Push Docker Image
         run: |
@@ -285,9 +284,8 @@ jobs:
           az keyvault secret show \
             --vault-name ${{ env.KEYVAULT }} \
             --name sta-env-vertex \
-            --query value -o tsv > secrets.json
-
-          jq -r 'to_entries | .[] | "\(.key)=\(.value|tojson)"' secrets.json > src/vertex/.env        
+            --query value -o tsv | \
+          jq -r 'to_entries | .[] | "\(.key)=\(.value|tojson)"' > src/vertex/.env        
 
       - name: Build and Push Docker Image
         run: |


### PR DESCRIPTION
## 🐛 Description
This PR resolves a critical "split-brain" environment issue affecting the Vertex application on Staging and Production. 

**The Bug:** When a user attempted to use Social Login (e.g., Google) on the deployed environments, the browser would incorrectly attempt to redirect them to `http://localhost:3000/...` instead of the correct `staging-vertex`/`vertex` API URL. Email login, however, continued to work.

## 🔍 Root Cause Analysis
Next.js requires client-side environment variables (prefixed with `NEXT_PUBLIC_`) to be present *during the build process* so they can be statically baked into the browser's JavaScript bundle. 

Upon auditing our Azure CI/CD workflows, we discovered a missing step in the `vertex` Docker build job. While other services (like `analytics-platform`) correctly pulled their secrets from Azure Key Vault to generate a `.env` file before `docker build`, the `vertex` block completely skipped this step. 

Because the Docker build environment lacked these secrets, Next.js fell back to its default development variables, permanently hardcoding the `localhost:3000` API fallback into the frontend code. (Email login succeeded because NextAuth runs dynamically on the server at runtime, where variables were properly injected).

## 🛠️ Solution
Added the missing Azure Key Vault secret extraction step to the `vertex` deployment jobs in both Staging and Production Azure workflows.

**Files Modified:**
* `.github/workflows/deploy-frontend-to-azurestaging.yml`
* `.github/workflows/deploy-frontend-to-azureprod.yml`

**Changes Made:**
Inserted the following step immediately before `docker build` to ensure the container has access to the `.env` file during the Next.js compilation phase:
```yaml
- name: Pull secrets from Key Vault
  run: |
    az keyvault secret show \
      --vault-name ${{ env.KEYVAULT }} \
      --name sta-env-vertex \ # (and prod-env-vertex)
      --query value -o tsv > secrets.json

    jq -r 'to_entries | .[] | "$.key)=$.value|tojson)"' secrets.json > src/vertex/.env

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD deployment workflows for staging and production environments to improve secret handling efficiency and streamline the build process configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->