### PR TITLE
Add Data Access entry point card to docs homepage product grid

### DIFF
--- a/src/docs-website/src/components/ProductSection/index.tsx
+++ b/src/docs-website/src/components/ProductSection/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Link from '@docusaurus/Link';
-import { AqCpuChip01, AqServer03, AqBarChartSquarePlus, AqMonitor, AqPhone01, AqDataflow01, AqArrowRight, AqCube02 } from '@airqo/icons-react';
+import { AqCpuChip01, AqServer03, AqBarChartSquarePlus, AqMonitor, AqPhone01, AqDataflow01, AqArrowRight, AqCube02, AqDatabase01 } from '@airqo/icons-react';
 import styles from './styles.module.css';
 
 type ProductItem = {
@@ -52,7 +52,13 @@ const ProductList: ProductItem[] = [
         description: 'Features that span across multiple products',
         link: '/cross-product/concepts/access-control',
         Icon: AqCube02,
-    }
+    },
+    {
+        title: 'Data Access',
+        description: 'Researcher guide, fair usage policy, and guidance on responsible data use',
+        link: '/data-access/researchers-guide',
+        Icon: AqDatabase01,
+    },
 ];
 
 function ProductCard({ title, description, link, Icon }: ProductItem) {


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Adds a "Data Access" card to the docs homepage product grid (`ProductSection/index.tsx`), linking to the researcher guide and fair usage policy pages introduced in the previous `docs-data-access` PR.

- Imports `AqDatabase01` icon from `@airqo/icons-react`.
- Adds a new `ProductList` entry with title "Data Access", a short description, and a link to `/data-access/researchers-guide`.

### Why is this change needed?
The `docs-data-access` PR added the researcher guide and fair usage policy as a new `data-access/` docs section, but provided no entry point from the homepage. The pages were deployed but undiscoverable — users had to know the direct URL to reach them. This card makes the section visible and navigable from the docs homepage alongside all other product sections.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:** N/A — docs-website frontend component only.

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Verified the homepage renders the new "Data Access" card and that clicking it navigates correctly to `/data-access/researchers-guide`. Confirmed no layout regressions in the product grid. Docusaurus build passes with no errors.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

The card is appended at the end of the `ProductList` array, so the existing product card order is unchanged. The `AqDatabase01` icon was chosen as it best represents data access/storage among the available `@airqo/icons-react` options.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Data Access" entry to the product section with direct navigation to the researchers guide resource.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->