### PR TITLE
feat(vertex-desktop): automate release tagging and add Linux build

### DIFF
--- a/.github/workflows/vertex-desktop-ci.yml
+++ b/.github/workflows/vertex-desktop-ci.yml
@@ -17,7 +17,7 @@ on:
       - ".github/workflows/vertex-desktop-release.yml"
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   desktop-quality:

--- a/.github/workflows/vertex-desktop-ci.yml
+++ b/.github/workflows/vertex-desktop-ci.yml
@@ -59,6 +59,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
       - name: Resolve version and tag
         id: version
         working-directory: src/vertex-desktop
@@ -84,7 +89,15 @@ jobs:
         if: steps.check.outputs.exists == 'false'
         env:
           TAG: ${{ steps.version.outputs.tag }}
+          BEFORE_SHA: ${{ github.event.before }}
+          AFTER_SHA: ${{ github.sha }}
         run: |
+          if [[ "${BEFORE_SHA}" =~ ^0+$ ]]; then
+            echo "No before SHA available (new branch); proceeding with tagging."
+          elif ! git diff --unified=0 "${BEFORE_SHA}" "${AFTER_SHA}" -- src/vertex-desktop/package.json | grep -qE '^[+-][[:space:]]*"version"[[:space:]]*:'; then
+            echo "No version change detected in src/vertex-desktop/package.json for this push; skipping auto-tag."
+            exit 0
+          fi
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag -a "${TAG}" -m "Vertex desktop release ${TAG}"

--- a/.github/workflows/vertex-desktop-ci.yml
+++ b/.github/workflows/vertex-desktop-ci.yml
@@ -16,6 +16,9 @@ on:
       - ".github/workflows/vertex-desktop-ci.yml"
       - ".github/workflows/vertex-desktop-release.yml"
 
+permissions:
+  contents: write
+
 jobs:
   desktop-quality:
     name: typecheck-and-build
@@ -42,3 +45,54 @@ jobs:
 
       - name: Build desktop runtime
         run: npm run build
+
+  auto-tag:
+    name: tag-release-if-version-bumped
+    needs: desktop-quality
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve version and tag
+        id: version
+        working-directory: src/vertex-desktop
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          TAG="vertex-desktop-v${VERSION}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Check if tag already exists
+        id: check
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          git fetch --tags --force
+          if git rev-parse "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create and push release tag
+        if: steps.check.outputs.exists == 'false'
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "${TAG}" -m "Vertex desktop release ${TAG}"
+          git push origin "${TAG}"
+          echo "Pushed tag ${TAG} - this will trigger vertex-desktop-release.yml"
+
+      - name: Skip (tag already exists)
+        if: steps.check.outputs.exists == 'true'
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+        run: echo "Tag ${TAG} already exists, skipping. Bump the version in src/vertex-desktop/package.json to cut a new release."

--- a/.github/workflows/vertex-desktop-ci.yml
+++ b/.github/workflows/vertex-desktop-ci.yml
@@ -94,9 +94,15 @@ jobs:
         run: |
           if [[ "${BEFORE_SHA}" =~ ^0+$ ]]; then
             echo "No before SHA available (new branch); proceeding with tagging."
-          elif ! git diff --unified=0 "${BEFORE_SHA}" "${AFTER_SHA}" -- src/vertex-desktop/package.json | grep -qE '^[+-][[:space:]]*"version"[[:space:]]*:'; then
-            echo "No version change detected in src/vertex-desktop/package.json for this push; skipping auto-tag."
-            exit 0
+          else
+            if ! DIFF_OUTPUT=$(git diff --unified=0 "${BEFORE_SHA}" "${AFTER_SHA}" -- src/vertex-desktop/package.json); then
+              echo "::error::git diff between ${BEFORE_SHA} and ${AFTER_SHA} failed; cannot determine if version changed."
+              exit 1
+            fi
+            if ! grep -qE '^[+-][[:space:]]*"version"[[:space:]]*:' <<< "${DIFF_OUTPUT}"; then
+              echo "No version change detected in src/vertex-desktop/package.json for this push; skipping auto-tag."
+              exit 0
+            fi
           fi
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/vertex-desktop-release.yml
+++ b/.github/workflows/vertex-desktop-release.yml
@@ -156,3 +156,71 @@ jobs:
           name: vertex-desktop-macos-${{ steps.tag.outputs.tag }}
           path: src/vertex-desktop/release/*
           if-no-files-found: error
+
+  release-linux:
+    name: build-and-publish-linux
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: src/vertex-desktop
+    env:
+      VERTEX_DESKTOP_ENV: production
+      VERTEX_DESKTOP_PROD_URL: https://vertex.airqo.net
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Resolve release tag
+        id: tag
+        shell: bash
+        env:
+          INPUT_TAG: ${{ inputs.release_tag }}
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            TAG="${INPUT_TAG}"
+          else
+            TAG="${GITHUB_REF_NAME}"
+          fi
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Ensure tag exists
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          git fetch --tags --force
+          git rev-parse "${RELEASE_TAG}" >/dev/null 2>&1
+
+      - name: Checkout release tag
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ steps.tag.outputs.tag }}
+        run: git checkout "${RELEASE_TAG}"
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: src/vertex-desktop/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build desktop app
+        run: npm run build
+
+      - name: Build and publish release artifacts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npx electron-builder --linux --publish always
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: vertex-desktop-linux-${{ steps.tag.outputs.tag }}
+          path: src/vertex-desktop/release/*
+          if-no-files-found: error

--- a/src/vertex-desktop/CHANGELOG.md
+++ b/src/vertex-desktop/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ---
 
-## Version 0.1.9
+## Version 0.1.10
 **Released:** July 05, 2026
 
 ### Fully Automated Tag-and-Release Pipeline + Linux Builds
@@ -12,17 +12,27 @@
 Removed the last manual step from cutting a desktop release: bumping `version` and merging to `staging` now tags and releases automatically. Added Linux packaging so installers publish for all three desktop platforms.
 
 <details>
-<summary><strong>CI/CD Enhancements (2)</strong></summary>
+<summary><strong>CI/CD Enhancements (4)</strong></summary>
 
 - **Auto-Tag Job**: Added an `auto-tag` job to `vertex-desktop-ci.yml` that runs after typecheck/build succeed on `staging`. It reads `version` from `package.json` and, if a matching `vertex-desktop-v<version>` tag doesn't exist yet, creates and pushes it — no local `git tag`/`git push` required.
+- **Version-Bump Guard**: `auto-tag` only tags when the push's diff actually changed the `version` field in `package.json`, preventing an unrelated push from re-cutting a release if a tag is ever missing (e.g. deleted).
+- **Explicit Node Setup**: `auto-tag` now sets up Node via `actions/setup-node@v4` instead of relying on the runner's preinstalled version, matching the other desktop jobs.
 - **Linux Release Job**: Added a `release-linux` job to `vertex-desktop-release.yml` that builds and publishes Linux artifacts alongside the existing Windows and macOS jobs.
 
 </details>
 
 <details>
-<summary><strong>Packaging & Distribution (1)</strong></summary>
+<summary><strong>Packaging & Distribution (2)</strong></summary>
 
 - **Linux Build Targets**: Configured `build.linux.target` (`AppImage`, `deb`) in `package.json` so `electron-builder --linux` has explicit output targets.
+- **Maintainer Email**: Set `author` to an email-bearing value so `electron-builder` can generate valid Debian package metadata for the `deb` target.
+
+</details>
+
+<details>
+<summary><strong>Security (1)</strong></summary>
+
+- **Scoped Permissions**: Reduced workflow-level `permissions` in `vertex-desktop-ci.yml` to `contents: read`, since only the `auto-tag` job needs write access (declared at the job level) and the `desktop-quality` job runs untrusted dependency install/build steps.
 
 </details>
 

--- a/src/vertex-desktop/CHANGELOG.md
+++ b/src/vertex-desktop/CHANGELOG.md
@@ -4,6 +4,47 @@
 
 ---
 
+## Version 0.1.9
+**Released:** July 05, 2026
+
+### Fully Automated Tag-and-Release Pipeline + Linux Builds
+
+Removed the last manual step from cutting a desktop release: bumping `version` and merging to `staging` now tags and releases automatically. Added Linux packaging so installers publish for all three desktop platforms.
+
+<details>
+<summary><strong>CI/CD Enhancements (2)</strong></summary>
+
+- **Auto-Tag Job**: Added an `auto-tag` job to `vertex-desktop-ci.yml` that runs after typecheck/build succeed on `staging`. It reads `version` from `package.json` and, if a matching `vertex-desktop-v<version>` tag doesn't exist yet, creates and pushes it — no local `git tag`/`git push` required.
+- **Linux Release Job**: Added a `release-linux` job to `vertex-desktop-release.yml` that builds and publishes Linux artifacts alongside the existing Windows and macOS jobs.
+
+</details>
+
+<details>
+<summary><strong>Packaging & Distribution (1)</strong></summary>
+
+- **Linux Build Targets**: Configured `build.linux.target` (`AppImage`, `deb`) in `package.json` so `electron-builder --linux` has explicit output targets.
+
+</details>
+
+<details>
+<summary><strong>Documentation (1)</strong></summary>
+
+- **Release Runbook**: Updated desktop README to describe the auto-tag flow and confirm Linux is part of the standard release.
+
+</details>
+
+<details>
+<summary><strong>Files Modified (4)</strong></summary>
+
+- `.github/workflows/vertex-desktop-ci.yml`
+- `.github/workflows/vertex-desktop-release.yml`
+- `package.json`
+- `README.md`
+
+</details>
+
+---
+
 ## Version 0.1.6
 **Released:** April 09, 2026
 

--- a/src/vertex-desktop/README.md
+++ b/src/vertex-desktop/README.md
@@ -61,7 +61,7 @@ Desktop CI and release are handled by:
 ### Auto-update release flow
 
 1. Bump `version` in `src/vertex-desktop/package.json` and merge that change into `staging` (normal PR flow) — that's the only local step.
-2. On push to `staging` touching `src/vertex-desktop/**`, `vertex-desktop-ci.yml` runs its `desktop-quality` job (typecheck + build), then its `auto-tag` job. `auto-tag` reads the version from `package.json`; if a `vertex-desktop-v<version>` tag doesn't already exist, it creates and pushes it automatically. If the tag already exists (i.e. you pushed without bumping the version), it skips.
+2. On push to `staging` that triggers `vertex-desktop-ci.yml` (changes under `src/vertex-desktop/**` and/or the workflow files), `vertex-desktop-ci.yml` runs its `desktop-quality` job (typecheck + build), then its `auto-tag` job. `auto-tag` reads the version from `package.json`; if a `vertex-desktop-v<version>` tag doesn't already exist, it creates and pushes it automatically. If the tag already exists (i.e. you pushed without bumping the version), it skips.
 3. Pushing that tag triggers `vertex-desktop-release`, which builds and publishes installers to GitHub Releases for:
 - Windows (`nsis`)
 - macOS (`dmg`, `zip`)

--- a/src/vertex-desktop/README.md
+++ b/src/vertex-desktop/README.md
@@ -60,19 +60,14 @@ Desktop CI and release are handled by:
 
 ### Auto-update release flow
 
-1. Bump `version` in `src/vertex-desktop/package.json`.
-2. Commit changes.
-3. Create and push a release tag (or run release workflow manually with an existing tag):
-
-```bash
-git tag vertex-desktop-v0.1.5
-git push origin vertex-desktop-v0.1.5
-```
-
-4. The `vertex-desktop-release` workflow builds and publishes installers to GitHub Releases for:
+1. Bump `version` in `src/vertex-desktop/package.json` and merge that change into `staging` (normal PR flow) — that's the only local step.
+2. On push to `staging` touching `src/vertex-desktop/**`, `vertex-desktop-ci.yml` runs its `desktop-quality` job (typecheck + build), then its `auto-tag` job. `auto-tag` reads the version from `package.json`; if a `vertex-desktop-v<version>` tag doesn't already exist, it creates and pushes it automatically. If the tag already exists (i.e. you pushed without bumping the version), it skips.
+3. Pushing that tag triggers `vertex-desktop-release`, which builds and publishes installers to GitHub Releases for:
 - Windows (`nsis`)
 - macOS (`dmg`, `zip`)
 - Linux (`AppImage`, `deb`)
+
+You can still create/push a `vertex-desktop-v*` tag manually, or run `vertex-desktop-release` via `workflow_dispatch` with an existing tag, if you need to re-run a release.
 
 `electron-updater` consumes these release assets (`latest.yml` + installer) to deliver in-app updates.
 

--- a/src/vertex-desktop/package.json
+++ b/src/vertex-desktop/package.json
@@ -64,7 +64,12 @@
       ]
     },
     "linux": {
-      "icon": "assets/icon.png"
+      "icon": "assets/icon.png",
+      "category": "Utility",
+      "target": [
+        "AppImage",
+        "deb"
+      ]
     },
     "nsis": {
       "oneClick": false,

--- a/src/vertex-desktop/package.json
+++ b/src/vertex-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vertex-desktop",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "private": true,
   "author": "AirQo <airqo.analytics@gmail.com>",
   "repository": {

--- a/src/vertex-desktop/package.json
+++ b/src/vertex-desktop/package.json
@@ -2,7 +2,7 @@
   "name": "vertex-desktop",
   "version": "0.1.9",
   "private": true,
-  "author": "AirQo",
+  "author": "AirQo <airqo.analytics@gmail.com>",
   "repository": {
     "type": "git",
     "url": "https://github.com/airqo-platform/AirQo-frontend.git"


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

- Adds an `auto-tag` job to `vertex-desktop-ci.yml` that runs after the `desktop-quality` (typecheck + build) job succeeds on `staging`. It reads `version` from `src/vertex-desktop/package.json` and, if a matching `vertex-desktop-v<version>` tag doesn't already exist, creates and pushes it automatically — removing the need to run `git tag`/`git push` locally to cut a desktop release.
- Adds a `release-linux` job to `vertex-desktop-release.yml`, mirroring the existing Windows/macOS jobs, so Linux installers (`AppImage`, `deb`) are built and published to GitHub Releases alongside Windows and macOS.
- Adds `build.linux.target: ["AppImage", "deb"]` to `src/vertex-desktop/package.json` so `electron-builder --linux` has explicit output targets (previously only `icon` was configured for Linux).
- Updates `src/vertex-desktop/README.md` to describe the new auto-tag flow and confirm Linux as a standard release target.
- Updates `src/vertex-desktop/CHANGELOG.md` with a `0.1.9` entry documenting this work.

Motivation: cutting a desktop release previously required bumping the version, committing, then manually creating and pushing a `vertex-desktop-v*` tag from a local terminal. This automates that last step so a normal PR merge to `staging` (with a version bump) is enough to trigger a full release.

Note: while working on this, several stale/corrupted release tags (`vertex-desktop-v0.1.8` through `v0.1.14`, which contained a zipped copy of the whole repo rather than real release assets) were identified and deleted from the remote. `package.json`'s version was intentionally kept at `0.1.9` (rather than bumped further) since that version was never actually released.

#### Status of maturity (all need to be checked before merging):

- [ ] I've tested this locally
- [ ] I consider this code done
- [ ] This change ready to hit production in its current state
- [x] The title of the PR states what changed and the related issues number (used for the release note).
- [ ] I've included issue number in the "Closes #ISSUE-NUMBER" part of the "[What are the relevant tickets?](#what-are-the-relevant-tickets)" section to [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] I've updated corresponding documentation for the changes in this PR.
- [ ] I have written unit and/or e2e tests for my change(s).

#### How should this be manually tested?

1. Merge this PR (or push a version bump on top of it) into `staging`.
2. Confirm `vertex-desktop-ci` runs `desktop-quality` then `auto-tag`, and that `auto-tag` pushes a `vertex-desktop-v<version>` tag.
3. Confirm that tag push triggers `vertex-desktop-release` and that Windows, macOS, and Linux jobs all build and publish artifacts to the GitHub Release.

#### What are the relevant tickets?

- Closes #<enter issue number here>

#### Screenshots (optional)

N/A — CI/workflow change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated desktop release tagging on staging pushes (creates `vertex-desktop-v<version>` when needed).
  * Added Linux desktop release builds and publishing, including AppImage and deb artifacts.
* **Documentation**
  * Updated the desktop “Auto-update release flow” guide to match the automated tag-and-release workflow, including re-run/tag fallback options.
* **Chores**
  * Updated the desktop changelog for version 0.1.10 and expanded Linux packaging configuration.
  * Bumped the desktop app version to 0.1.10.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->