### PR TITLE
Fix broken cross-product doc link after Analytics restructure (docs-website)

### DIFF
--- a/src/docs-website/docs/vertex/getting-started/for-organizations.md
+++ b/src/docs-website/docs/vertex/getting-started/for-organizations.md
@@ -10,7 +10,7 @@ An Organization Workspace is built for teams that manage a fleet of devices coll
 
 ## Getting Started
 1. **Switch to your Organization Workspace:** Select your organization from the workspace dropdown in the top right corner of Vertex. *(If your organization doesn't exist yet, you'll need to initialize it through the AirQo Analytics platform first.)*
-2. **Invite your team and assign roles from AirQo Analytics:** Team management isn't done in Vertex — it's handled on the AirQo Analytics platform. Under your organization's **Management** section, open **Members** to invite people by email, and use **Roles & Permissions** to create roles and control what each person can access. See the Analytics [Roles & Permissions guide](/docs/analytics/how-tos/platform-user-guide) for details.
+2. **Invite your team and assign roles from AirQo Analytics:** Team management isn't done in Vertex — it's handled on the AirQo Analytics platform. Under your organization's **Management** section, open **Members** to invite people by email, and use **Roles & Permissions** to create roles and control what each person can access. See the Analytics [Roles & Permissions guide](/docs/analytics/getting-started/platform-user-guide) for details.
 
 ## What to Do Next
 With your team invited and your workspace configured, you're ready to start managing hardware.

--- a/src/docs-website/docs/vertex/getting-started/for-organizations.md
+++ b/src/docs-website/docs/vertex/getting-started/for-organizations.md
@@ -10,7 +10,7 @@ An Organization Workspace is built for teams that manage a fleet of devices coll
 
 ## Getting Started
 1. **Switch to your Organization Workspace:** Select your organization from the workspace dropdown in the top right corner of Vertex. *(If your organization doesn't exist yet, you'll need to initialize it through the AirQo Analytics platform first.)*
-2. **Invite your team and assign roles from AirQo Analytics:** Team management isn't done in Vertex — it's handled on the AirQo Analytics platform. Under your organization's **Management** section, open **Members** to invite people by email, and use **Roles & Permissions** to create roles and control what each person can access. See the Analytics [Roles & Permissions guide](/docs/analytics/getting-started/platform-user-guide) for details.
+2. **Invite your team and assign roles from AirQo Analytics:** Team management isn't done in Vertex — it's handled on the AirQo Analytics platform. Under your organization's **Management** section, open **Members** to invite people by email, and use **Roles & Permissions** to create roles and control what each person can access. See the Analytics [Roles & Permissions guide](/docs/analytics/organizations/roles-and-permissions) for details.
 
 ## What to Do Next
 With your team invited and your workspace configured, you're ready to start managing hardware.


### PR DESCRIPTION
## Summary

Fixes a broken markdown link introduced by a merge collision between
two concurrently-landed PRs on `staging`.

`for-organizations.md` links to an Analytics guide for setting up
roles and permissions. The page it originally pointed to
(`platform-user-guide.md`) was moved from `docs/analytics/how-tos/` to
`docs/analytics/getting-started/` by a separate, concurrently-merged
PR restructuring the Analytics docs. The link was correct when written
against its own branch, but broke once both changes landed together in
`staging`, since the target no longer existed at the old path.

## Fix

While fixing the path, also switched the target: `staging` now has a
dedicated `docs/analytics/organizations/roles-and-permissions.md`
guide, which is more specific and detailed than the brief "Roles &
Permissions" section inside `platform-user-guide.md`. Points there
instead, at `/docs/analytics/organizations/roles-and-permissions`.

## Verification

`docusaurus build` was failing in CI with:

\`\`\`
Broken link on source page path = /docs/vertex/getting-started/for-organizations/:
   -> linking to /docs/analytics/how-tos/platform-user-guide/
\`\`\`

Reproduced the failure locally against an actual worktree of current
`staging` (not just this branch) under Node 22.23.1, matching the CI
runner, and confirmed an intermediate fix resolved cleanly with zero
broken-link warnings before switching to the more specific target page
above.

## Test plan

- [ ] `safe-checks` CI passes on this PR
- [ ] Click through to the Roles & Permissions guide from the
      deployed For Organizations page once merged