### PR TITLE
Hide login prompt in guest mode; wire up guest settings

### DIFF
--- a/src/mobile/lib/src/app/dashboard/pages/dashboard_page.dart
+++ b/src/mobile/lib/src/app/dashboard/pages/dashboard_page.dart
@@ -1,4 +1,3 @@
-import 'package:airqo/src/app/auth/pages/login_page.dart';
 import 'package:airqo/src/app/dashboard/pages/location_selection/location_selection_screen.dart';
 import 'package:airqo/src/app/shared/widgets/translated_text.dart';
 import 'package:airqo/src/app/dashboard/repository/country_repository.dart';
@@ -78,89 +77,10 @@ class _DashboardPageState extends State<DashboardPage> with UiLoggy {
   }
 
   void setView(DashboardView view, {String? country}) {
-    final authState = context.read<AuthBloc>().state;
-    final isGuest = authState is GuestUser;
-
-    if (isGuest && view == DashboardView.favorites) {
-      _showLoginPrompt();
-      return;
-    }
-
     setState(() {
       currentView = view;
       selectedCountry = country;
     });
-  }
-
-  void _showLoginPrompt() {
-    final isDarkMode = Theme.of(context).brightness == Brightness.dark;
-
-    showDialog(
-      context: context,
-      builder: (context) => AlertDialog(
-        backgroundColor:
-            isDarkMode ? AppColors.darkThemeBackground : Colors.white,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(12),
-        ),
-        title: TranslatedText(
-          'Feature Requires Account',
-          style: TextStyle(
-            fontSize: 20,
-            fontWeight: FontWeight.w700,
-            color: isDarkMode
-                ? AppColors.boldHeadlineColor2
-                : AppColors.boldHeadlineColor5,
-          ),
-        ),
-        content: TranslatedText(
-          'Create an account or sign in to access all features including personalized views.',
-          style: TextStyle(
-            fontSize: 16,
-            color: isDarkMode
-                ? AppColors.secondaryHeadlineColor2
-                : AppColors.secondaryHeadlineColor,
-          ),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context),
-            style: TextButton.styleFrom(
-              foregroundColor: isDarkMode ? Colors.grey[400] : Colors.grey[700],
-              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-            ),
-            child: const TranslatedText(
-              'Cancel',
-              style: TextStyle(
-                fontSize: 16,
-                fontWeight: FontWeight.w500,
-              ),
-            ),
-          ),
-          ElevatedButton(
-            style: ElevatedButton.styleFrom(
-              backgroundColor: AppColors.primaryColor,
-              foregroundColor: Colors.white,
-              padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
-            ),
-            onPressed: () {
-              Navigator.of(context).pop();
-              Navigator.push(
-                context,
-                MaterialPageRoute(builder: (context) => LoginPage()),
-              );
-            },
-            child: const TranslatedText(
-              'Sign In',
-              style: TextStyle(
-                fontSize: 16,
-                fontWeight: FontWeight.w600,
-              ),
-            ),
-          ),
-        ],
-      ),
-    );
   }
 
   Future<void> _refreshDashboard() async {

--- a/src/mobile/lib/src/app/dashboard/widgets/dashboard_app_bar.dart
+++ b/src/mobile/lib/src/app/dashboard/widgets/dashboard_app_bar.dart
@@ -1,4 +1,5 @@
 import 'package:airqo/src/app/auth/pages/login_page.dart';
+import 'package:airqo/src/app/profile/pages/guest_profile_page.dart';
 import 'package:airqo/src/app/profile/pages/profile_page.dart';
 import 'package:airqo/src/app/shared/widgets/translated_tooltip.dart';
 import 'package:flutter/material.dart';
@@ -72,37 +73,22 @@ class DashboardAppBar extends StatelessWidget implements PreferredSizeWidget {
   }
 
   Widget _buildGuestAvatar(BuildContext context) {
-    return TranslatedTooltip(
-      message: "Sign in or create an account",
-      preferBelow: true,
-      verticalOffset: 20,
-      showDuration: Duration(seconds: 2),
-      triggerMode: TooltipTriggerMode.tap,
-      decoration: BoxDecoration(
-        color: Colors.black87,
-        borderRadius: BorderRadius.circular(6),
-      ),
-      textStyle: TextStyle(
-        color: Colors.white,
-        fontSize: 12,
-      ),
-      child: GestureDetector(
-        onTap: () {
-          Navigator.of(context).push(
-            MaterialPageRoute(
-              builder: (context) => LoginPage(),
-            ),
-          );
-        },
-        child: CircleAvatar(
-          backgroundColor: Theme.of(context).highlightColor,
-          radius: 24,
-          child: Center(
-            child: SvgPicture.asset(
-              "assets/icons/user_icon.svg",
-              height: 22,
-              width: 22,
-            ),
+    return GestureDetector(
+      onTap: () {
+        Navigator.of(context).push(
+          MaterialPageRoute(
+            builder: (context) => const GuestProfilePage(),
+          ),
+        );
+      },
+      child: CircleAvatar(
+        backgroundColor: Theme.of(context).highlightColor,
+        radius: 24,
+        child: Center(
+          child: SvgPicture.asset(
+            "assets/icons/user_icon.svg",
+            height: 22,
+            width: 22,
           ),
         ),
       ),

--- a/src/mobile/lib/src/app/profile/pages/guest_about_page.dart
+++ b/src/mobile/lib/src/app/profile/pages/guest_about_page.dart
@@ -21,11 +21,15 @@ class _GuestAboutPageState extends State<GuestAboutPage> {
   }
 
   Future<void> _loadVersion() async {
-    final info = await PackageInfo.fromPlatform();
-    if (mounted) {
-      setState(() {
-        _appVersion = '${info.version}(${info.buildNumber})';
-      });
+    try {
+      final info = await PackageInfo.fromPlatform();
+      if (mounted) {
+        setState(() {
+          _appVersion = '${info.version}(${info.buildNumber})';
+        });
+      }
+    } catch (_) {
+      // Version unavailable; page renders without it
     }
   }
 

--- a/src/mobile/lib/src/app/profile/pages/guest_about_page.dart
+++ b/src/mobile/lib/src/app/profile/pages/guest_about_page.dart
@@ -1,0 +1,132 @@
+import 'package:airqo/src/app/profile/pages/guest_account_access_page.dart';
+import 'package:airqo/src/app/shared/widgets/translated_text.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/svg.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+
+class GuestAboutPage extends StatefulWidget {
+  const GuestAboutPage({super.key});
+
+  @override
+  State<GuestAboutPage> createState() => _GuestAboutPageState();
+}
+
+class _GuestAboutPageState extends State<GuestAboutPage> {
+  String _appVersion = '';
+
+  @override
+  void initState() {
+    super.initState();
+    _loadVersion();
+  }
+
+  Future<void> _loadVersion() async {
+    final info = await PackageInfo.fromPlatform();
+    if (mounted) {
+      setState(() {
+        _appVersion = '${info.version}(${info.buildNumber})';
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isDarkMode = Theme.of(context).brightness == Brightness.dark;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const TranslatedText('About'),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => Navigator.pop(context),
+        ),
+      ),
+      body: SingleChildScrollView(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // App identity
+            Center(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(vertical: 40),
+                child: Column(
+                  children: [
+                    SvgPicture.asset(
+                      'assets/images/shared/logo.svg',
+                      height: 56,
+                    ),
+                    const SizedBox(height: 14),
+                    if (_appVersion.isNotEmpty)
+                      Text(
+                        'Version $_appVersion',
+                        style: TextStyle(
+                          fontSize: 13,
+                          color: isDarkMode
+                              ? Colors.grey[400]
+                              : Colors.grey[600],
+                        ),
+                      ),
+                    const SizedBox(height: 4),
+                    Text(
+                      'A project by Makerere University',
+                      style: TextStyle(
+                        fontSize: 13,
+                        color: isDarkMode
+                            ? Colors.grey[400]
+                            : Colors.grey[600],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+
+            Divider(color: Theme.of(context).highlightColor),
+
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 20),
+              child: TranslatedText(
+                'AirQo operates Africa\'s leading air quality monitoring network, '
+                'providing real-time pollution data through locally designed sensors, '
+                'analytics platforms, and this mobile app across African cities.\n\n'
+                'Our mission: clean air for all African cities.',
+                style: TextStyle(
+                  fontSize: 14,
+                  color: Theme.of(context).textTheme.bodyMedium?.color,
+                  height: 1.65,
+                ),
+              ),
+            ),
+
+            const SizedBox(height: 60),
+
+            // Account access — intentionally subtle and far down the page
+            Divider(color: Theme.of(context).highlightColor),
+            ListTile(
+              contentPadding:
+                  const EdgeInsets.symmetric(horizontal: 24, vertical: 4),
+              title: TranslatedText(
+                'Account',
+                style: TextStyle(
+                  fontSize: 15,
+                  color: isDarkMode ? Colors.grey[500] : Colors.grey[500],
+                ),
+              ),
+              trailing: Icon(
+                Icons.chevron_right,
+                color: isDarkMode ? Colors.grey[600] : Colors.grey[400],
+                size: 20,
+              ),
+              onTap: () => Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (_) => const GuestAccountAccessPage(),
+                ),
+              ),
+            ),
+            const SizedBox(height: 40),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/src/mobile/lib/src/app/profile/pages/guest_account_access_page.dart
+++ b/src/mobile/lib/src/app/profile/pages/guest_account_access_page.dart
@@ -1,0 +1,97 @@
+import 'package:airqo/src/app/auth/pages/login_page.dart';
+import 'package:airqo/src/app/auth/pages/register_page.dart';
+import 'package:airqo/src/app/shared/widgets/translated_text.dart';
+import 'package:airqo/src/meta/utils/colors.dart';
+import 'package:flutter/material.dart';
+
+class GuestAccountAccessPage extends StatelessWidget {
+  const GuestAccountAccessPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final isDarkMode = Theme.of(context).brightness == Brightness.dark;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const TranslatedText('Account'),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => Navigator.pop(context),
+        ),
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const SizedBox(height: 24),
+            TranslatedText(
+              'Sign in or create an account to save your favourite locations, receive air quality alerts, and access personalised features.',
+              style: TextStyle(
+                fontSize: 15,
+                color: Theme.of(context).textTheme.bodyMedium?.color,
+                height: 1.6,
+              ),
+            ),
+            const SizedBox(height: 48),
+            SizedBox(
+              width: double.infinity,
+              height: 52,
+              child: ElevatedButton(
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: AppColors.primaryColor,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(4),
+                  ),
+                  elevation: 0,
+                ),
+                onPressed: () => Navigator.of(context).push(
+                  MaterialPageRoute(builder: (_) => CreateAccountScreen()),
+                ),
+                child: const TranslatedText(
+                  'Create Account',
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontWeight: FontWeight.w600,
+                    fontSize: 16,
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(height: 16),
+            SizedBox(
+              width: double.infinity,
+              height: 52,
+              child: OutlinedButton(
+                style: OutlinedButton.styleFrom(
+                  side: BorderSide(
+                    color: isDarkMode
+                        ? Colors.grey[600]!
+                        : AppColors.borderColor2,
+                  ),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(4),
+                  ),
+                ),
+                onPressed: () => Navigator.of(context).pushAndRemoveUntil(
+                  MaterialPageRoute(builder: (_) => LoginPage()),
+                  (route) => false,
+                ),
+                child: TranslatedText(
+                  'Sign In',
+                  style: TextStyle(
+                    fontWeight: FontWeight.w500,
+                    fontSize: 16,
+                    color: isDarkMode
+                        ? Colors.white
+                        : AppColors.boldHeadlineColor4,
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/src/mobile/lib/src/app/profile/pages/guest_profile_page.dart
+++ b/src/mobile/lib/src/app/profile/pages/guest_profile_page.dart
@@ -1,41 +1,10 @@
-import 'package:airqo/src/app/auth/pages/login_page.dart';
 import 'package:airqo/src/app/profile/pages/widgets/guest_settings_widget.dart';
 import 'package:airqo/src/app/shared/widgets/translated_text.dart';
-//import 'package:airqo/src/app/profile/pages/widgets/settings_tile.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
 
-import '../../../meta/utils/colors.dart';
-import '../../auth/pages/register_page.dart';
-import '../../shared/widgets/spinner.dart';
-
-class GuestProfilePage extends StatefulWidget {
+class GuestProfilePage extends StatelessWidget {
   const GuestProfilePage({super.key});
-
-  @override
-  State<GuestProfilePage> createState() => _GuestProfilePageState();
-}
-
-class _GuestProfilePageState extends State<GuestProfilePage> {
-  // Declare a loading state variable
-  bool isLoading = false;
-
-  void handleCreateAccount() async {
-    setState(() {
-      isLoading = true; // Set loading to true
-    });
-
-    // Simulate a delay for account creation or call an API here
-    await Future.delayed(Duration(seconds: 2));
-
-    setState(() {
-      isLoading = false; // Set loading to false once done
-    });
-
-    // Navigate to CreateAccountScreen or handle success
-    if (!mounted) return;
-    Navigator.of(context).push(MaterialPageRoute(builder: (context) => CreateAccountScreen()));
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -45,148 +14,75 @@ class _GuestProfilePageState extends State<GuestProfilePage> {
         actions: [
           IconButton(
               onPressed: () => Navigator.pop(context),
-              icon: Icon(Icons.close)),
-          SizedBox(width: 16)
+              icon: const Icon(Icons.close)),
+          const SizedBox(width: 16),
         ],
       ),
       body: SingleChildScrollView(
         child: Container(
           padding: const EdgeInsets.only(left: 16, right: 16, top: 8),
           child: Column(
-
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Row(
                 mainAxisAlignment: MainAxisAlignment.start,
                 children: [
-
-                Container(
-                  margin: const EdgeInsets.symmetric(horizontal: 20),
-                  child: CircleAvatar(
-                    backgroundColor: Theme.of(context).highlightColor,
-                    radius: 50,
-                    child: Center(
-                      child: SvgPicture.asset(
-                          "assets/icons/user_icon.svg"),
+                  Container(
+                    margin: const EdgeInsets.symmetric(horizontal: 20),
+                    child: CircleAvatar(
+                      backgroundColor: Theme.of(context).highlightColor,
+                      radius: 50,
+                      child: Center(
+                        child: SvgPicture.asset("assets/icons/user_icon.svg"),
+                      ),
                     ),
                   ),
-                ),
-
-
-                TranslatedText(
-                  "Guest User",
-                  style: TextStyle(
-                    color: Theme.of(context).textTheme.headlineSmall?.color,
-                    fontSize: 24,
-                    fontWeight: FontWeight.w700,
+                  TranslatedText(
+                    "Guest User",
+                    style: TextStyle(
+                      color: Theme.of(context).textTheme.headlineSmall?.color,
+                      fontSize: 24,
+                      fontWeight: FontWeight.w700,
+                    ),
                   ),
-                ),
-              ],),
-              SizedBox(height: 32),
+                ],
+              ),
+              const SizedBox(height: 32),
               Container(
                 margin: const EdgeInsets.symmetric(horizontal: 20),
                 child: TranslatedText(
                   'Settings',
-                style:TextStyle(
-                  color: Theme.of(context).textTheme.headlineSmall?.color,
-                  fontSize: 18,
-                  fontWeight: FontWeight.w500,
+                  style: TextStyle(
+                    color: Theme.of(context).textTheme.headlineSmall?.color,
+                    fontSize: 18,
+                    fontWeight: FontWeight.w500,
                   ),
-
                 ),
               ),
-              SizedBox(
-                height: 5,
-              ),
-
+              const SizedBox(height: 5),
               Divider(
-                color:Theme.of(context).highlightColor,
+                color: Theme.of(context).highlightColor,
                 indent: 20,
               ),
-
-
-
-
-              GuestSettingsWidget(),
-
-
-
-              SizedBox(
-                height: 18,
-              ),
-              InkWell(
-                onTap: () => Navigator.of(context).push(MaterialPageRoute(
-                builder: (context) => CreateAccountScreen())),
-                child: Container(
-                  height: 56,
-                  decoration: BoxDecoration(
-                      color: AppColors.primaryColor,
-                      borderRadius:
-                      BorderRadius.circular(4)),
-                  child: Center(
-                    child: isLoading
-                        ? Spinner()
-                        : TranslatedText(
-                      "Create Account",
-                      style: TextStyle(
-                        fontWeight: FontWeight.w500,
-                        color: Colors.white,
-                      ),
-                    ),
-                  ),
-                ),
-              ),
-
-              SizedBox(
-                height: 18,
-              ),
-              InkWell(
-                onTap: () => Navigator.of(context).pushAndRemoveUntil(MaterialPageRoute(
-                    builder: (context) => LoginPage()),(route) => false, ),
-                child: Container(
-                  height: 56,
-                  decoration: BoxDecoration(
-                      color: AppColors.backgroundColor2,
-                      border: Border.all(
-                          color: AppColors.borderColor2
-                      ),
-                      borderRadius:
-                      BorderRadius.circular(4)),
-                  child: Center(
-                    child: isLoading
-                        ? Spinner()
-                        : TranslatedText(
-                      "Login",
-                      style: TextStyle(
-                        fontWeight: FontWeight.w500,
-                        color: Colors.black,
-                      ),
-                    ),
-                  ),
-                ),
-              ),
-              SizedBox(
-                height: 76,
-              ),
-
+              const GuestSettingsWidget(),
+              const SizedBox(height: 76),
               Center(
-                  child: Column(
-                    children: [
-                      SvgPicture.asset('assets/images/shared/logo.svg',),
-                      SizedBox(height: 18,),
-                      Text(
-                        "3.40.1(1)",
-                        style: TextStyle(color: Theme.of(context).textTheme.headlineMedium?.color),),
-                      SizedBox(height: 18,),
-                      SvgPicture.asset('assets/images/shared/Frame 128.svg',
-                      colorFilter: ColorFilter.mode(Theme.of(context).textTheme.titleLarge?.color ?? Colors.black, BlendMode.srcIn),)
-                    ],
-                  ),
-
+                child: Column(
+                  children: [
+                    SvgPicture.asset('assets/images/shared/logo.svg'),
+                    const SizedBox(height: 18),
+                    SvgPicture.asset(
+                      'assets/images/shared/Frame 128.svg',
+                      colorFilter: ColorFilter.mode(
+                        Theme.of(context).textTheme.titleLarge?.color ??
+                            Colors.black,
+                        BlendMode.srcIn,
+                      ),
+                    ),
+                  ],
+                ),
               ),
-              SizedBox(
-                height: 220,
-              )
+              const SizedBox(height: 220),
             ],
           ),
         ),

--- a/src/mobile/lib/src/app/profile/pages/widgets/guest_settings_widget.dart
+++ b/src/mobile/lib/src/app/profile/pages/widgets/guest_settings_widget.dart
@@ -40,7 +40,16 @@ class _GuestSettingsWidgetState extends State<GuestSettingsWidget> {
       if (!serviceEnabled) {
         await Geolocator.openLocationSettings();
         serviceEnabled = await Geolocator.isLocationServiceEnabled();
-        if (!serviceEnabled) return;
+        if (!serviceEnabled) {
+          if (mounted) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(
+                content: TranslatedText('Location services still disabled.'),
+              ),
+            );
+          }
+          return;
+        }
       }
 
       LocationPermission permission = await Geolocator.checkPermission();

--- a/src/mobile/lib/src/app/profile/pages/widgets/guest_settings_widget.dart
+++ b/src/mobile/lib/src/app/profile/pages/widgets/guest_settings_widget.dart
@@ -1,10 +1,81 @@
 import 'package:airqo/src/app/feedback/pages/feedback_screen.dart';
+import 'package:airqo/src/app/profile/pages/guest_about_page.dart';
 import 'package:airqo/src/app/profile/pages/widgets/settings_tile.dart';
 import 'package:airqo/src/app/shared/services/feature_flag_service.dart';
+import 'package:airqo/src/app/shared/widgets/translated_text.dart';
 import 'package:flutter/material.dart';
+import 'package:geolocator/geolocator.dart';
 
-class GuestSettingsWidget extends StatelessWidget {
+class GuestSettingsWidget extends StatefulWidget {
   const GuestSettingsWidget({super.key});
+
+  @override
+  State<GuestSettingsWidget> createState() => _GuestSettingsWidgetState();
+}
+
+class _GuestSettingsWidgetState extends State<GuestSettingsWidget> {
+  bool _locationEnabled = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _checkLocationStatus();
+  }
+
+  Future<void> _checkLocationStatus() async {
+    final serviceEnabled = await Geolocator.isLocationServiceEnabled();
+    final permission = await Geolocator.checkPermission();
+    if (mounted) {
+      setState(() {
+        _locationEnabled = serviceEnabled &&
+            permission != LocationPermission.denied &&
+            permission != LocationPermission.deniedForever;
+      });
+    }
+  }
+
+  Future<void> _toggleLocation(bool value) async {
+    if (value) {
+      bool serviceEnabled = await Geolocator.isLocationServiceEnabled();
+      if (!serviceEnabled) {
+        await Geolocator.openLocationSettings();
+        serviceEnabled = await Geolocator.isLocationServiceEnabled();
+        if (!serviceEnabled) return;
+      }
+
+      LocationPermission permission = await Geolocator.checkPermission();
+      if (permission == LocationPermission.denied ||
+          permission == LocationPermission.deniedForever) {
+        permission = await Geolocator.requestPermission();
+        if (permission == LocationPermission.denied) {
+          if (mounted) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(
+                content: TranslatedText('Location permission denied.'),
+              ),
+            );
+          }
+          return;
+        } else if (permission == LocationPermission.deniedForever) {
+          if (mounted) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(
+                content: TranslatedText(
+                  'Location permission permanently denied. Please enable it in settings.',
+                ),
+              ),
+            );
+          }
+          await Geolocator.openAppSettings();
+          return;
+        }
+      }
+    }
+
+    if (mounted) {
+      setState(() => _locationEnabled = value);
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -12,18 +83,13 @@ class GuestSettingsWidget extends StatelessWidget {
       children: [
         const SizedBox(height: 8),
         SettingsTile(
-            switchValue: true,
-            iconPath: "assets/images/shared/location_icon.svg",
-            title: "Location",
-            onChanged: (_) {},
-            description:
-            "AirQo to use your precise location to locate the Air Quality of your nearest location"),
-        SettingsTile(
-            iconPath: "assets/icons/notification.svg",
-            title: "Notifications",
-            onChanged: (_) {},
-            description:
-            "Create an account to get air quality alerts"),
+          switchValue: _locationEnabled,
+          iconPath: "assets/images/shared/location_icon.svg",
+          title: "Location",
+          onChanged: _toggleLocation,
+          description:
+              "AirQo to use your precise location to locate the Air Quality of your nearest location",
+        ),
         if (FeatureFlagService.instance.isEnabled(AppFeatureFlag.feedback))
           SettingsTile(
             iconPath: "assets/images/shared/feedback_icon.svg",
@@ -38,13 +104,14 @@ class GuestSettingsWidget extends StatelessWidget {
           ),
         SettingsTile(
           iconPath: "assets/images/shared/airqo_story_icon.svg",
-          title: "Our Story",
-          onChanged: (_) {},
-        ),
-        SettingsTile(
-          iconPath: "assets/images/shared/terms_and_privacy.svg",
-          title: "Terms and Privacy Policy",
-          onChanged: (_) {},
+          title: "About",
+          onTap: () {
+            Navigator.of(context).push(
+              MaterialPageRoute(
+                builder: (context) => const GuestAboutPage(),
+              ),
+            );
+          },
         ),
       ],
     );

--- a/src/mobile/lib/src/app/shared/bloc/connectivity_bloc.dart
+++ b/src/mobile/lib/src/app/shared/bloc/connectivity_bloc.dart
@@ -11,8 +11,6 @@ part 'connectivity_state.dart';
 class ConnectivityBloc extends Bloc<ConnectivityEvent, ConnectivityState> {
   final Connectivity _connectivity;
   StreamSubscription? _connectivitySubscription;
-  bool _bannerDismissed = false;
-  bool get isBannerDismissed => _bannerDismissed;
 
   ConnectivityBloc(this._connectivity) : super(ConnectivityInitial()) {
     _checkInitialConnectivity();
@@ -28,6 +26,12 @@ class ConnectivityBloc extends Bloc<ConnectivityEvent, ConnectivityState> {
         emit(ConnectivityOnline());
       } else {
         emit(ConnectivityOffline());
+      }
+    });
+
+    on<ConnectivityBannerDismissed>((event, emit) {
+      if (state is ConnectivityOffline) {
+        emit(ConnectivityOffline(true));
       }
     });
   }
@@ -60,20 +64,4 @@ class ConnectivityBloc extends Bloc<ConnectivityEvent, ConnectivityState> {
     return super.close();
   }
 
-  @override
-  void onEvent(ConnectivityEvent event) {
-    if (event is ConnectivityBannerDismissed) {
-      _bannerDismissed = true;
-    }
-    super.onEvent(event);
-  }
-
-  Stream<ConnectivityState> mapEventToState(ConnectivityEvent event) async* {
-    if (event is ConnectivityChanged) {
-      yield event.isConnected ? ConnectivityOnline() : ConnectivityOffline();
-    } else if (event is ConnectivityBannerDismissed) {
-      _bannerDismissed = true;
-      yield state;
-    }
-  }
 }

--- a/src/mobile/lib/src/app/shared/bloc/connectivity_state.dart
+++ b/src/mobile/lib/src/app/shared/bloc/connectivity_state.dart
@@ -15,4 +15,7 @@ class ConnectivityOffline extends ConnectivityState {
   final bool isDismissed;
 
   const ConnectivityOffline([this.isDismissed = false]);
+
+  @override
+  List<Object?> get props => [isDismissed];
 }


### PR DESCRIPTION
- Remove Create Account and Login buttons from guest profile page
- Guest avatar in app bar now opens guest settings instead of login
- Remove login prompt dialog when guest taps My Places tab
- Make Location permission toggle functional in guest settings
- Drop non-functional settings tiles (Notifications, Our Story, Terms)
- Add About page with real AirQo content sourced from airqo.net
- Add Account Access page buried deep in settings as the only sign-in entry point
- Refactor ConnectivityBloc banner dismissed handling to use proper event handler



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Guest users now have access to a dedicated profile section with account information and app details.
  * Added location permission toggle in guest settings.

* **Improvements**
  * Guest avatar now navigates to the profile page.
  * Favorites view is no longer restricted for guest users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->