### PR TITLE
 Fix-Social-Authentication-Flow-for-Desktop-App

### DIFF
--- a/src/vertex/components/features/auth/social-auth-section.tsx
+++ b/src/vertex/components/features/auth/social-auth-section.tsx
@@ -83,26 +83,38 @@ export default function SocialAuthSection({
       ]
     : SOCIAL_PROVIDERS;
 
+  const isElectron =
+    typeof window !== 'undefined' &&
+    window.navigator.userAgent.toLowerCase().includes('electron');
+
   const handleSocialAuth = useCallback(
     (provider: SupportedSocialAuthProvider) => {
       if (typeof window === 'undefined' || disabled) return;
 
-      const redirectAfter = resolveOAuthRedirectAfterUrl(redirectPath);
       const queryParams: Record<string, string> = {};
 
-      if (redirectAfter) {
-        queryParams.redirect_after = redirectAfter;
+      if (isElectron) {
+        queryParams.redirect_after = 'vertex://login';
+      } else {
+        const redirectAfter = resolveOAuthRedirectAfterUrl(redirectPath);
+        if (redirectAfter) {
+          queryParams.redirect_after = redirectAfter;
+        }
       }
 
       if (provider === 'google') {
         queryParams.prompt = 'select_account';
       }
 
-
       try {
         setLastUsedOAuthProvider(provider);
         clearBackendOAuthSignedOutFlag();
-        window.location.replace(buildOAuthInitiationUrl(provider, queryParams));
+        const authUrl = buildOAuthInitiationUrl(provider, queryParams);
+        if (isElectron) {
+          window.open(authUrl, '_blank');
+        } else {
+          window.location.replace(authUrl);
+        }
       } catch (error) {
         showBanner({
           severity: 'error',
@@ -112,7 +124,7 @@ export default function SocialAuthSection({
         console.error(`Failed to start ${provider} OAuth flow:`, error);
       }
     },
-    [disabled, redirectPath, showBanner]
+    [disabled, isElectron, redirectPath, showBanner]
   );
 
 


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

Fixes broken social authentication (Google, GitHub, LinkedIn, X) when the Vertex web app runs inside the Electron desktop wrapper.

**Root cause:** Clicking a social login button in the desktop app called `window.location.replace(oauthUrl)`, which navigated the Electron BrowserWindow away from the app. Even though Electron's `will-navigate` handler intercepted it and opened the URL in the system browser, the `redirect_after` pointed to `https://vertex.airqo.net/home` — so after OAuth completed, the token landed in the system browser, not back in the desktop app. The desktop window stayed unauthenticated.

**Fix — `social-auth-section.tsx`:**

1. **Electron detection** — checks `navigator.userAgent` for the `electron` string at render time.

2. **Redirect override** — when running in Electron, sets `redirect_after=vertex://login` instead of the normal web URL. The backend then redirects to `vertex://login#token=JWT...` after successful auth. The OS routes this deep link back to the Electron app, which maps it to `http://localhost:3000/login#token=JWT...` and loads it in the BrowserWindow. The existing OAuth token consumer on the login page picks up the token from the URL hash and signs the user in.

3. **Navigation method** — switches from `window.location.replace` to `window.open(url, '_blank')` in Electron. This is intercepted by the existing `setWindowOpenHandler` in the desktop main process, which calls `shell.openExternal(url)` to open the OAuth page in the system browser cleanly, without navigating the BrowserWindow away from the app.

The web login flow is completely unchanged.

> **Note:** This fix requires the backend to allow `vertex://` as a valid scheme in the `redirect_after` parameter. The backend team has been notified to update the validation in `/api/v2/users/auth/callback/{provider}`.

#### Status of maturity (all need to be checked before merging):

- [x] I've tested this locally
- [x] I consider this code done
- [x] This change ready to hit production in its current state — _pending backend allowlist update for `vertex://` scheme_
- [x] The title of the PR states what changed and the related issues number (used for the release note).
- [x] I've included issue number in the "Closes #3640" part of the "[What are the relevant tickets?](#what-are-the-relevant-tickets)" section to [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [ ] I've updated corresponding documentation for the changes in this PR.
- [ ] I have written unit and/or e2e tests for my change(s).

#### How should this be manually tested?

1. Start the Next.js dev server: `cd src/vertex && npm run dev`
2. Wait for "Ready" in the terminal output
3. In a separate terminal, start the Electron app: `cd src/vertex-desktop && npm run start`
4. The desktop window should open pointing at `localhost:3000`
5. Navigate to the login page and click any social login button (Google, GitHub, etc.)
6. Confirm the OAuth page opens in your **system browser** (Chrome/Firefox), not inside the Electron window
7. Complete the login in the system browser
8. Confirm the Electron desktop window navigates to the home screen and the user is authenticated

**Web regression check:**
9. Open `localhost:3000` in a normal browser (not Electron)
10. Click any social login button — confirm it navigates the tab to the OAuth page as before

#### What are the relevant tickets?

- Closes #3640

#### Screenshots 

<img width="960" height="564" alt="66" src="https://github.com/user-attachments/assets/4799d975-1fff-4aaa-b08d-9fcab6e9de7f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced OAuth redirect handling for Electron application users.
  * Optimized social sign-in window behavior in Electron environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->