### PR TITLE
feat: allow guests to explore available cities from Near You empty state

### DIFF
--- a/src/mobile/lib/src/app/dashboard/pages/dashboard_page.dart
+++ b/src/mobile/lib/src/app/dashboard/pages/dashboard_page.dart
@@ -14,6 +14,7 @@ import '../widgets/dashboard_header.dart';
 import '../widgets/dashboard_loading.dart';
 import '../widgets/measurements_list.dart';
 import '../widgets/my_places_view.dart';
+import '../widgets/explore_countries_view.dart';
 import '../widgets/nearby_view.dart';
 import '../widgets/view_selector.dart';
 import 'package:loggy/loggy.dart';
@@ -144,7 +145,7 @@ class _DashboardPageState extends State<DashboardPage> with UiLoggy {
                   ),
                 ),
                 SliverToBoxAdapter(
-                  child: _buildContentForCurrentView(),
+                  child: _buildContentForCurrentView(isGuest: isGuest),
                 ),
               ],
             ),
@@ -175,7 +176,7 @@ class _DashboardPageState extends State<DashboardPage> with UiLoggy {
     );
   }
 
-  Widget _buildContentForCurrentView() {
+  Widget _buildContentForCurrentView({bool isGuest = false}) {
     return BlocBuilder<DashboardBloc, DashboardState>(
       builder: (context, state) {
         if (state is DashboardLoading && state.previousState == null) {
@@ -250,27 +251,28 @@ class _DashboardPageState extends State<DashboardPage> with UiLoggy {
             case DashboardView.nearYou:
               return NearbyView(
                 onNavigateToFavorites: () => setView(DashboardView.favorites),
-                onExploreCities: () {
-                  final activeCountries =
-                      CountryRepository.extractActiveCountryNames(
-                          state.response.measurements!);
-                  final firstCountry = activeCountries.isNotEmpty
-                      ? activeCountries.first
-                      : 'Uganda';
-                  setView(DashboardView.country, country: firstCountry);
-                },
+                onExploreCities: isGuest
+                    ? () => setView(DashboardView.explore)
+                    : null,
               );
 
             case DashboardView.country:
-              final countryMeasurements = state.response.measurements!
-                  .where((m) => m.siteDetails?.country == selectedCountry)
-                  .toList();
+              final countryMeasurements =
+                  (state.response.measurements ?? [])
+                      .where((m) => m.siteDetails?.country == selectedCountry)
+                      .toList();
 
               return MeasurementsList(measurements: countryMeasurements);
 
+            case DashboardView.explore:
+              return ExploreCountriesView(
+                measurements: state.response.measurements ?? [],
+              );
+
             default:
               return MeasurementsList(
-                measurements: state.response.measurements!.take(5).toList(),
+                measurements:
+                    (state.response.measurements ?? []).take(5).toList(),
               );
           }
         }

--- a/src/mobile/lib/src/app/dashboard/pages/dashboard_page.dart
+++ b/src/mobile/lib/src/app/dashboard/pages/dashboard_page.dart
@@ -250,6 +250,15 @@ class _DashboardPageState extends State<DashboardPage> with UiLoggy {
             case DashboardView.nearYou:
               return NearbyView(
                 onNavigateToFavorites: () => setView(DashboardView.favorites),
+                onExploreCities: () {
+                  final activeCountries =
+                      CountryRepository.extractActiveCountryNames(
+                          state.response.measurements!);
+                  final firstCountry = activeCountries.isNotEmpty
+                      ? activeCountries.first
+                      : 'Uganda';
+                  setView(DashboardView.country, country: firstCountry);
+                },
               );
 
             case DashboardView.country:

--- a/src/mobile/lib/src/app/dashboard/widgets/explore_countries_view.dart
+++ b/src/mobile/lib/src/app/dashboard/widgets/explore_countries_view.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:airqo/src/app/dashboard/models/airquality_response.dart';
+import 'package:airqo/src/app/dashboard/models/country_model.dart';
+import 'package:airqo/src/app/dashboard/widgets/analytics_card.dart';
+import 'package:airqo/src/app/shared/widgets/translated_text.dart';
+
+class ExploreCountriesView extends StatelessWidget {
+  final List<Measurement> measurements;
+
+  const ExploreCountriesView({super.key, required this.measurements});
+
+  Map<String, List<Measurement>> _groupByCountry() {
+    final grouped = <String, List<Measurement>>{};
+    for (final m in measurements) {
+      final country = m.siteDetails?.country;
+      if (country == null || country.isEmpty) continue;
+      grouped.putIfAbsent(country, () => []).add(m);
+    }
+    return grouped;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final grouped = _groupByCountry();
+    final countries = grouped.keys.toList()..sort();
+
+    return ListView.builder(
+      shrinkWrap: true,
+      physics: const NeverScrollableScrollPhysics(),
+      padding: EdgeInsets.zero,
+      itemCount: countries.length,
+      itemBuilder: (context, index) {
+        final country = countries[index];
+        final flag = CountryModel.getFlagFromCountryName(country);
+        final sample = grouped[country]!.first;
+
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 20, 16, 8),
+              child: TranslatedText(
+                '$flag  $country',
+                style: TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.w600,
+                  color: Theme.of(context).textTheme.headlineMedium?.color,
+                ),
+              ),
+            ),
+            AnalyticsCard(sample),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/src/mobile/lib/src/app/dashboard/widgets/nearby_view.dart
+++ b/src/mobile/lib/src/app/dashboard/widgets/nearby_view.dart
@@ -14,8 +14,9 @@ import 'package:airqo/src/app/shared/services/cache_manager.dart';
 
 class NearbyView extends StatefulWidget {
   final VoidCallback? onNavigateToFavorites;
+  final VoidCallback? onExploreCities;
 
-  const NearbyView({super.key, this.onNavigateToFavorites});
+  const NearbyView({super.key, this.onNavigateToFavorites, this.onExploreCities});
 
   @override
   State<NearbyView> createState() => _NearbyViewState();
@@ -496,7 +497,7 @@ class _NearbyViewState extends State<NearbyView> with UiLoggy {
                       ),
                       const SizedBox(height: 8),
                       TranslatedText(
-                        "But you can add your favorite location from areas where we have presence",
+                        "AirQo covers 15 African cities. Browse and explore air quality data from any of them.",
                         textAlign: TextAlign.center,
                         style: TextStyle(
                           fontSize: 16,
@@ -505,9 +506,9 @@ class _NearbyViewState extends State<NearbyView> with UiLoggy {
                       ),
                       const SizedBox(height: 24),
                       ElevatedButton.icon(
-                        onPressed: widget.onNavigateToFavorites ?? _retry,
-                        // icon: const Icon(Icons.favorite, color: Colors.white),
-                        label: const TranslatedText("Add Favorite Location"),
+                        onPressed: widget.onExploreCities ?? widget.onNavigateToFavorites ?? _retry,
+                        icon: const Icon(Icons.explore, color: Colors.white),
+                        label: const TranslatedText("Explore Available Cities"),
                         style: ElevatedButton.styleFrom(
                           backgroundColor: AppColors.primaryColor,
                           foregroundColor: Colors.white,

--- a/src/mobile/lib/src/app/dashboard/widgets/view_selector.dart
+++ b/src/mobile/lib/src/app/dashboard/widgets/view_selector.dart
@@ -6,7 +6,7 @@ import 'package:flutter/material.dart';
 import '../../../meta/utils/colors.dart';
 import 'package:airqo/src/app/dashboard/repository/country_repository.dart';
 
-enum DashboardView { all, nearYou ,favorites, country }
+enum DashboardView { all, nearYou, favorites, country, explore }
 
 class ViewSelector extends StatefulWidget {
   final DashboardView currentView;


### PR DESCRIPTION
When a guest has no nearby AirQo stations (e.g. outside Africa), the empty state now shows an "Explore Available Cities" button that switches directly to the country view instead of hitting the auth-gated LocationSelectionScreen.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Explore Cities" functionality in the nearby stations view, enabling users to browse available cities by country when no nearby stations are found. Updated the empty state messaging to highlight AirQo's coverage of 15 African cities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->