### PR TITLE
Replace git diff with GitHub API for fork-safe PR change detection

### DIFF
--- a/.github/workflows/deploy-frontend-azurepreview.yml
+++ b/.github/workflows/deploy-frontend-azurepreview.yml
@@ -52,23 +52,14 @@ jobs:
       run_docs: ${{ steps.check_files.outputs.run_docs }}
 
     steps:
-      - uses: actions/checkout@v4
-        with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.ref }}
-          fetch-depth: 0
-
       - name: check modified frontends
         id: check_files
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           echo "=============== list modified files ==============="
-          git fetch origin ${{ github.base_ref }}
-          git diff --name-only \
-            origin/${{ github.base_ref }}...${{ github.event.pull_request.head.sha }}
-
-          echo "========== check paths of modified files =========="
-          git diff --name-only \
-            origin/${{ github.base_ref }}...${{ github.event.pull_request.head.sha }} > files.txt
+          gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files \
+            --paginate --jq '.[].filename' | tee files.txt
 
           echo "run_calibrate_app=false" >>$GITHUB_OUTPUT
           echo "run_analytics_platform=false" >>$GITHUB_OUTPUT

--- a/.github/workflows/deploy-frontend-azurepreview.yml
+++ b/.github/workflows/deploy-frontend-azurepreview.yml
@@ -43,6 +43,8 @@ jobs:
 
   check:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     outputs:
       run_calibrate_app: ${{ steps.check_files.outputs.run_calibrate_app }}
       run_analytics_platform: ${{ steps.check_files.outputs.run_analytics_platform }}


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Replaces the git-based change detection in the `check` job of `.github/workflows/deploy-frontend-azurepreview.yml` with a direct GitHub API call. The checkout step and both `git fetch` / `git diff` commands are removed entirely. In their place, a single `gh api` call fetches the exact list of files changed in the PR from GitHub's own API:

```bash
gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files \
  --paginate --jq '.[].filename' | tee files.txt
```

The downstream path-matching loop that decides which preview deployments to trigger is unchanged.

### Why is this change needed?
The previous approach checked out the **fork's** repository code, making `origin` point to the contributor's fork rather than the upstream `airqo-platform/AirQo-frontend`. When the workflow then ran `git fetch origin staging`, it fetched the fork's `staging` branch — which can be days or weeks behind upstream.

The three-dot diff (`origin/staging...head.sha`) therefore computed a merge base against the fork's stale staging, not the real upstream staging. The gap between the fork's staging and the PR head included upstream commits that had touched `src/website/`, `src/docs-website/`, and `src/platform/` — causing preview deployments for all those projects to fire, even though the PR only modified `src/vertex/`.

This was confirmed live on PR [#3634](https://github.com/airqo-platform/AirQo-frontend/pull/3634) (external contributor, fork 3 days behind upstream), where website, docs, and analytics-platform previews all deployed unnecessarily alongside the correct vertex preview.

The GitHub API endpoint `/pulls/{number}/files` returns exactly the files a PR changes, computed server-side by GitHub from the correct merge base. It is authoritative, fork-safe, and requires no git history or checkout in the `check` job.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `.github/workflows/deploy-frontend-azurepreview.yml` — Azure PR preview deploy workflow (`check` job only)

No application source code is changed. No services are redeployed by this PR itself.

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Confirmed via live workflow run (PR #3634, run ID `27371428216`) that the previous git-based approach incorrectly triggered website, docs, and analytics-platform previews for a vertex-only PR from an external fork. The GitHub API approach returns only the files the PR actually changed, independent of fork branch staleness. Validated that `${{ github.repository }}` resolves to the base repo (`airqo-platform/AirQo-frontend`) in a `pull_request_target` context, ensuring the API call always targets the correct repo. The `--paginate` flag handles PRs with more than 30 changed files. `gh` CLI and `${{ github.token }}` are both available on all `ubuntu-latest` runners with default permissions.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

This PR addresses one of two issues identified during a broader preview-deployment investigation. A second issue — `pull_request_target` running with live Azure secrets while building Docker images from external fork code — has been flagged separately to the DevOps team and is not in scope here.

The `check` job now requires no checkout step, making it faster and simpler. The only credential used is the auto-provided `GITHUB_TOKEN` with default read permissions, which is sufficient for the `/pulls/{number}/files` API endpoint on a public repository.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized deployment workflow to improve file detection reliability during the build and deployment process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->