### PR TITLE
Add HCaptcha integration to NetworkCoverageAddMonitorDialog and update dependencies

### DIFF
--- a/src/website/package-lock.json
+++ b/src/website/package-lock.json
@@ -11,6 +11,7 @@
         "@airqo/icons-react": "0.2.7",
         "@eslint/config-array": "^0.19.0",
         "@eslint/object-schema": "^2.1.4",
+        "@hcaptcha/react-hcaptcha": "^2.0.2",
         "@radix-ui/react-accordion": "^1.2.1",
         "@radix-ui/react-dialog": "^1.1.2",
         "@radix-ui/react-dropdown-menu": "^2.1.2",
@@ -786,6 +787,12 @@
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
+    },
+    "node_modules/@hcaptcha/react-hcaptcha": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@hcaptcha/react-hcaptcha/-/react-hcaptcha-2.0.2.tgz",
+      "integrity": "sha512-VbuH6VJ6m3BHmVBHs0fL9t+suZd7PQEqCzqL2BiUbBvbHI3XfvSgdiug2QiEPN8zskbPTIV/FfGPF53JCckrow==",
       "license": "MIT"
     },
     "node_modules/@humanwhocodes/config-array": {

--- a/src/website/package.json
+++ b/src/website/package.json
@@ -17,6 +17,7 @@
     "@airqo/icons-react": "0.2.7",
     "@eslint/config-array": "^0.19.0",
     "@eslint/object-schema": "^2.1.4",
+    "@hcaptcha/react-hcaptcha": "^2.0.2",
     "@radix-ui/react-accordion": "^1.2.1",
     "@radix-ui/react-dialog": "^1.1.2",
     "@radix-ui/react-dropdown-menu": "^2.1.2",

--- a/src/website/src/views/solutions/NetworkCoverage/components/NetworkCoverageAddMonitorDialog.tsx
+++ b/src/website/src/views/solutions/NetworkCoverage/components/NetworkCoverageAddMonitorDialog.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable simple-import-sort/imports */
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import HCaptcha from '@hcaptcha/react-hcaptcha';
 import { FiX, FiMinus, FiPlus } from 'react-icons/fi';
 
 import { networkCoverageService } from '@/services/apiService';
@@ -57,12 +58,31 @@ const NetworkCoverageAddMonitorDialog: React.FC<Props> = ({
   });
 
   const dialogRef = useRef<HTMLDivElement | null>(null);
+  const scrollContainerRef = useRef<HTMLDivElement | null>(null);
+  const errorRef = useRef<HTMLParagraphElement | null>(null);
   const previousActiveElementRef = useRef<HTMLElement | null>(null);
   const closeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const captchaRef = useRef<HCaptcha>(null);
+  const [captchaToken, setCaptchaToken] = useState<string | null>(null);
 
   const [isSaving, setIsSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
+
+  const handleCaptchaVerify = useCallback((token: string) => {
+    setCaptchaToken(token);
+  }, []);
+
+  const handleCaptchaExpire = useCallback(() => {
+    setCaptchaToken(null);
+  }, []);
+
+  useEffect(() => {
+    if (error && errorRef.current && scrollContainerRef.current) {
+      errorRef.current.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+  }, [error]);
 
   useEffect(() => {
     if (isOpen) {
@@ -96,6 +116,7 @@ const NetworkCoverageAddMonitorDialog: React.FC<Props> = ({
       setMapVisible(false);
       setError(null);
       setSuccess(null);
+      setCaptchaToken(null);
     }
   }, [isOpen, initialCountryName, initialCountryIso2]);
 
@@ -391,6 +412,11 @@ const NetworkCoverageAddMonitorDialog: React.FC<Props> = ({
     if (lat < -90 || lat > 90) return 'Latitude must be between -90 and 90';
     if (lon < -180 || lon > 180)
       return 'Longitude must be between -180 and 180';
+    if (!network.trim()) return 'Network is required';
+    if (!operator.trim()) return 'Operator is required';
+    if (!manufacturer.trim()) return 'Manufacturer is required';
+    if (!pollutants.trim()) return 'Pollutants are required';
+    if (!captchaToken) return 'Please complete the captcha verification';
     return null;
   };
 
@@ -445,6 +471,7 @@ const NetworkCoverageAddMonitorDialog: React.FC<Props> = ({
           .filter(Boolean);
       if (viewDataUrl.trim()) payload.viewDataUrl = viewDataUrl.trim();
       if (publicData) payload.publicData = publicData;
+      if (captchaToken) payload.captchaToken = captchaToken;
 
       const response =
         await networkCoverageService.upsertNetworkCoverageRegistry(payload);
@@ -458,6 +485,8 @@ const NetworkCoverageAddMonitorDialog: React.FC<Props> = ({
 
       closeTimeoutRef.current = setTimeout(() => {
         setIsSaving(false);
+        setCaptchaToken(null);
+        captchaRef.current?.resetCaptcha();
         onClose();
         closeTimeoutRef.current = null;
       }, 600);
@@ -503,7 +532,10 @@ const NetworkCoverageAddMonitorDialog: React.FC<Props> = ({
           </button>
         </div>
 
-        <div className="max-h-[70vh] overflow-y-auto p-4">
+        <div
+          ref={scrollContainerRef}
+          className="max-h-[70vh] overflow-y-auto p-4"
+        >
           <p className="mb-3 text-sm text-slate-600">
             Add a new external monitor to the public registry. Required fields
             are highlighted.
@@ -661,7 +693,7 @@ const NetworkCoverageAddMonitorDialog: React.FC<Props> = ({
 
             <label className="block sm:col-span-2">
               <div className="mb-1 text-xs font-semibold text-slate-500">
-                Network
+                Network *
               </div>
               <input
                 value={network}
@@ -672,7 +704,7 @@ const NetworkCoverageAddMonitorDialog: React.FC<Props> = ({
 
             <label className="block sm:col-span-2">
               <div className="mb-1 text-xs font-semibold text-slate-500">
-                Operator
+                Operator *
               </div>
               <input
                 value={operator}
@@ -694,7 +726,7 @@ const NetworkCoverageAddMonitorDialog: React.FC<Props> = ({
 
             <label className="block">
               <div className="mb-1 text-xs font-semibold text-slate-500">
-                Manufacturer
+                Manufacturer *
               </div>
               <input
                 value={manufacturer}
@@ -705,7 +737,7 @@ const NetworkCoverageAddMonitorDialog: React.FC<Props> = ({
 
             <label className="block sm:col-span-2">
               <div className="mb-1 text-xs font-semibold text-slate-500">
-                Pollutants (comma separated)
+                Pollutants (comma separated) *
               </div>
               <input
                 value={pollutants}
@@ -894,10 +926,23 @@ const NetworkCoverageAddMonitorDialog: React.FC<Props> = ({
             </div>
           )}
 
-          {error && <p className="mt-3 text-sm text-red-600">{error}</p>}
+          {error && (
+            <p ref={errorRef} className="mt-3 text-sm text-red-600">
+              {error}
+            </p>
+          )}
           {success && (
             <p className="mt-3 text-sm text-emerald-700">{success}</p>
           )}
+
+          <div className="mt-4">
+            <HCaptcha
+              sitekey={process.env.NEXT_PUBLIC_HCAPTCHA_SITE_KEY!}
+              onVerify={handleCaptchaVerify}
+              onExpire={handleCaptchaExpire}
+              ref={captchaRef}
+            />
+          </div>
         </div>
 
         <div className="flex items-center justify-end gap-2 border-t px-4 py-3">

--- a/src/website/src/views/solutions/NetworkCoverage/components/NetworkCoverageAddMonitorDialog.tsx
+++ b/src/website/src/views/solutions/NetworkCoverage/components/NetworkCoverageAddMonitorDialog.tsx
@@ -63,7 +63,8 @@ const NetworkCoverageAddMonitorDialog: React.FC<Props> = ({
   const previousActiveElementRef = useRef<HTMLElement | null>(null);
   const closeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const captchaRef = useRef<HCaptcha>(null);
+  const captchaSiteKey = process.env.NEXT_PUBLIC_HCAPTCHA_SITE_KEY || '';
+  const captchaRef = useRef<HCaptcha | null>(null);
   const [captchaToken, setCaptchaToken] = useState<string | null>(null);
 
   const [isSaving, setIsSaving] = useState(false);
@@ -416,6 +417,8 @@ const NetworkCoverageAddMonitorDialog: React.FC<Props> = ({
     if (!operator.trim()) return 'Operator is required';
     if (!manufacturer.trim()) return 'Manufacturer is required';
     if (!pollutants.trim()) return 'Pollutants are required';
+    if (!captchaSiteKey)
+      return 'Captcha is not configured. Please contact support.';
     if (!captchaToken) return 'Please complete the captcha verification';
     return null;
   };
@@ -936,12 +939,18 @@ const NetworkCoverageAddMonitorDialog: React.FC<Props> = ({
           )}
 
           <div className="mt-4">
-            <HCaptcha
-              sitekey={process.env.NEXT_PUBLIC_HCAPTCHA_SITE_KEY!}
-              onVerify={handleCaptchaVerify}
-              onExpire={handleCaptchaExpire}
-              ref={captchaRef}
-            />
+            {captchaSiteKey ? (
+              <HCaptcha
+                sitekey={captchaSiteKey}
+                onVerify={handleCaptchaVerify}
+                onExpire={handleCaptchaExpire}
+                ref={captchaRef}
+              />
+            ) : (
+              <p className="text-sm text-amber-600">
+                Captcha is not configured. Please contact support.
+              </p>
+            )}
           </div>
         </div>
 


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

#### Status of maturity (all need to be checked before merging):

- [x] I've tested this locally
- [x] I consider this code done

#### Screenshots (optional)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HCaptcha verification requirement when saving network monitors.
  * Added required field indicators for Network, Operator, Manufacturer, and Pollutants fields.
  * Improved error messaging and auto-scrolling to error notifications in the monitor dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->