### PR TITLE
Reduce map marker icon size and fix markers field naming conflict

### DIFF
--- a/src/mobile/android/app/build.gradle
+++ b/src/mobile/android/app/build.gradle
@@ -98,7 +98,7 @@ android {
         applicationId "com.airqo.app"
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
-        minSdkVersion 23
+        minSdkVersion flutter.minSdkVersion
         targetSdkVersion 36
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/src/mobile/lib/src/app/map/pages/map_page.dart
+++ b/src/mobile/lib/src/app/map/pages/map_page.dart
@@ -42,7 +42,7 @@ class _MapScreenState extends State<MapScreen>
   List<Measurement> nearbyMeasurements = [];
   Position? userPosition;
 
-  List<Marker> markers = [];
+  Set<Marker> _mapMarkers = {};
   bool isInitializing = true;
   bool isRetrying = false;
   late GooglePlacesBloc googlePlacesBloc;
@@ -62,7 +62,7 @@ class _MapScreenState extends State<MapScreen>
     if (mounted) setState(() {});
     if (userPosition != null) {
       _cameraController.snapToPosition(userPosition!);
-    } else if (markers.isNotEmpty) {
+    } else if (_mapMarkers.isNotEmpty) {
       _cameraController.fitMeasurementsInView(allMeasurements);
     }
   }
@@ -170,14 +170,14 @@ class _MapScreenState extends State<MapScreen>
     if (!mounted || seq != _markerBuildSeq) return;
     if (mounted) {
       setState(() {
-        markers = newMarkers;
+        _mapMarkers = newMarkers.toSet();
         isInitializing = false;
       });
     }
     // Only fit on initial data load, not on later marker refreshes.
     if (source != null &&
         _cameraController.isInitialized &&
-        markers.isNotEmpty &&
+        _mapMarkers.isNotEmpty &&
         userPosition == null) {
       _cameraController.fitMeasurementsInView(allMeasurements);
     }
@@ -334,7 +334,7 @@ class _MapScreenState extends State<MapScreen>
           listener: (context, state) {
             if (state is DashboardLoaded &&
                 state.response.measurements?.isNotEmpty == true &&
-                (markers.isEmpty || allMeasurements.isEmpty)) {
+                (_mapMarkers.isEmpty || allMeasurements.isEmpty)) {
               _initializeWithData(state.response);
             }
           },
@@ -346,7 +346,7 @@ class _MapScreenState extends State<MapScreen>
                   ? state.response
                   : (state as MapLoadedFromCache).response;
               if (response.measurements?.isNotEmpty == true &&
-                  (markers.isEmpty || allMeasurements.isEmpty)) {
+                  (_mapMarkers.isEmpty || allMeasurements.isEmpty)) {
                 _initializeWithData(response);
               }
             } else if (state is MapLoadingError) {
@@ -380,10 +380,10 @@ class _MapScreenState extends State<MapScreen>
       ],
       child: Scaffold(
         resizeToAvoidBottomInset: false,
-        body: isInitializing && markers.isEmpty && allMeasurements.isEmpty
+        body: isInitializing && _mapMarkers.isEmpty && allMeasurements.isEmpty
             ? const MapLoadingView()
             : (!isInitializing &&
-                    markers.isEmpty &&
+                    _mapMarkers.isEmpty &&
                     allMeasurements.isEmpty &&
                     !isRetrying)
                 ? MapErrorView(onRetry: _retryLoading, isOffline: !CacheManager().isConnected)
@@ -408,7 +408,7 @@ class _MapScreenState extends State<MapScreen>
           minMaxZoomPreference: MinMaxZoomPreference.unbounded,
           onMapCreated: _onMapCreated,
           initialCameraPosition: const CameraPosition(target: _center, zoom: 6),
-          markers: markers.toSet(),
+          markers: _mapMarkers,
           onTap: (_) {
             if (mounted) setState(() => _selectedCardMeasurement = null);
           },

--- a/src/mobile/lib/src/app/map/utils/map_marker_builder.dart
+++ b/src/mobile/lib/src/app/map/utils/map_marker_builder.dart
@@ -3,6 +3,7 @@ import 'package:airqo/src/app/map/utils/map_aq_presentation.dart';
 import 'package:airqo/src/meta/utils/utils.dart';
 import 'package:airqo/src/meta/utils/widget_to_map_icon.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/painting.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 
 class MapMarkerBuilder {
@@ -39,7 +40,10 @@ class MapMarkerBuilder {
 
     return Marker(
       onTap: () => onTap(measurement),
-      icon: await bitmapDescriptorFromSvgAsset(resolvedPath),
+      icon: await bitmapDescriptorFromSvgAsset(
+        resolvedPath,
+        const Size(10, 10),
+      ),
       position: LatLng(
         measurement.siteDetails!.approximateLatitude!,
         measurement.siteDetails!.approximateLongitude!,


### PR DESCRIPTION
- Shrink map marker icons from 24x24 to 10x10 logical pixels
- Rename markers field to _mapMarkers to resolve conflict with google_maps_flutter 2.7+ native markers property
- Update minSdkVersion to use flutter.minSdkVersion



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Android minimum SDK version to improve device compatibility and support

* **Improvements**
  * Optimized map marker tracking and rendering to enhance map performance and responsiveness
  * Refined marker icon sizing for improved clarity and visibility on maps

<!-- end of auto-generated comment: release notes by coderabbit.ai -->