### PR TITLE
Add standalone Vertex CI with Codecov test coverage reporting

### DIFF
--- a/.github/workflows/safe-checks.yml
+++ b/.github/workflows/safe-checks.yml
@@ -102,6 +102,13 @@ jobs:
         run: cd src/vertex && npx tsc --noEmit
       - name: Test & Coverage
         run: cd src/vertex && npm run test:coverage
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        with:
+          directory: src/vertex/coverage/
+          flags: vertex
 
   check-platform:
     needs: detect-changes

--- a/.github/workflows/safe-checks.yml
+++ b/.github/workflows/safe-checks.yml
@@ -14,7 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       website: ${{ steps.check.outputs.website }}
-      vertex: ${{ steps.check.outputs.vertex }}
       platform: ${{ steps.check.outputs.platform }}
       beacon: ${{ steps.check.outputs.beacon }}
       calibrate: ${{ steps.check.outputs.calibrate }}
@@ -35,7 +34,6 @@ jobs:
           cat files.txt
 
           echo "website=false"   >> $GITHUB_OUTPUT
-          echo "vertex=false"    >> $GITHUB_OUTPUT
           echo "platform=false"  >> $GITHUB_OUTPUT
           echo "beacon=false"    >> $GITHUB_OUTPUT
           echo "calibrate=false" >> $GITHUB_OUTPUT
@@ -45,9 +43,6 @@ jobs:
           do
             if [[ $file == src/website/* ]]; then
               echo "website=true" >> $GITHUB_OUTPUT
-            fi
-            if [[ $file == src/vertex/* ]]; then
-              echo "vertex=true" >> $GITHUB_OUTPUT
             fi
             if [[ $file == src/platform/* ]]; then
               echo "platform=true" >> $GITHUB_OUTPUT
@@ -80,35 +75,6 @@ jobs:
         run: cd src/website && npm ci
       - name: Lint
         run: cd src/website && npm run lint --if-present
-
-  check-vertex:
-    needs: detect-changes
-    if: needs.detect-changes.outputs.vertex == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-        with:
-          persist-credentials: false
-      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af
-        with:
-          node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: src/vertex/package-lock.json
-      - name: Install dependencies
-        run: cd src/vertex && npm ci
-      - name: Lint
-        run: cd src/vertex && npm run lint --if-present
-      - name: Type Check
-        run: cd src/vertex && npx tsc --noEmit
-      - name: Test & Coverage
-        run: cd src/vertex && npm run test:coverage
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        with:
-          directory: src/vertex/coverage/
-          flags: vertex
 
   check-platform:
     needs: detect-changes

--- a/.github/workflows/vertex-ci.yml
+++ b/.github/workflows/vertex-ci.yml
@@ -1,0 +1,60 @@
+name: vertex-ci
+
+on:
+  pull_request:
+    branches:
+      - staging
+    paths:
+      - "src/vertex/**"
+      - ".github/workflows/vertex-ci.yml"
+  push:
+    branches:
+      - staging
+    paths:
+      - "src/vertex/**"
+      - ".github/workflows/vertex-ci.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  check-vertex:
+    name: check-vertex
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: src/vertex
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: src/vertex/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint --if-present
+
+      - name: Type Check
+        run: npx tsc --noEmit
+
+      - name: Test & Coverage
+        run: npm run test:coverage
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        continue-on-error: true
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        with:
+          directory: src/vertex/coverage/
+          flags: vertex
+          fail_ci_if_error: false

--- a/.github/workflows/vertex-ci.yml
+++ b/.github/workflows/vertex-ci.yml
@@ -50,11 +50,10 @@ jobs:
         run: npm run test:coverage
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         continue-on-error: true
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           directory: src/vertex/coverage/
           flags: vertex
           fail_ci_if_error: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,22 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+      vertex:
+        flags:
+          - vertex
+        informational: true
+
+flags:
+  vertex:
+    paths:
+      - src/vertex/
+    carryforward: false
+
+comment:
+  layout: "flags, diff"
+  require_changes: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,11 +1,11 @@
 coverage:
   status:
     project:
-      default:
+      vertex:
+        flags:
+          - vertex
         informational: true
     patch:
-      default:
-        informational: true
       vertex:
         flags:
           - vertex

--- a/codecov.yml
+++ b/codecov.yml
@@ -15,7 +15,7 @@ flags:
   vertex:
     paths:
       - src/vertex/
-    carryforward: false
+    carryforward: true
 
 comment:
   layout: "flags, diff"

--- a/src/vertex/README.md
+++ b/src/vertex/README.md
@@ -1,5 +1,7 @@
 # Vertex (Web App)
 
+[![codecov](https://codecov.io/gh/airqo-platform/AirQo-frontend/branch/staging/graph/badge.svg?flag=vertex)](https://codecov.io/gh/airqo-platform/AirQo-frontend/flags/vertex)
+
 `vertex` is the AirQo web application for Device and Network management.
 
 ## Quick start
@@ -42,6 +44,8 @@ npm run dev
 ## Testing
 
 Vertex uses Vitest and React Testing Library for unit, hook, and component tests. Follow the internal testing conventions in `app/_docs/internal/TESTING.md` when adding or updating tests.
+
+The badge above reflects overall coverage from the latest `staging` run. The `check-vertex` job in `.github/workflows/safe-checks.yml` runs lint, typecheck, and `test:coverage` on every PR touching Vertex, then uploads results to Codecov under the `vertex` flag; patch coverage (coverage of new/changed lines) is reported on every PR. See `app/_docs/internal/TESTING.md` for coverage priorities by area and current scope.
 
 ## Environment variables
 

--- a/src/vertex/README.md
+++ b/src/vertex/README.md
@@ -1,5 +1,6 @@
 # Vertex (Web App)
 
+[![vertex-ci](https://github.com/airqo-platform/AirQo-frontend/actions/workflows/vertex-ci.yml/badge.svg?branch=staging)](https://github.com/airqo-platform/AirQo-frontend/actions/workflows/vertex-ci.yml)
 [![codecov](https://codecov.io/gh/airqo-platform/AirQo-frontend/branch/staging/graph/badge.svg?flag=vertex)](https://codecov.io/gh/airqo-platform/AirQo-frontend/flags/vertex)
 
 `vertex` is the AirQo web application for Device and Network management.
@@ -45,7 +46,7 @@ npm run dev
 
 Vertex uses Vitest and React Testing Library for unit, hook, and component tests. Follow the internal testing conventions in `app/_docs/internal/TESTING.md` when adding or updating tests.
 
-The badge above reflects overall coverage from the latest `staging` run. The `check-vertex` job in `.github/workflows/safe-checks.yml` runs lint, typecheck, and `test:coverage` on every PR touching Vertex, then uploads results to Codecov under the `vertex` flag; patch coverage (coverage of new/changed lines) is reported on every PR. See `app/_docs/internal/TESTING.md` for coverage priorities by area and current scope.
+The badges above reflect the latest `staging` run: build/test status and overall coverage. `.github/workflows/vertex-ci.yml` runs lint, typecheck, and `test:coverage` on every PR and push to `staging` that touches Vertex, then uploads results to Codecov under the `vertex` flag; patch coverage (coverage of new/changed lines) is reported on every PR. See `app/_docs/internal/TESTING.md` for coverage priorities by area and current scope.
 
 ## Environment variables
 

--- a/src/vertex/app/_docs/internal/TESTING.md
+++ b/src/vertex/app/_docs/internal/TESTING.md
@@ -197,6 +197,10 @@ Prioritize meaningful coverage for:
 
 Do not add low-value tests just to increase coverage numbers.
 
+The `check-vertex` job in `.github/workflows/safe-checks.yml` runs the suite with coverage on every PR that touches Vertex, and uploads results to Codecov under the `vertex` flag (see root `codecov.yml`). Project and patch coverage checks are currently informational (visible on the PR, non-blocking) rather than an enforced gate, consistent with treating coverage as a signal rather than a target. The coverage badge in this app's `README.md` reflects the latest `staging` run.
+
+Flaky-test-rate tracking is deferred: it needs a separate mechanism (for example Codecov Test Analytics or a retry-count script) beyond the coverage upload above, and isn't wired up yet.
+
 ## Deferred test areas
 
 Proxy and network-heavy utilities should be tested in a later integration-style pass with explicit mocks for axios, NextAuth, environment config, and Next.js request/response objects.

--- a/src/vertex/app/_docs/internal/TESTING.md
+++ b/src/vertex/app/_docs/internal/TESTING.md
@@ -201,6 +201,8 @@ The `check-vertex` job in `.github/workflows/safe-checks.yml` runs the suite wit
 
 Flaky-test-rate tracking is deferred: it needs a separate mechanism (for example Codecov Test Analytics or a retry-count script) beyond the coverage upload above, and isn't wired up yet.
 
+Known gap: `safe-checks.yml` (shared across all frontend projects in this monorepo) only triggers on `pull_request`, not on `push` to `staging`. This means Codecov's stored baseline for `staging` can lag well behind its actual tip, making PR-vs-base diffs less reliable than they should be. Fixing it means adding a push trigger to a workflow shared by five other projects, so it's left as a follow-up decision rather than changed here.
+
 ## Deferred test areas
 
 Proxy and network-heavy utilities should be tested in a later integration-style pass with explicit mocks for axios, NextAuth, environment config, and Next.js request/response objects.

--- a/src/vertex/app/_docs/internal/TESTING.md
+++ b/src/vertex/app/_docs/internal/TESTING.md
@@ -197,11 +197,11 @@ Prioritize meaningful coverage for:
 
 Do not add low-value tests just to increase coverage numbers.
 
-The `check-vertex` job in `.github/workflows/safe-checks.yml` runs the suite with coverage on every PR that touches Vertex, and uploads results to Codecov under the `vertex` flag (see root `codecov.yml`). Project and patch coverage checks are currently informational (visible on the PR, non-blocking) rather than an enforced gate, consistent with treating coverage as a signal rather than a target. The coverage badge in this app's `README.md` reflects the latest `staging` run.
+`.github/workflows/vertex-ci.yml` runs the suite with coverage on every PR and push to `staging` that touches Vertex, and uploads results to Codecov under the `vertex` flag (see root `codecov.yml`). Project and patch coverage checks are currently informational (visible on the PR, non-blocking) rather than an enforced gate, consistent with treating coverage as a signal rather than a target. The build/test status and coverage badges in this app's `README.md` reflect the latest `staging` run.
+
+Vertex previously ran as a conditional job inside the shared `safe-checks.yml` (still used by the other frontend projects in this monorepo). It was split into its own workflow so it could push-trigger on `staging` independently — keeping Codecov's baseline fresh — without changing CI behavior for the other five projects.
 
 Flaky-test-rate tracking is deferred: it needs a separate mechanism (for example Codecov Test Analytics or a retry-count script) beyond the coverage upload above, and isn't wired up yet.
-
-Known gap: `safe-checks.yml` (shared across all frontend projects in this monorepo) only triggers on `pull_request`, not on `push` to `staging`. This means Codecov's stored baseline for `staging` can lag well behind its actual tip, making PR-vs-base diffs less reliable than they should be. Fixing it means adding a push trigger to a workflow shared by five other projects, so it's left as a follow-up decision rather than changed here.
 
 ## Deferred test areas
 

--- a/src/vertex/app/changelog.md
+++ b/src/vertex/app/changelog.md
@@ -2,6 +2,41 @@
 
 > **Note**: This changelog consolidates all recent improvements, features, and fixes to the AirQo Vertex frontend.
 
+## Version 2.0.14
+**Released:** July 5, 2026
+
+### CI & Test Coverage Reporting
+
+Gave Vertex its own standalone CI workflow and wired up automated coverage reporting, closing the gap where Vertex had no dedicated pipeline visibility into test health.
+
+<details>
+<summary><strong>New: <code>vertex-ci.yml</code> workflow</strong></summary>
+
+- Vertex's checks (lint, typecheck, `test:coverage`) moved out of the shared, multi-project `safe-checks.yml` into a dedicated `.github/workflows/vertex-ci.yml`, matching the existing `vertex-desktop-ci.yml` / `vertex-performance.yml` pattern.
+- Runs on both `pull_request` and `push` to `staging` (scoped to `src/vertex/**`), so it can keep its Codecov baseline fresh independently — without changing CI behaviour for the other five frontend projects still in `safe-checks.yml`.
+- Fork-contributor PRs are unaffected: the trigger type (`pull_request`, not `pull_request_target`) is unchanged, and the Codecov upload step is hardened with `continue-on-error` / `fail_ci_if_error: false` so a missing token on a fork PR can never fail lint/typecheck/test results.
+
+</details>
+
+<details>
+<summary><strong>New: Codecov integration under a <code>vertex</code> flag</strong></summary>
+
+- Coverage uploads to Codecov scoped via `flags: vertex` (see root `codecov.yml`), with `carryforward: true` since coverage only uploads when Vertex files change.
+- Project and patch coverage checks are informational (visible, non-blocking) for now, consistent with `TESTING.md`'s stance that coverage is a quality signal, not a target.
+- Added `lcov` to Vitest's coverage reporters for reliable Codecov parsing.
+
+</details>
+
+<details>
+<summary><strong>README &amp; docs</strong></summary>
+
+- Build-status and coverage badges added to `src/vertex/README.md`.
+- `app/_docs/internal/TESTING.md` documents the CI wiring and explicitly defers flaky-test-rate tracking as a follow-up.
+
+</details>
+
+---
+
 ## Version 2.0.13
 **Released:** July 3, 2026
 

--- a/src/vertex/vitest.config.ts
+++ b/src/vertex/vitest.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
     setupFiles: ["./vitest.setup.ts"],
     coverage: {
       provider: "v8",
-      reporter: ["text", "json", "html"],
+      reporter: ["text", "json", "html", "lcov"],
       // Thresholds are intentionally not enforced yet
       // lines: 80,
       // functions: 80,


### PR DESCRIPTION
## Summary
- Give Vertex its own standalone CI workflow, `.github/workflows/vertex-ci.yml`, matching the existing `vertex-desktop-ci.yml` / `vertex-performance.yml` pattern instead of running as one conditional job inside the shared, six-project `safe-checks.yml`.
- Upload Vertex's test coverage to Codecov under a `vertex` flag (`codecov.yml`), with `carryforward: true` since coverage only uploads when Vertex files change (fixes a mismatched-upload-count warning seen in earlier CI runs on this PR).
- Runs on both `pull_request` and `push` to `staging`, so Codecov's comparison baseline stays fresh — this was previously stale by thousands of commits because `safe-checks.yml` only ever triggered on `pull_request`. This change is scoped to Vertex only; the other five projects still in `safe-checks.yml` are unaffected.
- Add `lcov` to Vertex's Vitest coverage reporters (Codecov's preferred format), and surface build-status + coverage badges in `src/vertex/README.md`.
- Document the wiring in `TESTING.md`, and explicitly defer flaky-test-rate tracking as a follow-up (needs Codecov Test Analytics or a retry-count script, not wired up yet).
- Add a changelog entry (`src/vertex/app/changelog.md`, v2.0.14).

## Fork-contributor safety
`safe-checks.yml` exists partly so contributor PRs from forks (which don't have repo-secret access) still get CI signal. This PR preserves that: `vertex-ci.yml` uses the same `pull_request` (not `pull_request_target`) trigger as before, so secret exposure to forks is unchanged. The Codecov upload step is additionally hardened with `continue-on-error: true` and `fail_ci_if_error: false`, so a missing `CODECOV_TOKEN` on a fork PR can never fail lint/typecheck/test results.

## Test plan
- [x] `npm run test:coverage` run locally in `src/vertex` — suite passes, `coverage/lcov.info` generated (baseline: ~53% statements / ~44% branches).
- [x] Validated all changed/added YAML files parse correctly.
- [x] Confirmed `vertex-desktop-ci.yml` has no changes and is unaffected.
- [ ] Confirm `vertex-ci` appears as a check on this PR and passes.
- [ ] Confirm `safe-checks` still runs cleanly for the other five projects with `check-vertex` removed.
- [ ] Confirm the Codecov comparison no longer shows a stale/mismatched-base warning on the next push.
