### PR TITLE
chore(vertex-desktop): bump version to 0.1.11

### DIFF
--- a/src/vertex-desktop/CHANGELOG.md
+++ b/src/vertex-desktop/CHANGELOG.md
@@ -29,6 +29,27 @@ Replaced system-browser OAuth flow with a dedicated Electron child window so the
 
 </details>
 
+### Release Pipeline Fixes
+
+Follow-up to 0.1.10's release automation: the auto-tag job's pushed tag wasn't actually triggering a release build, and the Linux job itself was broken.
+
+<details>
+<summary><strong>CI/CD Fixes (3)</strong></summary>
+
+- **Explicit Release Dispatch**: `auto-tag` now explicitly dispatches `vertex-desktop-release.yml` via `workflow_dispatch` after pushing the tag, since a tag pushed with the default `GITHUB_TOKEN` does not trigger other workflows' `on: push: tags:` (GitHub's anti-recursion guard). The dispatch is pinned to the tag itself (not the branch) so the workflow definition GitHub loads matches the same commit the build checks out.
+- **Context Values via env**: `github.repository`/`github.ref_name` are now passed through `env:` instead of interpolated directly into the shell script, avoiding raw template-expression expansion in `run:`.
+- **Linux Icon Size**: Upsized `assets/icon.png` from 96x96 to 512x512 (re-extracted from `icon.icns`); electron-builder's AppImage packaging requires at least 256x256, so the Linux build was failing on every run.
+
+</details>
+
+<details>
+<summary><strong>Files Modified (2)</strong></summary>
+
+- `.github/workflows/vertex-desktop-ci.yml`
+- `assets/icon.png`
+
+</details>
+
 ---
 
 ## Version 0.1.10

--- a/src/vertex-desktop/package.json
+++ b/src/vertex-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vertex-desktop",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "private": true,
   "author": "AirQo <airqo.analytics@gmail.com>",
   "repository": {


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

Bumps `src/vertex-desktop/package.json` from `0.1.10` to `0.1.11`, matching the version already documented in `CHANGELOG.md` for the OAuth child-window work (#3729, `main/auth-window.ts`) that merged to `staging` without a version bump.

Merging this will exercise the full, now-fixed release pipeline end to end for the first time:
1. `desktop-quality` runs typecheck/build.
2. `auto-tag` detects the version bump, pushes `vertex-desktop-v0.1.11`, and explicitly dispatches `vertex-desktop-release.yml` (see #3747 — tag pushes via the default `GITHUB_TOKEN` don't auto-trigger other workflows).
3. `vertex-desktop-release.yml` builds and publishes a draft GitHub Release with Windows, macOS, and (for the first time working) Linux installers — the Linux job was previously failing on an undersized icon, fixed in #3747.

The release lands as a **draft** — per team preference, a human still reviews and clicks "Publish" before it's live for users/`electron-updater`.

Note: the existing `0.1.10` draft release is incomplete (missing Linux, predates the icon fix) and can be discarded once this one is reviewed and published.

#### Status of maturity (all need to be checked before merging):

- [x] I've tested this locally
- [ ] I consider this code done
- [ ] This change ready to hit production in its current state
- [x] The title of the PR states what changed and the related issues number (used for the release note).
- [ ] I've included issue number in the "Closes #ISSUE-NUMBER" part of the "[What are the relevant tickets?](#what-are-the-relevant-tickets)" section to [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] I've updated corresponding documentation for the changes in this PR.
- [ ] I have written unit and/or e2e tests for my change(s).

#### How should this be manually tested?

1. Merge this PR.
2. Watch the Actions tab: `vertex-desktop-ci` should run `desktop-quality` then `auto-tag`, and `auto-tag` should dispatch `vertex-desktop-release.yml`.
3. Confirm `vertex-desktop-release.yml`'s Windows, macOS, and Linux jobs all succeed.
4. Review the resulting draft release (should have 15+ assets including an `.AppImage` and `.deb`) and publish it when ready.

#### What are the relevant tickets?

- Closes #<enter issue number here>

#### Screenshots (optional)

N/A — version bump / CI validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the desktop app version to **0.1.11**.
* **Bug Fixes**
  * Improved the release pipeline so desktop builds can publish reliably.
  * Ensured release workflows are triggered correctly during tag-based releases.
  * Adjusted packaged app assets so Linux AppImage packaging completes successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->