### PR TITLE
Fix Data Access missing from docs side panel product dropdown

### DIFF
--- a/src/docs-website/src/components/ProductDropdown/index.tsx
+++ b/src/docs-website/src/components/ProductDropdown/index.tsx
@@ -10,7 +10,8 @@ import {
     AqPhone01,
     AqChevronSelectorVertical,
     AqCheck,
-    AqCube02
+    AqCube02,
+    AqDatabase01
 } from '@airqo/icons-react';
 
 type Product = {
@@ -56,7 +57,13 @@ const PRODUCTS: Product[] = [
         path: '/docs/cross-product',
         icon: AqCube02,
         landingPath: '/docs/cross-product/concepts/access-control',
-    }
+    },
+    {
+        title: 'Data Access',
+        path: '/docs/data-access',
+        icon: AqDatabase01,
+        landingPath: '/docs/data-access/researchers-guide',
+    },
 ];
 
 export default function ProductDropdown() {


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Adds "Data Access" as a selectable option in the `ProductDropdown` component used in the docs side panel. The `AqDatabase01` icon and the `/docs/data-access/researchers-guide` landing path are wired up alongside the existing products.

### Why is this change needed?
When navigating to any `/docs/data-access/*` page (e.g. the Researcher's Guide), the side panel product selector had no matching entry for `data-access`, so it fell back to the first item in the list — "Analytics" — and displayed that as the active product instead of "Data Access".

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `src/docs-website` — `src/components/ProductDropdown/index.tsx`

---

## :test_tube: Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:**
Navigated to `/docs/data-access/researchers-guide/` and confirmed the side panel now shows "Data Access" as the active selection instead of "Analytics". Verified all other product routes (`/docs/analytics`, `/docs/vertex`, etc.) still resolve to their correct entries.

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes
The `AqDatabase01` icon imported here was already used for the Data Access card in `ProductSection/index.tsx`, keeping the icon consistent between the home page grid and the side panel dropdown.

---

## :white_check_mark: Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new "Data Access" option to the product dropdown menu, providing users with quick access to documentation and dedicated landing page resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->