### PR TITLE
Add HCAPTCHA site key as build argument in Dockerfile

### DIFF
--- a/src/website/Dockerfile
+++ b/src/website/Dockerfile
@@ -16,13 +16,15 @@ ARG API_URL
 # Public (NEXT_PUBLIC_) variables may be embedded in the client bundle.
 ARG NEXT_PUBLIC_GA_MEASUREMENT_ID
 ARG NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN
+ARG NEXT_PUBLIC_HCAPTCHA_SITE_KEY
 
 # Set environment variables for build (server-side variables)
 # Only set non-sensitive values. Do not store secrets in ENV here.
 # Provide secrets at runtime instead.
 ENV API_URL=$API_URL \
     NEXT_PUBLIC_GA_MEASUREMENT_ID=$NEXT_PUBLIC_GA_MEASUREMENT_ID \
-    NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN=$NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN
+    NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN=$NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN \
+    NEXT_PUBLIC_HCAPTCHA_SITE_KEY=$NEXT_PUBLIC_HCAPTCHA_SITE_KEY
 
 # Install dependencies and build
 COPY package*.json ./


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

#### Status of maturity (all need to be checked before merging):

- [x] I've tested this locally
- [x] I consider this code done

#### Screenshots (optional)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to support hCaptcha site key as a build-time variable, alongside existing configuration keys for analytics and mapping services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->