### PR TITLE
feat(vertex-desktop): add macOS code signing, notarization, and CI re…

### DIFF
--- a/.github/workflows/vertex-desktop-release.yml
+++ b/.github/workflows/vertex-desktop-release.yml
@@ -22,7 +22,6 @@ jobs:
       run:
         working-directory: src/vertex-desktop
     env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       CSC_IDENTITY_AUTO_DISCOVERY: "false"
       VERTEX_DESKTOP_ENV: production
       VERTEX_DESKTOP_PROD_URL: https://vertex.airqo.net
@@ -31,6 +30,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Resolve release tag
         id: tag
@@ -73,6 +73,8 @@ jobs:
         run: npm run build
 
       - name: Build and publish release artifacts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npx electron-builder --win nsis --publish always
 
       - name: Upload build artifacts
@@ -89,7 +91,6 @@ jobs:
       run:
         working-directory: src/vertex-desktop
     env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       APPLE_ID: ${{ secrets.APPLE_ID }}
       APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
       APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
@@ -102,6 +103,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Resolve release tag
         id: tag
@@ -144,6 +146,8 @@ jobs:
         run: npm run build
 
       - name: Build and publish release artifacts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npx electron-builder --mac --publish always
 
       - name: Upload build artifacts

--- a/.github/workflows/vertex-desktop-release.yml
+++ b/.github/workflows/vertex-desktop-release.yml
@@ -82,4 +82,73 @@ jobs:
           path: src/vertex-desktop/release/*
           if-no-files-found: error
 
-  # macOS/Linux builds are intentionally disabled for now.
+  release-mac:
+    name: build-and-publish-macos
+    runs-on: macos-latest
+    defaults:
+      run:
+        working-directory: src/vertex-desktop
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      APPLE_ID: ${{ secrets.APPLE_ID }}
+      APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+      CSC_LINK: ${{ secrets.CSC_LINK }}
+      CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+      VERTEX_DESKTOP_ENV: production
+      VERTEX_DESKTOP_PROD_URL: https://vertex.airqo.net
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve release tag
+        id: tag
+        shell: bash
+        env:
+          INPUT_TAG: ${{ inputs.release_tag }}
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            TAG="${INPUT_TAG}"
+          else
+            TAG="${GITHUB_REF_NAME}"
+          fi
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Ensure tag exists
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          git fetch --tags --force
+          git rev-parse "${RELEASE_TAG}" >/dev/null 2>&1
+
+      - name: Checkout release tag
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ steps.tag.outputs.tag }}
+        run: git checkout "${RELEASE_TAG}"
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: src/vertex-desktop/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build desktop app
+        run: npm run build
+
+      - name: Build and publish release artifacts
+        run: npx electron-builder --mac --publish always
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: vertex-desktop-macos-${{ steps.tag.outputs.tag }}
+          path: src/vertex-desktop/release/*
+          if-no-files-found: error

--- a/src/vertex-desktop/assets/entitlements.mac.plist
+++ b/src/vertex-desktop/assets/entitlements.mac.plist
@@ -4,5 +4,7 @@
   <dict>
     <key>com.apple.security.cs.allow-jit</key>
     <true/>
+    <key>com.apple.security.network.client</key>
+    <true/>
   </dict>
 </plist>

--- a/src/vertex-desktop/package.json
+++ b/src/vertex-desktop/package.json
@@ -50,6 +50,7 @@
         "nsis"
       ]
     },
+    "afterSign": "scripts/notarize.js",
     "mac": {
       "icon": "assets/icon.icns",
       "category": "public.app-category.productivity",
@@ -85,6 +86,7 @@
     "electron-updater": "^6.6.2"
   },
   "devDependencies": {
+    "@electron/notarize": "^2.5.0",
     "@types/node": "^20.19.11",
     "concurrently": "^9.2.1",
     "electron": "^37.2.6",

--- a/src/vertex-desktop/preload/index.ts
+++ b/src/vertex-desktop/preload/index.ts
@@ -31,6 +31,11 @@ const applyDesktopStyles = (): void => {
   );
   document.documentElement.classList.add("vertex-desktop-enabled");
 
+  // Inject platform class so the web layer can adapt layout per OS
+  // (e.g. title bar padding for macOS traffic lights vs Windows controls).
+  const platformClass = process.platform === 'darwin' ? 'vertex-platform-mac' : 'vertex-platform-win';
+  document.documentElement.classList.add(platformClass);
+
   // Dispatch a custom event each time navigation completes so the
   // DesktopTitleBar React component can re-check canGoBack().
   const dispatchNavigated = () => {

--- a/src/vertex-desktop/scripts/notarize.js
+++ b/src/vertex-desktop/scripts/notarize.js
@@ -20,7 +20,13 @@ exports.default = async function notarizing(context) {
   const teamId = process.env.APPLE_TEAM_ID;
 
   if (!appleId || !appleIdPassword || !teamId) {
-    console.log('Skipping notarization: Apple credentials not configured.');
+    if (process.env.CI) {
+      throw new Error(
+        'Notarization failed: APPLE_ID, APPLE_APP_SPECIFIC_PASSWORD, and APPLE_TEAM_ID ' +
+        'must all be set in CI. An unnotarized macOS build would be blocked by Gatekeeper.'
+      );
+    }
+    console.log('Skipping notarization: Apple credentials not configured (local build).');
     return;
   }
 

--- a/src/vertex-desktop/scripts/notarize.js
+++ b/src/vertex-desktop/scripts/notarize.js
@@ -1,0 +1,41 @@
+// @ts-check
+const { notarize } = require('@electron/notarize');
+
+/**
+ * electron-builder afterSign hook — notarizes the macOS .app with Apple.
+ * Skips silently when Apple credentials are absent (local/non-CI builds).
+ *
+ * Required env vars (set in CI by maintainers):
+ *   APPLE_ID                   — developer Apple ID email
+ *   APPLE_APP_SPECIFIC_PASSWORD — app-specific password for that Apple ID
+ *   APPLE_TEAM_ID              — 10-character Apple Developer Team ID
+ */
+exports.default = async function notarizing(context) {
+  const { electronPlatformName, appOutDir } = context;
+
+  if (electronPlatformName !== 'darwin') return;
+
+  const appleId = process.env.APPLE_ID;
+  const appleIdPassword = process.env.APPLE_APP_SPECIFIC_PASSWORD;
+  const teamId = process.env.APPLE_TEAM_ID;
+
+  if (!appleId || !appleIdPassword || !teamId) {
+    console.log('Skipping notarization: Apple credentials not configured.');
+    return;
+  }
+
+  const appName = context.packager.appInfo.productName;
+  const appPath = `${appOutDir}/${appName}.app`;
+
+  console.log(`Notarizing ${appPath}...`);
+
+  await notarize({
+    tool: 'notarytool',
+    appPath,
+    appleId,
+    appleIdPassword,
+    teamId,
+  });
+
+  console.log(`Notarization complete for ${appName}.`);
+};

--- a/src/vertex/components/layout/desktop-titlebar.tsx
+++ b/src/vertex/components/layout/desktop-titlebar.tsx
@@ -27,6 +27,7 @@ type AppRegionStyle = React.CSSProperties & { WebkitAppRegion?: AppRegion };
 
 export default function DesktopTitleBar() {
   const [isDesktop, setIsDesktop] = useState(false);
+  const [isMac, setIsMac] = useState(false);
   const [canGoBack, setCanGoBack] = useState(false);
   const [isDark, setIsDark] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
@@ -36,6 +37,7 @@ export default function DesktopTitleBar() {
   useEffect(() => {
     if (typeof window !== 'undefined' && window.vertexDesktop) {
       setIsDesktop(true);
+      setIsMac(document.documentElement.classList.contains('vertex-platform-mac'));
 
       // Check initial back-button state
       window.vertexDesktop.canGoBack().then(setCanGoBack).catch(() => setCanGoBack(false));
@@ -132,9 +134,10 @@ export default function DesktopTitleBar() {
     display: 'flex',
     alignItems: 'center',
     gap: 8,
-    paddingLeft: 12,
-    // Reserve space for the native Windows OS controls on the right
-    paddingRight: 148,
+    // On macOS the traffic lights sit on the left (~80px); on Windows the
+    // native minimize/maximize/close controls are on the right (~148px).
+    paddingLeft: isMac ? 80 : 12,
+    paddingRight: isMac ? 12 : 148,
     background: bg,
     borderBottom: 'none',
     zIndex: 2147483647,


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

Adds everything required to build, sign, notarize, and release the Vertex Desktop app for macOS. Previously only Windows was supported — macOS users were blocked by Gatekeeper because the app was unsigned and unnotarized.

**What was broken:**
The `.dmg` could be built locally but macOS would refuse to open it ("app cannot be opened because it is from an unidentified developer"). There was also no CI job to produce or publish macOS artifacts.

**What this PR adds:**

- **Notarization script** (`scripts/notarize.js`): runs after electron-builder signs the app, uploads it to Apple's servers for malware scanning, and waits for approval. Skips gracefully when Apple credentials are absent so local/Windows builds are unaffected.
- **Entitlement** (`entitlements.mac.plist`): adds `com.apple.security.network.client` so the hardened-runtime app can make network requests (required since Vertex loads a remote URL).
- **`@electron/notarize`** added as a dev dependency and wired into electron-builder via the `afterSign` hook in `package.json`.
- **CI job** (`vertex-desktop-release.yml`): new `release-mac` job on `macos-latest` that builds, notarizes, and publishes `.dmg` + `.zip` artifacts to the GitHub release. References Apple Developer secrets that maintainers inject at release time.
- **Platform-aware title bar**: the preload injects `vertex-platform-mac` or `vertex-platform-win` on `<html>`, and `desktop-titlebar.tsx` uses this to swap padding — `paddingLeft: 80` on macOS (traffic lights are on the left) vs `paddingRight: 148` on Windows (native controls are on the right).

---

#### ⚠️ Note on Apple Secrets

The CI notarization step requires `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`, `APPLE_TEAM_ID`, `CSC_LINK`, and `CSC_KEY_PASSWORD`. These are not stored in the repo. Once this PR is reviewed, please ping a maintainer to schedule a 15-minute session to inject fresh secrets and trigger the workflow manually to validate the macOS build end-to-end.

---

#### Files Changed

| File | What changed |
|------|-------------|
| `scripts/notarize.js` | New — Apple notarization hook |
| `assets/entitlements.mac.plist` | Added `network.client` entitlement |
| `package.json` | Added `@electron/notarize`, wired `afterSign` hook |
| `.github/workflows/vertex-desktop-release.yml` | Added `release-mac` CI job |
| `src/vertex-desktop/preload/index.ts` | Injects `vertex-platform-mac/win` CSS class |
| `src/vertex/components/layout/desktop-titlebar.tsx` | Platform-aware title bar padding |

---

#### Status of maturity (all need to be checked before merging):

- [ ] I've tested this locally
- [ ] I consider this code done
- [ ] This change ready to hit production in its current state
- [x] The title of the PR states what changed and the related issues number (used for the release note).
- [ ] I've included issue number in the "Closes #3691" part of the "[What are the relevant tickets?](#what-are-the-relevant-tickets)" section to [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [ ] I've updated corresponding documentation for the changes in this PR.
- [ ] I have written unit and/or e2e tests for my change(s).

---

#### How should this be manually tested?

1. Run `npm run dist:mac` inside `src/vertex-desktop/` on a macOS machine — confirm a `.dmg` is produced in `release/`.
2. Install the `.dmg` and open the app — confirm it launches without Gatekeeper warnings (requires notarization via CI with Apple secrets).
3. On macOS, confirm the title bar does not overlap the native traffic light buttons.
4. On Windows, confirm the existing title bar layout is unchanged.
5. Trigger the `vertex-desktop-release` workflow via `workflow_dispatch` (after maintainer injects secrets) — confirm both `release-windows` and `release-mac` jobs complete and artifacts appear on the GitHub release.

---

#### What are the relevant tickets?

- Closes #3691

---

#### Reviewers

@Baalmart @Psalmz777 @ebainomu @Codebmk

---

#### Screenshots (optional)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added macOS desktop build and release support.
  * Desktop UI now adjusts spacing based on the operating system for a better titlebar layout on macOS.

* **Bug Fixes**
  * Improved macOS app signing and notarization handling to support smoother installation and distribution.
  * Enabled the network-client permission needed for macOS desktop networking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->