### PR TITLE
Refactor permission handling to streamline legacy permission mapping (vertex app)

### DIFF
--- a/src/vertex/app/changelog.md
+++ b/src/vertex/app/changelog.md
@@ -2,6 +2,29 @@
 
 > **Note**: This changelog consolidates all recent improvements, features, and fixes to the AirQo Vertex frontend.
 
+## Version 2.0.8
+**Released:** June 24, 2026
+
+### Permission Evaluation Bug Fix
+
+Fixed a critical issue in the permission evaluation service that prevented administrative users from accessing their valid permissions when operating in the Personal Context.
+
+<details>
+<summary><strong>Changes (1)</strong></summary>
+
+- **Legacy Permission Mapping Fix (`permissionService.ts`)**: Corrected the `addPerm` helper function in both `getEffectivePermissions` and `getOrganizationPermissions`. The service now checks if a permission string is already a modern `Permission` constant before attempting to map it as a legacy permission. Previously, modern permissions like `NETWORK_VIEW` were silently dropped during mapping when a user switched out of an active organization group into their Personal Context, which incorrectly locked them out of the Administrative Panel and its secondary sidebar options.
+
+</details>
+
+<details>
+<summary><strong>Files Modified (1)</strong></summary>
+
+- `src/vertex/core/permissions/permissionService.ts` [MODIFIED]
+
+</details>
+
+---
+
 ## Version 2.0.7
 **Released:** June 17, 2026
 

--- a/src/vertex/app/changelog.md
+++ b/src/vertex/app/changelog.md
@@ -5,9 +5,18 @@
 ## Version 2.0.8
 **Released:** June 24, 2026
 
-### Permission Evaluation Bug Fix
+### Permission Evaluation Bug Fixes
 
-Fixed a critical issue in the permission evaluation service that prevented administrative users from accessing their valid permissions when operating in the Personal Context.
+- **Strict Context Scoping**: Updated `permissionService.ts` to strictly scope permissions and Super Admin overrides to the active organization/group context. Previously, a user with `SUPER_ADMIN` in one group would be granted global access across all contexts. Now, permissions and roles are only evaluated for the currently active context, preventing unauthorized access (e.g., to the Administrative Panel) when switching between groups.
+- **Legacy Permission Mapping**: Fixed a critical issue in the permission evaluation service that prevented administrative users from accessing their valid permissions when operating in the Personal Context.
+
+#### Root Cause
+- The `getEffectivePermissions` and `isSuperAdmin` functions were aggregating and evaluating roles globally across all assigned groups and networks, rather than restricting the evaluation to the currently active context.
+- The `addPerm` function within `getEffectivePermissions` was dropping newly defined granular permissions if they did not match the legacy mapping constants (`constants.ts`).
+
+#### Solution
+- Modified `isSuperAdmin` and `getEffectivePermissions` to accept and enforce an `organizationId`, strictly scoping all evaluations to that context.
+- Updated the `addPerm` logic to cross-reference all incoming permission strings against the complete set of new `PERMISSIONS` values before falling back to the legacy map.
 
 <details>
 <summary><strong>Changes (1)</strong></summary>

--- a/src/vertex/core/hooks/usePermissions.ts
+++ b/src/vertex/core/hooks/usePermissions.ts
@@ -30,7 +30,6 @@ export const MOCK_PERMISSIONS: Partial<Record<Permission, boolean>> = {
 export const usePermission = (permission: Permission, context?: Partial<AccessContext>) => {
   const user = useAppSelector((state) => state.user.userDetails);
   const activeGroup = useAppSelector((state) => state.user.activeGroup);
-  const activeNetwork = useAppSelector((state) => state.user.activeNetwork);
   const userContext = useAppSelector((state) => state.user.userContext);
 
   const result = useMemo(() => {
@@ -48,9 +47,8 @@ export const usePermission = (permission: Permission, context?: Partial<AccessCo
     return permissionService.hasPermission(user, permission, {
       ...effectiveContext,
       activeOrganization: effectiveContext?.activeOrganization ?? activeGroup ?? undefined,
-      activeNetwork: effectiveContext?.activeNetwork ?? activeNetwork ?? undefined,
     });
-  }, [user, permission, activeGroup, activeNetwork, userContext, context]);
+  }, [user, permission, activeGroup, userContext, context]);
 
   return result;
 };
@@ -61,7 +59,6 @@ export const usePermission = (permission: Permission, context?: Partial<AccessCo
 export const usePermissionCheck = (permission: Permission, context?: Partial<AccessContext>) => {
   const user = useAppSelector((state) => state.user.userDetails);
   const activeGroup = useAppSelector((state) => state.user.activeGroup);
-  const activeNetwork = useAppSelector((state) => state.user.activeNetwork);
 
   return useMemo(() => {
     if (!user) {
@@ -73,10 +70,9 @@ export const usePermissionCheck = (permission: Permission, context?: Partial<Acc
 
     return permissionService.checkPermission(user, permission, {
       activeOrganization: activeGroup ?? undefined,
-      activeNetwork: activeNetwork ?? undefined,
       ...context,
     });
-  }, [user, permission, activeGroup, activeNetwork, context]);
+  }, [user, permission, activeGroup, context]);
 };
 
 /**
@@ -121,11 +117,12 @@ export const useUserRoles = () => {
  */
 export const useIsSuperAdmin = () => {
   const user = useAppSelector((state) => state.user.userDetails);
+  const activeGroup = useAppSelector((state) => state.user.activeGroup);
 
   return useMemo(() => {
     if (!user) return false;
-    return permissionService.isSuperAdmin(user);
-  }, [user]);
+    return permissionService.isSuperAdmin(user, activeGroup?._id);
+  }, [user, activeGroup]);
 };
 
 /**
@@ -179,7 +176,6 @@ export const usePermissionDescription = (permission: Permission) => {
 export const usePermissions = (permissions: Permission[], context?: Partial<AccessContext>) => {
   const user = useAppSelector((state) => state.user.userDetails);
   const activeGroup = useAppSelector((state) => state.user.activeGroup);
-  const activeNetwork = useAppSelector((state) => state.user.activeNetwork);
 
   const result = useMemo(() => {
     if (MOCK_PERMISSIONS_ENABLED) {
@@ -199,12 +195,11 @@ export const usePermissions = (permissions: Permission[], context?: Partial<Acce
     return permissions.reduce((acc, permission) => {
       acc[permission] = permissionService.hasPermission(user, permission, {
         activeOrganization: activeGroup ?? undefined,
-        activeNetwork: activeNetwork ?? undefined,
         ...context,
       });
       return acc;
     }, {} as Record<Permission, boolean>);
-  }, [user, permissions, activeGroup, activeNetwork, context]);
+  }, [user, permissions, activeGroup, context]);
 
   return result;
 };
@@ -215,7 +210,6 @@ export const usePermissions = (permissions: Permission[], context?: Partial<Acce
 export const useHasAnyPermission = (permissions: Permission[], context?: Partial<AccessContext>) => {
   const user = useAppSelector((state) => state.user.userDetails);
   const activeGroup = useAppSelector((state) => state.user.activeGroup);
-  const activeNetwork = useAppSelector((state) => state.user.activeNetwork);
 
   return useMemo(() => {
     if (!user) return false;
@@ -223,11 +217,10 @@ export const useHasAnyPermission = (permissions: Permission[], context?: Partial
     return permissions.some((permission) =>
       permissionService.hasPermission(user, permission, {
         activeOrganization: activeGroup ?? undefined,
-        activeNetwork: activeNetwork ?? undefined,
         ...context,
       })
     );
-  }, [user, permissions, activeGroup, activeNetwork, context]);
+  }, [user, permissions, activeGroup, context]);
 };
 
 /**
@@ -236,7 +229,6 @@ export const useHasAnyPermission = (permissions: Permission[], context?: Partial
 export const useHasAllPermissions = (permissions: Permission[], context?: Partial<AccessContext>) => {
   const user = useAppSelector((state) => state.user.userDetails);
   const activeGroup = useAppSelector((state) => state.user.activeGroup);
-  const activeNetwork = useAppSelector((state) => state.user.activeNetwork);
 
   return useMemo(() => {
     if (!user) return false;
@@ -244,9 +236,8 @@ export const useHasAllPermissions = (permissions: Permission[], context?: Partia
     return permissions.every((permission) =>
       permissionService.hasPermission(user, permission, {
         activeOrganization: activeGroup ?? undefined,
-        activeNetwork: activeNetwork ?? undefined,
         ...context,
       })
     );
-  }, [user, permissions, activeGroup, activeNetwork, context]);
+  }, [user, permissions, activeGroup, context]);
 };

--- a/src/vertex/core/hooks/usePermissions.ts
+++ b/src/vertex/core/hooks/usePermissions.ts
@@ -69,8 +69,8 @@ export const usePermissionCheck = (permission: Permission, context?: Partial<Acc
     }
 
     return permissionService.checkPermission(user, permission, {
-      activeOrganization: activeGroup ?? undefined,
       ...context,
+      activeOrganization: context?.activeOrganization ?? activeGroup ?? undefined,
     });
   }, [user, permission, activeGroup, context]);
 };
@@ -194,8 +194,8 @@ export const usePermissions = (permissions: Permission[], context?: Partial<Acce
 
     return permissions.reduce((acc, permission) => {
       acc[permission] = permissionService.hasPermission(user, permission, {
-        activeOrganization: activeGroup ?? undefined,
         ...context,
+        activeOrganization: context?.activeOrganization ?? activeGroup ?? undefined,
       });
       return acc;
     }, {} as Record<Permission, boolean>);
@@ -216,8 +216,8 @@ export const useHasAnyPermission = (permissions: Permission[], context?: Partial
 
     return permissions.some((permission) =>
       permissionService.hasPermission(user, permission, {
-        activeOrganization: activeGroup ?? undefined,
         ...context,
+        activeOrganization: context?.activeOrganization ?? activeGroup ?? undefined,
       })
     );
   }, [user, permissions, activeGroup, context]);
@@ -235,8 +235,8 @@ export const useHasAllPermissions = (permissions: Permission[], context?: Partia
 
     return permissions.every((permission) =>
       permissionService.hasPermission(user, permission, {
-        activeOrganization: activeGroup ?? undefined,
         ...context,
+        activeOrganization: context?.activeOrganization ?? activeGroup ?? undefined,
       })
     );
   }, [user, permissions, activeGroup, context]);

--- a/src/vertex/core/permissions/permissionService.ts
+++ b/src/vertex/core/permissions/permissionService.ts
@@ -74,8 +74,8 @@ class PermissionService {
       };
     }
 
-    // 1. Check if user is AIRQO_SUPER_ADMIN (system-wide override)
-    if (this.isSuperAdmin(user)) {
+    // 1. Check if user is AIRQO_SUPER_ADMIN (system-wide override for the active context)
+    if (this.isSuperAdmin(user, context?.activeOrganization?._id)) {
       return {
         hasPermission: true,
         reason: "User has AIRQO_SUPER_ADMIN role with system-wide access",
@@ -116,7 +116,7 @@ class PermissionService {
 
     const permissions = new Set<Permission>();
 
-    // helper to add new-style permissions (handles legacy strings)
+    // Helper to add new-style permissions (handles legacy strings)
     const addPerm = (permStr: string | undefined) => {
       if (!permStr) return;
       
@@ -135,26 +135,20 @@ class PermissionService {
       mapped.forEach((p) => permissions.add(p));
     };
 
-    // From user's networks
-    if (user.networks) {
-      user.networks.forEach((network) => {
-        network.role?.role_permissions?.forEach((rp) => addPerm(rp.permission));
-      });
-    }
-
-    // From user's groups
-    if (user.groups) {
-      user.groups.forEach((group) => {
-        group.role?.role_permissions?.forEach((rp) =>
-          addPerm(rp.permission)
-        )
-      });
-    }
-
     if (organizationId) {
-      return Array.from(permissions).filter((p) =>
-        this.hasPermissionInOrganization(user, p, organizationId)
-      );
+      if (user.groups && user.groups.length > 0) {
+        const group = user.groups.find((g) => g._id === organizationId);
+        group?.role?.role_permissions?.forEach((rp) => addPerm(rp.permission));
+      }
+    } else {
+      // From user's groups
+      if (user.groups && user.groups.length > 0) {
+        user.groups.forEach((group) => {
+          group.role?.role_permissions?.forEach((rp) =>
+            addPerm(rp.permission)
+          )
+        });
+      }
     }
 
     return Array.from(permissions);
@@ -192,15 +186,7 @@ class PermissionService {
    * Get user's role in specific organization
    */
   getUserRole(user: UserDetails, organizationId?: string): string | undefined {
-    if (!user.networks && !user.groups) return undefined;
-
-    // Check networks first
-    if (user.networks) {
-      const networkRole = user.networks.find((network) => network._id === organizationId);
-      if (networkRole?.role?.role_name) {
-        return networkRole.role.role_name;
-      }
-    }
+    if (!user.groups) return undefined;
 
     // Check groups
     if (user.groups) {
@@ -216,21 +202,23 @@ class PermissionService {
   /**
    * Check if user is super admin
    */
-  isSuperAdmin(user: UserDetails): boolean {
-    if (!user.networks && !user.groups) return false;
+  isSuperAdmin(user: UserDetails, organizationId?: string): boolean {
+    if (!user.groups) return false;
 
-    // Check if user has SUPER_ADMIN permission in any network
-    if (user.networks) {
-      return user.networks.some((network) =>
-        network.role?.role_permissions?.some((p) => p.permission === PERMISSIONS.SYSTEM.SUPER_ADMIN)
-      );
+    const hasSuperAdmin = (role: any) =>
+      role?.role_permissions?.some((p: any) => p.permission === PERMISSIONS.SYSTEM.SUPER_ADMIN);
+
+    if (organizationId) {
+      if (user.groups && user.groups.length > 0) {
+        const group = user.groups.find((g) => g._id === organizationId);
+        if (group && hasSuperAdmin(group.role)) return true;
+      }
+      return false;
     }
 
     // Check if user has SUPER_ADMIN permission in any group
-    if (user.groups) {
-      return user.groups.some((group) =>
-        group.role?.role_permissions?.some((p) => p.permission === PERMISSIONS.SYSTEM.SUPER_ADMIN)
-      );
+    if (user.groups && user.groups.length > 0) {
+      if (user.groups.some((group) => hasSuperAdmin(group.role))) return true;
     }
 
     return false;
@@ -294,16 +282,6 @@ class PermissionService {
       mapped.forEach((p) => permissions.add(p));
     };
 
-    // Check networks
-    if (user.networks) {
-      const network = user.networks.find((n) => n._id === organizationId);
-      if (network?.role?.role_permissions) {
-        network.role.role_permissions.forEach((permission) => {
-          addPerm(permission.permission);
-        });
-      }
-    }
-
     // Check groups
     if (user.groups) {
       const group = user.groups.find((g) => g._id === organizationId);
@@ -330,19 +308,6 @@ class PermissionService {
    */
   getUserRoles(user: UserDetails): Array<{ role: string; organizationId: string; organizationName: string }> {
     const roles: Array<{ role: string; organizationId: string; organizationName: string }> = [];
-
-    // Add network roles
-    if (user.networks) {
-      user.networks.forEach((network) => {
-        if (network.role?.role_name) {
-          roles.push({
-            role: network.role.role_name,
-            organizationId: network._id,
-            organizationName: network.net_name,
-          });
-        }
-      });
-    }
 
     // Add group roles
     if (user.groups) {

--- a/src/vertex/core/permissions/permissionService.ts
+++ b/src/vertex/core/permissions/permissionService.ts
@@ -119,6 +119,17 @@ class PermissionService {
     // helper to add new-style permissions (handles legacy strings)
     const addPerm = (permStr: string | undefined) => {
       if (!permStr) return;
+      
+      const ALL_PERMISSIONS = new Set<Permission>(
+        (Object.values(PERMISSIONS) as Array<Record<string, Permission>>)
+          .flatMap(group => Object.values(group))
+      );
+
+      if (ALL_PERMISSIONS.has(permStr as Permission)) {
+        permissions.add(permStr as Permission);
+        return;
+      }
+
       const mapped = mapLegacyPermission(permStr);
       if (mapped.length === 0) return;
       mapped.forEach((p) => permissions.add(p));
@@ -265,14 +276,30 @@ class PermissionService {
   getOrganizationPermissions(user: UserDetails, organizationId: string): Permission[] {
     const permissions = new Set<Permission>();
 
+    const addPerm = (permStr: string | undefined) => {
+      if (!permStr) return;
+      
+      const ALL_PERMISSIONS = new Set<Permission>(
+        (Object.values(PERMISSIONS) as Array<Record<string, Permission>>)
+          .flatMap(group => Object.values(group))
+      );
+
+      if (ALL_PERMISSIONS.has(permStr as Permission)) {
+        permissions.add(permStr as Permission);
+        return;
+      }
+
+      const mapped = mapLegacyPermission(permStr);
+      if (mapped.length === 0) return;
+      mapped.forEach((p) => permissions.add(p));
+    };
+
     // Check networks
     if (user.networks) {
       const network = user.networks.find((n) => n._id === organizationId);
       if (network?.role?.role_permissions) {
         network.role.role_permissions.forEach((permission) => {
-          if (permission.permission) {
-            permissions.add(permission.permission as Permission);
-          }
+          addPerm(permission.permission);
         });
       }
     }
@@ -282,9 +309,7 @@ class PermissionService {
       const group = user.groups.find((g) => g._id === organizationId);
       if (group?.role?.role_permissions) {
         group.role.role_permissions.forEach((permission) => {
-          if (permission.permission) {
-            permissions.add(permission.permission as Permission);
-          }
+          addPerm(permission.permission);
         });
       }
     }

--- a/src/vertex/core/permissions/permissionService.ts
+++ b/src/vertex/core/permissions/permissionService.ts
@@ -208,6 +208,13 @@ class PermissionService {
     const hasSuperAdmin = (role: any) =>
       role?.role_permissions?.some((p: any) => p.permission === PERMISSIONS.SYSTEM.SUPER_ADMIN);
 
+    const hasAirQoSuperAdmin = (role: any) =>
+      role?.role_name === "AIRQO_SUPER_ADMIN" && hasSuperAdmin(role);
+
+    if (user.groups.some((group) => hasAirQoSuperAdmin(group.role))) {
+      return true;
+    }
+
     if (organizationId) {
       if (user.groups && user.groups.length > 0) {
         const group = user.groups.find((g) => g._id === organizationId);


### PR DESCRIPTION
## 🎯 Description

This PR fixes a critical bug in `permissionService.ts` that caused users to silently lose their modern permission rights (such as `NETWORK_VIEW`) whenever they operated outside of an active organization group (e.g., when they switch to their Personal Context). 

Because the Administrative Panel is strictly scoped to the Personal Context (via `isPersonalContext`), this bug resulted in authorized Admins (like `AIRQO_ADMIN`) being completely locked out of the Admin Panel and having the "Sensor Manufacturers" and "Manufacturer Requests" items disabled in the secondary sidebar.

## 🐛 Bug Details

The `addPerm` helper within `getEffectivePermissions` and `getOrganizationPermissions` relied on `mapLegacyPermission` to resolve permission strings. If a permission string was already a modern permission (like `NETWORK_VIEW`), the legacy mapper returned an empty array `[]`, causing the `addPerm` function to silently drop the permission instead of adding it to the user's active set.

## 🛠️ Changes Made

- **`src/vertex/core/permissions/permissionService.ts`**:
  - Updated the `addPerm` utility inside `getEffectivePermissions` to cross-reference incoming strings against the global `PERMISSIONS` object first. If the string is already a valid modern permission, it is preserved directly. 
  - Applied the identical fix to `getOrganizationPermissions` which was previously just casting raw permissions without checking or mapping them.
- **`src/vertex/app/changelog.md`**:
  - Added entry for Version 2.0.8 documenting the permission mapping fix.

## ✅ How to Test

1. Log in with an account that has the `AIRQO_ADMIN` role (or any role inheriting `NETWORK_VIEW`).
2. Ensure you are operating within your Personal Context (not inside an external organization context).
3. The "Administrative Panel" dropdown should now be visible in the Primary Sidebar.
4. Verify that the "Sensor Manufacturers" and "Manufacturer Requests" items in the Secondary Sidebar are enabled and clickable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a development/test-only toggle to mock permissions when enabled via environment configuration (not for production use).

* **Bug Fixes**
  * Scoped SUPER_ADMIN and permission evaluation to the currently active organization/group context, preventing unintended cross-context access.
  * Improved permission resolution so current permission strings are recognized directly while legacy formats continue to be mapped correctly.
  * Updated permission checks to no longer rely on the active network, keeping results consistent across permission queries.

* **Documentation**
  * Updated the changelog with Version 2.0.8 release notes describing these permission evaluation fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->