### PR TITLE
Refactor Primary Sidebar Access to Use Granular Permissions

### DIFF
--- a/src/vertex/components/layout/primary-sidebar.tsx
+++ b/src/vertex/components/layout/primary-sidebar.tsx
@@ -89,22 +89,18 @@ const PrimarySidebar: React.FC<PrimarySidebarProps> = ({
 }) => {
   const router = useRouter();
   const pathname = usePathname();
-  const { getContextPermissions } = useUserContext();
+  const { getContextPermissions, isPersonalContext, activeGroup } = useUserContext();
   const permissions = getContextPermissions();
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [isRecentOpen, setIsRecentOpen] = useState(false);
   const { visitedPages } = useRecentlyVisited();
-  const { activeGroup } = useUserContext();
   const timeoutRef = React.useRef<NodeJS.Timeout | null>(null);
   const recentTimeoutRef = React.useRef<NodeJS.Timeout | null>(null);
 
-  // Determine if user can view Admin Panel (Role based ONLY)
   const canViewAdminPanel = React.useMemo(() => {
-    if (!activeGroup?.role?.role_name) return false;
-
-    const allowedRoles = ['AIRQO_SUPER_ADMIN', 'AIRQO_ADMIN', 'AIRQO_NETWORK_ADMIN'];
-    return allowedRoles.includes(activeGroup.role.role_name);
-  }, [activeGroup]);
+    if (!isPersonalContext) return false;
+    return !!permissions.canViewNetworks;
+  }, [isPersonalContext, permissions.canViewNetworks]);
 
   const navigateWithShimmer = (targetPath: string, navigate: () => void) => {
     if (pathname === targetPath) return;


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

Replaces the static role-name array check that gated the Administrative Panel entry in the primary sidebar with a dynamic, permission-based model tied to the user's active organizational context.

**Before:** The sidebar checked whether `activeGroup.role.role_name` was one of three hardcoded strings (`AIRQO_SUPER_ADMIN`, `AIRQO_ADMIN`, `AIRQO_NETWORK_ADMIN`). This approach was brittle — role name changes on the backend would silently break visibility without any compile-time or runtime warning. It also called `useUserContext()` twice, creating a redundant hook invocation.

**After:** `canViewAdminPanel` now evaluates two conditions sourced from the existing permission infrastructure:

1. `isPersonalContext` — the user must be operating within the AirQo group (personal context). External organisation members (`userContext === 'external-org'`) are excluded at the context level regardless of their permissions.
2. `permissions.canViewNetworks` — the user must hold the `NETWORK.VIEW` capability as resolved by `getContextPermissions()`, which reads live permission data from Redux via `usePermission(PERMISSIONS.NETWORK.VIEW)`.

**Additional cleanup:** Consolidated two separate `useUserContext()` calls (lines 92 and 97) into a single destructure, removing the redundant second call. `activeGroup` is still destructured from the same call as it remains needed for the group badge display in the sidebar header.

**Files changed:**
- `src/vertex/components/layout/primary-sidebar.tsx` — `canViewAdminPanel` logic and hook consolidation

No other files were modified. The `AdminDropdownItem` components inside the dropdown already used `permissions.canViewNetworks`, `canViewDevices`, etc. for per-item gating — those are unchanged.

---

#### Status of maturity (all need to be checked before merging):

- [x] I've tested this locally
- [x] I consider this code done
- [x] This change ready to hit production in its current state
- [x] The title of the PR states what changed and the related issues number (used for the release note).
- [x] I've included issue number in the "Closes #3654" part of the "[What are the relevant tickets?](#what-are-the-relevant-tickets)" section to [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] I've updated corresponding documentation for the changes in this PR.
- [ ] I have written unit and/or e2e tests for my change(s).

---

#### How should this be manually tested?

1. **Admin user (AirQo group, has NETWORK.VIEW):**
   - Log in with a user who holds the `NETWORK.VIEW` permission and whose active group is the AirQo personal group.
   - Open the primary sidebar (hamburger menu).
   - Confirm the **Administrative Panel** entry is visible and the dropdown opens correctly.

2. **External org user (has NETWORK.VIEW but wrong context):**
   - Log in with a user who holds `NETWORK.VIEW` but belongs to an external organisation (`userContext === 'external-org'`).
   - Open the primary sidebar.
   - Confirm the **Administrative Panel** entry is **not visible** — `isPersonalContext` is `false` so the check short-circuits.

3. **AirQo user without NETWORK.VIEW:**
   - Log in with a user in the AirQo group who does **not** hold the `NETWORK.VIEW` permission.
   - Open the primary sidebar.
   - Confirm the **Administrative Panel** entry is **not visible**.

4. **Regression — non-admin AirQo user:**
   - Confirm that the Home nav item and Recently Visited dropdown remain unaffected for all user types.

---

#### What are the relevant tickets?

- Closes #3654


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Administrative Panel access control to use permission-based logic instead of role-based checks, ensuring users with appropriate permissions can access the panel while restricting access for others based on context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->