### PR TITLE
fix: set stable User-Agent and standardise Authorization header on all API calls

### DIFF
--- a/src/mobile/lib/src/app/auth/repository/auth_repository_impl.dart
+++ b/src/mobile/lib/src/app/auth/repository/auth_repository_impl.dart
@@ -8,6 +8,7 @@ import 'package:airqo/src/app/auth/repository/social_auth_repository.dart';
 import 'package:airqo/src/app/auth/services/auth_token_storage.dart';
 import 'package:airqo/src/app/auth/services/oauth_service.dart';
 import 'package:airqo/src/app/shared/repository/secure_storage_repository.dart';
+import 'package:airqo/src/meta/utils/api_utils.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/http.dart';
@@ -31,12 +32,11 @@ class AuthImpl extends AuthRepository implements SocialAuthRepository {
           Uri.parse("${dotenv.env["AIRQO_API_URL"]}/api/v2/users/loginUser"),
           body: jsonEncode({"userName": username, "password": password}),
           headers: {
-            "Authorization": dotenv.env["AIRQO_MOBILE_TOKEN"] ??
-                (throw StateError(
-                    'AIRQO_MOBILE_TOKEN environment variable is missing')),
+            "Authorization":
+                "JWT ${dotenv.env["AIRQO_MOBILE_TOKEN"] ?? (throw StateError('AIRQO_MOBILE_TOKEN environment variable is missing'))}",
             "Accept": "application/json",
             "Content-Type": "application/json",
-            "User-Agent": "AirQo-Mobile/3.0 (Flutter)",
+            "User-Agent": ApiUtils.mobileUserAgent,
           });
 
       if (loginResponse.statusCode == 200) {
@@ -139,7 +139,7 @@ class AuthImpl extends AuthRepository implements SocialAuthRepository {
           headers: {
             "Accept": "application/json",
             "Content-Type": "application/json",
-            "User-Agent": "AirQo-Mobile/3.0 (Flutter)",
+            "User-Agent": ApiUtils.mobileUserAgent,
           });
 
       if (registerResponse.statusCode >= 200 &&
@@ -195,12 +195,11 @@ class AuthImpl extends AuthRepository implements SocialAuthRepository {
         Uri.parse(
             '${dotenv.env["AIRQO_API_URL"]}/api/v2/users/reset-password-request'),
         headers: {
-          "Authorization": dotenv.env["AIRQO_MOBILE_TOKEN"] ??
-              (throw StateError(
-                  'AIRQO_MOBILE_TOKEN environment variable is missing')),
+          "Authorization":
+              "JWT ${dotenv.env["AIRQO_MOBILE_TOKEN"] ?? (throw StateError('AIRQO_MOBILE_TOKEN environment variable is missing'))}",
           "Accept": "application/json",
           "Content-Type": "application/json",
-          "User-Agent": "AirQo-Mobile/3.0 (Flutter)",
+          "User-Agent": ApiUtils.mobileUserAgent,
         },
         body: jsonEncode({'email': email}),
       );
@@ -252,10 +251,10 @@ class AuthImpl extends AuthRepository implements SocialAuthRepository {
         Uri.parse(
             "${dotenv.env["AIRQO_API_URL"]}/api/v2/users/verify-email/$token"),
         headers: {
-          "Authorization": apiToken,
+          "Authorization": "JWT $apiToken",
           "Content-Type": "application/json",
           "Accept": "application/json",
-          "User-Agent": "AirQo-Mobile/3.0 (Flutter)",
+          "User-Agent": ApiUtils.mobileUserAgent,
         },
         body: json.encode({"email": email}),
       );
@@ -306,7 +305,7 @@ class AuthImpl extends AuthRepository implements SocialAuthRepository {
             '${dotenv.env["AIRQO_API_URL"]}/api/v2/users/reset-password/$token'),
         headers: {
           'Content-Type': 'application/json',
-          'User-Agent': 'AirQo-Mobile/3.0 (Flutter)',
+          'User-Agent': ApiUtils.mobileUserAgent,
         },
         body: jsonEncode(
             {'password': password, 'confirmPassword': confirmPassword}),
@@ -421,7 +420,7 @@ class AuthImpl extends AuthRepository implements SocialAuthRepository {
           "Authorization": "JWT ${_sanitizeToken(authToken)}",
           "Accept": "application/json",
           "Content-Type": "application/json",
-          "User-Agent": "AirQo-Mobile/3.0 (Flutter)",
+          "User-Agent": ApiUtils.mobileUserAgent,
         },
       ).timeout(const Duration(seconds: 30));
 

--- a/src/mobile/lib/src/app/auth/repository/auth_repository_impl.dart
+++ b/src/mobile/lib/src/app/auth/repository/auth_repository_impl.dart
@@ -35,7 +35,8 @@ class AuthImpl extends AuthRepository implements SocialAuthRepository {
                 (throw StateError(
                     'AIRQO_MOBILE_TOKEN environment variable is missing')),
             "Accept": "application/json",
-            "Content-Type": "application/json"
+            "Content-Type": "application/json",
+            "User-Agent": "AirQo-Mobile/3.0 (Flutter)",
           });
 
       if (loginResponse.statusCode == 200) {
@@ -137,7 +138,8 @@ class AuthImpl extends AuthRepository implements SocialAuthRepository {
           body: registerInputModelToJson(model),
           headers: {
             "Accept": "application/json",
-            "Content-Type": "application/json"
+            "Content-Type": "application/json",
+            "User-Agent": "AirQo-Mobile/3.0 (Flutter)",
           });
 
       if (registerResponse.statusCode >= 200 &&
@@ -197,7 +199,8 @@ class AuthImpl extends AuthRepository implements SocialAuthRepository {
               (throw StateError(
                   'AIRQO_MOBILE_TOKEN environment variable is missing')),
           "Accept": "application/json",
-          "Content-Type": "application/json"
+          "Content-Type": "application/json",
+          "User-Agent": "AirQo-Mobile/3.0 (Flutter)",
         },
         body: jsonEncode({'email': email}),
       );
@@ -251,7 +254,8 @@ class AuthImpl extends AuthRepository implements SocialAuthRepository {
         headers: {
           "Authorization": apiToken,
           "Content-Type": "application/json",
-          "Accept": "application/json"
+          "Accept": "application/json",
+          "User-Agent": "AirQo-Mobile/3.0 (Flutter)",
         },
         body: json.encode({"email": email}),
       );
@@ -300,7 +304,10 @@ class AuthImpl extends AuthRepository implements SocialAuthRepository {
       final response = await http.post(
         Uri.parse(
             '${dotenv.env["AIRQO_API_URL"]}/api/v2/users/reset-password/$token'),
-        headers: {'Content-Type': 'application/json'},
+        headers: {
+          'Content-Type': 'application/json',
+          'User-Agent': 'AirQo-Mobile/3.0 (Flutter)',
+        },
         body: jsonEncode(
             {'password': password, 'confirmPassword': confirmPassword}),
       );
@@ -413,7 +420,8 @@ class AuthImpl extends AuthRepository implements SocialAuthRepository {
         headers: {
           "Authorization": "JWT ${_sanitizeToken(authToken)}",
           "Accept": "application/json",
-          "Content-Type": "application/json"
+          "Content-Type": "application/json",
+          "User-Agent": "AirQo-Mobile/3.0 (Flutter)",
         },
       ).timeout(const Duration(seconds: 30));
 

--- a/src/mobile/lib/src/app/auth/services/auth_helper.dart
+++ b/src/mobile/lib/src/app/auth/services/auth_helper.dart
@@ -182,6 +182,7 @@ class AuthHelper {
           'Authorization': 'JWT $token',
           'Content-Type': 'application/json',
           'Accept': '*/*',
+          'User-Agent': 'AirQo-Mobile/3.0 (Flutter)',
         },
       ).timeout(const Duration(seconds: 10));
 

--- a/src/mobile/lib/src/app/auth/services/auth_helper.dart
+++ b/src/mobile/lib/src/app/auth/services/auth_helper.dart
@@ -182,7 +182,7 @@ class AuthHelper {
           'Authorization': 'JWT $token',
           'Content-Type': 'application/json',
           'Accept': '*/*',
-          'User-Agent': 'AirQo-Mobile/3.0 (Flutter)',
+          'User-Agent': ApiUtils.mobileUserAgent,
         },
       ).timeout(const Duration(seconds: 10));
 

--- a/src/mobile/lib/src/app/dashboard/repository/dashboard_repository.dart
+++ b/src/mobile/lib/src/app/dashboard/repository/dashboard_repository.dart
@@ -95,6 +95,7 @@ class DashboardImpl extends DashboardRepository with UiLoggy {
           ),
           headers: {
             'Content-Type': 'application/json',
+            'User-Agent': ApiUtils.mobileUserAgent,
           },
         );
         
@@ -157,6 +158,7 @@ class DashboardImpl extends DashboardRepository with UiLoggy {
         ),
         headers: {
           'Content-Type': 'application/json',
+          'User-Agent': ApiUtils.mobileUserAgent,
         },
       );
       

--- a/src/mobile/lib/src/app/dashboard/repository/forecast_repository.dart
+++ b/src/mobile/lib/src/app/dashboard/repository/forecast_repository.dart
@@ -69,6 +69,7 @@ class ForecastImpl extends ForecastRepository with UiLoggy {
 
   static const Map<String, String> _headers = {
     'Content-Type': 'application/json',
+    'User-Agent': ApiUtils.mobileUserAgent,
   };
 
   Map<String, String> _baseParams(String siteId) => {

--- a/src/mobile/lib/src/app/dashboard/repository/nearest_places_repository.dart
+++ b/src/mobile/lib/src/app/dashboard/repository/nearest_places_repository.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'package:airqo/src/meta/utils/api_utils.dart';
 import 'package:http/http.dart' as http;
 import 'package:loggy/loggy.dart';
 import 'package:airqo/src/app/dashboard/models/nearest_places_model.dart';
@@ -55,6 +56,7 @@ class NearestPlacesRepository {
         headers: {
           'Authorization': 'JWT $authToken',
           'Content-Type': 'application/json',
+          'User-Agent': ApiUtils.mobileUserAgent,
         },
       );
 
@@ -119,6 +121,7 @@ class NearestPlacesRepository {
         headers: {
           'Authorization': 'JWT $authToken',
           'Content-Type': 'application/json',
+          'User-Agent': ApiUtils.mobileUserAgent,
         },
       );
 

--- a/src/mobile/lib/src/app/dashboard/repository/sites_repository.dart
+++ b/src/mobile/lib/src/app/dashboard/repository/sites_repository.dart
@@ -27,6 +27,7 @@ class SitesImpl extends SitesRepository with NetworkLoggy {
     final headers = {
       "Accept": "application/json",
       "Content-Type": "application/json",
+      "User-Agent": "AirQo-Mobile/3.0 (Flutter)",
     };
     if (userToken != null && (userToken as String).isNotEmpty) {
       headers["Authorization"] = "JWT $userToken";

--- a/src/mobile/lib/src/app/dashboard/repository/sites_repository.dart
+++ b/src/mobile/lib/src/app/dashboard/repository/sites_repository.dart
@@ -27,7 +27,7 @@ class SitesImpl extends SitesRepository with NetworkLoggy {
     final headers = {
       "Accept": "application/json",
       "Content-Type": "application/json",
-      "User-Agent": "AirQo-Mobile/3.0 (Flutter)",
+      "User-Agent": ApiUtils.mobileUserAgent,
     };
     if (userToken != null && (userToken as String).isNotEmpty) {
       headers["Authorization"] = "JWT $userToken";

--- a/src/mobile/lib/src/app/dashboard/repository/user_preferences_repository.dart
+++ b/src/mobile/lib/src/app/dashboard/repository/user_preferences_repository.dart
@@ -24,7 +24,8 @@ class UserPreferencesImpl extends UserPreferencesRepository with NetworkLoggy {
   Future<Map<String, String>> _getHeaders({bool useAppToken = false}) async {
     final headers = {
       "Accept": "application/json",
-      "Content-Type": "application/json"
+      "Content-Type": "application/json",
+      "User-Agent": "AirQo-Mobile/3.0 (Flutter)",
     };
 
     if (!useAppToken) {

--- a/src/mobile/lib/src/app/dashboard/repository/user_preferences_repository.dart
+++ b/src/mobile/lib/src/app/dashboard/repository/user_preferences_repository.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'package:airqo/src/meta/utils/api_utils.dart';
 import 'package:http/http.dart' as http;
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:loggy/loggy.dart';
@@ -25,7 +26,7 @@ class UserPreferencesImpl extends UserPreferencesRepository with NetworkLoggy {
     final headers = {
       "Accept": "application/json",
       "Content-Type": "application/json",
-      "User-Agent": "AirQo-Mobile/3.0 (Flutter)",
+      "User-Agent": ApiUtils.mobileUserAgent,
     };
 
     if (!useAppToken) {

--- a/src/mobile/lib/src/app/exposure/repository/hourly_readings_repository_impl.dart
+++ b/src/mobile/lib/src/app/exposure/repository/hourly_readings_repository_impl.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:airqo/src/meta/utils/api_utils.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:http/http.dart' as http;
 import 'package:loggy/loggy.dart';
@@ -45,7 +46,7 @@ class HourlyReadingsRepositoryImpl extends HourlyReadingsRepository with Network
     final headers = {
       'Accept': 'application/json',
       'Content-Type': 'application/json',
-      'User-Agent': 'AirQo-Mobile/3.0 (Flutter)',
+      'User-Agent': ApiUtils.mobileUserAgent,
     };
     if (userToken != null && userToken.isNotEmpty) {
       headers['Authorization'] = 'JWT $userToken';

--- a/src/mobile/lib/src/app/exposure/repository/hourly_readings_repository_impl.dart
+++ b/src/mobile/lib/src/app/exposure/repository/hourly_readings_repository_impl.dart
@@ -45,13 +45,14 @@ class HourlyReadingsRepositoryImpl extends HourlyReadingsRepository with Network
     final headers = {
       'Accept': 'application/json',
       'Content-Type': 'application/json',
+      'User-Agent': 'AirQo-Mobile/3.0 (Flutter)',
     };
     if (userToken != null && userToken.isNotEmpty) {
       headers['Authorization'] = 'JWT $userToken';
     } else {
       final appToken = dotenv.env['AIRQO_MOBILE_TOKEN'];
       if (appToken != null && appToken.isNotEmpty) {
-        headers['Authorization'] = appToken;
+        headers['Authorization'] = 'JWT $appToken';
       }
     }
     return headers;

--- a/src/mobile/lib/src/app/profile/pages/edit_profile.dart
+++ b/src/mobile/lib/src/app/profile/pages/edit_profile.dart
@@ -201,6 +201,7 @@ class _EditProfileState extends State<EditProfile> with UiLoggy {
         headers: {
           'Authorization': 'JWT $authToken',
           'Content-Type': 'application/json',
+          'User-Agent': 'AirQo-Mobile/3.0 (Flutter)',
         },
         body: json.encode(body),
       );

--- a/src/mobile/lib/src/app/profile/pages/edit_profile.dart
+++ b/src/mobile/lib/src/app/profile/pages/edit_profile.dart
@@ -10,6 +10,7 @@ import 'package:airqo/src/app/auth/services/auth_helper.dart';
 import 'package:airqo/src/app/auth/services/auth_token_storage.dart';
 import 'package:airqo/src/app/shared/repository/global_auth_manager.dart';
 import 'package:airqo/src/app/shared/repository/secure_storage_repository.dart';
+import 'package:airqo/src/meta/utils/api_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:http/http.dart' as http;
@@ -201,7 +202,7 @@ class _EditProfileState extends State<EditProfile> with UiLoggy {
         headers: {
           'Authorization': 'JWT $authToken',
           'Content-Type': 'application/json',
-          'User-Agent': 'AirQo-Mobile/3.0 (Flutter)',
+          'User-Agent': ApiUtils.mobileUserAgent,
         },
         body: json.encode(body),
       );

--- a/src/mobile/lib/src/app/shared/repository/base_repository.dart
+++ b/src/mobile/lib/src/app/shared/repository/base_repository.dart
@@ -149,7 +149,7 @@ class BaseRepository with UiLoggy {
         'Authorization': 'JWT $token',
         'Accept': '*/*',
         'Content-Type': 'application/json',
-        'User-Agent': 'AirQo-Mobile/3.0 (Flutter)',
+        'User-Agent': ApiUtils.mobileUserAgent,
       },
     );
 
@@ -172,7 +172,7 @@ class BaseRepository with UiLoggy {
         'Authorization': 'JWT $token',
         'Accept': '*/*',
         'Content-Type': 'application/json',
-        'User-Agent': 'AirQo-Mobile/3.0 (Flutter)',
+        'User-Agent': ApiUtils.mobileUserAgent,
       },
     );
 
@@ -188,7 +188,7 @@ class BaseRepository with UiLoggy {
     final headers = <String, String>{
       'Accept': '*/*',
       'Content-Type': 'application/json',
-      'User-Agent': 'AirQo-Mobile/3.0 (Flutter)',
+      'User-Agent': ApiUtils.mobileUserAgent,
       if (token != null) 'Authorization': 'JWT $token',
     };
 
@@ -221,7 +221,7 @@ class BaseRepository with UiLoggy {
         'Accept': '*/*',
         'Authorization': 'JWT $token',
         'Content-Type': 'application/json',
-        'User-Agent': 'AirQo-Mobile/3.0 (Flutter)',
+        'User-Agent': ApiUtils.mobileUserAgent,
       },
     );
 
@@ -242,7 +242,7 @@ class BaseRepository with UiLoggy {
       headers: {
         "Accept": "*/*",
         "Content-Type": "application/json",
-        "User-Agent": "AirQo-Mobile/3.0 (Flutter)",
+        "User-Agent": ApiUtils.mobileUserAgent,
       },
     );
 

--- a/src/mobile/lib/src/app/shared/repository/base_repository.dart
+++ b/src/mobile/lib/src/app/shared/repository/base_repository.dart
@@ -149,6 +149,7 @@ class BaseRepository with UiLoggy {
         'Authorization': 'JWT $token',
         'Accept': '*/*',
         'Content-Type': 'application/json',
+        'User-Agent': 'AirQo-Mobile/3.0 (Flutter)',
       },
     );
 
@@ -171,6 +172,7 @@ class BaseRepository with UiLoggy {
         'Authorization': 'JWT $token',
         'Accept': '*/*',
         'Content-Type': 'application/json',
+        'User-Agent': 'AirQo-Mobile/3.0 (Flutter)',
       },
     );
 
@@ -186,6 +188,7 @@ class BaseRepository with UiLoggy {
     final headers = <String, String>{
       'Accept': '*/*',
       'Content-Type': 'application/json',
+      'User-Agent': 'AirQo-Mobile/3.0 (Flutter)',
       if (token != null) 'Authorization': 'JWT $token',
     };
 
@@ -218,6 +221,7 @@ class BaseRepository with UiLoggy {
         'Accept': '*/*',
         'Authorization': 'JWT $token',
         'Content-Type': 'application/json',
+        'User-Agent': 'AirQo-Mobile/3.0 (Flutter)',
       },
     );
 
@@ -235,7 +239,11 @@ class BaseRepository with UiLoggy {
     final response = await http.post(
       Uri.parse(url),
       body: json.encode(data),
-      headers: {"Accept": "*/*", "Content-Type": "application/json"},
+      headers: {
+        "Accept": "*/*",
+        "Content-Type": "application/json",
+        "User-Agent": "AirQo-Mobile/3.0 (Flutter)",
+      },
     );
 
     loggy.info("Unauthenticated POST response status: ${response.statusCode}");

--- a/src/mobile/lib/src/app/shared/repository/base_repository_extension.dart
+++ b/src/mobile/lib/src/app/shared/repository/base_repository_extension.dart
@@ -27,7 +27,8 @@ extension BaseRepositoryExtension on BaseRepository {
       headers: {
         "Authorization": "JWT $token",
         "Accept": "*/*",
-        "Content-Type": "application/json"
+        "Content-Type": "application/json",
+        "User-Agent": "AirQo-Mobile/3.0 (Flutter)",
       }
     );
     

--- a/src/mobile/lib/src/app/shared/repository/base_repository_extension.dart
+++ b/src/mobile/lib/src/app/shared/repository/base_repository_extension.dart
@@ -28,7 +28,7 @@ extension BaseRepositoryExtension on BaseRepository {
         "Authorization": "JWT $token",
         "Accept": "*/*",
         "Content-Type": "application/json",
-        "User-Agent": "AirQo-Mobile/3.0 (Flutter)",
+        "User-Agent": ApiUtils.mobileUserAgent,
       }
     );
     

--- a/src/mobile/lib/src/meta/utils/api_utils.dart
+++ b/src/mobile/lib/src/meta/utils/api_utils.dart
@@ -3,6 +3,8 @@ import 'package:flutter_dotenv/flutter_dotenv.dart';
 class ApiUtils {
   const ApiUtils._();
 
+  static const String mobileUserAgent = 'AirQo-Mobile/3.0 (Flutter)';
+
   static String baseUrl =
       dotenv.env['AIRQO_API_URL'] ?? "http://localhost:3001";
 


### PR DESCRIPTION

- Add AirQo-Mobile/3.0 (Flutter) User-Agent to every HTTP call site (base_repository, auth, hourly readings, preferences, sites, profile) so the server can identify the client regardless of Dart runtime version
- Fix Authorization header in hourly_readings_repository_impl fallback path from raw app token to 'JWT <token>' to match expected format



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized request headers across the mobile app to include a platform-specific User-Agent for backend requests.
  * Normalized authorization header format to use a consistent JWT prefix where applicable, improving token handling and API compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->