### PR TITLE
fix: update API documentation links to new platform URL

### DIFF
--- a/src/website/src/components/layouts/Footer.tsx
+++ b/src/website/src/components/layouts/Footer.tsx
@@ -269,7 +269,7 @@ const Footer = () => {
               </li>
               <li>
                 <Link
-                  href="https://docs.airqo.net/airqo-rest-api-documentation/"
+                  href="https://platform.airqo.net/docs/api/intro/"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="text-gray-600 hover:underline"

--- a/src/website/src/lib/navItems.ts
+++ b/src/website/src/lib/navItems.ts
@@ -103,7 +103,7 @@ export const NAV_ITEMS: NavMenuSection = {
     {
       title: 'Documentation',
       description: 'API guides and technical resources',
-      href: 'https://docs.airqo.net/airqo-rest-api-documentation/',
+      href: 'https://platform.airqo.net/docs/api/intro/',
       newTab: true,
     },
     {

--- a/src/website/src/views/products/ApiPage.tsx
+++ b/src/website/src/views/products/ApiPage.tsx
@@ -235,9 +235,7 @@ const ApiPage = () => {
 
             <CustomButton
               onClick={() =>
-                window.open(
-                  'https://docs.airqo.net/airqo-rest-api-documentation/',
-                )
+                window.open('https://platform.airqo.net/docs/api/intro/')
               }
               className=" text-white "
             >


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

#### Status of maturity (all need to be checked before merging):

- [ ] I've tested this locally
- [ ] I consider this code done
- [ ] This change ready to hit production in its cu

#### Screenshots (optional)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the app’s documentation links to open the new API docs location.
  * The Documentation link in the footer, navigation menu, and API page now points to the latest platform docs URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->