### PR TITLE
feat: implement daily and hourly forecast functionality

### DIFF
--- a/src/platform/src/modules/airqo-map/components/sidebar/WeeklyForecastCard.tsx
+++ b/src/platform/src/modules/airqo-map/components/sidebar/WeeklyForecastCard.tsx
@@ -74,8 +74,10 @@ function getAqiBgClass(category: string | undefined): string {
   const c = category.toLowerCase();
   if (c.includes('good')) return 'bg-green-50 border-green-200';
   if (c.includes('moderate')) return 'bg-yellow-50 border-yellow-200';
-  if (c.includes('sensitive') || c.includes('usg')) return 'bg-orange-50 border-orange-200';
-  if (c.includes('unhealthy') && !c.includes('very')) return 'bg-red-50 border-red-200';
+  if (c.includes('sensitive') || c.includes('usg'))
+    return 'bg-orange-50 border-orange-200';
+  if (c.includes('unhealthy') && !c.includes('very'))
+    return 'bg-red-50 border-red-200';
   if (c.includes('very unhealthy')) return 'bg-purple-50 border-purple-200';
   if (c.includes('hazardous')) return 'bg-pink-50 border-pink-200';
   return 'bg-gray-50 border-gray-200';
@@ -109,7 +111,7 @@ const DailyPill: React.FC<{
   item: DailyForecastItem;
   isToday: boolean;
 }> = ({ item, isToday }) => {
-  const pm25 = resolveParsedNumber(item.forecast?.pm2_5_mean) ?? 0;
+  const pm25 = resolveParsedNumber(item.forecast?.pm2_5_mean);
   const pm25Low = resolveParsedNumber(item.forecast?.pm2_5_low);
   const pm25High = resolveParsedNumber(item.forecast?.pm2_5_high);
   const aqiCategory = item.aqi?.aqi_category ?? item.aqi?.label ?? '';
@@ -119,7 +121,7 @@ const DailyPill: React.FC<{
   const temp = resolveParsedNumber(item.met?.air_temperature);
   const humidity = resolveParsedNumber(item.met?.relative_humidity);
 
-  const airInfo = getAirQualityInfo(pm25, 'pm2_5');
+  const airInfo = getAirQualityInfo(pm25 ?? 0, 'pm2_5');
   const ForecastIcon = airInfo.icon;
   const bgClass = getAqiBgClass(aqiCategory || airInfo.label);
 
@@ -127,14 +129,16 @@ const DailyPill: React.FC<{
     <div className="max-w-[220px] space-y-1.5 text-left">
       <p className="font-semibold text-white">{getFullDate(item.date)}</p>
       <p className="text-xs text-white">
-        <span className="font-medium">AQI:</span> {aqiCategory || airInfo.label}
+        <span className="font-medium">AQI:</span>{' '}
+        {aqiCategory || airInfo.label}
       </p>
       {aqiLabel && (
         <p className="text-xs leading-snug text-gray-200">{aqiLabel}</p>
       )}
       {pm25Low != null && pm25High != null && (
         <p className="text-xs text-white">
-          <span className="font-medium">PM₂.₅:</span> {pm25Low.toFixed(1)} – {pm25High.toFixed(1)} µg/m³
+          <span className="font-medium">PM₂.₅:</span> {pm25Low.toFixed(1)} –{' '}
+          {pm25High.toFixed(1)} µg/m³
         </p>
       )}
       {temp != null && (
@@ -177,7 +181,9 @@ const DailyPill: React.FC<{
         <span
           className={cn(
             'text-base font-bold mb-1',
-            isToday ? 'text-white' : 'text-gray-900'
+            isToday
+              ? 'text-white'
+              : 'text-gray-900 dark:text-gray-100'
           )}
         >
           {getDateNum(item.date)}
@@ -195,7 +201,7 @@ const DailyPill: React.FC<{
             isToday ? 'text-white' : 'text-gray-700'
           )}
         >
-          {pm25.toFixed(1)}
+          {pm25 != null ? pm25.toFixed(1) : '--'}
         </span>
 
         {/* Confidence */}
@@ -221,7 +227,7 @@ const HourlyPill: React.FC<{
   item: HourlyForecastItem;
   isFirst: boolean;
 }> = ({ item, isFirst }) => {
-  const pm25 = resolveParsedNumber(item.forecast?.pm2_5_mean) ?? 0;
+  const pm25 = resolveParsedNumber(item.forecast?.pm2_5_mean);
   const aqiCategory = item.aqi?.aqi_category ?? item.aqi?.label ?? '';
   const aqiLabel = item.aqi?.label ?? '';
   const trendMessage = item.aqi?.trend_message;
@@ -229,7 +235,7 @@ const HourlyPill: React.FC<{
   const temp = resolveParsedNumber(item.met?.air_temperature);
   const humidity = resolveParsedNumber(item.met?.relative_humidity);
 
-  const airInfo = getAirQualityInfo(pm25, 'pm2_5');
+  const airInfo = getAirQualityInfo(pm25 ?? 0, 'pm2_5');
   const ForecastIcon = airInfo.icon;
   const bgClass = getAqiBgClass(aqiCategory || airInfo.label);
 
@@ -237,13 +243,15 @@ const HourlyPill: React.FC<{
     <div className="max-w-[220px] space-y-1.5 text-left">
       <p className="font-semibold text-white">{getFullTime(item.timestamp)}</p>
       <p className="text-xs text-white">
-        <span className="font-medium">AQI:</span> {aqiCategory || airInfo.label}
+        <span className="font-medium">AQI:</span>{' '}
+        {aqiCategory || airInfo.label}
       </p>
       {aqiLabel && (
         <p className="text-xs leading-snug text-gray-200">{aqiLabel}</p>
       )}
       <p className="text-xs text-white">
-        <span className="font-medium">PM₂.₅:</span> {pm25.toFixed(1)} µg/m³
+        <span className="font-medium">PM₂.₅:</span>{' '}
+        {pm25 != null ? `${pm25.toFixed(1)} µg/m³` : '--'}
       </p>
       {temp != null && (
         <p className="text-xs text-white">
@@ -293,7 +301,7 @@ const HourlyPill: React.FC<{
             isFirst ? 'text-white' : 'text-gray-700'
           )}
         >
-          {pm25.toFixed(1)}
+          {pm25 != null ? pm25.toFixed(1) : '--'}
         </span>
 
         {/* Temp */}
@@ -344,16 +352,14 @@ export const WeeklyForecastCard: React.FC<WeeklyForecastCardProps> = ({
 }) => {
   const [mode, setMode] = React.useState<ForecastMode>('daily');
 
-  const {
-    dailyItems,
-    hourlyItems,
-    isLoading,
-    error,
-  } = useForecast({
+  const { dailyItems, hourlyItems, isLoading, error } = useForecast({
     siteId,
     mode,
     enabled: !!siteId,
   });
+
+  const activeItems = mode === 'daily' ? dailyItems : hourlyItems;
+  const showEmpty = !isLoading && !error && activeItems.length === 0;
 
   return (
     <Card className="border border-gray-200 dark:border-gray-700 shadow-sm">
@@ -388,8 +394,8 @@ export const WeeklyForecastCard: React.FC<WeeklyForecastCardProps> = ({
           </div>
         )}
 
-        {/* Empty */}
-        {!isLoading && !error && (!dailyItems?.length && !hourlyItems?.length) && (
+        {/* Empty — mode-aware */}
+        {showEmpty && (
           <div className="flex flex-col items-center justify-center py-6 text-center">
             <AqCloudOff className="w-8 h-8 text-gray-400 mb-2" />
             <p className="text-sm text-gray-500">
@@ -414,20 +420,22 @@ export const WeeklyForecastCard: React.FC<WeeklyForecastCardProps> = ({
         )}
 
         {/* Hourly view */}
-        {!isLoading && !error && mode === 'hourly' && hourlyItems.length > 0 && (
-          <div className="w-full overflow-x-auto overflow-y-hidden -mx-1 px-1">
-            <div className="flex gap-1.5 min-w-max py-1">
-              {hourlyItems.slice(0, 24).map((item, idx) => (
-                <HourlyPill
-                  key={item.timestamp}
-                  item={item}
-                  isFirst={idx === 0}
-                />
-              ))}
+        {!isLoading &&
+          !error &&
+          mode === 'hourly' &&
+          hourlyItems.length > 0 && (
+            <div className="w-full overflow-x-auto overflow-y-hidden -mx-1 px-1">
+              <div className="flex gap-1.5 min-w-max py-1">
+                {hourlyItems.slice(0, 24).map((item, idx) => (
+                  <HourlyPill
+                    key={item.timestamp}
+                    item={item}
+                    isFirst={idx === 0}
+                  />
+                ))}
+              </div>
             </div>
-          </div>
-        )}
-
+          )}
       </CardContent>
     </Card>
   );

--- a/src/platform/src/modules/airqo-map/components/sidebar/WeeklyForecastCard.tsx
+++ b/src/platform/src/modules/airqo-map/components/sidebar/WeeklyForecastCard.tsx
@@ -2,138 +2,433 @@
 
 import * as React from 'react';
 import { cn } from '@/shared/lib/utils';
-// Icons are now imported from the centralized utility
 import { getAirQualityInfo } from '@/shared/utils/airQuality';
-import { useForecast } from '../../hooks';
+import { useForecast, type ForecastMode } from '../../hooks/useForecast';
 import { AqCloudOff } from '@airqo/icons-react';
 import { LoadingSpinner } from '../../../../shared/components/ui/loading-spinner';
+import { Card, CardContent } from '@/shared/components/ui/card';
+import { Tooltip } from 'flowbite-react';
+import {
+  resolveParsedNumber,
+  type DailyForecastItem,
+  type HourlyForecastItem,
+} from '../../../../shared/types/api';
 
 interface WeeklyForecastCardProps {
   siteId?: string;
 }
 
+const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+function safeParseDate(value: string | undefined | null): Date | null {
+  if (!value) return null;
+  try {
+    const d = new Date(value);
+    if (Number.isNaN(d.getTime())) return null;
+    return d;
+  } catch {
+    return null;
+  }
+}
+
+function getDayLabel(value: string | undefined | null): string {
+  const d = safeParseDate(value);
+  if (!d) return '';
+  return DAY_LABELS[d.getDay()];
+}
+
+function getDateNum(value: string | undefined | null): string {
+  const d = safeParseDate(value);
+  if (!d) return '--';
+  return String(d.getDate());
+}
+
+function getFullDate(value: string | undefined | null): string {
+  const d = safeParseDate(value);
+  if (!d) return '';
+  return d.toLocaleDateString('en-US', {
+    weekday: 'long',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+function getHourLabel(value: string | undefined | null): string {
+  const d = safeParseDate(value);
+  if (!d) return '--:--';
+  return `${String(d.getHours()).padStart(2, '0')}:00`;
+}
+
+function getFullTime(value: string | undefined | null): string {
+  const d = safeParseDate(value);
+  if (!d) return '';
+  return d.toLocaleTimeString('en-US', {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: true,
+  });
+}
+
+function getAqiBgClass(category: string | undefined): string {
+  if (!category) return 'bg-gray-50 border-gray-200';
+  const c = category.toLowerCase();
+  if (c.includes('good')) return 'bg-green-50 border-green-200';
+  if (c.includes('moderate')) return 'bg-yellow-50 border-yellow-200';
+  if (c.includes('sensitive') || c.includes('usg')) return 'bg-orange-50 border-orange-200';
+  if (c.includes('unhealthy') && !c.includes('very')) return 'bg-red-50 border-red-200';
+  if (c.includes('very unhealthy')) return 'bg-purple-50 border-purple-200';
+  if (c.includes('hazardous')) return 'bg-pink-50 border-pink-200';
+  return 'bg-gray-50 border-gray-200';
+}
+
+// ── Tab selector ─────────────────────────────────────────────────────────────
+const ModeTabs: React.FC<{
+  active: ForecastMode;
+  onChange: (m: ForecastMode) => void;
+}> = ({ active, onChange }) => (
+  <div className="flex gap-1 p-0.5 bg-gray-100 dark:bg-gray-800 rounded-lg">
+    {(['daily', 'hourly'] as const).map(m => (
+      <button
+        key={m}
+        onClick={() => onChange(m)}
+        className={cn(
+          'flex-1 text-xs font-medium py-1.5 rounded-md transition-all duration-200 capitalize',
+          active === m
+            ? 'bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 shadow-sm'
+            : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'
+        )}
+      >
+        {m}
+      </button>
+    ))}
+  </div>
+);
+
+// ── Daily forecast pill ──────────────────────────────────────────────────────
+const DailyPill: React.FC<{
+  item: DailyForecastItem;
+  isToday: boolean;
+}> = ({ item, isToday }) => {
+  const pm25 = resolveParsedNumber(item.forecast?.pm2_5_mean) ?? 0;
+  const pm25Low = resolveParsedNumber(item.forecast?.pm2_5_low);
+  const pm25High = resolveParsedNumber(item.forecast?.pm2_5_high);
+  const aqiCategory = item.aqi?.aqi_category ?? item.aqi?.label ?? '';
+  const aqiLabel = item.aqi?.label ?? '';
+  const trendMessage = item.aqi?.trend_message;
+  const confidence = resolveParsedNumber(item.forecast?.forecast_confidence);
+  const temp = resolveParsedNumber(item.met?.air_temperature);
+  const humidity = resolveParsedNumber(item.met?.relative_humidity);
+
+  const airInfo = getAirQualityInfo(pm25, 'pm2_5');
+  const ForecastIcon = airInfo.icon;
+  const bgClass = getAqiBgClass(aqiCategory || airInfo.label);
+
+  const tooltipContent = (
+    <div className="max-w-[220px] space-y-1.5 text-left">
+      <p className="font-semibold text-white">{getFullDate(item.date)}</p>
+      <p className="text-xs text-white">
+        <span className="font-medium">AQI:</span> {aqiCategory || airInfo.label}
+      </p>
+      {aqiLabel && (
+        <p className="text-xs leading-snug text-gray-200">{aqiLabel}</p>
+      )}
+      {pm25Low != null && pm25High != null && (
+        <p className="text-xs text-white">
+          <span className="font-medium">PM₂.₅:</span> {pm25Low.toFixed(1)} – {pm25High.toFixed(1)} µg/m³
+        </p>
+      )}
+      {temp != null && (
+        <p className="text-xs text-white">
+          <span className="font-medium">Temp:</span> {temp.toFixed(0)}°C
+        </p>
+      )}
+      {humidity != null && (
+        <p className="text-xs text-white">
+          <span className="font-medium">Humidity:</span> {humidity.toFixed(0)}%
+        </p>
+      )}
+      {trendMessage && (
+        <p className="text-xs italic text-gray-300">{trendMessage}</p>
+      )}
+    </div>
+  );
+
+  return (
+    <Tooltip content={tooltipContent} placement="top">
+      <div
+        className={cn(
+          'flex flex-col items-center rounded-xl py-2.5 px-2.5 min-w-[64px] border transition-all duration-200 flex-shrink-0 cursor-default',
+          isToday
+            ? 'bg-blue-600 border-blue-600 shadow-md'
+            : cn(bgClass, 'hover:shadow-sm')
+        )}
+      >
+        {/* Day name */}
+        <span
+          className={cn(
+            'text-[11px] font-medium mb-0.5',
+            isToday ? 'text-blue-100' : 'text-gray-500'
+          )}
+        >
+          {getDayLabel(item.date)}
+        </span>
+
+        {/* Date number */}
+        <span
+          className={cn(
+            'text-base font-bold mb-1',
+            isToday ? 'text-white' : 'text-gray-900'
+          )}
+        >
+          {getDateNum(item.date)}
+        </span>
+
+        {/* Icon */}
+        <div className="flex items-center justify-center mb-1">
+          <ForecastIcon className="w-5 h-5" />
+        </div>
+
+        {/* PM2.5 value */}
+        <span
+          className={cn(
+            'text-[11px] font-semibold',
+            isToday ? 'text-white' : 'text-gray-700'
+          )}
+        >
+          {pm25.toFixed(1)}
+        </span>
+
+        {/* Confidence */}
+        {confidence != null && (
+          <span
+            className={cn(
+              'text-[9px] mt-0.5 px-1.5 py-0.5 rounded-full font-medium',
+              isToday
+                ? 'bg-blue-500 text-blue-100'
+                : 'bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400'
+            )}
+          >
+            {confidence.toFixed(0)}%
+          </span>
+        )}
+      </div>
+    </Tooltip>
+  );
+};
+
+// ── Hourly forecast pill ─────────────────────────────────────────────────────
+const HourlyPill: React.FC<{
+  item: HourlyForecastItem;
+  isFirst: boolean;
+}> = ({ item, isFirst }) => {
+  const pm25 = resolveParsedNumber(item.forecast?.pm2_5_mean) ?? 0;
+  const aqiCategory = item.aqi?.aqi_category ?? item.aqi?.label ?? '';
+  const aqiLabel = item.aqi?.label ?? '';
+  const trendMessage = item.aqi?.trend_message;
+  const confidence = resolveParsedNumber(item.forecast?.forecast_confidence);
+  const temp = resolveParsedNumber(item.met?.air_temperature);
+  const humidity = resolveParsedNumber(item.met?.relative_humidity);
+
+  const airInfo = getAirQualityInfo(pm25, 'pm2_5');
+  const ForecastIcon = airInfo.icon;
+  const bgClass = getAqiBgClass(aqiCategory || airInfo.label);
+
+  const tooltipContent = (
+    <div className="max-w-[220px] space-y-1.5 text-left">
+      <p className="font-semibold text-white">{getFullTime(item.timestamp)}</p>
+      <p className="text-xs text-white">
+        <span className="font-medium">AQI:</span> {aqiCategory || airInfo.label}
+      </p>
+      {aqiLabel && (
+        <p className="text-xs leading-snug text-gray-200">{aqiLabel}</p>
+      )}
+      <p className="text-xs text-white">
+        <span className="font-medium">PM₂.₅:</span> {pm25.toFixed(1)} µg/m³
+      </p>
+      {temp != null && (
+        <p className="text-xs text-white">
+          <span className="font-medium">Temp:</span> {temp.toFixed(0)}°C
+        </p>
+      )}
+      {humidity != null && (
+        <p className="text-xs text-white">
+          <span className="font-medium">Humidity:</span> {humidity.toFixed(0)}%
+        </p>
+      )}
+      {trendMessage && (
+        <p className="text-xs italic text-gray-300">{trendMessage}</p>
+      )}
+    </div>
+  );
+
+  return (
+    <Tooltip content={tooltipContent} placement="top">
+      <div
+        className={cn(
+          'flex flex-col items-center rounded-xl py-2 px-1.5 min-w-[52px] border transition-all duration-200 flex-shrink-0 cursor-default',
+          isFirst
+            ? 'bg-blue-600 border-blue-600 shadow-md'
+            : cn(bgClass, 'hover:shadow-sm')
+        )}
+      >
+        {/* Hour */}
+        <span
+          className={cn(
+            'text-[10px] font-medium mb-0.5',
+            isFirst ? 'text-blue-100' : 'text-gray-500'
+          )}
+        >
+          {getHourLabel(item.timestamp)}
+        </span>
+
+        {/* Icon */}
+        <div className="flex items-center justify-center mb-1">
+          <ForecastIcon className="w-4 h-4" />
+        </div>
+
+        {/* PM2.5 */}
+        <span
+          className={cn(
+            'text-[10px] font-semibold',
+            isFirst ? 'text-white' : 'text-gray-700'
+          )}
+        >
+          {pm25.toFixed(1)}
+        </span>
+
+        {/* Temp */}
+        {temp != null && (
+          <span
+            className={cn(
+              'text-[9px] mt-0.5',
+              isFirst ? 'text-blue-100' : 'text-gray-500'
+            )}
+          >
+            {temp.toFixed(0)}°C
+          </span>
+        )}
+
+        {/* Humidity */}
+        {humidity != null && (
+          <span
+            className={cn(
+              'text-[9px]',
+              isFirst ? 'text-blue-100' : 'text-gray-400'
+            )}
+          >
+            {humidity.toFixed(0)}%
+          </span>
+        )}
+
+        {/* Confidence */}
+        {confidence != null && (
+          <span
+            className={cn(
+              'text-[8px] mt-0.5 px-1 py-0.5 rounded-full font-medium',
+              isFirst
+                ? 'bg-blue-500 text-blue-100'
+                : 'bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400'
+            )}
+          >
+            {confidence.toFixed(0)}%
+          </span>
+        )}
+      </div>
+    </Tooltip>
+  );
+};
+
+// ── Main component ───────────────────────────────────────────────────────────
 export const WeeklyForecastCard: React.FC<WeeklyForecastCardProps> = ({
   siteId,
 }) => {
-  // Use the forecast hook to fetch real data
-  const { forecast, isLoading, error } = useForecast({
+  const [mode, setMode] = React.useState<ForecastMode>('daily');
+
+  const {
+    dailyItems,
+    hourlyItems,
+    isLoading,
+    error,
+  } = useForecast({
     siteId,
+    mode,
     enabled: !!siteId,
   });
 
-  // Handle loading state
-  if (isLoading) {
-    return (
-      <div className="w-full space-y-3">
-        <div className="flex items-center justify-center py-4">
-          <LoadingSpinner size={24} />
-          <span className="ml-2 text-sm text-muted-foreground">
-            Loading forecast...
-          </span>
-        </div>
-      </div>
-    );
-  }
-
-  // Handle error state
-  if (error) {
-    return (
-      <div className="w-full space-y-3">
-        <div className="flex items-center justify-center py-4 text-center">
-          <AqCloudOff className="w-8 h-8 text-muted-foreground mb-2" />
-          <p className="text-sm text-muted-foreground">
-            Unable to load forecast data
-          </p>
-        </div>
-      </div>
-    );
-  }
-
-  // Handle no data state
-  if (!forecast || forecast.length === 0) {
-    return (
-      <div className="w-full space-y-3">
-        <div className="flex items-center justify-center py-4 text-center">
-          <AqCloudOff className="w-8 h-8 text-muted-foreground mb-2" />
-          <p className="text-sm text-muted-foreground">
-            No forecast data available
-          </p>
-        </div>
-      </div>
-    );
-  }
-
   return (
-    <div className="w-full space-y-3">
-      {/* Horizontally scrollable forecast */}
-      <div className="w-full overflow-x-auto overflow-y-hidden">
-        <div className="flex gap-2 sm:gap-3 min-w-max py-2">
-          {forecast.slice(0, 7).map((forecastItem, index) => {
-            const forecastAqInfo = getAirQualityInfo(
-              forecastItem.pm2_5 || 0,
-              'pm2_5'
-            );
-            const ForecastIcon = forecastAqInfo.icon;
-            const isToday = index === 0; // First item is today
-
-            // Parse the time to get day and date
-            const forecastDate = new Date(forecastItem.time);
-            const dayNames = ['S', 'M', 'T', 'W', 'T', 'F', 'S'];
-            const dayLetter = dayNames[forecastDate.getDay()];
-            const dateNumber = forecastDate.getDate();
-
-            // Get background color based on air quality
-            const getBgColorClass = () => {
-              const level = forecastAqInfo.level.toLowerCase();
-              if (level.includes('good')) return 'bg-green-50';
-              if (level.includes('moderate')) return 'bg-yellow-50';
-              if (level.includes('sensitive')) return 'bg-orange-50';
-              if (level.includes('unhealthy') && !level.includes('very'))
-                return 'bg-red-50';
-              if (level.includes('very unhealthy')) return 'bg-purple-50';
-              if (level.includes('hazardous')) return 'bg-pink-50';
-              return 'bg-gray-50';
-            };
-
-            return (
-              <div
-                key={index}
-                className={cn(
-                  'flex flex-col items-center rounded-full py-2 px-1 min-w-[36px] sm:min-w-[40px] transition-all duration-200 flex-shrink-0',
-                  isToday
-                    ? 'bg-blue-600 shadow-lg scale-105'
-                    : `${getBgColorClass()} border border-gray-200`
-                )}
-              >
-                {/* Day letter */}
-                <span
-                  className={cn(
-                    'text-xs font-medium mb-0.5',
-                    isToday ? 'text-white' : 'text-gray-600'
-                  )}
-                >
-                  {dayLetter}
-                </span>
-
-                {/* Date number */}
-                <span
-                  className={cn(
-                    'text-sm font-semibold mb-1',
-                    isToday ? 'text-white' : 'text-gray-400'
-                  )}
-                >
-                  {String(dateNumber).padStart(2, '0')}
-                </span>
-
-                {/* Air quality icon */}
-                <div className="flex items-center justify-center">
-                  <ForecastIcon className="w-4 h-4 sm:w-5 sm:h-5" />
-                </div>
-              </div>
-            );
-          })}
+    <Card className="border border-gray-200 dark:border-gray-700 shadow-sm">
+      <CardContent className="p-4 space-y-3">
+        {/* Header */}
+        <div className="flex items-center justify-between">
+          <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+            Air Quality Forecast
+          </h3>
         </div>
-      </div>
-    </div>
+
+        {/* Mode tabs */}
+        <ModeTabs active={mode} onChange={setMode} />
+
+        {/* Loading */}
+        {isLoading && (
+          <div className="flex items-center justify-center py-6">
+            <LoadingSpinner size={20} />
+            <span className="ml-2 text-sm text-gray-500">
+              Loading forecast...
+            </span>
+          </div>
+        )}
+
+        {/* Error */}
+        {!isLoading && error && (
+          <div className="flex flex-col items-center justify-center py-6 text-center">
+            <AqCloudOff className="w-8 h-8 text-gray-400 mb-2" />
+            <p className="text-sm text-gray-500">
+              Unable to load forecast data
+            </p>
+          </div>
+        )}
+
+        {/* Empty */}
+        {!isLoading && !error && (!dailyItems?.length && !hourlyItems?.length) && (
+          <div className="flex flex-col items-center justify-center py-6 text-center">
+            <AqCloudOff className="w-8 h-8 text-gray-400 mb-2" />
+            <p className="text-sm text-gray-500">
+              No forecast data available
+            </p>
+          </div>
+        )}
+
+        {/* Daily view */}
+        {!isLoading && !error && mode === 'daily' && dailyItems.length > 0 && (
+          <div className="w-full overflow-x-auto overflow-y-hidden -mx-1 px-1">
+            <div className="flex gap-2 min-w-max py-1">
+              {dailyItems.slice(0, 7).map((item, idx) => (
+                <DailyPill
+                  key={item.date}
+                  item={item}
+                  isToday={idx === 0}
+                />
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Hourly view */}
+        {!isLoading && !error && mode === 'hourly' && hourlyItems.length > 0 && (
+          <div className="w-full overflow-x-auto overflow-y-hidden -mx-1 px-1">
+            <div className="flex gap-1.5 min-w-max py-1">
+              {hourlyItems.slice(0, 24).map((item, idx) => (
+                <HourlyPill
+                  key={item.timestamp}
+                  item={item}
+                  isFirst={idx === 0}
+                />
+              ))}
+            </div>
+          </div>
+        )}
+
+      </CardContent>
+    </Card>
   );
 };

--- a/src/platform/src/modules/airqo-map/hooks/index.ts
+++ b/src/platform/src/modules/airqo-map/hooks/index.ts
@@ -11,6 +11,10 @@ export { useMapReadings } from './useMapReadings';
 export type { UseMapReadingsResult } from './useMapReadings';
 
 export { useForecast } from './useForecast';
-export type { UseForecastParams, UseForecastResult } from './useForecast';
+export type {
+  UseForecastParams,
+  UseForecastResult,
+  ForecastMode,
+} from './useForecast';
 
 export { useSiteChartData } from './useSiteChartData';

--- a/src/platform/src/modules/airqo-map/hooks/useForecast.ts
+++ b/src/platform/src/modules/airqo-map/hooks/useForecast.ts
@@ -33,6 +33,21 @@ export interface UseForecastResult {
   refetch: () => Promise<void>;
 }
 
+/** Do not retry on 5xx, network errors, or aborts */
+const RETRY_CONFIG = {
+  retry: (failureCount: number, error: Error) => {
+    if (
+      error.name === 'CanceledError' ||
+      error.name === 'AbortError' ||
+      error.message === 'canceled'
+    ) {
+      return false;
+    }
+    return failureCount < 1;
+  },
+  retryDelay: 1000,
+};
+
 /**
  * Hook for fetching daily or hourly forecast data for a specific site.
  * Uses the new v2 forecasting API endpoints.
@@ -49,14 +64,15 @@ export function useForecast({
   // ── Daily query ────────────────────────────────────────────────────────────
   const dailyQuery = useQuery<DailyForecastResponse, Error>({
     queryKey: ['map', 'forecast', 'daily', siteId ?? 'none'],
-    queryFn: async () => {
+    queryFn: async ({ signal }) => {
       if (!siteId) throw new Error('Site ID is required');
-      return deviceService.getDailyForecast(siteId);
+      return deviceService.getDailyForecast(siteId, signal);
     },
     enabled: shouldFetchFromApi && mode === 'daily',
     networkMode: 'online',
     staleTime: 1000 * 60 * 10,
     gcTime: 1000 * 60 * 60 * 12,
+    ...RETRY_CONFIG,
   });
 
   // ── Hourly query ───────────────────────────────────────────────────────────
@@ -69,14 +85,20 @@ export function useForecast({
       hourlyPage,
       hourlyLimit,
     ],
-    queryFn: async () => {
+    queryFn: async ({ signal }) => {
       if (!siteId) throw new Error('Site ID is required');
-      return deviceService.getHourlyForecast(siteId, hourlyPage, hourlyLimit);
+      return deviceService.getHourlyForecast(
+        siteId,
+        hourlyPage,
+        hourlyLimit,
+        signal
+      );
     },
     enabled: shouldFetchFromApi && mode === 'hourly',
     networkMode: 'online',
     staleTime: 1000 * 60 * 10,
     gcTime: 1000 * 60 * 60 * 12,
+    ...RETRY_CONFIG,
   });
 
   const activeQuery = mode === 'daily' ? dailyQuery : hourlyQuery;

--- a/src/platform/src/modules/airqo-map/hooks/useForecast.ts
+++ b/src/platform/src/modules/airqo-map/hooks/useForecast.ts
@@ -3,78 +3,143 @@ import { useMemo, useCallback } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { deviceService } from '../../../shared/services/deviceService';
 import type {
-  ForecastResponse,
-  ForecastData,
-  AQIRanges,
+  DailyForecastResponse,
+  DailyForecastSite,
+  DailyForecastItem,
+  HourlyForecastResponse,
+  HourlyForecastSite,
+  HourlyForecastItem,
 } from '../../../shared/types/api';
+
+export type ForecastMode = 'daily' | 'hourly';
 
 export interface UseForecastParams {
   siteId?: string;
+  mode?: ForecastMode;
   enabled?: boolean;
+  hourlyPage?: number;
+  hourlyLimit?: number;
 }
 
 export interface UseForecastResult {
-  forecast: ForecastData[];
-  aqiRanges: AQIRanges | null;
+  dailyForecasts: DailyForecastSite[];
+  hourlyForecasts: HourlyForecastSite[];
+  dailyItems: DailyForecastItem[];
+  hourlyItems: HourlyForecastItem[];
+  siteName: string | null;
+  units: Record<string, string> | null;
   isLoading: boolean;
   error: string | null;
   refetch: () => Promise<void>;
 }
 
 /**
- * Hook for fetching forecast data for a specific site
+ * Hook for fetching daily or hourly forecast data for a specific site.
+ * Uses the new v2 forecasting API endpoints.
  */
 export function useForecast({
   siteId,
+  mode = 'daily',
   enabled = true,
+  hourlyPage = 1,
+  hourlyLimit = 24,
 }: UseForecastParams = {}): UseForecastResult {
   const shouldFetchFromApi = Boolean(siteId && enabled);
 
-  const {
-    data,
-    isLoading,
-    error,
-    refetch: refetchQuery,
-  } = useQuery<ForecastResponse, Error>({
-    queryKey: ['map', 'forecast', siteId ?? 'none'],
+  // ── Daily query ────────────────────────────────────────────────────────────
+  const dailyQuery = useQuery<DailyForecastResponse, Error>({
+    queryKey: ['map', 'forecast', 'daily', siteId ?? 'none'],
     queryFn: async () => {
-      if (!siteId) {
-        throw new Error('Site ID is required');
-      }
-      return deviceService.getForecastAuthenticated(siteId);
+      if (!siteId) throw new Error('Site ID is required');
+      return deviceService.getDailyForecast(siteId);
     },
-    enabled: shouldFetchFromApi,
+    enabled: shouldFetchFromApi && mode === 'daily',
     networkMode: 'online',
     staleTime: 1000 * 60 * 10,
     gcTime: 1000 * 60 * 60 * 12,
   });
 
-  const forecast = useMemo(() => {
-    if (!siteId || !enabled) {
-      return [];
+  // ── Hourly query ───────────────────────────────────────────────────────────
+  const hourlyQuery = useQuery<HourlyForecastResponse, Error>({
+    queryKey: [
+      'map',
+      'forecast',
+      'hourly',
+      siteId ?? 'none',
+      hourlyPage,
+      hourlyLimit,
+    ],
+    queryFn: async () => {
+      if (!siteId) throw new Error('Site ID is required');
+      return deviceService.getHourlyForecast(siteId, hourlyPage, hourlyLimit);
+    },
+    enabled: shouldFetchFromApi && mode === 'hourly',
+    networkMode: 'online',
+    staleTime: 1000 * 60 * 10,
+    gcTime: 1000 * 60 * 60 * 12,
+  });
+
+  const activeQuery = mode === 'daily' ? dailyQuery : hourlyQuery;
+
+  // ── Derived state ──────────────────────────────────────────────────────────
+  const dailyForecasts = useMemo<DailyForecastSite[]>(() => {
+    if (!siteId || !enabled) return [];
+    return dailyQuery.data?.data?.forecasts ?? [];
+  }, [dailyQuery.data?.data?.forecasts, enabled, siteId]);
+
+  const hourlyForecasts = useMemo<HourlyForecastSite[]>(() => {
+    if (!siteId || !enabled) return [];
+    return hourlyQuery.data?.data?.forecasts ?? [];
+  }, [hourlyQuery.data?.data?.forecasts, enabled, siteId]);
+
+  const dailyItems = useMemo<DailyForecastItem[]>(() => {
+    if (dailyForecasts.length === 0) return [];
+    return dailyForecasts[0]?.forecasts ?? [];
+  }, [dailyForecasts]);
+
+  const hourlyItems = useMemo<HourlyForecastItem[]>(() => {
+    if (hourlyForecasts.length === 0) return [];
+    return hourlyForecasts[0]?.forecasts ?? [];
+  }, [hourlyForecasts]);
+
+  const siteName = useMemo<string | null>(() => {
+    if (mode === 'daily' && dailyForecasts.length > 0) {
+      return dailyForecasts[0]?.site_details?.site_name ?? null;
     }
-
-    return data?.forecasts ?? [];
-  }, [data?.forecasts, enabled, siteId]);
-
-  const aqiRanges = useMemo<AQIRanges | null>(() => {
-    if (!siteId || !enabled) {
-      return null;
+    if (mode === 'hourly' && hourlyForecasts.length > 0) {
+      return hourlyForecasts[0]?.site_details?.site_name ?? null;
     }
+    return null;
+  }, [mode, dailyForecasts, hourlyForecasts]);
 
-    return data?.aqi_ranges ?? null;
-  }, [data?.aqi_ranges, enabled, siteId]);
+  const units = useMemo<Record<string, string> | null>(() => {
+    if (mode === 'daily' && dailyQuery.data?.data?.units) {
+      return dailyQuery.data.data.units as unknown as Record<string, string>;
+    }
+    if (mode === 'hourly' && hourlyQuery.data?.data?.units) {
+      return hourlyQuery.data.data.units as unknown as Record<string, string>;
+    }
+    return null;
+  }, [mode, dailyQuery.data?.data?.units, hourlyQuery.data?.data?.units]);
 
   const refetch = useCallback(async () => {
     if (!shouldFetchFromApi) return;
-    await refetchQuery();
-  }, [refetchQuery, shouldFetchFromApi]);
+    if (mode === 'daily') {
+      await dailyQuery.refetch();
+    } else {
+      await hourlyQuery.refetch();
+    }
+  }, [shouldFetchFromApi, mode, dailyQuery, hourlyQuery]);
 
   return {
-    forecast,
-    aqiRanges,
-    isLoading: shouldFetchFromApi ? isLoading : false,
-    error: shouldFetchFromApi ? (error?.message ?? null) : null,
+    dailyForecasts,
+    hourlyForecasts,
+    dailyItems,
+    hourlyItems,
+    siteName,
+    units,
+    isLoading: shouldFetchFromApi ? activeQuery.isLoading : false,
+    error: shouldFetchFromApi ? (activeQuery.error?.message ?? null) : null,
     refetch,
   };
 }

--- a/src/platform/src/modules/data-download/utils/dataExportFile.ts
+++ b/src/platform/src/modules/data-download/utils/dataExportFile.ts
@@ -96,10 +96,10 @@ const getNormalizedString = (value: unknown): string | undefined => {
 
 /**
  * Strip leading apostrophes and HTML-encoded apostrophes (&apos; / &#39;)
- * from string values that represent numbers, then convert to actual numbers.
- * The upstream API sometimes prefixes negative values with these characters,
- * which corrupts exports. Additionally, CSV-parsed values arrive as strings
- * even when they represent numbers.
+ * from string values. The upstream API sometimes prefixes negative values
+ * with these characters, which corrupts exports. Values are kept as strings
+ * to preserve exact precision from the API — converting to Number can lose
+ * digits for high-precision floats like coordinates.
  */
 const sanitizeNumericString = (value: unknown): unknown => {
   if (typeof value !== 'string') return value;
@@ -121,12 +121,8 @@ const sanitizeNumericString = (value: unknown): unknown => {
 
   cleaned = cleaned.trim();
 
-  // Convert numeric strings to actual numbers
-  if (cleaned !== '' && !isNaN(Number(cleaned))) {
-    return Number(cleaned);
-  }
-
-  return value;
+  // Return cleaned string — do NOT convert to Number to preserve full precision
+  return cleaned;
 };
 
 const normalizeDownloadRecord = (record: DownloadRecord): DownloadRecord => {
@@ -235,9 +231,14 @@ const escapeCsvValue = (value: unknown) => {
     return '""';
   }
 
-  // Numbers should never be prefixed — they are not formula-injection risks
+  // Numeric values (number type) — no prefix, no wrapping quotes
   if (typeof value === 'number') {
     return Number.isFinite(value) ? String(value) : '""';
+  }
+
+  // Numeric strings — emit as bare value to preserve full precision
+  if (typeof value === 'string' && value !== '' && !isNaN(Number(value))) {
+    return value;
   }
 
   const stringValue = String(value);
@@ -743,8 +744,14 @@ const buildWorksheetCellXml = (
     return `<c r="${cellReference}"${styleAttribute}/>`;
   }
 
+  // Numbers — use numeric format style (2) to preserve full precision display
   if (typeof value === 'number' && Number.isFinite(value)) {
-    return `<c r="${cellReference}"${styleAttribute}><v>${value}</v></c>`;
+    return `<c r="${cellReference}" s="2"><v>${value}</v></c>`;
+  }
+
+  // Numeric strings — write as <v> with numeric format to preserve full precision
+  if (typeof value === 'string' && value !== '' && !isNaN(Number(value))) {
+    return `<c r="${cellReference}" s="2"><v>${value}</v></c>`;
   }
 
   if (typeof value === 'boolean') {
@@ -972,6 +979,9 @@ const ROOT_RELATIONSHIPS_XML = `<?xml version="1.0" encoding="UTF-8" standalone=
 
 const STYLES_XML = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <numFmts count="1">
+    <numFmt numFmtId="164" formatCode="0.000000000000000"/>
+  </numFmts>
   <fonts count="2">
     <font><sz val="11"/><name val="Calibri"/></font>
     <font><b/><sz val="11"/><name val="Calibri"/></font>
@@ -982,9 +992,10 @@ const STYLES_XML = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
   </fills>
   <borders count="1"><border><left/><right/><top/><bottom/><diagonal/></border></borders>
   <cellStyleXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0"/></cellStyleXfs>
-  <cellXfs count="2">
+  <cellXfs count="3">
     <xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0"/>
     <xf numFmtId="0" fontId="1" fillId="0" borderId="0" xfId="0" applyFont="1"/>
+    <xf numFmtId="164" fontId="0" fillId="0" borderId="0" xfId="0" applyNumberFormat="1"/>
   </cellXfs>
   <cellStyles count="1"><cellStyle name="Normal" xfId="0" builtinId="0"/></cellStyles>
   <dxfs count="0"/>

--- a/src/platform/src/modules/data-download/utils/dataExportFile.ts
+++ b/src/platform/src/modules/data-download/utils/dataExportFile.ts
@@ -237,7 +237,11 @@ const escapeCsvValue = (value: unknown) => {
   }
 
   // Numeric strings — emit as bare value to preserve full precision
-  if (typeof value === 'string' && value !== '' && !isNaN(Number(value))) {
+  if (
+    typeof value === 'string' &&
+    value.trim() !== '' &&
+    Number.isFinite(Number(value))
+  ) {
     return value;
   }
 
@@ -750,7 +754,11 @@ const buildWorksheetCellXml = (
   }
 
   // Numeric strings — write as <v> with numeric format to preserve full precision
-  if (typeof value === 'string' && value !== '' && !isNaN(Number(value))) {
+  if (
+    typeof value === 'string' &&
+    value.trim() !== '' &&
+    Number.isFinite(Number(value))
+  ) {
     return `<c r="${cellReference}" s="2"><v>${value}</v></c>`;
   }
 

--- a/src/platform/src/modules/data-download/utils/dataExportFile.ts
+++ b/src/platform/src/modules/data-download/utils/dataExportFile.ts
@@ -94,8 +94,48 @@ const getNormalizedString = (value: unknown): string | undefined => {
   return undefined;
 };
 
+/**
+ * Strip leading apostrophes and HTML-encoded apostrophes (&apos; / &#39;)
+ * from string values that represent numbers, then convert to actual numbers.
+ * The upstream API sometimes prefixes negative values with these characters,
+ * which corrupts exports. Additionally, CSV-parsed values arrive as strings
+ * even when they represent numbers.
+ */
+const sanitizeNumericString = (value: unknown): unknown => {
+  if (typeof value !== 'string') return value;
+
+  let cleaned = value;
+
+  // Strip leading &apos; or &#39; (HTML entity for apostrophe)
+  while (
+    cleaned.startsWith('&apos;') ||
+    cleaned.startsWith('&#39;')
+  ) {
+    cleaned = cleaned.slice(cleaned.startsWith('&apos;') ? 6 : 5);
+  }
+
+  // Strip leading literal apostrophes
+  while (cleaned.startsWith("'")) {
+    cleaned = cleaned.slice(1);
+  }
+
+  cleaned = cleaned.trim();
+
+  // Convert numeric strings to actual numbers
+  if (cleaned !== '' && !isNaN(Number(cleaned))) {
+    return Number(cleaned);
+  }
+
+  return value;
+};
+
 const normalizeDownloadRecord = (record: DownloadRecord): DownloadRecord => {
   const normalizedRecord: DownloadRecord = { ...record };
+
+  // Sanitize all values — strip apostrophe prefixes from numeric strings
+  for (const key of Object.keys(normalizedRecord)) {
+    normalizedRecord[key] = sanitizeNumericString(normalizedRecord[key]);
+  }
 
   const existingDatetime = getNormalizedString(normalizedRecord['datetime']);
   if (existingDatetime) {
@@ -195,13 +235,17 @@ const escapeCsvValue = (value: unknown) => {
     return '""';
   }
 
+  // Numbers should never be prefixed — they are not formula-injection risks
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? String(value) : '""';
+  }
+
   const stringValue = String(value);
   const trimmedValue = stringValue.trimStart();
   const firstVisibleCharacter = trimmedValue[0];
   const needsNeutralize =
     firstVisibleCharacter === '=' ||
     firstVisibleCharacter === '+' ||
-    firstVisibleCharacter === '-' ||
     firstVisibleCharacter === '@' ||
     stringValue.charAt(0) === '\t' ||
     stringValue.charAt(0) === '\r';

--- a/src/platform/src/shared/services/deviceService.ts
+++ b/src/platform/src/shared/services/deviceService.ts
@@ -20,7 +20,8 @@ import type {
   GridsSummaryParams,
   CountriesResponse,
   MapReadingsResponse,
-  ForecastResponse,
+  DailyForecastResponse,
+  HourlyForecastResponse,
   CohortResponse,
 } from '../types/api';
 
@@ -613,19 +614,48 @@ export class DeviceService {
     return data as MapReadingsResponse;
   }
 
-  // Get forecast data - authenticated endpoint
-  async getForecastAuthenticated(siteId: string): Promise<ForecastResponse> {
-    await this.ensureAuthenticated();
-    const response = await this.authenticatedClient.get<
-      ForecastResponse | ApiErrorResponse
-    >(`/predict/daily-forecast?site_id=${siteId}`);
+  // Get daily forecast data - new v2 endpoint (proxied to avoid CORS)
+  async getDailyForecast(siteId: string): Promise<DailyForecastResponse> {
+    const response = await this.serverClient.get<
+      DailyForecastResponse | ApiErrorResponse
+    >(`/predict/daily-forecasting/?site_id=${siteId}`);
     const data = response.data;
 
-    if ('success' in data && !data.success) {
-      throw new Error(data.message || 'Failed to get forecast data');
+    if (
+      'success' in data &&
+      !data.success &&
+      'message' in data &&
+      typeof data.message === 'string'
+    ) {
+      throw new Error(data.message || 'Failed to get daily forecast data');
     }
 
-    return data as ForecastResponse;
+    return data as DailyForecastResponse;
+  }
+
+  // Get hourly forecast data - new v2 endpoint (proxied to avoid CORS)
+  async getHourlyForecast(
+    siteId: string,
+    page = 1,
+    limit = 24
+  ): Promise<HourlyForecastResponse> {
+    const response = await this.serverClient.get<
+      HourlyForecastResponse | ApiErrorResponse
+    >(
+      `/predict/hourly-forecasting/?site_id=${siteId}&page=${page}&limit=${limit}`
+    );
+    const data = response.data;
+
+    if (
+      'success' in data &&
+      !data.success &&
+      'message' in data &&
+      typeof data.message === 'string'
+    ) {
+      throw new Error(data.message || 'Failed to get hourly forecast data');
+    }
+
+    return data as HourlyForecastResponse;
   }
 }
 

--- a/src/platform/src/shared/services/deviceService.ts
+++ b/src/platform/src/shared/services/deviceService.ts
@@ -615,10 +615,13 @@ export class DeviceService {
   }
 
   // Get daily forecast data - new v2 endpoint (proxied to avoid CORS)
-  async getDailyForecast(siteId: string): Promise<DailyForecastResponse> {
+  async getDailyForecast(
+    siteId: string,
+    signal?: AbortSignal
+  ): Promise<DailyForecastResponse> {
     const response = await this.serverClient.get<
       DailyForecastResponse | ApiErrorResponse
-    >(`/predict/daily-forecasting/?site_id=${siteId}`);
+    >(`/predict/daily-forecasting/?site_id=${siteId}`, { signal });
     const data = response.data;
 
     if (
@@ -637,12 +640,14 @@ export class DeviceService {
   async getHourlyForecast(
     siteId: string,
     page = 1,
-    limit = 24
+    limit = 24,
+    signal?: AbortSignal
   ): Promise<HourlyForecastResponse> {
     const response = await this.serverClient.get<
       HourlyForecastResponse | ApiErrorResponse
     >(
-      `/predict/hourly-forecasting/?site_id=${siteId}&page=${page}&limit=${limit}`
+      `/predict/hourly-forecasting/?site_id=${siteId}&page=${page}&limit=${limit}`,
+      { signal }
     );
     const data = response.data;
 

--- a/src/platform/src/shared/types/api.ts
+++ b/src/platform/src/shared/types/api.ts
@@ -997,7 +997,196 @@ export interface MapReadingsResponse {
   measurements: MapReading[];
 }
 
-// Forecast types
+// Forecast types – Daily Forecasting API v2
+
+export interface DailyForecastMet {
+  air_temperature?: ParsedNumber;
+  relative_humidity?: ParsedNumber;
+  air_pressure_at_sea_level?: ParsedNumber;
+  precipitation_amount?: ParsedNumber;
+  cloud_area_fraction?: ParsedNumber;
+  wind_speed?: ParsedNumber;
+  wind_from_direction?: ParsedNumber;
+  wind_direction_compass?: string;
+}
+
+export interface DailyForecastAqi {
+  aqi_value?: ParsedNumber;
+  label?: string;
+  trend_message?: string | null;
+  aqi_category?: string;
+  aqi_color_name?: string;
+  aqi_color?: string;
+}
+
+export interface DailyForecastItem {
+  date: string;
+  forecast: {
+    pm2_5_mean?: ParsedNumber;
+    pm2_5_low?: ParsedNumber;
+    pm2_5_high?: ParsedNumber;
+    pm2_5_min?: ParsedNumber;
+    pm2_5_max?: ParsedNumber;
+    forecast_confidence?: ParsedNumber;
+  };
+  aqi?: DailyForecastAqi;
+  met?: DailyForecastMet;
+  created_at?: string;
+}
+
+export interface DailyForecastSiteDetails {
+  site_id: string;
+  site_name: string;
+  site_latitude?: ParsedNumber;
+  site_longitude?: ParsedNumber;
+}
+
+export interface DailyForecastSite {
+  site_details: DailyForecastSiteDetails;
+  start_date?: string;
+  end_date?: string;
+  days?: number;
+  total?: number;
+  forecasts: DailyForecastItem[];
+}
+
+export interface DailyForecastUnits {
+  pm2_5: string;
+  air_temperature: string;
+  relative_humidity: string;
+  air_pressure_at_sea_level: string;
+  precipitation_amount: string;
+  cloud_area_fraction: string;
+  wind_speed: string;
+  wind_from_direction: string;
+  forecast_confidence: string;
+}
+
+export interface DailyForecastScope {
+  type?: string;
+  id?: string;
+  grid_id?: string;
+}
+
+export interface DailyForecastResponse {
+  success: boolean;
+  data: {
+    start_date: string;
+    end_date: string;
+    days: number;
+    total: number;
+    units: DailyForecastUnits;
+    forecasts: DailyForecastSite[];
+    scope?: DailyForecastScope;
+    sites_count?: number;
+    sites_with_forecasts_count?: number;
+    site_names?: string[];
+  };
+}
+
+// Forecast types – Hourly Forecasting API v2
+
+/** Some numeric fields may arrive as a plain number or {source, parsedValue} */
+export type ParsedNumber = number | { source: string; parsedValue: number };
+
+/** Extract a usable number from a ParsedNumber */
+export function resolveParsedNumber(value: ParsedNumber | undefined | null): number | undefined {
+  if (value == null) return undefined;
+  if (typeof value === 'number') return value;
+  if (typeof value === 'object' && 'parsedValue' in value) return value.parsedValue;
+  return undefined;
+}
+
+export interface HourlyForecastMet {
+  air_temperature?: ParsedNumber;
+  relative_humidity?: ParsedNumber;
+  air_pressure_at_sea_level?: ParsedNumber;
+  precipitation_amount?: ParsedNumber;
+  cloud_area_fraction?: ParsedNumber;
+  wind_speed?: ParsedNumber;
+  wind_from_direction?: ParsedNumber;
+  wind_direction_compass?: string;
+}
+
+export interface HourlyForecastAqi {
+  aqi_value?: ParsedNumber;
+  label?: string;
+  trend_message?: string | null;
+  aqi_category?: string;
+  aqi_color_name?: string;
+  aqi_color?: string;
+}
+
+export interface HourlyForecastItem {
+  timestamp: string;
+  forecast: {
+    pm2_5_mean?: ParsedNumber;
+    pm2_5_q10?: ParsedNumber;
+    pm2_5_q90?: ParsedNumber;
+    forecast_confidence?: ParsedNumber;
+  };
+  aqi?: HourlyForecastAqi;
+  met?: HourlyForecastMet;
+  created_at?: string;
+}
+
+export interface HourlyForecastSiteDetails {
+  site_id: string;
+  site_name: string;
+  site_latitude?: ParsedNumber;
+  site_longitude?: ParsedNumber;
+}
+
+export interface HourlyForecastSite {
+  site_details: HourlyForecastSiteDetails;
+  start_timestamp?: string;
+  end_timestamp?: string;
+  hours?: number;
+  total?: number;
+  page?: number;
+  limit?: number;
+  total_pages?: number;
+  has_next?: boolean;
+  forecasts: HourlyForecastItem[];
+}
+
+export interface HourlyForecastUnits {
+  pm2_5: string;
+  air_temperature: string;
+  relative_humidity: string;
+  air_pressure_at_sea_level: string;
+  precipitation_amount: string;
+  cloud_area_fraction: string;
+  wind_speed: string;
+  wind_from_direction: string;
+  forecast_confidence: string;
+}
+
+export interface HourlyForecastScope {
+  type?: string;
+  id?: string;
+  grid_id?: string;
+}
+
+export interface HourlyForecastResponse {
+  success: boolean;
+  data: {
+    start_date: string;
+    end_date: string;
+    total: number;
+    page?: number;
+    limit?: number;
+    has_next?: boolean;
+    units: HourlyForecastUnits;
+    forecasts: HourlyForecastSite[];
+    scope?: HourlyForecastScope;
+    sites_count?: number;
+    sites_with_forecasts_count?: number;
+    site_names?: string[];
+  };
+}
+
+// Legacy forecast types (kept for backward compatibility)
 export interface ForecastData {
   time: string;
   pm2_5: number;


### PR DESCRIPTION
#### Status of maturity (all need to be checked before merging):

- [x] I've tested this locally
- [x] I consider this code done

#### Screenshots (optional)
<img width="1874" height="1294" alt="image" src="https://github.com/user-attachments/assets/b1768893-5d60-4928-a3f5-90d4980c6036" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an hourly forecast view (next 24 hours) with a mode toggle to switch between daily and hourly displays
  * Enhanced forecast cards with richer tooltips (AQI, PM2.5, temperature, humidity, and trends)

* **Refactor**
  * Reworked the forecast card UI to improve layout, scrolling, and in-card handling of loading, empty, and error states

* **Bug Fixes**
  * Improved CSV/XLSX export value formatting and sanitized problematic leading characters for cleaner spreadsheet output
<!-- end of auto-generated comment: release notes by coderabbit.ai -->