### PR TITLE
Add trip exposure route analysis flow

### DIFF
--- a/src/mobile/docs/exposure-route-api-ideation.md
+++ b/src/mobile/docs/exposure-route-api-ideation.md
@@ -1,0 +1,229 @@
+# Exposure Route API Ideation Notes
+
+This note captures the route-based air quality documentation shared in screenshots and connects it to the current mobile Exposure feature for future design and implementation work.
+
+## Why This Matters
+
+The current Exposure tab in mobile is place-based:
+
+- Users declare places like `Home`, `Work`, or `School`
+- The app fetches hourly PM2.5 for those saved places
+- Exposure is summarized by time windows and simple `Low` / `Moderate` / `High` levels
+- `My Trips` is still a placeholder in the current UI
+
+The route API documented below gives us a realistic path toward a trip-based exposure experience.
+
+## Documented API Concept
+
+The screenshots describe a two-step route workflow:
+
+1. Find monitoring locations near a travel route
+2. Use the returned site IDs to fetch actual air quality measurements
+
+This enables route-aware exposure instead of only place-aware exposure.
+
+## Step 1: Find Nearest Locations
+
+Endpoint:
+
+```text
+POST /api/v2/devices/metadata/routes/nearest-locations
+```
+
+Purpose:
+
+- Identify air quality monitoring locations within a configurable distance from a route polyline
+
+Request body:
+
+| Parameter | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `polyline` | `Array<Object>` | Yes | Route coordinates; must contain at least 2 points |
+| `radius` | `number` | Yes | Search radius in kilometers; valid range `0.1 - 50` |
+
+Polyline object structure:
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `lat` | `number` | Yes | Latitude, valid range `-90 to 90` |
+| `lng` | `number` | Yes | Longitude, valid range `-180 to 180` |
+
+Important note from the docs:
+
+- Polyline coordinates are expected to come from a mapping provider after decoding an encoded route polyline
+
+## Step 2: Obtain the Route Polyline
+
+Before calling the route endpoint, a client app must generate a route polyline from a mapping service.
+
+Recommended sources from the screenshots:
+
+- Google Maps Directions API
+- Mapbox Directions API
+- OpenRouteService
+
+Expected process:
+
+1. Request a route between origin and destination
+2. Extract the encoded polyline from the response
+3. Decode it into `[{ lat, lng }]`
+
+Polyline decoding libraries mentioned:
+
+- JavaScript/TypeScript: `@googlemaps/polyline-codec`, `polyline-encoded`
+- Flutter/Dart: `flutter_polyline_points`
+- Python: `polyline`
+
+## Step 3: Retrieve Air Quality Measurements
+
+Once nearby monitoring locations are found, the docs show a second fetch for actual measurements.
+
+Example pattern:
+
+```text
+/api/v2/devices/measurements?site_id=<comma-separated-site-ids>&recent=yes
+```
+
+Purpose:
+
+- Convert route-adjacent site IDs into actual air quality data that the app can rank, display, or summarize
+
+## End-to-End Workflow
+
+From the screenshots, the complete route flow is:
+
+1. Get route polyline from a mapping service
+2. Call `POST /api/v2/devices/metadata/routes/nearest-locations`
+3. Extract returned nearby site IDs
+4. Fetch measurements for those site IDs
+5. Display route-aware air quality in the UI
+
+## Common Use Cases From the Docs
+
+- Mobile navigation apps
+  - Show route air quality to help users make informed travel decisions
+- Fleet management
+  - Monitor route exposure for vehicles and optimize routes for driver health
+- Urban planning
+  - Identify weak monitoring coverage along road networks
+- Health applications
+  - Recommend cleaner routes for people with respiratory conditions
+
+## Best Practices From the Docs
+
+1. Optimize polyline density
+   - Too many points may hurt performance
+   - Too few points may miss relevant nearby locations
+2. Choose search radius by context
+   - Urban: `0.5 - 2 km`
+   - Suburban: `2 - 5 km`
+   - Rural: `5 - 20 km`
+3. Handle empty results safely
+4. Cache results for common or repeated routes
+5. Add robust network and API error handling
+6. Be mindful of rate limiting for frequent live route checks
+
+## What This Could Mean For The Current Mobile Exposure Feature
+
+The current codebase already supports:
+
+- Place-based exposure
+- Hourly readings by saved site
+- A `My Trips` tab placeholder
+
+This route API suggests a clean `Exposure v2` direction:
+
+### Product direction
+
+- Turn `My Trips` into a real trip exposure workflow
+- Let users compare two routes by air quality
+- Show cleaner commute options, not just destination air quality
+- Surface “high exposure segments” along a trip
+
+### Data flow direction
+
+Possible mobile flow:
+
+1. User chooses origin and destination
+2. App requests route polyline from mapping provider
+3. App calls route-nearest-locations endpoint
+4. App fetches measurements for returned site IDs
+5. App computes route summary metrics
+6. App renders:
+   - cleanest route
+   - average route exposure
+   - highest-risk segment
+   - time-of-day recommendations
+
+## Strong Feature Ideas For Ideation
+
+### 1. My Trips becomes real
+
+- Saved commute routes
+- Typical departure windows
+- Daily trip exposure summary
+
+### 2. Cleaner route recommendations
+
+- “Fastest route” vs “cleaner route”
+- Simple tradeoff messaging like:
+  - `+8 mins, lower PM2.5`
+
+### 3. Route segment insights
+
+- Highlight dirty segments along the route
+- Show where readings spike
+
+### 4. Exposure-aware alerts
+
+- Warn if a frequently used route is unusually polluted today
+- Suggest alternate route or delayed departure
+
+### 5. Research and health use cases
+
+- Repeated route exposure logging
+- Exposure trends across commutes
+- Symptom survey prompts after high-exposure trips
+
+## Implementation Notes For Flutter Mobile
+
+Likely building blocks in the current app:
+
+- Exposure tab shell:
+  - `src/mobile/lib/src/app/exposure/pages/exposure_dashboard_view.dart`
+- Current exposure models:
+  - `src/mobile/lib/src/app/exposure/models/declared_place.dart`
+- Current readings fetch pattern:
+  - `src/mobile/lib/src/app/exposure/repository/hourly_readings_repository_impl.dart`
+
+Probable new pieces:
+
+- Route selection model
+- Mapping provider integration
+- Polyline decoding utility
+- Route-nearby-locations repository
+- Route measurement aggregation service
+- `My Trips` production UI
+
+## Open Questions
+
+- What does the nearest-locations response schema look like exactly?
+- Does it return sites only, or also devices, cohorts, and grids in separate collections?
+- How should route exposure be summarized:
+  - average PM2.5
+  - weighted segment score
+  - worst-segment score
+  - time-weighted cumulative exposure
+- Should route results be cached per origin/destination pair?
+- Do we want single-route display first, or route comparison first?
+
+## Suggested Next Steps
+
+1. Confirm the exact response schema for `nearest-locations`
+2. Define a route exposure scoring model for mobile
+3. Decide whether `My Trips` starts with:
+   - saved commute routes
+   - one-off route checks
+   - route comparison
+4. Prototype a minimal flow using one route and one summary card
+5. Add product copy for route recommendations and exposure messaging

--- a/src/mobile/lib/src/app/exposure/models/route_exposure_summary.dart
+++ b/src/mobile/lib/src/app/exposure/models/route_exposure_summary.dart
@@ -1,0 +1,71 @@
+import 'package:airqo/src/app/dashboard/models/airquality_response.dart';
+import 'package:airqo/src/app/dashboard/models/user_preferences_model.dart';
+import 'package:airqo/src/app/exposure/models/declared_place.dart';
+import 'package:equatable/equatable.dart';
+
+class RouteMonitoringSite extends Equatable {
+  final String id;
+  final String name;
+
+  const RouteMonitoringSite({
+    required this.id,
+    required this.name,
+  });
+
+  @override
+  List<Object?> get props => [id, name];
+}
+
+class RouteExposureSummary extends Equatable {
+  final SelectedSite origin;
+  final SelectedSite destination;
+  final String distanceLabel;
+  final String durationLabel;
+  final double radiusKm;
+  final int sampledPointCount;
+  final List<RouteMonitoringSite> nearbySites;
+  final List<Measurement> measurements;
+  final double? averagePm25;
+  final double? peakPm25;
+  final ExposureLevel? exposureLevel;
+  final String headline;
+  final String guidance;
+  final String? highestSiteName;
+
+  const RouteExposureSummary({
+    required this.origin,
+    required this.destination,
+    required this.distanceLabel,
+    required this.durationLabel,
+    required this.radiusKm,
+    required this.sampledPointCount,
+    required this.nearbySites,
+    required this.measurements,
+    required this.averagePm25,
+    required this.peakPm25,
+    required this.exposureLevel,
+    required this.headline,
+    required this.guidance,
+    required this.highestSiteName,
+  });
+
+  bool get hasMeasurements => averagePm25 != null && peakPm25 != null;
+
+  @override
+  List<Object?> get props => [
+        origin,
+        destination,
+        distanceLabel,
+        durationLabel,
+        radiusKm,
+        sampledPointCount,
+        nearbySites,
+        measurements,
+        averagePm25,
+        peakPm25,
+        exposureLevel,
+        headline,
+        guidance,
+        highestSiteName,
+      ];
+}

--- a/src/mobile/lib/src/app/exposure/pages/exposure_dashboard_view.dart
+++ b/src/mobile/lib/src/app/exposure/pages/exposure_dashboard_view.dart
@@ -16,6 +16,7 @@ import 'package:airqo/src/app/exposure/models/declared_place.dart';
 import 'package:airqo/src/app/exposure/services/exposure_place_readings.dart';
 import 'package:airqo/src/app/exposure/widgets/declared_place_card.dart';
 import 'package:airqo/src/app/exposure/widgets/entry_place_card.dart';
+import 'package:airqo/src/app/exposure/widgets/my_trips_view.dart';
 import 'package:airqo/src/app/exposure/widgets/place_card_tour.dart';
 import 'package:airqo/src/meta/utils/colors.dart';
 
@@ -26,7 +27,6 @@ import 'package:airqo/src/meta/utils/colors.dart';
 /// Empty-state floating chips (SVG, tinted in _FloatingTypeTag).
 const String _kEmptyStateHomeIconAsset = 'assets/icons/home_icon.svg';
 const String _kEmptyStateWorkIconAsset = 'assets/icons/place_type_work_tab.svg';
-
 
 // ---------------------------------------------------------------------------
 
@@ -109,10 +109,13 @@ class _ExposureBodyState extends State<_ExposureBody> {
           final favourites = dashState is DashboardLoaded
               ? (dashState.userPreferences?.selectedSites ?? <SelectedSite>[])
               : <SelectedSite>[];
-          final untagged = favourites.where((s) => !declaredIds.contains(s.id)).toList();
+          final untagged =
+              favourites.where((s) => !declaredIds.contains(s.id)).toList();
 
-          final showEmptyMyPlaces =
-              loaded != null && _myPlacesSelected && declared.isEmpty && untagged.isEmpty;
+          final showEmptyMyPlaces = loaded != null &&
+              _myPlacesSelected &&
+              declared.isEmpty &&
+              untagged.isEmpty;
 
           /// Single "day of view" for cards (weekday vs weekend windows). Replace with
           /// calendar/date-picker state when historical days are supported.
@@ -134,8 +137,7 @@ class _ExposureBodyState extends State<_ExposureBody> {
               ),
               if (!_myPlacesSelected)
                 SliverFillRemaining(
-                  hasScrollBody: false,
-                  child: _MyTripsPlaceholder(isDark: Theme.of(context).brightness == Brightness.dark),
+                  child: MyTripsView(savedSites: favourites),
                 )
               else
                 SliverPadding(
@@ -156,14 +158,15 @@ class _ExposureBodyState extends State<_ExposureBody> {
                           // Attach key to first card so the tour can locate it.
                           key: i == 0 ? _firstCardKey : null,
                           place: p,
-                          exposureLevel: avg != null ? ExposureLevelExtension.fromPm25(avg) : null,
+                          exposureLevel: avg != null
+                              ? ExposureLevelExtension.fromPm25(avg)
+                              : null,
                           hourlyReadings: readings,
                           dayOfView: dayOfView,
                         );
                       }),
                       ...untagged.map((s) => EntryPlaceCard(site: s)),
-                      if (showEmptyMyPlaces)
-                        const _EmptyState(),
+                      if (showEmptyMyPlaces) const _EmptyState(),
                     ]),
                   ),
                 ),
@@ -257,7 +260,9 @@ class _ExposurePill extends StatelessWidget {
           decoration: BoxDecoration(
             color: selected
                 ? AppColors.primaryColor
-                : (isDark ? AppColors.darkHighlight : AppColors.dividerColorlight),
+                : (isDark
+                    ? AppColors.darkHighlight
+                    : AppColors.dividerColorlight),
             borderRadius: BorderRadius.circular(30),
           ),
           alignment: Alignment.center,
@@ -272,49 +277,6 @@ class _ExposurePill extends StatelessWidget {
             ),
           ),
         ),
-      ),
-    );
-  }
-}
-
-class _MyTripsPlaceholder extends StatelessWidget {
-  final bool isDark;
-
-  const _MyTripsPlaceholder({required this.isDark});
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 32),
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          Icon(
-            Icons.route_rounded,
-            size: 48,
-            color: isDark ? AppColors.boldHeadlineColor2 : AppColors.boldHeadlineColor,
-          ),
-          const SizedBox(height: 16),
-          Text(
-            'My Trips',
-            textAlign: TextAlign.center,
-            style: TextStyle(
-              fontSize: 18,
-              fontWeight: FontWeight.w600,
-              color: isDark ? Colors.white : AppColors.boldHeadlineColor5,
-            ),
-          ),
-          const SizedBox(height: 8),
-          Text(
-            'Trip-based exposure will show here.',
-            textAlign: TextAlign.center,
-            style: TextStyle(
-              fontSize: 15,
-              height: 1.4,
-              color: isDark ? AppColors.secondaryHeadlineColor2 : AppColors.boldHeadlineColor,
-            ),
-          ),
-        ],
       ),
     );
   }
@@ -430,7 +392,9 @@ class _EmptyState extends StatelessWidget {
               style: TextStyle(
                 fontSize: 15,
                 fontWeight: FontWeight.w400,
-                color: isDark ? AppColors.secondaryHeadlineColor2 : AppColors.boldHeadlineColor,
+                color: isDark
+                    ? AppColors.secondaryHeadlineColor2
+                    : AppColors.boldHeadlineColor,
                 height: 1.4,
               ),
             ),
@@ -475,6 +439,7 @@ class _PreviewCard extends StatelessWidget {
   final String name;
   final bool showBadge;
   final bool isDark;
+
   /// Shorter card for the second row (Kawempe) to keep CTA above the fold.
   final bool compact;
 
@@ -680,7 +645,8 @@ class _FloatingTypeTag extends StatelessWidget {
     final borderSide = isActive
         ? BorderSide.none
         : BorderSide(
-            color: isDark ? AppColors.dividerColordark : const Color(0xFFE1E7EC),
+            color:
+                isDark ? AppColors.dividerColordark : const Color(0xFFE1E7EC),
           );
 
     return Material(

--- a/src/mobile/lib/src/app/exposure/repository/route_exposure_repository.dart
+++ b/src/mobile/lib/src/app/exposure/repository/route_exposure_repository.dart
@@ -1,0 +1,10 @@
+import 'package:airqo/src/app/dashboard/models/user_preferences_model.dart';
+import 'package:airqo/src/app/exposure/models/route_exposure_summary.dart';
+
+abstract class RouteExposureRepository {
+  Future<RouteExposureSummary> buildTripExposure({
+    required SelectedSite origin,
+    required SelectedSite destination,
+    double radiusKm = 2.5,
+  });
+}

--- a/src/mobile/lib/src/app/exposure/repository/route_exposure_repository_impl.dart
+++ b/src/mobile/lib/src/app/exposure/repository/route_exposure_repository_impl.dart
@@ -1,0 +1,354 @@
+import 'dart:convert';
+
+import 'package:airqo/src/app/dashboard/models/airquality_response.dart';
+import 'package:airqo/src/app/dashboard/models/user_preferences_model.dart';
+import 'package:airqo/src/app/exposure/models/route_exposure_summary.dart';
+import 'package:airqo/src/app/exposure/repository/route_exposure_repository.dart';
+import 'package:airqo/src/app/exposure/services/route_exposure_summary_builder.dart';
+import 'package:airqo/src/app/shared/repository/secure_storage_repository.dart';
+import 'package:airqo/src/meta/utils/api_utils.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:http/http.dart' as http;
+
+class RouteExposureRepositoryImpl implements RouteExposureRepository {
+  RouteExposureRepositoryImpl({
+    http.Client? httpClient,
+    RouteExposureSummaryBuilder? summaryBuilder,
+  })  : _httpClient = httpClient ?? http.Client(),
+        _summaryBuilder = summaryBuilder ?? const RouteExposureSummaryBuilder();
+
+  final http.Client _httpClient;
+  final RouteExposureSummaryBuilder _summaryBuilder;
+
+  @override
+  Future<RouteExposureSummary> buildTripExposure({
+    required SelectedSite origin,
+    required SelectedSite destination,
+    double radiusKm = 2.5,
+  }) async {
+    final originLat = origin.latitude;
+    final originLng = origin.longitude;
+    final destinationLat = destination.latitude;
+    final destinationLng = destination.longitude;
+
+    if (originLat == null || originLng == null) {
+      throw Exception('The origin location is missing coordinates.');
+    }
+    if (destinationLat == null || destinationLng == null) {
+      throw Exception('The destination location is missing coordinates.');
+    }
+
+    final directions = await _fetchDirections(
+      originName: origin.name,
+      originLat: originLat,
+      originLng: originLng,
+      destinationName: destination.name,
+      destinationLat: destinationLat,
+      destinationLng: destinationLng,
+    );
+    final nearbySites = await _fetchNearbySites(
+      routePoints: directions.routePoints,
+      radiusKm: radiusKm,
+    );
+    final measurements = await _fetchMeasurements(nearbySites);
+
+    return _summaryBuilder.build(
+      origin: origin,
+      destination: destination,
+      distanceLabel: directions.distanceLabel,
+      durationLabel: directions.durationLabel,
+      radiusKm: radiusKm,
+      sampledPointCount: directions.routePoints.length,
+      nearbySites: nearbySites,
+      measurements: measurements,
+    );
+  }
+
+  Future<_DirectionsRoute> _fetchDirections({
+    required String originName,
+    required double originLat,
+    required double originLng,
+    required String destinationName,
+    required double destinationLat,
+    required double destinationLng,
+  }) async {
+    final apiKey = dotenv.env['GOOGLE_MAPS_API_KEY'];
+    if (apiKey == null || apiKey.isEmpty) {
+      throw Exception(
+          'GOOGLE_MAPS_API_KEY is missing from the mobile environment.');
+    }
+
+    final uri = Uri.https('maps.googleapis.com', '/maps/api/directions/json', {
+      'origin': '$originLat,$originLng',
+      'destination': '$destinationLat,$destinationLng',
+      'mode': 'driving',
+      'key': apiKey,
+    });
+
+    final response = await _httpClient.get(uri);
+    if (response.statusCode != 200) {
+      throw Exception('Failed to fetch trip directions.');
+    }
+
+    final body = jsonDecode(response.body) as Map<String, dynamic>;
+    final status = (body['status'] ?? '').toString();
+    final errorMessage = (body['error_message'] ?? '').toString();
+    final routes = (body['routes'] as List<dynamic>? ?? const []);
+    if (routes.isEmpty) {
+      throw Exception(
+        _directionsErrorMessage(
+          originName: originName,
+          destinationName: destinationName,
+          status: status,
+          errorMessage: errorMessage,
+        ),
+      );
+    }
+
+    final route = routes.first as Map<String, dynamic>;
+    final legs = (route['legs'] as List<dynamic>? ?? const []);
+    if (legs.isEmpty) {
+      throw Exception('No trip leg details were returned for this route.');
+    }
+
+    final leg = legs.first as Map<String, dynamic>;
+    final encodedPolyline = ((route['overview_polyline']
+            as Map<String, dynamic>?)?['points'] as String?) ??
+        '';
+    final routePoints = _thinPolyline(_decodePolyline(encodedPolyline));
+    if (routePoints.length < 2) {
+      throw Exception('The route polyline was too short to analyze.');
+    }
+
+    return _DirectionsRoute(
+      routePoints: routePoints,
+      distanceLabel:
+          ((leg['distance'] as Map<String, dynamic>?)?['text'] as String?) ??
+              '--',
+      durationLabel:
+          ((leg['duration'] as Map<String, dynamic>?)?['text'] as String?) ??
+              '--',
+    );
+  }
+
+  Future<List<RouteMonitoringSite>> _fetchNearbySites({
+    required List<_RoutePoint> routePoints,
+    required double radiusKm,
+  }) async {
+    final response = await _httpClient.post(
+      Uri.parse(
+          '${ApiUtils.baseUrl}/api/v2/devices/metadata/routes/nearest-locations'),
+      headers: await _getAuthHeaders(),
+      body: jsonEncode({
+        'polyline': routePoints
+            .map((point) => {
+                  'lat': point.lat,
+                  'lng': point.lng,
+                })
+            .toList(),
+        'radius': radiusKm,
+      }),
+    );
+
+    if (response.statusCode != 200) {
+      throw Exception('Failed to find monitoring locations near this route.');
+    }
+
+    final body = jsonDecode(response.body) as Map<String, dynamic>;
+    final data = body['data'] ?? body;
+    final rawSites = data is Map<String, dynamic>
+        ? data['sites'] ?? data['siteDetails']
+        : data;
+    if (rawSites is! List) {
+      return const [];
+    }
+
+    final seenIds = <String>{};
+    final sites = <RouteMonitoringSite>[];
+    for (final item in rawSites.whereType<Map<String, dynamic>>()) {
+      final id =
+          (item['_id'] ?? item['id'] ?? item['site_id'] ?? '').toString();
+      if (id.isEmpty || seenIds.contains(id)) {
+        continue;
+      }
+      final name = (item['name'] ??
+              item['site_name'] ??
+              item['search_name'] ??
+              'Unnamed site')
+          .toString();
+      seenIds.add(id);
+      sites.add(RouteMonitoringSite(id: id, name: name));
+    }
+    return sites;
+  }
+
+  Future<List<Measurement>> _fetchMeasurements(
+      List<RouteMonitoringSite> nearbySites) async {
+    if (nearbySites.isEmpty) {
+      return const [];
+    }
+
+    final uri =
+        Uri.parse('${ApiUtils.baseUrl}/api/v2/devices/measurements').replace(
+      queryParameters: {
+        'site_id': nearbySites.map((site) => site.id).join(','),
+        'recent': 'yes',
+      },
+    );
+
+    final response =
+        await _httpClient.get(uri, headers: await _getAuthHeaders());
+    if (response.statusCode != 200) {
+      throw Exception('Failed to fetch route measurements.');
+    }
+
+    final body = jsonDecode(response.body) as Map<String, dynamic>;
+    final rawMeasurements = body['measurements'] ??
+        body['data'] ??
+        body['readings'] ??
+        ((body['data'] is Map<String, dynamic>)
+            ? body['data']['measurements']
+            : null);
+
+    if (rawMeasurements is! List) {
+      return const [];
+    }
+
+    return rawMeasurements
+        .whereType<Map<String, dynamic>>()
+        .map(Measurement.fromJson)
+        .where((measurement) => measurement.pm25?.value != null)
+        .toList();
+  }
+
+  Future<Map<String, String>> _getAuthHeaders() async {
+    final headers = <String, String>{
+      'Accept': 'application/json',
+      'Content-Type': 'application/json',
+      'User-Agent': ApiUtils.mobileUserAgent,
+    };
+
+    final userToken = await SecureStorageRepository.instance
+        .getSecureData(SecureStorageKeys.authToken);
+    if (userToken != null && userToken.isNotEmpty) {
+      headers['Authorization'] = 'JWT $userToken';
+      return headers;
+    }
+
+    final appToken = dotenv.env['AIRQO_MOBILE_TOKEN'];
+    if (appToken != null && appToken.isNotEmpty) {
+      headers['Authorization'] = 'JWT $appToken';
+    }
+    return headers;
+  }
+
+  List<_RoutePoint> _decodePolyline(String encoded) {
+    if (encoded.isEmpty) {
+      return const [];
+    }
+
+    final points = <_RoutePoint>[];
+    var index = 0;
+    var lat = 0;
+    var lng = 0;
+
+    while (index < encoded.length) {
+      var shift = 0;
+      var result = 0;
+      int byte;
+      do {
+        byte = encoded.codeUnitAt(index++) - 63;
+        result |= (byte & 0x1f) << shift;
+        shift += 5;
+      } while (byte >= 0x20);
+      final deltaLat = (result & 1) != 0 ? ~(result >> 1) : (result >> 1);
+      lat += deltaLat;
+
+      shift = 0;
+      result = 0;
+      do {
+        byte = encoded.codeUnitAt(index++) - 63;
+        result |= (byte & 0x1f) << shift;
+        shift += 5;
+      } while (byte >= 0x20);
+      final deltaLng = (result & 1) != 0 ? ~(result >> 1) : (result >> 1);
+      lng += deltaLng;
+
+      points.add(_RoutePoint(lat / 1E5, lng / 1E5));
+    }
+
+    return points;
+  }
+
+  List<_RoutePoint> _thinPolyline(List<_RoutePoint> points,
+      {int maxPoints = 60}) {
+    if (points.length <= maxPoints) {
+      return points;
+    }
+
+    final stride = (points.length / maxPoints).ceil();
+    final sampled = <_RoutePoint>[];
+    for (var index = 0; index < points.length; index += stride) {
+      sampled.add(points[index]);
+    }
+    if (sampled.last != points.last) {
+      sampled.add(points.last);
+    }
+    return sampled;
+  }
+
+  String _directionsErrorMessage({
+    required String originName,
+    required String destinationName,
+    required String status,
+    required String errorMessage,
+  }) {
+    final statusText = status.isEmpty ? 'UNKNOWN' : status;
+    final providerDetail = errorMessage.isEmpty ? '' : ' $errorMessage';
+
+    switch (statusText) {
+      case 'ZERO_RESULTS':
+        return 'Google Maps could not find a drivable route between $originName and $destinationName using the saved place coordinates. Try a different pair of saved places or re-save one of them.';
+      case 'NOT_FOUND':
+        return 'Google Maps could not recognize the saved coordinates for $originName or $destinationName. Try re-saving the place.$providerDetail';
+      case 'REQUEST_DENIED':
+        return 'Google Maps rejected the route request.$providerDetail';
+      case 'OVER_QUERY_LIMIT':
+        return 'Google Maps rate-limited the route request. Please try again in a moment.';
+      case 'INVALID_REQUEST':
+        return 'The route request was incomplete. Please try a different trip.';
+      default:
+        return 'Google Maps did not return a usable route between $originName and $destinationName ($statusText).$providerDetail';
+    }
+  }
+}
+
+class _DirectionsRoute {
+  final List<_RoutePoint> routePoints;
+  final String distanceLabel;
+  final String durationLabel;
+
+  const _DirectionsRoute({
+    required this.routePoints,
+    required this.distanceLabel,
+    required this.durationLabel,
+  });
+}
+
+class _RoutePoint {
+  final double lat;
+  final double lng;
+
+  const _RoutePoint(this.lat, this.lng);
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is _RoutePoint &&
+          runtimeType == other.runtimeType &&
+          lat == other.lat &&
+          lng == other.lng;
+
+  @override
+  int get hashCode => Object.hash(lat, lng);
+}

--- a/src/mobile/lib/src/app/exposure/repository/route_exposure_repository_impl.dart
+++ b/src/mobile/lib/src/app/exposure/repository/route_exposure_repository_impl.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:airqo/src/app/dashboard/models/airquality_response.dart';
@@ -11,6 +12,8 @@ import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:http/http.dart' as http;
 
 class RouteExposureRepositoryImpl implements RouteExposureRepository {
+  static const Duration _requestTimeout = Duration(seconds: 15);
+
   RouteExposureRepositoryImpl({
     http.Client? httpClient,
     RouteExposureSummaryBuilder? summaryBuilder,
@@ -85,7 +88,10 @@ class RouteExposureRepositoryImpl implements RouteExposureRepository {
       'key': apiKey,
     });
 
-    final response = await _httpClient.get(uri);
+    final response = await _withRequestTimeout(
+      _httpClient.get(uri),
+      'Trip directions request timed out.',
+    );
     if (response.statusCode != 200) {
       throw Exception('Failed to fetch trip directions.');
     }
@@ -135,19 +141,22 @@ class RouteExposureRepositoryImpl implements RouteExposureRepository {
     required List<_RoutePoint> routePoints,
     required double radiusKm,
   }) async {
-    final response = await _httpClient.post(
-      Uri.parse(
-          '${ApiUtils.baseUrl}/api/v2/devices/metadata/routes/nearest-locations'),
-      headers: await _getAuthHeaders(),
-      body: jsonEncode({
-        'polyline': routePoints
-            .map((point) => {
-                  'lat': point.lat,
-                  'lng': point.lng,
-                })
-            .toList(),
-        'radius': radiusKm,
-      }),
+    final response = await _withRequestTimeout(
+      _httpClient.post(
+        Uri.parse(
+            '${ApiUtils.baseUrl}/api/v2/devices/metadata/routes/nearest-locations'),
+        headers: await _getAuthHeaders(),
+        body: jsonEncode({
+          'polyline': routePoints
+              .map((point) => {
+                    'lat': point.lat,
+                    'lng': point.lng,
+                  })
+              .toList(),
+          'radius': radiusKm,
+        }),
+      ),
+      'Route monitoring locations request timed out.',
     );
 
     if (response.statusCode != 200) {
@@ -196,8 +205,10 @@ class RouteExposureRepositoryImpl implements RouteExposureRepository {
       },
     );
 
-    final response =
-        await _httpClient.get(uri, headers: await _getAuthHeaders());
+    final response = await _withRequestTimeout(
+      _httpClient.get(uri, headers: await _getAuthHeaders()),
+      'Route measurements request timed out.',
+    );
     if (response.statusCode != 200) {
       throw Exception('Failed to fetch route measurements.');
     }
@@ -240,6 +251,17 @@ class RouteExposureRepositoryImpl implements RouteExposureRepository {
       headers['Authorization'] = 'JWT $appToken';
     }
     return headers;
+  }
+
+  Future<http.Response> _withRequestTimeout(
+    Future<http.Response> request,
+    String timeoutMessage,
+  ) async {
+    try {
+      return await request.timeout(_requestTimeout);
+    } on TimeoutException {
+      throw Exception(timeoutMessage);
+    }
   }
 
   List<_RoutePoint> _decodePolyline(String encoded) {

--- a/src/mobile/lib/src/app/exposure/services/route_exposure_summary_builder.dart
+++ b/src/mobile/lib/src/app/exposure/services/route_exposure_summary_builder.dart
@@ -1,0 +1,106 @@
+import 'package:airqo/src/app/dashboard/models/airquality_response.dart';
+import 'package:airqo/src/app/dashboard/models/user_preferences_model.dart';
+import 'package:airqo/src/app/exposure/models/declared_place.dart';
+import 'package:airqo/src/app/exposure/models/route_exposure_summary.dart';
+
+class RouteExposureSummaryBuilder {
+  const RouteExposureSummaryBuilder();
+
+  RouteExposureSummary build({
+    required SelectedSite origin,
+    required SelectedSite destination,
+    required String distanceLabel,
+    required String durationLabel,
+    required double radiusKm,
+    required int sampledPointCount,
+    required List<RouteMonitoringSite> nearbySites,
+    required List<Measurement> measurements,
+  }) {
+    final pm25Values = measurements
+        .map((measurement) => measurement.pm25?.value)
+        .whereType<double>()
+        .toList();
+
+    if (pm25Values.isEmpty) {
+      return RouteExposureSummary(
+        origin: origin,
+        destination: destination,
+        distanceLabel: distanceLabel,
+        durationLabel: durationLabel,
+        radiusKm: radiusKm,
+        sampledPointCount: sampledPointCount,
+        nearbySites: nearbySites,
+        measurements: measurements,
+        averagePm25: null,
+        peakPm25: null,
+        exposureLevel: null,
+        headline: nearbySites.isEmpty
+            ? 'No route monitoring coverage'
+            : 'No recent route readings yet',
+        guidance: nearbySites.isEmpty
+            ? 'We did not find monitoring locations close to this route. Try another route or check a busier corridor.'
+            : 'We found nearby monitoring locations, but none had recent PM2.5 readings to summarize right now.',
+        highestSiteName: null,
+      );
+    }
+
+    final averagePm25 =
+        pm25Values.reduce((sum, value) => sum + value) / pm25Values.length;
+    final peakPm25 =
+        pm25Values.reduce((left, right) => left > right ? left : right);
+    final exposureLevel = ExposureLevelExtension.fromPm25(averagePm25);
+
+    Measurement? highestMeasurement;
+    for (final measurement in measurements) {
+      if (measurement.pm25?.value == peakPm25) {
+        highestMeasurement = measurement;
+        break;
+      }
+    }
+
+    return RouteExposureSummary(
+      origin: origin,
+      destination: destination,
+      distanceLabel: distanceLabel,
+      durationLabel: durationLabel,
+      radiusKm: radiusKm,
+      sampledPointCount: sampledPointCount,
+      nearbySites: nearbySites,
+      measurements: measurements,
+      averagePm25: averagePm25,
+      peakPm25: peakPm25,
+      exposureLevel: exposureLevel,
+      headline: _headlineFor(exposureLevel),
+      guidance: _guidanceFor(exposureLevel, origin.name, destination.name),
+      highestSiteName: highestMeasurement?.siteDetails?.name ??
+          highestMeasurement?.siteId ??
+          (nearbySites.isNotEmpty ? nearbySites.first.name : null),
+    );
+  }
+
+  String _headlineFor(ExposureLevel level) {
+    switch (level) {
+      case ExposureLevel.low:
+        return 'This route looks relatively clean';
+      case ExposureLevel.moderate:
+        return 'This route has noticeable pollution';
+      case ExposureLevel.high:
+        return 'This route has elevated exposure';
+    }
+  }
+
+  String _guidanceFor(
+    ExposureLevel level,
+    String originName,
+    String destinationName,
+  ) {
+    switch (level) {
+      case ExposureLevel.low:
+        return 'Air between $originName and $destinationName is mostly clean based on nearby route monitors.';
+      case ExposureLevel.moderate:
+        return 'Air between $originName and $destinationName is mixed. Sensitive groups may want to reduce repeated exposure on this trip.';
+      case ExposureLevel.high:
+        return 'Air between $originName and $destinationName is elevated along this route. If possible, reduce travel during dirtier hours.';
+    }
+  }
+}

--- a/src/mobile/lib/src/app/exposure/services/route_exposure_summary_builder.dart
+++ b/src/mobile/lib/src/app/exposure/services/route_exposure_summary_builder.dart
@@ -72,9 +72,8 @@ class RouteExposureSummaryBuilder {
       exposureLevel: exposureLevel,
       headline: _headlineFor(exposureLevel),
       guidance: _guidanceFor(exposureLevel, origin.name, destination.name),
-      highestSiteName: highestMeasurement?.siteDetails?.name ??
-          highestMeasurement?.siteId ??
-          (nearbySites.isNotEmpty ? nearbySites.first.name : null),
+      highestSiteName:
+          highestMeasurement?.siteDetails?.name ?? highestMeasurement?.siteId,
     );
   }
 

--- a/src/mobile/lib/src/app/exposure/widgets/my_trips_view.dart
+++ b/src/mobile/lib/src/app/exposure/widgets/my_trips_view.dart
@@ -1,0 +1,579 @@
+import 'package:airqo/src/app/dashboard/models/user_preferences_model.dart';
+import 'package:airqo/src/app/exposure/models/route_exposure_summary.dart';
+import 'package:airqo/src/app/exposure/repository/route_exposure_repository.dart';
+import 'package:airqo/src/app/exposure/repository/route_exposure_repository_impl.dart';
+import 'package:airqo/src/app/exposure/widgets/exposure_level_chip.dart';
+import 'package:airqo/src/meta/utils/colors.dart';
+import 'package:flutter/material.dart';
+
+class MyTripsView extends StatefulWidget {
+  const MyTripsView({
+    super.key,
+    required this.savedSites,
+    RouteExposureRepository? repository,
+  }) : repository = repository ?? const _RouteExposureRepositoryFactory();
+
+  final List<SelectedSite> savedSites;
+  final RouteExposureRepository repository;
+
+  @override
+  State<MyTripsView> createState() => _MyTripsViewState();
+}
+
+class _MyTripsViewState extends State<MyTripsView> {
+  String? _originId;
+  String? _destinationId;
+  bool _isLoading = false;
+  String? _errorMessage;
+  RouteExposureSummary? _summary;
+
+  List<SelectedSite> get _eligibleSites => widget.savedSites
+      .where((site) => site.latitude != null && site.longitude != null)
+      .toList();
+
+  @override
+  void initState() {
+    super.initState();
+    _syncSelection();
+  }
+
+  @override
+  void didUpdateWidget(covariant MyTripsView oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.savedSites != widget.savedSites) {
+      _syncSelection();
+    }
+  }
+
+  void _syncSelection() {
+    final sites = _eligibleSites;
+    if (sites.length < 2) {
+      _originId = null;
+      _destinationId = null;
+      return;
+    }
+
+    _originId =
+        sites.any((site) => site.id == _originId) ? _originId : sites.first.id;
+    final fallbackDestination = sites.firstWhere(
+      (site) => site.id != _originId,
+      orElse: () => sites[1],
+    );
+    _destinationId =
+        sites.any((site) => site.id == _destinationId && site.id != _originId)
+            ? _destinationId
+            : fallbackDestination.id;
+  }
+
+  SelectedSite? _findSite(String? id) {
+    for (final site in _eligibleSites) {
+      if (site.id == id) {
+        return site;
+      }
+    }
+    return null;
+  }
+
+  Future<void> _loadTripExposure() async {
+    final origin = _findSite(_originId);
+    final destination = _findSite(_destinationId);
+    if (origin == null || destination == null) {
+      return;
+    }
+
+    setState(() {
+      _isLoading = true;
+      _errorMessage = null;
+    });
+
+    try {
+      final summary = await widget.repository.buildTripExposure(
+        origin: origin,
+        destination: destination,
+      );
+      if (!mounted) return;
+      setState(() {
+        _summary = summary;
+      });
+    } catch (error) {
+      if (!mounted) return;
+      setState(() {
+        _errorMessage = error.toString().replaceFirst('Exception: ', '');
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final sites = _eligibleSites;
+    final titleColor = AppTextColors.headline(context);
+    final bodyColor = AppTextColors.muted(context);
+
+    if (sites.length < 2) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 28),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Text(
+                'Add at least two saved places to analyze a trip.',
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  fontSize: 18,
+                  fontWeight: FontWeight.w700,
+                  color: titleColor,
+                ),
+              ),
+              const SizedBox(height: 10),
+              Text(
+                'My Trips uses your existing saved AirQo locations as route endpoints.',
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  fontSize: 14,
+                  color: bodyColor,
+                  height: 1.5,
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    return ListView(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 32),
+      children: [
+        _TripSelectorCard(
+          sites: sites,
+          originId: _originId!,
+          destinationId: _destinationId!,
+          isLoading: _isLoading,
+          onOriginChanged: (value) {
+            setState(() {
+              _originId = value;
+              if (_destinationId == value) {
+                _destinationId =
+                    sites.firstWhere((site) => site.id != value).id;
+              }
+            });
+          },
+          onDestinationChanged: (value) {
+            setState(() {
+              _destinationId = value;
+            });
+          },
+          onSwap: () {
+            setState(() {
+              final currentOrigin = _originId;
+              _originId = _destinationId;
+              _destinationId = currentOrigin;
+            });
+          },
+          onAnalyze: _loadTripExposure,
+        ),
+        if (_errorMessage != null) ...[
+          const SizedBox(height: 12),
+          _TripMessageCard(
+            title: 'We could not analyze this trip',
+            message: _errorMessage!,
+            isError: true,
+          ),
+        ],
+        if (_summary != null) ...[
+          const SizedBox(height: 12),
+          _RouteExposureSummaryCard(summary: _summary!),
+        ],
+      ],
+    );
+  }
+}
+
+class _TripSelectorCard extends StatelessWidget {
+  const _TripSelectorCard({
+    required this.sites,
+    required this.originId,
+    required this.destinationId,
+    required this.isLoading,
+    required this.onOriginChanged,
+    required this.onDestinationChanged,
+    required this.onSwap,
+    required this.onAnalyze,
+  });
+
+  final List<SelectedSite> sites;
+  final String originId;
+  final String destinationId;
+  final bool isLoading;
+  final ValueChanged<String?> onOriginChanged;
+  final ValueChanged<String?> onDestinationChanged;
+  final VoidCallback onSwap;
+  final VoidCallback onAnalyze;
+
+  @override
+  Widget build(BuildContext context) {
+    final titleColor = AppTextColors.headline(context);
+    final bodyColor = AppTextColors.muted(context);
+
+    return Container(
+      decoration: AppSurfaceColors.elevatedCardDecoration(context, radius: 10),
+      padding: const EdgeInsets.all(18),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Check route exposure',
+            style: TextStyle(
+              fontSize: 18,
+              fontWeight: FontWeight.w700,
+              color: titleColor,
+            ),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            'Use your saved places as trip endpoints and summarize PM2.5 along the route.',
+            style: TextStyle(
+              fontSize: 14,
+              height: 1.5,
+              color: bodyColor,
+            ),
+          ),
+          const SizedBox(height: 16),
+          _TripDropdownField(
+            label: 'From',
+            value: originId,
+            sites: sites,
+            onChanged: onOriginChanged,
+          ),
+          const SizedBox(height: 12),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.end,
+            children: [
+              IconButton(
+                tooltip: 'Swap trip endpoints',
+                onPressed: isLoading ? null : onSwap,
+                icon: const Icon(Icons.swap_vert_rounded),
+              ),
+            ],
+          ),
+          _TripDropdownField(
+            label: 'To',
+            value: destinationId,
+            sites: sites,
+            onChanged: onDestinationChanged,
+          ),
+          const SizedBox(height: 18),
+          SizedBox(
+            width: double.infinity,
+            child: ElevatedButton(
+              onPressed:
+                  isLoading || originId == destinationId ? null : onAnalyze,
+              style: ElevatedButton.styleFrom(
+                backgroundColor: AppColors.primaryColor,
+                foregroundColor: Colors.white,
+                padding: const EdgeInsets.symmetric(vertical: 14),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(14),
+                ),
+              ),
+              child: isLoading
+                  ? const SizedBox(
+                      width: 20,
+                      height: 20,
+                      child: CircularProgressIndicator(
+                        strokeWidth: 2.2,
+                        valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+                      ),
+                    )
+                  : const Text(
+                      'Analyze trip exposure',
+                      style: TextStyle(fontWeight: FontWeight.w700),
+                    ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _TripDropdownField extends StatelessWidget {
+  const _TripDropdownField({
+    required this.label,
+    required this.value,
+    required this.sites,
+    required this.onChanged,
+  });
+
+  final String label;
+  final String value;
+  final List<SelectedSite> sites;
+  final ValueChanged<String?> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final fillColor = AppSurfaceColors.nested(context);
+    final borderColor = AppSurfaceColors.border(context);
+    final headlineColor = AppTextColors.headline(context);
+
+    return DropdownButtonFormField<String>(
+      key: ValueKey(value),
+      initialValue: value,
+      decoration: InputDecoration(
+        labelText: label,
+        filled: true,
+        fillColor: fillColor,
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(14),
+          borderSide: BorderSide(color: borderColor),
+        ),
+        enabledBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(14),
+          borderSide: BorderSide(color: borderColor),
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(14),
+          borderSide: BorderSide(color: AppColors.primaryColor),
+        ),
+      ),
+      items: sites
+          .map(
+            (site) => DropdownMenuItem<String>(
+              value: site.id,
+              child: Text(
+                site.name,
+                overflow: TextOverflow.ellipsis,
+                style: TextStyle(color: headlineColor),
+              ),
+            ),
+          )
+          .toList(),
+      onChanged: onChanged,
+    );
+  }
+}
+
+class _RouteExposureSummaryCard extends StatelessWidget {
+  const _RouteExposureSummaryCard({required this.summary});
+
+  final RouteExposureSummary summary;
+
+  @override
+  Widget build(BuildContext context) {
+    final titleColor = AppTextColors.headline(context);
+    final bodyColor = AppTextColors.muted(context);
+
+    return Container(
+      decoration: AppSurfaceColors.elevatedCardDecoration(context, radius: 10),
+      padding: const EdgeInsets.all(18),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            '${summary.origin.name} to ${summary.destination.name}',
+            style: TextStyle(
+              fontSize: 18,
+              fontWeight: FontWeight.w700,
+              color: titleColor,
+            ),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            '${summary.distanceLabel} • ${summary.durationLabel} • ${summary.nearbySites.length} nearby monitors',
+            style: TextStyle(
+              fontSize: 14,
+              color: bodyColor,
+            ),
+          ),
+          const SizedBox(height: 16),
+          if (summary.exposureLevel != null)
+            ExposureLevelChip(level: summary.exposureLevel!)
+          else
+            _TripMessageCard(
+              title: summary.headline,
+              message: summary.guidance,
+            ),
+          if (summary.hasMeasurements) ...[
+            const SizedBox(height: 16),
+            Row(
+              children: [
+                Expanded(
+                  child: _TripStatTile(
+                    label: 'Average PM2.5',
+                    value: '${summary.averagePm25!.toStringAsFixed(1)} µg/m³',
+                  ),
+                ),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: _TripStatTile(
+                    label: 'Peak PM2.5',
+                    value: '${summary.peakPm25!.toStringAsFixed(1)} µg/m³',
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            Text(
+              summary.headline,
+              style: TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.w700,
+                color: titleColor,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              summary.guidance,
+              style: TextStyle(
+                fontSize: 14,
+                height: 1.6,
+                color: bodyColor,
+              ),
+            ),
+            if (summary.highestSiteName != null) ...[
+              const SizedBox(height: 12),
+              Text(
+                'Highest route reading near ${summary.highestSiteName}',
+                style: TextStyle(
+                  fontSize: 13,
+                  fontWeight: FontWeight.w600,
+                  color: bodyColor,
+                ),
+              ),
+            ],
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _TripStatTile extends StatelessWidget {
+  const _TripStatTile({
+    required this.label,
+    required this.value,
+  });
+
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    final titleColor = AppTextColors.headline(context);
+    final bodyColor = AppTextColors.muted(context);
+
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: AppSurfaceColors.nested(context),
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(color: AppSurfaceColors.border(context)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            label,
+            style: TextStyle(
+              fontSize: 12,
+              color: bodyColor,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            value,
+            style: TextStyle(
+              fontSize: 16,
+              fontWeight: FontWeight.w700,
+              color: titleColor,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _TripMessageCard extends StatelessWidget {
+  const _TripMessageCard({
+    required this.title,
+    required this.message,
+    this.isError = false,
+  });
+
+  final String title;
+  final String message;
+  final bool isError;
+
+  @override
+  Widget build(BuildContext context) {
+    final backgroundColor = isError
+        ? AppTextColors.errorBackground(context)
+        : AppSurfaceColors.nested(context);
+    final titleColor = isError
+        ? AppTextColors.errorForeground(context)
+        : AppTextColors.headline(context);
+    final bodyColor = isError
+        ? AppTextColors.errorForeground(context)
+        : AppTextColors.muted(context);
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: backgroundColor,
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(
+          color: isError
+              ? AppTextColors.errorForeground(context).withValues(alpha: 0.25)
+              : AppSurfaceColors.border(context),
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: TextStyle(
+              fontSize: 15,
+              fontWeight: FontWeight.w700,
+              color: titleColor,
+            ),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            message,
+            style: TextStyle(
+              fontSize: 14,
+              height: 1.5,
+              color: bodyColor,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _RouteExposureRepositoryFactory implements RouteExposureRepository {
+  const _RouteExposureRepositoryFactory();
+
+  @override
+  Future<RouteExposureSummary> buildTripExposure({
+    required SelectedSite origin,
+    required SelectedSite destination,
+    double radiusKm = 2.5,
+  }) {
+    return RouteExposureRepositoryImpl().buildTripExposure(
+      origin: origin,
+      destination: destination,
+      radiusKm: radiusKm,
+    );
+  }
+}

--- a/src/mobile/lib/src/app/exposure/widgets/my_trips_view.dart
+++ b/src/mobile/lib/src/app/exposure/widgets/my_trips_view.dart
@@ -84,6 +84,7 @@ class _MyTripsViewState extends State<MyTripsView> {
     setState(() {
       _isLoading = true;
       _errorMessage = null;
+      _summary = null;
     });
 
     try {
@@ -158,6 +159,8 @@ class _MyTripsViewState extends State<MyTripsView> {
           onOriginChanged: (value) {
             setState(() {
               _originId = value;
+              _summary = null;
+              _errorMessage = null;
               if (_destinationId == value) {
                 _destinationId =
                     sites.firstWhere((site) => site.id != value).id;
@@ -167,6 +170,8 @@ class _MyTripsViewState extends State<MyTripsView> {
           onDestinationChanged: (value) {
             setState(() {
               _destinationId = value;
+              _summary = null;
+              _errorMessage = null;
             });
           },
           onSwap: () {
@@ -174,6 +179,8 @@ class _MyTripsViewState extends State<MyTripsView> {
               final currentOrigin = _originId;
               _originId = _destinationId;
               _destinationId = currentOrigin;
+              _summary = null;
+              _errorMessage = null;
             });
           },
           onAnalyze: _loadTripExposure,
@@ -564,13 +571,16 @@ class _TripMessageCard extends StatelessWidget {
 class _RouteExposureRepositoryFactory implements RouteExposureRepository {
   const _RouteExposureRepositoryFactory();
 
+  static final RouteExposureRepositoryImpl _delegate =
+      RouteExposureRepositoryImpl();
+
   @override
   Future<RouteExposureSummary> buildTripExposure({
     required SelectedSite origin,
     required SelectedSite destination,
     double radiusKm = 2.5,
   }) {
-    return RouteExposureRepositoryImpl().buildTripExposure(
+    return _delegate.buildTripExposure(
       origin: origin,
       destination: destination,
       radiusKm: radiusKm,

--- a/src/mobile/test/app/exposure/repository/route_exposure_repository_impl_test.dart
+++ b/src/mobile/test/app/exposure/repository/route_exposure_repository_impl_test.dart
@@ -1,0 +1,184 @@
+import 'dart:convert';
+
+import 'package:airqo/src/app/dashboard/models/user_preferences_model.dart';
+import 'package:airqo/src/app/exposure/models/declared_place.dart';
+import 'package:airqo/src/app/exposure/repository/route_exposure_repository_impl.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    dotenv.testLoad(mergeWith: {
+      'AIRQO_API_URL': 'https://api.airqo.net',
+      'AIRQO_MOBILE_TOKEN': 'test-token',
+      'GOOGLE_MAPS_API_KEY': 'test-maps-key',
+    });
+  });
+
+  test('buildTripExposure combines directions, nearby sites, and measurements',
+      () async {
+    final requests = <Uri>[];
+    final repository = RouteExposureRepositoryImpl(
+      httpClient: _FakeClient((request) async {
+        requests.add(request.url);
+
+        if (request.url.host == 'maps.googleapis.com') {
+          return http.Response(
+              jsonEncode({
+                'routes': [
+                  {
+                    'overview_polyline': {
+                      'points': '_p~iF~ps|U_ulLnnqC_mqNvxq`@',
+                    },
+                    'legs': [
+                      {
+                        'distance': {'text': '12 km'},
+                        'duration': {'text': '28 mins'},
+                      }
+                    ],
+                  }
+                ],
+              }),
+              200);
+        }
+
+        if (request.url.path
+            .endsWith('/devices/metadata/routes/nearest-locations')) {
+          final body = jsonDecode(request.body) as Map<String, dynamic>;
+          expect(body['radius'], 2.5);
+          expect((body['polyline'] as List).length, greaterThanOrEqualTo(2));
+
+          return http.Response(
+              jsonEncode({
+                'success': true,
+                'data': {
+                  'sites': [
+                    {'_id': 'site-1', 'name': 'Central Monitor'},
+                    {'_id': 'site-2', 'name': 'Roadside Monitor'},
+                  ],
+                },
+              }),
+              200);
+        }
+
+        if (request.url.path.endsWith('/devices/measurements')) {
+          expect(request.url.queryParameters['recent'], 'yes');
+          expect(request.url.queryParameters['site_id'], 'site-1,site-2');
+
+          return http.Response(
+              jsonEncode({
+                'measurements': [
+                  {
+                    'site_id': 'site-1',
+                    'siteDetails': {'name': 'Central Monitor'},
+                    'pm2_5': {'value': 18.4},
+                  },
+                  {
+                    'site_id': 'site-2',
+                    'siteDetails': {'name': 'Roadside Monitor'},
+                    'pm2_5': {'value': 42.7},
+                  },
+                ],
+              }),
+              200);
+        }
+
+        throw UnsupportedError('Unhandled request: ${request.url}');
+      }),
+    );
+
+    final summary = await repository.buildTripExposure(
+      origin: const SelectedSite(
+        id: 'origin',
+        name: 'Origin',
+        searchName: 'Origin',
+        latitude: 0.3476,
+        longitude: 32.5825,
+      ),
+      destination: const SelectedSite(
+        id: 'destination',
+        name: 'Destination',
+        searchName: 'Destination',
+        latitude: 0.3136,
+        longitude: 32.5811,
+      ),
+    );
+
+    expect(requests, hasLength(3));
+    expect(summary.distanceLabel, '12 km');
+    expect(summary.durationLabel, '28 mins');
+    expect(summary.nearbySites, hasLength(2));
+    expect(summary.averagePm25, closeTo(30.55, 0.001));
+    expect(summary.peakPm25, 42.7);
+    expect(summary.highestSiteName, 'Roadside Monitor');
+    expect(summary.exposureLevel?.label, 'Moderate');
+  });
+
+  test('buildTripExposure surfaces a clear directions error for zero results',
+      () async {
+    final repository = RouteExposureRepositoryImpl(
+      httpClient: _FakeClient((request) async {
+        if (request.url.host == 'maps.googleapis.com') {
+          return http.Response(
+            jsonEncode({
+              'status': 'ZERO_RESULTS',
+              'routes': [],
+            }),
+            200,
+          );
+        }
+
+        throw UnsupportedError('Unhandled request: ${request.url}');
+      }),
+    );
+
+    expect(
+      () => repository.buildTripExposure(
+        origin: const SelectedSite(
+          id: 'origin',
+          name: 'Fire Station, Nairobi',
+          searchName: 'Fire Station, Nairobi',
+          latitude: -1.2864,
+          longitude: 36.8172,
+        ),
+        destination: const SelectedSite(
+          id: 'destination',
+          name: 'Kampala Metropolitan CPS',
+          searchName: 'Kampala Metropolitan CPS',
+          latitude: 0.3476,
+          longitude: 32.5825,
+        ),
+      ),
+      throwsA(
+        isA<Exception>().having(
+          (error) => error.toString(),
+          'message',
+          contains(
+            'Google Maps could not find a drivable route between Fire Station, Nairobi and Kampala Metropolitan CPS',
+          ),
+        ),
+      ),
+    );
+  });
+}
+
+class _FakeClient extends http.BaseClient {
+  _FakeClient(this._handler);
+
+  final Future<http.Response> Function(http.Request request) _handler;
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    final httpRequest = request as http.Request;
+    final response = await _handler(httpRequest);
+    return http.StreamedResponse(
+      Stream.value(response.bodyBytes),
+      response.statusCode,
+      headers: response.headers,
+      request: request,
+    );
+  }
+}

--- a/src/mobile/test/app/exposure/widgets/my_trips_view_test.dart
+++ b/src/mobile/test/app/exposure/widgets/my_trips_view_test.dart
@@ -1,0 +1,112 @@
+import 'package:airqo/src/app/dashboard/models/airquality_response.dart';
+import 'package:airqo/src/app/dashboard/models/user_preferences_model.dart';
+import 'package:airqo/src/app/exposure/models/declared_place.dart';
+import 'package:airqo/src/app/exposure/models/route_exposure_summary.dart';
+import 'package:airqo/src/app/exposure/repository/route_exposure_repository.dart';
+import 'package:airqo/src/app/exposure/widgets/my_trips_view.dart';
+import 'package:airqo/src/meta/utils/colors.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('MyTripsView shows a route summary after analysis',
+      (tester) async {
+    final repository = _FakeRouteExposureRepository();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppTheme.lightTheme,
+        home: Scaffold(
+          body: MyTripsView(
+            savedSites: const [
+              SelectedSite(
+                id: 'site-1',
+                name: 'Home',
+                searchName: 'Home',
+                latitude: 0.3476,
+                longitude: 32.5825,
+              ),
+              SelectedSite(
+                id: 'site-2',
+                name: 'Office',
+                searchName: 'Office',
+                latitude: 0.3136,
+                longitude: 32.5811,
+              ),
+            ],
+            repository: repository,
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Analyze trip exposure'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    expect(find.text('Home to Office'), findsOneWidget);
+    expect(find.text('Average PM2.5'), findsOneWidget);
+    expect(find.text('24.8 µg/m³'), findsNWidgets(2));
+    expect(find.textContaining('Highest route reading near City Square'),
+        findsOneWidget);
+  });
+
+  testWidgets('MyTripsView explains when there are not enough saved sites',
+      (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppTheme.lightTheme,
+        home: const Scaffold(
+          body: MyTripsView(
+            savedSites: [
+              SelectedSite(
+                id: 'site-1',
+                name: 'Home',
+                searchName: 'Home',
+                latitude: 0.3476,
+                longitude: 32.5825,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Add at least two saved places to analyze a trip.'),
+        findsOneWidget);
+  });
+}
+
+class _FakeRouteExposureRepository implements RouteExposureRepository {
+  @override
+  Future<RouteExposureSummary> buildTripExposure({
+    required SelectedSite origin,
+    required SelectedSite destination,
+    double radiusKm = 2.5,
+  }) async {
+    return RouteExposureSummary(
+      origin: origin,
+      destination: destination,
+      distanceLabel: '9 km',
+      durationLabel: '19 mins',
+      radiusKm: radiusKm,
+      sampledPointCount: 12,
+      nearbySites: const [
+        RouteMonitoringSite(id: 'monitor-1', name: 'City Square'),
+      ],
+      measurements: [
+        Measurement(
+          siteId: 'monitor-1',
+          pm25: Pm25(value: 24.8),
+          siteDetails: SiteDetails(name: 'City Square'),
+        ),
+      ],
+      averagePm25: 24.8,
+      peakPm25: 24.8,
+      exposureLevel: ExposureLevel.moderate,
+      headline: 'This route has noticeable pollution',
+      guidance: 'Air between Home and Office is mixed.',
+      highestSiteName: 'City Square',
+    );
+  }
+}


### PR DESCRIPTION
Users are able to see exposure over time of their saved trips. Feature still behind feature flag. Google maps key does not grant mobile app permission to use the routing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added trip exposure analysis between two saved places.
  * Displays route distance, travel time, nearby monitoring sites, PM2.5 averages and peaks, exposure status, and guidance.
  * Shows the highest-reading monitoring location when available.

* **Bug Fixes**
  * Replaced the My Trips placeholder with the trip analysis experience.
  * Added a clear message when fewer than two saved places are available.
  * Improved handling of unavailable routes and missing exposure measurements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->