### PR TITLE
Fix historical data overviews to direct users to Metadata API for ID discovery

### DIFF
--- a/src/docs-website/docs/api/for-cities/historical-data.md
+++ b/src/docs-website/docs/api/for-cities/historical-data.md
@@ -23,7 +23,7 @@ Direct Grid ID filtering will be added to the Analytics API in a future release.
 
 ## Overview
 
-To query historical data for your Grid, use the site names or device names from your Grid in the Analytics API request. You can discover the sites in your Grid by calling the [recent measurements endpoint](./recent-measurements.md) first and collecting the `site_id` and `device` values.
+To query historical data for your Grid, supply the Site IDs or device names for that Grid in the Analytics API request. Use the [Metadata API](../reference/metadata.md#get-all-site-and-device-ids-for-a-grid) (`GET /api/v2/devices/grids/{GRID_ID}/generate`) to retrieve all site and device identifiers for your Grid.
 
 ---
 

--- a/src/docs-website/docs/api/for-partners/historical-data.md
+++ b/src/docs-website/docs/api/for-partners/historical-data.md
@@ -14,7 +14,7 @@ Historical data access requires a **Standard Tier** subscription or above.
 :::caution Cohort ID direct filtering — coming soon
 The Analytics API does not yet accept `cohort_id` as a request parameter. You must supply individual **device names** (`device_names`) in the request body instead.
 
-**Workaround:** Call the [Metadata API](../reference/metadata.md#get-all-site-and-device-ids-for-a-cohort) (`GET /api/v2/devices/cohorts/{COHORT_ID}/generate`) to retrieve all device identifiers for your Cohort, then include those in your Analytics API request.
+**Workaround:** Call the [Metadata API](../reference/metadata.md#get-all-site-and-device-ids-for-a-cohort) (`GET /api/v2/devices/cohorts/{COHORT_ID}/generate`) to retrieve the `device_name` values for your Cohort, then pass them as the `device_names` parameter in your Analytics API request.
 
 Direct Cohort ID filtering will be added to the Analytics API in a future release.
 :::

--- a/src/docs-website/docs/api/for-partners/historical-data.md
+++ b/src/docs-website/docs/api/for-partners/historical-data.md
@@ -23,7 +23,7 @@ Direct Cohort ID filtering will be added to the Analytics API in a future releas
 
 ## Overview
 
-Historical data for your Cohort is fetched via the Analytics API by specifying the device names that belong to your Cohort. If you do not know the device names, use the recent measurements endpoint first — the `device` field in each measurement is the device name.
+Historical data for your Cohort is fetched via the Analytics API by specifying the device names that belong to your Cohort. Use the [Metadata API](../reference/metadata.md#get-all-site-and-device-ids-for-a-cohort) (`GET /api/v2/devices/cohorts/{COHORT_ID}/generate`) to retrieve all device names for your Cohort.
 
 ---
 


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Corrects the Overview sections of both historical-data pages to direct users to the Metadata API for ID discovery instead of the recent measurements endpoint.

- **`for-cities/historical-data.md`**: Overview now instructs users to call `GET /api/v2/devices/grids/{GRID_ID}/generate` to retrieve site and device identifiers for their Grid.
- **`for-partners/historical-data.md`**: Overview now instructs users to call `GET /api/v2/devices/cohorts/{COHORT_ID}/generate` to retrieve device names for their Cohort.

### Why is this change needed?
The previous overviews told users to call the recent measurements endpoint as a workaround for discovering device names and site IDs. This is misleading because:
1. The Metadata API is the correct, authoritative source for resource discovery.
2. The caution blocks on the same pages already reference the Metadata API — the overviews were inconsistent with content on the same page.
3. The recent measurements endpoint only returns data for the last 7 days, making it unreliable for users who have not yet received any measurements.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [x] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:** N/A — documentation only.

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Verified that both edited Overview paragraphs now link correctly to the Metadata API reference page and that the internal anchor links (`#get-all-site-and-device-ids-for-a-grid` and `#get-all-site-and-device-ids-for-a-cohort`) resolve to existing sections in `reference/metadata.md`. Docusaurus build confirmed passing with no broken-link errors.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

The `reference/finding-ids.md` page also mentions the recent measurements endpoint as a tertiary option for discovering Site IDs — this was intentionally left unchanged because the Metadata API is already listed as the primary option there, and having a supplementary fallback on a reference page is appropriate.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated historical data query guidance for city API to use the Metadata API endpoint for obtaining Site IDs and device names instead of using recent measurements as a workaround.
  * Updated historical data query guidance for partner API to fetch Cohort device names via the Metadata API endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->