### PR TITLE
Fix device activity crash and add root-layout error boundary

### DIFF
--- a/src/vertex-template/components/features/devices/device-activity-item.tsx
+++ b/src/vertex-template/components/features/devices/device-activity-item.tsx
@@ -58,7 +58,9 @@ const DeviceActivityItem: React.FC<DeviceActivityItemProps> = ({
                         </span>
                     </div>
                     <h4 className="text-base font-medium text-gray-900 leading-none">
-                        {activity.description.charAt(0).toUpperCase() + activity.description.slice(1)}
+                        {typeof activity.description === "string" && activity.description
+                            ? activity.description.charAt(0).toUpperCase() + activity.description.slice(1)
+                            : "No description available"}
                     </h4>
                     {activity.activity_by && (
                         <div className="text-sm text-gray-500">

--- a/src/vertex-template/components/features/devices/device-activity-item.tsx
+++ b/src/vertex-template/components/features/devices/device-activity-item.tsx
@@ -58,8 +58,8 @@ const DeviceActivityItem: React.FC<DeviceActivityItemProps> = ({
                         </span>
                     </div>
                     <h4 className="text-base font-medium text-gray-900 leading-none">
-                        {typeof activity.description === "string" && activity.description
-                            ? activity.description.charAt(0).toUpperCase() + activity.description.slice(1)
+                        {typeof activity.description === "string" && activity.description.trim()
+                            ? activity.description.trim().charAt(0).toUpperCase() + activity.description.trim().slice(1)
                             : "No description available"}
                     </h4>
                     {activity.activity_by && (

--- a/src/vertex/app/changelog.md
+++ b/src/vertex/app/changelog.md
@@ -2,6 +2,41 @@
 
 > **Note**: This changelog consolidates all recent improvements, features, and fixes to the AirQo Vertex frontend.
 
+## Version 2.0.15
+**Released:** July 6, 2026
+
+### Device Activity Crash Fix & Root-Layout Error Boundary
+
+Fixed a crash on the Device Details page caused by activity records with a missing `description`, and closed a gap where errors escaping the root layout fell through to Next.js's generic, unstyled error screen instead of the app's branded error UI.
+
+<details>
+<summary><strong>Device Activity Timeline Crash Fix (2)</strong></summary>
+
+- **`device-activity-item.tsx`**: `activity.description.charAt(0)` was called unconditionally, crashing the whole page whenever the API returned an activity record with a `null`/missing `description` (the rest of the file already guarded this field with a `typeof` check — this one call site was missed). Now falls back to `"No description available"` when the field isn't a non-empty string.
+- Applied the identical guard to the duplicated component in `vertex-template` for consistency.
+
+</details>
+
+<details>
+<summary><strong>New: `app/global-error.tsx`</strong></summary>
+
+- Next.js's `app/error.tsx` only catches errors thrown in nested route segments — it can't catch errors thrown in the root layout itself (e.g. a crash inside `Providers`/`ClientLayout`). Without a `global-error.tsx`, those errors fell through to Next's hardcoded "Application error: a client-side exception has occurred" fallback.
+- Added a self-contained `global-error.tsx` (own `<html>`/`<body>`, no Redux dependency since the store itself may be the thing that crashed) styled to match the existing `ForbiddenError` page — same `OopsIcon`, "Oops!" heading pattern, `ReusableButton` actions ("Go to Login" / "Try again"), and error-code footer convention.
+- Verified against a production build (`next build && next start`); dev mode's overlay masks this boundary entirely, so testing had to happen outside dev mode.
+
+</details>
+
+<details>
+<summary><strong>Files Modified &amp; Added (3)</strong></summary>
+
+- `src/vertex/components/features/devices/device-activity-item.tsx` [MODIFIED]
+- `src/vertex-template/components/features/devices/device-activity-item.tsx` [MODIFIED]
+- `src/vertex/app/global-error.tsx` [NEW]
+
+</details>
+
+---
+
 ## Version 2.0.14
 **Released:** July 5, 2026
 

--- a/src/vertex/app/global-error.tsx
+++ b/src/vertex/app/global-error.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { useEffect } from 'react';
+import './globals.css';
+import logger from '@/lib/logger';
+import OopsIcon from '@/public/icons/Errors/OopsIcon';
+import ReusableButton from '@/components/shared/button/ReusableButton';
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    logger.error('Root layout error', error);
+  }, [error]);
+
+  return (
+    <html lang="en">
+      <body className="min-h-screen bg-background antialiased">
+        <div className="relative w-screen h-screen overflow-x-hidden flex items-center justify-center">
+          <div className="flex flex-col justify-center items-center w-full md:px-48 px-6">
+            <OopsIcon className="text-primary" />
+
+            <div className="flex flex-col justify-center items-center w-full mt-6">
+              <h1 className="text-4xl md:text-[40px] font-normal w-full max-w-xl text-center text-gray-900 md:leading-[56px]">
+                <span className="text-primary font-bold">Oops!</span> Something went wrong.
+              </h1>
+              <span className="text-primary/70 mt-2 text-center">
+                We apologize for the inconvenience. Please try again or return to login.
+              </span>
+
+              <div className="flex gap-4 mt-6">
+                <ReusableButton
+                  variant="outlined"
+                  className="w-40"
+                  onClick={() => window.location.assign('/login')}
+                >
+                  Go to Login
+                </ReusableButton>
+                <ReusableButton className="w-40" onClick={() => reset()}>
+                  Try again
+                </ReusableButton>
+              </div>
+
+              <p className="text-center text-gray-400 py-6">
+                Error code: 500 application error
+              </p>
+            </div>
+          </div>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/src/vertex/components/features/devices/device-activity-item.tsx
+++ b/src/vertex/components/features/devices/device-activity-item.tsx
@@ -58,7 +58,9 @@ const DeviceActivityItem: React.FC<DeviceActivityItemProps> = ({
                         </span>
                     </div>
                     <h4 className="text-base font-medium text-gray-900 leading-none">
-                        {activity.description.charAt(0).toUpperCase() + activity.description.slice(1)}
+                        {typeof activity.description === "string" && activity.description
+                            ? activity.description.charAt(0).toUpperCase() + activity.description.slice(1)
+                            : "No description available"}
                     </h4>
                     {activity.activity_by && (
                         <div className="text-sm text-gray-500">

--- a/src/vertex/components/features/devices/device-activity-item.tsx
+++ b/src/vertex/components/features/devices/device-activity-item.tsx
@@ -58,8 +58,8 @@ const DeviceActivityItem: React.FC<DeviceActivityItemProps> = ({
                         </span>
                     </div>
                     <h4 className="text-base font-medium text-gray-900 leading-none">
-                        {typeof activity.description === "string" && activity.description
-                            ? activity.description.charAt(0).toUpperCase() + activity.description.slice(1)
+                        {typeof activity.description === "string" && activity.description.trim()
+                            ? activity.description.trim().charAt(0).toUpperCase() + activity.description.trim().slice(1)
                             : "No description available"}
                     </h4>
                     {activity.activity_by && (


### PR DESCRIPTION
## Summary
- Guard against activity records with a missing `description` before calling `.charAt` on it — this was crashing the Device Details page (e.g. `admin/networks/[id]/devices/[deviceId]`) whenever the API returned an activity with a null/missing description. Fixed in both `src/vertex` and the duplicated `src/vertex-template` copy.
- Add `src/vertex/app/global-error.tsx` to catch errors that escape the root layout (e.g. a crash inside `Providers`), which previously fell through to Next.js's generic unstyled "Application error: a client-side exception has occurred" screen. Styled to match the existing `ForbiddenError` page (`OopsIcon`, "Oops!" heading, `ReusableButton` actions, error-code footer).
- Updated `src/vertex/app/changelog.md` with a new Version 2.0.15 entry.

## Test plan
- [x] `tsc --noEmit` passes for both `device-activity-item.tsx` fixes
- [x] Verified `global-error.tsx` renders correctly in a **production build** (`next build && next start`) by forcing a root-layout crash — confirmed the branded fallback UI renders instead of Next's default, and both "Go to Login" and "Try again" actions work
- [ ] Manual smoke test on staging deploy for the original device details page crash

<img width="1280" height="878" alt="image" src="https://github.com/user-attachments/assets/469e3e88-6a3b-4d54-8df5-89847ddeed0f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Device Activity Timeline rendering so missing or non-text activity descriptions now display “No description available” instead of causing display issues.
  * Improved app-wide error handling to consistently show the branded error screen (with retry and a button to return to login) rather than an unstyled fallback.
* **Documentation**
  * Updated the app changelog with a new Version 2.0.15 entry detailing these fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->