### PR TITLE
feat(mobile): add lazy loading and shimmer placeholders

### DIFF
--- a/src/mobile/lib/src/app/dashboard/pages/location_selection/components/location_list_view.dart
+++ b/src/mobile/lib/src/app/dashboard/pages/location_selection/components/location_list_view.dart
@@ -382,7 +382,7 @@ class LocationListView extends StatelessWidget with UiLoggy {
     List<Measurement> selected,
     List<Measurement> unselected,
   ) {
-    final label = unselected.isEmpty && selected.isNotEmpty
+    final label = selected.isNotEmpty
         ? "Other Locations"
         : "All Locations";
     return Container(

--- a/src/mobile/lib/src/app/dashboard/pages/location_selection/components/location_list_view.dart
+++ b/src/mobile/lib/src/app/dashboard/pages/location_selection/components/location_list_view.dart
@@ -300,85 +300,117 @@ class LocationListView extends StatelessWidget with UiLoggy {
         loggy.debug(
             'Split measurements: ${selectedMeasurements.length} selected, ${unselectedMeasurements.length} unselected');
 
-        return ListView(
-          children: [
-            if (selectedMeasurements.isNotEmpty) ...[
-              Container(
-                margin: const EdgeInsets.only(top: 12, bottom: 4),
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-                decoration: BoxDecoration(
-                  color: Theme.of(context).brightness == Brightness.dark
-                      ? AppColors.darkHighlight.withValues(alpha: 0.5)
-                      : AppColors.lightHighlight.withValues(alpha: 0.5),
-                ),
-                child: Row(
-                  children: [
-                    Icon(
-                      Icons.favorite,
-                      size: 18,
-                      color: AppColors.primaryColor,
-                    ),
-                    const SizedBox(width: 8),
-                    TranslatedText(
-                      "Favorite Locations",
-                      style: TextStyle(
-                        fontSize: 15,
-                        fontWeight: FontWeight.bold,
-                        color: Theme.of(context).textTheme.headlineSmall?.color,
-                      ),
-                    ),
-                    const Spacer(),
-                    Text(
-                      "${selectedMeasurements.length}",
-                      style: TextStyle(
-                        fontSize: 14,
-                        fontWeight: FontWeight.bold,
-                        color: AppColors.primaryColor,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-              ...selectedMeasurements
-                  .map((m) => _buildLocationTile(m, context: context)),
-              const Divider(thickness: 1, height: 16),
-            ],
-            Container(
-              margin: const EdgeInsets.only(top: 8, bottom: 4),
-              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-              decoration: BoxDecoration(
-                color: Theme.of(context).brightness == Brightness.dark
-                    ? AppColors.darkHighlight.withValues(alpha: 0.5)
-                    : AppColors.lightHighlight.withValues(alpha: 0.5),
-              ),
-              child: Row(
-                children: [
-                  Icon(
-                    Icons.location_on,
-                    size: 18,
-                    color: Theme.of(context).textTheme.headlineSmall?.color,
-                  ),
-                  const SizedBox(width: 8),
-                  TranslatedText(
-                    unselectedMeasurements.isEmpty &&
-                            selectedMeasurements.isNotEmpty
-                        ? "Other Locations"
-                        : "All Locations",
-                    style: TextStyle(
-                      fontSize: 15,
-                      fontWeight: FontWeight.bold,
-                      color: Theme.of(context).textTheme.headlineSmall?.color,
-                    ),
-                  ),
-                ],
-              ),
-            ),
-            ...unselectedMeasurements
-                .map((m) => _buildLocationTile(m, context: context)),
-          ],
+        return ListView.builder(
+          itemCount: _mainListItemCount(selectedMeasurements, unselectedMeasurements),
+          itemBuilder: (context, index) => _buildMainListItem(
+            context,
+            index,
+            selectedMeasurements,
+            unselectedMeasurements,
+          ),
         );
       },
+    );
+  }
+
+  int _mainListItemCount(List<Measurement> selected, List<Measurement> unselected) {
+    // With favorites: [favHeader, ...selected, divider, allHeader, ...unselected]
+    // Without:        [allHeader, ...unselected]
+    return selected.isNotEmpty
+        ? 1 + selected.length + 1 + 1 + unselected.length
+        : 1 + unselected.length;
+  }
+
+  Widget _buildMainListItem(
+    BuildContext context,
+    int index,
+    List<Measurement> selected,
+    List<Measurement> unselected,
+  ) {
+    if (selected.isNotEmpty) {
+      if (index == 0) return _buildFavoritesHeader(context, selected.length);
+      if (index <= selected.length) {
+        return _buildLocationTile(selected[index - 1], context: context);
+      }
+      if (index == selected.length + 1) return const Divider(thickness: 1, height: 16);
+      if (index == selected.length + 2) {
+        return _buildSectionHeader(context, selected, unselected);
+      }
+      return _buildLocationTile(unselected[index - selected.length - 3], context: context);
+    }
+    if (index == 0) return _buildSectionHeader(context, selected, unselected);
+    return _buildLocationTile(unselected[index - 1], context: context);
+  }
+
+  Widget _buildFavoritesHeader(BuildContext context, int count) {
+    return Container(
+      margin: const EdgeInsets.only(top: 12, bottom: 4),
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      decoration: BoxDecoration(
+        color: Theme.of(context).brightness == Brightness.dark
+            ? AppColors.darkHighlight.withValues(alpha: 0.5)
+            : AppColors.lightHighlight.withValues(alpha: 0.5),
+      ),
+      child: Row(
+        children: [
+          Icon(Icons.favorite, size: 18, color: AppColors.primaryColor),
+          const SizedBox(width: 8),
+          TranslatedText(
+            "Favorite Locations",
+            style: TextStyle(
+              fontSize: 15,
+              fontWeight: FontWeight.bold,
+              color: Theme.of(context).textTheme.headlineSmall?.color,
+            ),
+          ),
+          const Spacer(),
+          Text(
+            "$count",
+            style: TextStyle(
+              fontSize: 14,
+              fontWeight: FontWeight.bold,
+              color: AppColors.primaryColor,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSectionHeader(
+    BuildContext context,
+    List<Measurement> selected,
+    List<Measurement> unselected,
+  ) {
+    final label = unselected.isEmpty && selected.isNotEmpty
+        ? "Other Locations"
+        : "All Locations";
+    return Container(
+      margin: const EdgeInsets.only(top: 8, bottom: 4),
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      decoration: BoxDecoration(
+        color: Theme.of(context).brightness == Brightness.dark
+            ? AppColors.darkHighlight.withValues(alpha: 0.5)
+            : AppColors.lightHighlight.withValues(alpha: 0.5),
+      ),
+      child: Row(
+        children: [
+          Icon(
+            Icons.location_on,
+            size: 18,
+            color: Theme.of(context).textTheme.headlineSmall?.color,
+          ),
+          const SizedBox(width: 8),
+          TranslatedText(
+            label,
+            style: TextStyle(
+              fontSize: 15,
+              fontWeight: FontWeight.bold,
+              color: Theme.of(context).textTheme.headlineSmall?.color,
+            ),
+          ),
+        ],
+      ),
     );
   }
 

--- a/src/mobile/lib/src/app/learn/pages/kya_page.dart
+++ b/src/mobile/lib/src/app/learn/pages/kya_page.dart
@@ -172,21 +172,17 @@ class _KyaPageState extends State<KyaPage> with UiLoggy {
             ShimmerContainer(height: 200, borderRadius: 8, width: double.infinity),
           ]);
         } else if (state is LessonsLoaded) {
-          return SingleChildScrollView(
-            child: Column(
-              children: state.model.kyaLessons
-                  .map((lesson) => KyaLessonContainer(lesson))
-                  .toList(),
-            ),
+          return ListView.builder(
+            itemCount: state.model.kyaLessons.length,
+            itemBuilder: (context, index) =>
+                KyaLessonContainer(state.model.kyaLessons[index]),
           );
         } else if (state is LessonsLoadingError) {
           if (state.cachedModel != null) {
-            return SingleChildScrollView(
-              child: Column(
-                children: state.cachedModel!.kyaLessons
-                    .map((lesson) => KyaLessonContainer(lesson))
-                    .toList(),
-              ),
+            return ListView.builder(
+              itemCount: state.cachedModel!.kyaLessons.length,
+              itemBuilder: (context, index) =>
+                  KyaLessonContainer(state.cachedModel!.kyaLessons[index]),
             );
           }
           return RefreshIndicator(

--- a/src/mobile/lib/src/app/learn/pages/kya_page.dart
+++ b/src/mobile/lib/src/app/learn/pages/kya_page.dart
@@ -166,7 +166,7 @@ class _KyaPageState extends State<KyaPage> with UiLoggy {
     return BlocBuilder<KyaBloc, KyaState>(
       builder: (context, state) {
         if (state is LessonsLoading || _isRetrying) {
-          return Column(children: [
+          return ListView(children: [
             ShimmerContainer(height: 200, borderRadius: 8, width: double.infinity),
             const SizedBox(height: 16),
             ShimmerContainer(height: 200, borderRadius: 8, width: double.infinity),

--- a/src/mobile/lib/src/app/learn/widgets/kya_lesson_container.dart
+++ b/src/mobile/lib/src/app/learn/widgets/kya_lesson_container.dart
@@ -1,5 +1,6 @@
 import 'package:airqo/src/app/learn/models/lesson_response_model.dart';
 import 'package:airqo/src/app/learn/pages/lesson_page.dart';
+import 'package:airqo/src/app/shared/widgets/loading_widget.dart';
 import 'package:airqo/src/app/shared/widgets/translated_text.dart';
 import 'package:flutter/material.dart';
 
@@ -30,6 +31,18 @@ class KyaLessonContainer extends StatelessWidget {
                   child: Image.network(
                     kyaLesson.image,
                     fit: BoxFit.cover,
+                    loadingBuilder: (context, child, loadingProgress) {
+                      if (loadingProgress == null) return child;
+                      return ShimmerContainer(
+                        height: double.infinity,
+                        width: double.infinity,
+                        borderRadius: 8,
+                      );
+                    },
+                    errorBuilder: (context, error, stackTrace) => Container(
+                      color: Theme.of(context).highlightColor,
+                      child: const Center(child: Icon(Icons.broken_image, size: 48)),
+                    ),
                   ),
                 ),
               ),

--- a/src/mobile/lib/src/app/profile/pages/profile_page.dart
+++ b/src/mobile/lib/src/app/profile/pages/profile_page.dart
@@ -276,6 +276,10 @@ class _ProfilePageState extends State<ProfilePage> with UiLoggy {
           fit: BoxFit.cover,
           width: 100,
           height: 100,
+          loadingBuilder: (context, child, loadingProgress) {
+            if (loadingProgress == null) return child;
+            return initialsWidget;
+          },
           errorBuilder: (context, error, stackTrace) {
             loggy.warning('Error loading profile image: $error');
             return initialsWidget;


### PR DESCRIPTION
- Replace ListView(children: [...]) with ListView.builder in location list view and kya page for on-demand tile rendering
- Add ShimmerContainer placeholder to lesson card images while loading
- Add loadingBuilder to profile page Image.network to show initials during fetch



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Lesson images now display loading placeholders and handle errors gracefully.
  * Profile pictures show a fallback display while images load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->