### PR TITLE
Add "My Sites" page for Personal Context

### DIFF
--- a/src/vertex/app/(authenticated)/sites/my-sites/page.tsx
+++ b/src/vertex/app/(authenticated)/sites/my-sites/page.tsx
@@ -3,16 +3,19 @@
 import { useRouter } from "next/navigation";
 import { useMySites } from "@/core/hooks/useSites";
 import { useAppSelector } from "@/core/redux/hooks";
+import { useUserContext } from "@/core/hooks/useUserContext";
 import { RouteGuard } from "@/components/layout/accessConfig/route-guard";
 import { PERMISSIONS } from "@/core/permissions/constants";
 import ClientPaginatedSitesTable from "@/components/features/sites/client-paginated-sites-table";
 
 const MySitesPage = () => {
   const router = useRouter();
+  const { userContext } = useUserContext();
   const { userDetails, activeGroup } = useAppSelector((state) => state.user);
   const { data: mySitesData, isLoading, error } = useMySites(
     userDetails?._id || "",
-    activeGroup?._id
+    activeGroup?._id,
+    { enabled: userContext === 'personal' }
   );
 
   const sites = mySitesData?.sites || [];

--- a/src/vertex/app/(authenticated)/sites/my-sites/page.tsx
+++ b/src/vertex/app/(authenticated)/sites/my-sites/page.tsx
@@ -1,133 +1,45 @@
 "use client";
 
-import React from "react";
-import { useSearchParams } from "next/navigation";
-import { AqMarkerPin01 } from "@airqo/icons-react";
-import { Card, CardContent } from "@/components/ui/card";
+import { useRouter } from "next/navigation";
 import { useMySites } from "@/core/hooks/useSites";
 import { useAppSelector } from "@/core/redux/hooks";
 import { useUserContext } from "@/core/hooks/useUserContext";
 import { RouteGuard } from "@/components/layout/accessConfig/route-guard";
 import { PERMISSIONS } from "@/core/permissions/constants";
 import ClientPaginatedSitesTable from "@/components/features/sites/client-paginated-sites-table";
-import ReusableButton from "@/components/shared/button/ReusableButton";
-import dynamic from "next/dynamic";
-
-const CreateSiteForm = dynamic(
-  () =>
-    import("@/components/features/sites/create-site-form").then(
-      (mod) => mod.CreateSiteForm
-    ),
-  {
-    ssr: false,
-    loading: () => (
-      <div className="w-36 h-10 rounded-lg bg-gray-200 animate-pulse" />
-    ),
-  }
-);
 
 const MySitesPage = () => {
+  const router = useRouter();
   const { userDetails, activeGroup } = useAppSelector((state) => state.user);
   const { userScope } = useUserContext();
 
-  const {
-    data: mySitesData,
-    isLoading,
-    error,
-  } = useMySites(userDetails?._id || "", activeGroup?._id, {
-    enabled: userScope === "personal",
-  });
+  const { data: mySitesData, isLoading, error } = useMySites(
+    userDetails?._id || "",
+    activeGroup?._id,
+    { enabled: userScope === "personal" }
+  );
 
   const sites = mySitesData?.sites || [];
-
-  const searchParams = useSearchParams();
-  const rawStatus = searchParams.get("status");
-  const statusFilter = [
-    "operational",
-    "transmitting",
-    "not_transmitting",
-    "data_available",
-  ].includes(rawStatus || "")
-    ? rawStatus
-    : null;
-
-  const filteredSites = React.useMemo(() => {
-    if (!statusFilter) return sites;
-    return sites.filter((site) => {
-      if (statusFilter === "operational")
-        return site.rawOnlineStatus === true && site.isOnline === true;
-      if (statusFilter === "transmitting")
-        return site.rawOnlineStatus === true && site.isOnline === false;
-      if (statusFilter === "not_transmitting")
-        return site.rawOnlineStatus === false && site.isOnline === false;
-      if (statusFilter === "data_available")
-        return site.rawOnlineStatus === false && site.isOnline === true;
-      return true;
-    });
-  }, [sites, statusFilter]);
-
-  if (error) {
-    return (
-      <RouteGuard permission={PERMISSIONS.SITE.VIEW}>
-        <div>
-          <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4 mb-6">
-            <div>
-              <h1 className="text-2xl font-semibold">My Sites</h1>
-              <p className="text-muted-foreground">
-                Manage your personal monitoring sites
-              </p>
-            </div>
-          </div>
-          <Card>
-            <CardContent className="pt-12 pb-12">
-              <div className="text-center">
-                <AqMarkerPin01 className="mx-auto h-12 w-12 text-muted-foreground mb-4" />
-                <h3 className="text-lg font-semibold mb-2">
-                  Unable to load sites
-                </h3>
-                <p className="text-muted-foreground mb-4">
-                  There was an error loading your sites. Please try again or
-                  contact support if the problem persists.
-                </p>
-                <ReusableButton onClick={() => window.location.reload()}>
-                  Retry
-                </ReusableButton>
-              </div>
-            </CardContent>
-          </Card>
-        </div>
-      </RouteGuard>
-    );
-  }
 
   return (
     <RouteGuard permission={PERMISSIONS.SITE.VIEW}>
       <div>
-        <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4 mb-6">
+        <div className="mb-3">
           <div>
-            <div className="flex items-center gap-2">
-              <h1 className="text-2xl font-semibold">My Sites</h1>
-              {statusFilter && (
-                <span className="text-sm px-2 py-1 rounded-full bg-primary/10 text-primary font-medium">
-                  Filtered: {statusFilter.replace(/_/g, " ")}
-                </span>
-              )}
-            </div>
-            <p className="text-muted-foreground">
+            <h1 className="text-2xl font-semibold">My Sites</h1>
+            <p className="text-sm text-muted-foreground">
               Manage your personal monitoring sites
             </p>
           </div>
-          <div className="flex gap-2 items-center">
-            <CreateSiteForm basePath="/sites" />
-          </div>
         </div>
-
-        <ClientPaginatedSitesTable
-          sites={filteredSites}
-          isLoading={isLoading}
-          error={error}
-          multiSelect
-        />
+        <div className="flex flex-col gap-6">
+          <ClientPaginatedSitesTable
+            sites={sites}
+            isLoading={isLoading}
+            error={error}
+            onSiteClick={(site) => router.push(`/sites/${site._id}`)}
+          />
+        </div>
       </div>
     </RouteGuard>
   );

--- a/src/vertex/app/(authenticated)/sites/my-sites/page.tsx
+++ b/src/vertex/app/(authenticated)/sites/my-sites/page.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import React from "react";
+import { useSearchParams } from "next/navigation";
+import { AqMarkerPin01 } from "@airqo/icons-react";
+import { Card, CardContent } from "@/components/ui/card";
+import { useMySites } from "@/core/hooks/useSites";
+import { useAppSelector } from "@/core/redux/hooks";
+import { useUserContext } from "@/core/hooks/useUserContext";
+import { RouteGuard } from "@/components/layout/accessConfig/route-guard";
+import { PERMISSIONS } from "@/core/permissions/constants";
+import ClientPaginatedSitesTable from "@/components/features/sites/client-paginated-sites-table";
+import ReusableButton from "@/components/shared/button/ReusableButton";
+import dynamic from "next/dynamic";
+
+const CreateSiteForm = dynamic(
+  () =>
+    import("@/components/features/sites/create-site-form").then(
+      (mod) => mod.CreateSiteForm
+    ),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="w-36 h-10 rounded-lg bg-gray-200 animate-pulse" />
+    ),
+  }
+);
+
+const MySitesPage = () => {
+  const { userDetails, activeGroup } = useAppSelector((state) => state.user);
+  const { userScope } = useUserContext();
+
+  const {
+    data: mySitesData,
+    isLoading,
+    error,
+  } = useMySites(userDetails?._id || "", activeGroup?._id, {
+    enabled: userScope === "personal",
+  });
+
+  const sites = mySitesData?.sites || [];
+
+  const searchParams = useSearchParams();
+  const rawStatus = searchParams.get("status");
+  const statusFilter = [
+    "operational",
+    "transmitting",
+    "not_transmitting",
+    "data_available",
+  ].includes(rawStatus || "")
+    ? rawStatus
+    : null;
+
+  const filteredSites = React.useMemo(() => {
+    if (!statusFilter) return sites;
+    return sites.filter((site) => {
+      if (statusFilter === "operational")
+        return site.rawOnlineStatus === true && site.isOnline === true;
+      if (statusFilter === "transmitting")
+        return site.rawOnlineStatus === true && site.isOnline === false;
+      if (statusFilter === "not_transmitting")
+        return site.rawOnlineStatus === false && site.isOnline === false;
+      if (statusFilter === "data_available")
+        return site.rawOnlineStatus === false && site.isOnline === true;
+      return true;
+    });
+  }, [sites, statusFilter]);
+
+  if (error) {
+    return (
+      <RouteGuard permission={PERMISSIONS.SITE.VIEW}>
+        <div>
+          <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4 mb-6">
+            <div>
+              <h1 className="text-2xl font-semibold">My Sites</h1>
+              <p className="text-muted-foreground">
+                Manage your personal monitoring sites
+              </p>
+            </div>
+          </div>
+          <Card>
+            <CardContent className="pt-12 pb-12">
+              <div className="text-center">
+                <AqMarkerPin01 className="mx-auto h-12 w-12 text-muted-foreground mb-4" />
+                <h3 className="text-lg font-semibold mb-2">
+                  Unable to load sites
+                </h3>
+                <p className="text-muted-foreground mb-4">
+                  There was an error loading your sites. Please try again or
+                  contact support if the problem persists.
+                </p>
+                <ReusableButton onClick={() => window.location.reload()}>
+                  Retry
+                </ReusableButton>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </RouteGuard>
+    );
+  }
+
+  return (
+    <RouteGuard permission={PERMISSIONS.SITE.VIEW}>
+      <div>
+        <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4 mb-6">
+          <div>
+            <div className="flex items-center gap-2">
+              <h1 className="text-2xl font-semibold">My Sites</h1>
+              {statusFilter && (
+                <span className="text-sm px-2 py-1 rounded-full bg-primary/10 text-primary font-medium">
+                  Filtered: {statusFilter.replace(/_/g, " ")}
+                </span>
+              )}
+            </div>
+            <p className="text-muted-foreground">
+              Manage your personal monitoring sites
+            </p>
+          </div>
+          <div className="flex gap-2 items-center">
+            <CreateSiteForm basePath="/sites" />
+          </div>
+        </div>
+
+        <ClientPaginatedSitesTable
+          sites={filteredSites}
+          isLoading={isLoading}
+          error={error}
+          multiSelect
+        />
+      </div>
+    </RouteGuard>
+  );
+};
+
+export default MySitesPage;

--- a/src/vertex/app/(authenticated)/sites/my-sites/page.tsx
+++ b/src/vertex/app/(authenticated)/sites/my-sites/page.tsx
@@ -3,7 +3,6 @@
 import { useRouter } from "next/navigation";
 import { useMySites } from "@/core/hooks/useSites";
 import { useAppSelector } from "@/core/redux/hooks";
-import { useUserContext } from "@/core/hooks/useUserContext";
 import { RouteGuard } from "@/components/layout/accessConfig/route-guard";
 import { PERMISSIONS } from "@/core/permissions/constants";
 import ClientPaginatedSitesTable from "@/components/features/sites/client-paginated-sites-table";
@@ -11,18 +10,15 @@ import ClientPaginatedSitesTable from "@/components/features/sites/client-pagina
 const MySitesPage = () => {
   const router = useRouter();
   const { userDetails, activeGroup } = useAppSelector((state) => state.user);
-  const { userScope } = useUserContext();
-
   const { data: mySitesData, isLoading, error } = useMySites(
     userDetails?._id || "",
-    activeGroup?._id,
-    { enabled: userScope === "personal" }
+    activeGroup?._id
   );
 
   const sites = mySitesData?.sites || [];
 
   return (
-    <RouteGuard permission={PERMISSIONS.SITE.VIEW}>
+    <RouteGuard permission={PERMISSIONS.SITE.VIEW} allowedContexts={['personal']} redirectTo="/home" showError={false}>
       <div>
         <div className="mb-3">
           <div>

--- a/src/vertex/app/changelog.md
+++ b/src/vertex/app/changelog.md
@@ -4,6 +4,39 @@
 
 ---
 
+## Version 2.0.5
+**Released:** June 11, 2026
+
+### My Sites Page — Personal Context
+
+Introduced a dedicated **My Sites** page for users operating in a Personal Context, mirroring the existing My Devices flow to ensure consistent behavior across personal assets.
+
+<details>
+<summary><strong>Changes (6)</strong></summary>
+
+- **API**: Added `getMySites(userId, groupIds?, cohortIds?)` to the `sites` API object. Calls `GET /devices/sites/my-sites` with `user_id`, `group_ids` (comma-separated), `cohort_ids` (comma-separated), and `tenant=airqo` query params. Returns `SitesSummaryResponse`. Header `X-Auth-Type: JWT` included.
+- **Adapter type**: Added `getMySites: typeof sites.getMySites` to the `VertexAdapter` interface so the method is correctly typed through the adapter layer.
+- **Hook**: Added `useMySites(userId, organizationId?, options?)` to `useSites.ts`, mirroring `useMyDevices` exactly. Imports `usePersonalUserCohorts` to resolve personal cohort IDs; filters `userDetails.groups` to exclude the "airqo" group when building `groupIds`; falls back to `userDetails.cohort_ids` if no personal cohorts are found. Query key includes `userId`, `organizationId || activeGroup?._id`, `groupIds`, and `cohortIds`.
+- **Route**: Added `MY_SITES: '/sites/my-sites'` to `ROUTE_LINKS` in `routes.ts`.
+- **Sidebar**: Destructured `isPersonalContext` from `useUserContext()` in `secondary-sidebar.tsx`. Added a "My Sites" `NavItem` (icon: `AqMarkerPin01`) under the "Personal assets" section, rendered only when `isPersonalContext === true` (i.e. the user's active group is the `airqo` group). Remains hidden when the user has switched to an external organisation context.
+- **Page**: Created `my-sites/page.tsx` with `RouteGuard` (`PERMISSIONS.SITE.VIEW`), status filter badge, client-side filtering on `rawOnlineStatus`/`isOnline`, `ClientPaginatedSitesTable` with `multiSelect`, `CreateSiteForm` with `basePath="/sites"` to prevent non-admin users being routed to `/admin/sites` after creation, and an error state card with retry.
+
+</details>
+
+<details>
+<summary><strong>Files Updated (6)</strong></summary>
+
+- `src/vertex/core/apis/sites.ts` [MODIFIED]
+- `src/vertex/core/adapters/types.ts` [MODIFIED]
+- `src/vertex/core/hooks/useSites.ts` [MODIFIED]
+- `src/vertex/core/routes.ts` [MODIFIED]
+- `src/vertex/components/layout/secondary-sidebar.tsx` [MODIFIED]
+- `src/vertex/app/(authenticated)/sites/my-sites/page.tsx` [NEW]
+
+</details>
+
+---
+
 ## Version 2.0.4
 **Released:** June 11, 2026
 

--- a/src/vertex/app/changelog.md
+++ b/src/vertex/app/changelog.md
@@ -5,21 +5,22 @@
 ---
 
 ## Version 2.0.5
-**Released:** June 11, 2026
+**Released:** June 12, 2026
 
 ### My Sites Page — Personal Context
 
 Introduced a dedicated **My Sites** page for users operating in a Personal Context, mirroring the existing My Devices flow to ensure consistent behavior across personal assets.
 
 <details>
-<summary><strong>Changes (6)</strong></summary>
+<summary><strong>Changes (7)</strong></summary>
 
 - **API**: Added `getMySites(userId, groupIds?, cohortIds?)` to the `sites` API object. Calls `GET /devices/sites/my-sites` with `user_id`, `group_ids` (comma-separated), `cohort_ids` (comma-separated), and `tenant=airqo` query params. Returns `SitesSummaryResponse`. Header `X-Auth-Type: JWT` included.
 - **Adapter type**: Added `getMySites: typeof sites.getMySites` to the `VertexAdapter` interface so the method is correctly typed through the adapter layer.
 - **Hook**: Added `useMySites(userId, organizationId?, options?)` to `useSites.ts`, mirroring `useMyDevices` exactly. Imports `usePersonalUserCohorts` to resolve personal cohort IDs; filters `userDetails.groups` to exclude the "airqo" group when building `groupIds`; falls back to `userDetails.cohort_ids` if no personal cohorts are found. Query key includes `userId`, `organizationId || activeGroup?._id`, `groupIds`, and `cohortIds`.
 - **Route**: Added `MY_SITES: '/sites/my-sites'` to `ROUTE_LINKS` in `routes.ts`.
 - **Sidebar**: Destructured `isPersonalContext` from `useUserContext()` in `secondary-sidebar.tsx`. Added a "My Sites" `NavItem` (icon: `AqMarkerPin01`) under the "Personal assets" section, rendered only when `isPersonalContext === true` (i.e. the user's active group is the `airqo` group). Remains hidden when the user has switched to an external organisation context.
-- **Page**: Created `my-sites/page.tsx` with `RouteGuard` (`PERMISSIONS.SITE.VIEW`), status filter badge, client-side filtering on `rawOnlineStatus`/`isOnline`, `ClientPaginatedSitesTable` with `multiSelect`, `CreateSiteForm` with `basePath="/sites"` to prevent non-admin users being routed to `/admin/sites` after creation, and an error state card with retry.
+- **Page**: Created `my-sites/page.tsx` matching the layout of `sites/overview/page.tsx` — simple title/description header with no action buttons, `ClientPaginatedSitesTable` with an `onSiteClick` handler that routes to `/sites/[id]` (the non-admin site details page). Removed `CreateSiteForm`, status filter badge, complex error card, and `useSearchParams` logic as they are not needed for the personal context use case.
+- **Site row navigation**: Passing `onSiteClick` to `ClientPaginatedSitesTable` overrides the component's default `/admin/sites/[id]` routing so personal-context users land on `/sites/[id]` instead. Back navigation from the site details page uses the existing `router.back()` call, which correctly returns the user to `/sites/my-sites`.
 
 </details>
 

--- a/src/vertex/components/layout/secondary-sidebar.tsx
+++ b/src/vertex/components/layout/secondary-sidebar.tsx
@@ -50,7 +50,7 @@ const SecondarySidebar: React.FC<SecondarySidebarProps> = ({
   activeModule,
   onNavigate,
 }) => {
-  const { getContextPermissions, isExternalOrg } =
+  const { getContextPermissions, isExternalOrg, isPersonalContext } =
     useUserContext();
   const contextPermissions = getContextPermissions();
   const pathname = usePathname();
@@ -143,6 +143,18 @@ const SecondarySidebar: React.FC<SecondarySidebarProps> = ({
                     isCollapsed={isCollapsed}
                     onClick={onNavigate}
                   />
+                  {isPersonalContext && (
+                    <NavItem
+                      item={{
+                        href: ROUTE_LINKS.MY_SITES,
+                        icon: AqMarkerPin01,
+                        label: 'My Sites',
+                        disabled: false,
+                      }}
+                      isCollapsed={isCollapsed}
+                      onClick={onNavigate}
+                    />
+                  )}
 
                   <SidebarSectionHeading isCollapsed={isCollapsed}>
                     Data Access & Visibility

--- a/src/vertex/components/layout/secondary-sidebar.tsx
+++ b/src/vertex/components/layout/secondary-sidebar.tsx
@@ -153,7 +153,6 @@ const SecondarySidebar: React.FC<SecondarySidebarProps> = ({
                     isCollapsed={isCollapsed}
                     onClick={onNavigate}
                   />
-
                   <SidebarSectionHeading isCollapsed={isCollapsed}>
                     Data Access & Visibility
                   </SidebarSectionHeading>

--- a/src/vertex/components/layout/secondary-sidebar.tsx
+++ b/src/vertex/components/layout/secondary-sidebar.tsx
@@ -50,7 +50,7 @@ const SecondarySidebar: React.FC<SecondarySidebarProps> = ({
   activeModule,
   onNavigate,
 }) => {
-  const { getContextPermissions, isExternalOrg, isPersonalContext } =
+  const { getContextPermissions, isExternalOrg } =
     useUserContext();
   const contextPermissions = getContextPermissions();
   const pathname = usePathname();
@@ -143,18 +143,16 @@ const SecondarySidebar: React.FC<SecondarySidebarProps> = ({
                     isCollapsed={isCollapsed}
                     onClick={onNavigate}
                   />
-                  {isPersonalContext && (
-                    <NavItem
-                      item={{
-                        href: ROUTE_LINKS.MY_SITES,
-                        icon: AqMarkerPin01,
-                        label: 'My Sites',
-                        disabled: false,
-                      }}
-                      isCollapsed={isCollapsed}
-                      onClick={onNavigate}
-                    />
-                  )}
+                  <NavItem
+                    item={{
+                      href: ROUTE_LINKS.MY_SITES,
+                      icon: AqMarkerPin01,
+                      label: 'My Sites',
+                      disabled: false,
+                    }}
+                    isCollapsed={isCollapsed}
+                    onClick={onNavigate}
+                  />
 
                   <SidebarSectionHeading isCollapsed={isCollapsed}>
                     Data Access & Visibility

--- a/src/vertex/core/adapters/types.ts
+++ b/src/vertex/core/adapters/types.ts
@@ -31,6 +31,7 @@ export interface VertexAdapter extends BaseApis {
   getSites: typeof sites.getSitesSummary;
   getSite: typeof sites.getSiteDetails;
   getSitesByStatus: typeof sites.getSitesByStatusApi;
+  getMySites: typeof sites.getMySites;
   getNetworks: typeof networks.getNetworksApi;
   getCurrentUser: typeof users.getUserDetails;
   login: typeof users.loginWithDetails;

--- a/src/vertex/core/apis/sites.ts
+++ b/src/vertex/core/apis/sites.ts
@@ -262,6 +262,29 @@ export const sites = {
     }
   },
 
+  getMySites: async (
+    userId: string,
+    groupIds?: string[],
+    cohortIds?: string[]
+  ): Promise<SitesSummaryResponse> => {
+    try {
+      const params = new URLSearchParams({ user_id: userId, tenant: "airqo" });
+      if (groupIds && groupIds.length > 0) {
+        params.append("group_ids", groupIds.join(","));
+      }
+      if (cohortIds && cohortIds.length > 0) {
+        params.append("cohort_ids", cohortIds.join(","));
+      }
+      const response = await createSecureApiClient().get<SitesSummaryResponse>(
+        `/devices/sites/my-sites?${params.toString()}`,
+        { headers: { "X-Auth-Type": "JWT" } }
+      );
+      return response.data;
+    } catch (error) {
+      throw error;
+    }
+  },
+
   refreshSiteMetadata: async (siteId: string): Promise<SiteRefreshResponse> => {
     try {
       const response = await createSecureApiClient().put<SiteRefreshResponse>(

--- a/src/vertex/core/apis/sites.ts
+++ b/src/vertex/core/apis/sites.ts
@@ -264,8 +264,8 @@ export const sites = {
 
   getMySites: async (
     userId: string,
-    groupIds?: string[],
-    cohortIds?: string[]
+    groupIds: string[],
+    cohortIds: string[]
   ): Promise<SitesSummaryResponse> => {
     try {
       const params = new URLSearchParams({ user_id: userId, tenant: "airqo" });

--- a/src/vertex/core/hooks/useSites.ts
+++ b/src/vertex/core/hooks/useSites.ts
@@ -8,7 +8,7 @@ import {
 } from "../apis/sites";
 import { adapter } from '../adapters';
 import { DeviceActivitiesResponse } from "../apis/devices";
-import { useGroupCohorts } from "./useCohorts";
+import { useGroupCohorts, usePersonalUserCohorts } from "./useCohorts";
 import { useAppSelector } from "../redux/hooks";
 import { useMemo } from "react";
 import { AxiosError } from "axios";
@@ -284,4 +284,51 @@ export const useRefreshSiteMetadata = (options?: UseRefreshSiteMetadataOptions) 
       options?.onError?.(error);
     },
   });
+};
+
+export const useMySites = (
+  userId: string,
+  organizationId?: string,
+  options: { enabled?: boolean } = {}
+) => {
+  const activeGroup = useAppSelector((state) => state.user.activeGroup);
+  const userDetails = useAppSelector((state) => state.user.userDetails);
+  const { enabled = true } = options;
+
+  type UserGroup = {
+    _id: string;
+    grp_title?: string;
+  };
+
+  const { data: personalCohortIds, isLoading: isPersonalCohortsLoading } =
+    usePersonalUserCohorts(userId, { enabled: !!userId && enabled });
+
+  const groupIds = userDetails?.groups
+    ? (userDetails.groups as UserGroup[])
+        .filter((g) => g.grp_title?.toLowerCase() !== "airqo")
+        .map((g) => g._id)
+    : userDetails?.group_ids || [];
+
+  const cohortIds =
+    personalCohortIds && personalCohortIds.length > 0
+      ? personalCohortIds
+      : userDetails?.cohort_ids || [];
+
+  const query = useQuery<SitesSummaryResponse, AxiosError<ErrorResponse>>({
+    queryKey: [
+      "mySites",
+      userId,
+      organizationId || activeGroup?._id,
+      groupIds,
+      cohortIds,
+    ],
+    queryFn: () => adapter.getMySites(userId, groupIds, cohortIds),
+    enabled: !!userId && enabled && !!userDetails && !isPersonalCohortsLoading,
+    staleTime: 60_000,
+  });
+
+  return {
+    ...query,
+    isLoading: query.isLoading || isPersonalCohortsLoading,
+  };
 };

--- a/src/vertex/core/routes.ts
+++ b/src/vertex/core/routes.ts
@@ -8,6 +8,7 @@ export const ROUTE_LINKS = {
   GRIDS: '/admin/grids',
   ADMIN_SHIPPING: '/admin/shipping',
   MY_DEVICES: '/devices/my-devices',
+  MY_SITES: '/sites/my-sites',
   ORG_OVERVIEW: '/home',
   ORG_ASSETS: '/devices/overview',
   DEVICE_COHORTS: '/cohorts',


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

Introduces a dedicated **My Sites** page for users in a Personal Context, mirroring the existing My Devices flow to ensure consistent behavior across personal assets.

**What was added:**
- `getMySites` API method on the `sites` object — calls `GET /devices/sites/my-sites` with `user_id`, `group_ids`, `cohort_ids`, and `tenant=airqo` params, returning `SitesSummaryResponse` with `X-Auth-Type: JWT`.
- `getMySites` explicitly declared on the `VertexAdapter` interface so the method is correctly typed through the adapter layer.
- `useMySites` hook in `useSites.ts` — mirrors `useMyDevices` exactly: resolves personal cohort IDs via `usePersonalUserCohorts`, builds `groupIds` by filtering out the "airqo" group from `userDetails.groups`, and falls back to `userDetails.cohort_ids` when no personal cohorts exist.
- `MY_SITES: '/sites/my-sites'` route constant added to `ROUTE_LINKS`.
- "My Sites" sidebar entry under **Personal assets**, visible only when `isPersonalContext === true` (active group is the `airqo` group) — hidden when the user switches to an external organisation context.
- `/sites/my-sites/page.tsx` — `RouteGuard` with `PERMISSIONS.SITE.VIEW`, status filter badge, client-side filtering on `rawOnlineStatus`/`isOnline`, `ClientPaginatedSitesTable` with multi-select, `CreateSiteForm` with `basePath="/sites"` to prevent non-admin users being redirected to `/admin/sites` after site creation, and an error state card with retry.

---

#### Status of maturity (all need to be checked before merging):

- [x] I've tested this locally
- [x] I consider this code done
- [x] This change ready to hit production in its current state
- [x] The title of the PR states what changed and the related issues number (used for the release note).
- [x] I've included issue number in the "Closes #3457" part of the "[What are the relevant tickets?](#what-are-the-relevant-tickets)" section to [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] I've updated corresponding documentation for the changes in this PR.
- [ ] I have written unit and/or e2e tests for my change(s).

---

#### How should this be manually tested?

1. Log in as a user whose active group is `airqo` (Personal Context).
2. Navigate to the **Devices** module — confirm "My Sites" appears under **Personal assets** in the sidebar below "My Devices".
3. Click **My Sites** — confirm the page loads at `/sites/my-sites` and displays the user's personal sites in the table.
4. Apply a status filter via `?status=operational` (or other valid values) — confirm the table filters correctly.
5. Click **Add Site**, fill in the form, and submit — confirm the app routes to `/sites/<new-site-id>` (not `/admin/sites/<id>`).
6. Switch context to an external organisation — confirm "My Sites" disappears from the sidebar.
7. Log in as a user without `SITE_VIEW` permission — confirm the page shows the `RouteGuard` access-denied state.

---

#### What are the relevant tickets?

- Closes #3457

---

#### Screenshots (optional)
<img width="960" height="516" alt="image" src="https://github.com/user-attachments/assets/3c09f9cf-e663-4c3c-8457-6633514bd956" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "My Sites" page at /sites/my-sites for personal-context users with paginated site listings, click-to-open site details, and back navigation.
  * Sidebar shows a "My Sites" nav item only in personal context.
  * Listings respect personal user/group/cohort context and surface loading/error states with retry.

* **Documentation**
  * Changelog updated for the My Sites release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->