### PR TITLE
Fix two-dot diff triggering unnecessary PR preview deployments

### DIFF
--- a/.github/workflows/deploy-frontend-azurepreview.yml
+++ b/.github/workflows/deploy-frontend-azurepreview.yml
@@ -64,13 +64,11 @@ jobs:
           echo "=============== list modified files ==============="
           git fetch origin ${{ github.base_ref }}
           git diff --name-only \
-            origin/${{ github.base_ref }} \
-            ${{ github.event.pull_request.head.sha }}
+            origin/${{ github.base_ref }}...${{ github.event.pull_request.head.sha }}
 
           echo "========== check paths of modified files =========="
           git diff --name-only \
-            origin/${{ github.base_ref }} \
-            ${{ github.event.pull_request.head.sha }} > files.txt
+            origin/${{ github.base_ref }}...${{ github.event.pull_request.head.sha }} > files.txt
 
           echo "run_calibrate_app=false" >>$GITHUB_OUTPUT
           echo "run_analytics_platform=false" >>$GITHUB_OUTPUT

--- a/.github/workflows/safe-checks.yml
+++ b/.github/workflows/safe-checks.yml
@@ -31,8 +31,7 @@ jobs:
         run: |
           git fetch origin ${{ github.base_ref }}
           git diff --name-only \
-            origin/${{ github.base_ref }} \
-            ${{ github.event.pull_request.head.sha }} > files.txt
+            origin/${{ github.base_ref }}...${{ github.event.pull_request.head.sha }} > files.txt
           cat files.txt
 
           echo "website=false"   >> $GITHUB_OUTPUT


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Fixes the change-detection logic in two GitHub Actions workflows by correcting a two-dot `git diff` to a three-dot `git diff`. The affected files are `.github/workflows/deploy-frontend-azurepreview.yml` and `.github/workflows/safe-checks.yml`.

### Why is this change needed?
A two-dot diff (`git diff A B`) compares the full snapshot of the base branch tip against the PR head. When `staging` has accumulated commits from multiple projects since a PR branched, every changed file across all those staging commits appears in the diff — causing preview deployments and lint checks to fire for every project, even when the PR only touches one. The three-dot diff (`git diff A...B`) correctly limits the comparison to only what the PR itself changed, relative to the common ancestor.

This was introduced by commit `581ab1999` ("edited workflows", 1 June 2026), which changed both files from the previously correct three-dot syntax.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `.github/workflows/deploy-frontend-azurepreview.yml` — Azure PR preview deploy workflow
- `.github/workflows/safe-checks.yml` — PR lint/build check workflow

No application source code was changed. No services are redeployed by this PR itself.

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Verified via `git log` and `git show` that the broken two-dot diff was introduced in commit `581ab1999`. The three-dot syntax was the correct form used prior to that commit and has been restored. The fix can be validated by opening a PR that only modifies `src/vertex/` and confirming that only the vertex preview deploy job triggers.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

Two further issues were identified during this investigation but are **not addressed in this PR** — they have been flagged separately to the DevOps team for review:

1. **`pull_request_target` + PR head checkout** — `deploy-frontend-azurepreview.yml` uses `pull_request_target` (which runs with repo secrets) while checking out PR contributor code. This is safe for internal-only PRs but warrants confirmation that no external fork contributions are possible.

2. **Unpinned third-party action versions** — `deploy-frontend-azurepreview.yml` references actions by mutable version tags (`@v5`, `@v2`) rather than immutable commit SHAs, unlike `safe-checks.yml` which already pins all actions. Should be addressed to reduce supply-chain risk given these workflows hold `AZURE_CREDENTIALS` and `ACR_PASSWORD`.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow configuration to improve change detection for deployments and service checks. Modified git diff logic used by CI/CD pipelines to more accurately identify which services require validation and preview deployment based on file changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->