### PR TITLE
Integrate h captcha into the sensor manufacturer request form

### DIFF
--- a/src/vertex/app/changelog.md
+++ b/src/vertex/app/changelog.md
@@ -4,6 +4,33 @@
 
 ---
 
+## Version 2.0.3
+**Released:** June 11, 2026
+
+### hCaptcha Integration — Sensor Manufacturer Request Form
+
+Added hCaptcha verification to the public-facing Sensor Manufacturer Request form (`NetworkRequestDialog`) to protect the unauthenticated `/api/devices/network-creation-requests` endpoint from automated abuse and spam submissions.
+
+<details>
+<summary><strong>Changes (4)</strong></summary>
+
+- **Schema**: Added optional `captchaToken` field to `networkRequestSchema` to align the Zod schema with the POST body sent to the backend.
+- **Dialog**: Wired `HCaptchaWidget` into the form with `onVerify`/`onExpire` handlers managing a `captchaToken` state variable. The Submit button is disabled until the CAPTCHA is verified. The token is included in the POST body alongside form data.
+- **Reset on close**: `handleClose` now calls `captchaRef.current?.reset()` and clears `captchaToken` state so the widget is fully reset when the dialog is dismissed or cancelled.
+- **Reset on error**: `onError` also resets the widget and clears `captchaToken` so the Submit button re-disables and the user must re-verify before retrying.
+
+</details>
+
+<details>
+<summary><strong>Files Updated (2)</strong></summary>
+
+- `src/vertex/components/features/networks/network-request-dialog.tsx` [MODIFIED]
+- `src/vertex/components/features/networks/schema.ts` [MODIFIED]
+
+</details>
+
+---
+
 ## Version 2.0.2
 **Released:** June 10, 2026
 

--- a/src/vertex/components/features/networks/network-request-dialog.tsx
+++ b/src/vertex/components/features/networks/network-request-dialog.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Form, FormField } from "@/components/ui/form";
 import ReusableDialog from "@/components/shared/dialog/ReusableDialog";
 import ReusableInputField from "@/components/shared/inputfield/ReusableInputField";
+import { HCaptchaWidget, HCaptchaWidgetHandle } from "@/components/ui/hcaptcha-widget";
 import { networkRequestSchema, NetworkRequestValues } from "./schema";
 import { useAppSelector } from "@/core/redux/hooks";
 import { getApiErrorMessage } from "@/core/utils/getApiErrorMessage";
@@ -23,13 +24,15 @@ export function NetworkRequestDialog({ open, onOpenChange }: NetworkRequestDialo
     const queryClient = useQueryClient();
     const { showBanner } = useBanner();
     const { showBannerWithDelay } = useBannerWithDelay();
+    const [captchaToken, setCaptchaToken] = useState("");
+    const captchaRef = useRef<HCaptchaWidgetHandle>(null);
 
     const { mutate: submitRequest, isPending } = useMutation({
         mutationFn: async (data: NetworkRequestValues) => {
             const response = await fetch("/api/devices/network-creation-requests", {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
-                body: JSON.stringify(data),
+                body: JSON.stringify({ ...data, captchaToken }),
             });
             if (!response.ok) {
                 const errorData = await response.json().catch(() => ({ message: "Request failed" }));
@@ -44,8 +47,10 @@ export function NetworkRequestDialog({ open, onOpenChange }: NetworkRequestDialo
             queryClient.invalidateQueries({ queryKey: ["network-requests"] });
             showBannerWithDelay({ severity: 'success', message: resp.message || "Your request for a new Sensor Manufacturer has been submitted successfully!", scoped: true });
         },
-        onError: (error) => {            
+        onError: (error) => {
             showBanner({ severity: 'error', message: getApiErrorMessage(error), scoped: true });
+            setCaptchaToken("");
+            captchaRef.current?.reset();
         },
     });
 
@@ -78,6 +83,8 @@ export function NetworkRequestDialog({ open, onOpenChange }: NetworkRequestDialo
     const handleClose = useCallback(() => {
         onOpenChange(false);
         form.reset();
+        setCaptchaToken("");
+        captchaRef.current?.reset();
     }, [form, onOpenChange]);
 
     const onSubmit = (values: NetworkRequestValues) => {
@@ -102,7 +109,7 @@ export function NetworkRequestDialog({ open, onOpenChange }: NetworkRequestDialo
             primaryAction={{
                 label: isPending ? "Submitting..." : "Submit Request",
                 onClick: form.handleSubmit(onSubmit),
-                disabled: isPending,
+                disabled: isPending || !captchaToken,
             }}
             secondaryAction={{
                 label: "Cancel",
@@ -217,6 +224,11 @@ export function NetworkRequestDialog({ open, onOpenChange }: NetworkRequestDialo
                             )} 
                         />
                     </div>
+                    <HCaptchaWidget
+                        ref={captchaRef}
+                        onVerify={(token) => setCaptchaToken(token)}
+                        onExpire={() => setCaptchaToken("")}
+                    />
                 </form>
             </Form>
         </ReusableDialog>

--- a/src/vertex/components/features/networks/network-request-dialog.tsx
+++ b/src/vertex/components/features/networks/network-request-dialog.tsx
@@ -90,6 +90,11 @@ export function NetworkRequestDialog({ open, onOpenChange }: NetworkRequestDialo
     }, [form, onOpenChange]);
 
     const onSubmit = (values: NetworkRequestValues) => {
+        if (hcaptchaEnabled && !captchaToken) {
+            showBanner({ severity: 'error', message: 'Please complete the CAPTCHA before submitting.', scoped: true });
+            return;
+        }
+
         const cleanedValues = Object.fromEntries(
             Object.entries(values).filter(([, v]) => v !== "" && v !== null && v !== undefined)
         ) as NetworkRequestValues;

--- a/src/vertex/components/features/networks/network-request-dialog.tsx
+++ b/src/vertex/components/features/networks/network-request-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
@@ -13,6 +13,7 @@ import { useAppSelector } from "@/core/redux/hooks";
 import { getApiErrorMessage } from "@/core/utils/getApiErrorMessage";
 import { useBanner } from "@/context/banner-context";
 import { useBannerWithDelay } from "@/core/hooks/useBannerWithDelay";
+import { isHCaptchaEnabled } from "@/lib/envConstants";
 
 interface NetworkRequestDialogProps {
     open: boolean;
@@ -26,13 +27,14 @@ export function NetworkRequestDialog({ open, onOpenChange }: NetworkRequestDialo
     const { showBannerWithDelay } = useBannerWithDelay();
     const [captchaToken, setCaptchaToken] = useState("");
     const captchaRef = useRef<HCaptchaWidgetHandle>(null);
+    const hcaptchaEnabled = useMemo(() => isHCaptchaEnabled(), []);
 
     const { mutate: submitRequest, isPending } = useMutation({
         mutationFn: async (data: NetworkRequestValues) => {
             const response = await fetch("/api/devices/network-creation-requests", {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ ...data, captchaToken }),
+                body: JSON.stringify({ ...data, ...(hcaptchaEnabled && { captchaToken }) }),
             });
             if (!response.ok) {
                 const errorData = await response.json().catch(() => ({ message: "Request failed" }));
@@ -109,7 +111,7 @@ export function NetworkRequestDialog({ open, onOpenChange }: NetworkRequestDialo
             primaryAction={{
                 label: isPending ? "Submitting..." : "Submit Request",
                 onClick: form.handleSubmit(onSubmit),
-                disabled: isPending || !captchaToken,
+                disabled: isPending || (hcaptchaEnabled && !captchaToken),
             }}
             secondaryAction={{
                 label: "Cancel",
@@ -224,11 +226,13 @@ export function NetworkRequestDialog({ open, onOpenChange }: NetworkRequestDialo
                             )} 
                         />
                     </div>
-                    <HCaptchaWidget
-                        ref={captchaRef}
-                        onVerify={(token) => setCaptchaToken(token)}
-                        onExpire={() => setCaptchaToken("")}
-                    />
+                    {hcaptchaEnabled ? (
+                        <HCaptchaWidget
+                            ref={captchaRef}
+                            onVerify={(token) => setCaptchaToken(token)}
+                            onExpire={() => setCaptchaToken("")}
+                        />
+                    ) : null}
                 </form>
             </Form>
         </ReusableDialog>

--- a/src/vertex/components/features/networks/schema.ts
+++ b/src/vertex/components/features/networks/schema.ts
@@ -26,6 +26,7 @@ export const networkRequestSchema = z.object({
     net_category: z.string().optional(),
     net_description: z.string().optional(),
     net_acronym: z.string().optional(),
+    captchaToken: z.string().optional(),
 });
 
 export type NetworkRequestValues = z.infer<typeof networkRequestSchema>;


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

Adds hCaptcha verification to the public-facing Sensor Manufacturer Request
form (`NetworkRequestDialog`) to protect the unauthenticated
`/api/devices/network-creation-requests` endpoint from automated abuse and
spam submissions.

The backend CAPTCHA middleware is already wired — it accepts a `captchaToken`
field in the POST body and will enforce it once the backend secret key is
activated. This PR completes the frontend integration.

**Changes made:**
- `schema.ts` — added optional `captchaToken: z.string().optional()` to
  `networkRequestSchema` to keep the Zod schema aligned with the POST body.
- `network-request-dialog.tsx` — integrated `HCaptchaWidget` following the
  same pattern as the login page:
  - `hcaptchaEnabled` flag derived from `isHCaptchaEnabled()` via `useMemo`
    to conditionally enable all CAPTCHA behaviour at runtime.
  - `<HCaptchaWidget>` rendered at the bottom of the form only when
    `hcaptchaEnabled` is true, with `onVerify` and `onExpire` handlers.
  - `captchaToken` only included in the POST body when `hcaptchaEnabled`
    is true: `{ ...data, ...(hcaptchaEnabled && { captchaToken }) }`.
  - Submit button gated with `disabled: isPending || (hcaptchaEnabled && !captchaToken)`
    so it remains usable when CAPTCHA is disabled.
  - `handleClose` resets the widget and clears `captchaToken` on dialog
    dismiss or cancel.
  - `onError` also resets the widget and clears `captchaToken` so the user
    must re-verify before retrying a failed submission.

**Dependencies:**
- Requires `HCaptchaWidget` component (`src/vertex/components/ui/hcaptcha-widget.tsx`) — already merged.
- Requires `NEXT_PUBLIC_HCAPTCHA_SITE_KEY` set in `.env.local` to render the widget locally.

---

#### Status of maturity (all need to be checked before merging):

- [ ] I've tested this locally
- [ ] I consider this code done
- [ ] This change ready to hit production in its current state
- [ ] The title of the PR states what changed and the related issues number (used for the release note).
- [ ] I've included issue number in the "Closes #ISSUE-NUMBER" part of the "[What are the relevant tickets?](#what-are-the-relevant-tickets)" section to [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [ ] I've updated corresponding documentation for the changes in this PR.
- [ ] I have written unit and/or e2e tests for my change(s).

---

#### How should this be manually tested?

1. Add your own hCaptcha site key to `.env.local`:
NEXT_PUBLIC_HCAPTCHA_SITE_KEY=your-site-key-here


2. Run the app locally and navigate to the page that renders `NetworkRequestDialog`.
3. Open the **Request New Sensor Manufacturer** dialog.
4. Confirm the hCaptcha widget renders at the bottom of the form.
5. Confirm the **Submit Request** button is disabled before completing the CAPTCHA.
6. Complete the CAPTCHA — confirm the Submit button becomes enabled.
7. Submit the form with valid data — confirm the request succeeds and the dialog closes.
8. Re-open the dialog — confirm the widget is reset and the Submit button is disabled again.
9. Trigger a submission error — confirm the widget resets and the Submit button re-disables, requiring re-verification before retrying.
10. Click **Cancel** without submitting — confirm the widget resets on close.
11. Remove `NEXT_PUBLIC_HCAPTCHA_SITE_KEY` from `.env.local` and reload — confirm the widget does not render and the Submit button is not blocked.

---

#### What are the relevant tickets?

- Closes#### Summary of Changes (What does this PR do?)

Adds hCaptcha verification to the public-facing Sensor Manufacturer Request
form (`NetworkRequestDialog`) to protect the unauthenticated
`/api/devices/network-creation-requests` endpoint from automated abuse and
spam submissions.

**Changes made:**
- `schema.ts` — added optional `captchaToken: z.string().optional()` to
  `networkRequestSchema` to keep the Zod schema aligned with the POST body.
- `network-request-dialog.tsx` — integrated `HCaptchaWidget` following the
  same pattern as the login page:
  - `hcaptchaEnabled` flag derived from `isHCaptchaEnabled()` via `useMemo`
    to conditionally enable all CAPTCHA behaviour at runtime.
  - `<HCaptchaWidget>` rendered at the bottom of the form only when
    `hcaptchaEnabled` is true, with `onVerify` and `onExpire` handlers.
  - `captchaToken` only included in the POST body when `hcaptchaEnabled`
    is true: `{ ...data, ...(hcaptchaEnabled && { captchaToken }) }`.
  - Submit button gated with `disabled: isPending || (hcaptchaEnabled && !captchaToken)`
    so it remains usable when CAPTCHA is disabled.
  - `handleClose` resets the widget and clears `captchaToken` on dialog
    dismiss or cancel.
  - `onError` also resets the widget and clears `captchaToken` so the user
    must re-verify before retrying a failed submission.

#### Status of maturity (all need to be checked before merging):

- [ ] I've tested this locally
- [ ] I consider this code done
- [ ] This change ready to hit production in its current state
- [ ] The title of the PR states what changed and the related issues number (used for the release note).
- [ ] I've included issue number in the "Closes #3485" part of the "[What are the relevant tickets?](#what-are-the-relevant-tickets)" section to [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [ ] I've updated corresponding documentation for the changes in this PR.
- [ ] I have written unit and/or e2e tests for my change(s).

---

#### How should this be manually tested?

1. Add your own hCaptcha site key to `.env.local`:
NEXT_PUBLIC_HCAPTCHA_SITE_KEY=your-site-key-here


2. Run the app locally and navigate to the page that renders `NetworkRequestDialog`.
3. Open the **Request New Sensor Manufacturer** dialog.
4. Confirm the hCaptcha widget renders at the bottom of the form.
5. Confirm the **Submit Request** button is disabled before completing the CAPTCHA.
6. Complete the CAPTCHA — confirm the Submit button becomes enabled.
7. Submit the form with valid data — confirm the request succeeds and the dialog closes.
8. Re-open the dialog — confirm the widget is reset and the Submit button is disabled again.
9. Trigger a submission error — confirm the widget resets and the Submit button re-disables, requiring re-verification before retrying.
10. Click **Cancel** without submitting — confirm the widget resets on close.
11. Remove `NEXT_PUBLIC_HCAPTCHA_SITE_KEY` from `.env.local` and reload — confirm the widget does not render and the Submit button is not blocked.

---

#### What are the relevant tickets?

- Closes #3485

#### Screenshots (optional)
<img width="1366" height="768" alt="hp1" src="https://github.com/user-attachments/assets/6b408eac-f1ca-403d-bea3-d779e50da947" />
<img width="1366" height="768" alt="hp2" src="https://github.com/user-attachments/assets/745e6338-bb5b-4316-876f-8dfc0c003426" />
<img width="1366" height="768" alt="hp3" src="https://github.com/user-attachments/assets/fa54ff29-01f3-4b7a-ba8c-ec7e142fc1e2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * hCaptcha verification step added to the Sensor Manufacturer Request form; submit button disabled until verification is complete

* **Improvements**
  * Shipping label printing errors now display as in-app banner messages instead of browser alerts

* **Documentation**
  * Changelog updated with Version 2.0.3 release information documenting new hCaptcha integration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->