### PR TITLE
Add `declare module '*.css'` to vertex-desktop.d.ts to resolve ts errors

### DIFF
--- a/src/vertex/types/vertex-desktop.d.ts
+++ b/src/vertex/types/vertex-desktop.d.ts
@@ -1,3 +1,5 @@
+declare module '*.css';
+
 interface VertexDesktopApi {
   getAppVersion: () => Promise<string>;
   getBranding: () => Promise<{ name: string; iconDataUrl: string }>;


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)
- Fixes ts side effect errors in `Mini-map` component
- **Solution**
- Please set `NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN`=pk.eyJ1...your_token in `staging`.


#### Status of maturity (all need to be checked before merging):

- [x] I've tested this locally
- [x] I consider this code done
- [x] This change ready to hit production in its current state
- [x] The title of the PR states what changed and the related issues number (used for the release note).
- [ ] I've included issue number in the "Closes #3543" part of the "[What are the relevant tickets?](#what-are-the-relevant-tickets)" section to [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [ ] I've updated corresponding documentation for the changes in this PR.
- [ ] I have written unit and/or e2e tests for my change(s).

#### What are the relevant tickets?

- Closes #3543
<img width="960" height="564" alt="Screenshot 2026-06-15 132227" src="https://github.com/user-attachments/assets/f5c41b4b-29e7-483d-89e0-674c30907923" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Resolved TypeScript type errors when importing CSS files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->