### PR TITLE
fix(mobile): update Clean Air Forum selfie filter title and dates

### DIFF
--- a/src/mobile/lib/src/app/dashboard/utils/clean_air_forum_branding.dart
+++ b/src/mobile/lib/src/app/dashboard/utils/clean_air_forum_branding.dart
@@ -28,11 +28,14 @@ class CleanAirForumBrand {
   /// the Figma template exactly (distinct from [scrimTeal]).
   static const Color sharedCaptionText = Color(0xFF1F3D3D);
 
-  /// Host city + year shown under the "Clean Air Forum" wordmark.
+  /// Wordmark shown top-left on the selfie filter card.
+  static const String title = 'Africa CLEAN - Air Forum';
+
+  /// Host city + year shown under the [title] wordmark.
   static const String edition = 'Pretoria 2026';
 
   /// Event date range shown in the corner of the filter card.
-  static const String dateRange = '13TH-16TH JULY';
+  static const String dateRange = '14TH-16TH JULY';
 }
 
 /// Reference canvas width the Figma "AQ/CAF" templates were designed at.
@@ -65,7 +68,7 @@ class AirQoIconMark extends StatelessWidget {
   }
 }
 
-/// AirQo icon + "Clean Air Forum" wordmark lockup shown top-left on the
+/// AirQo icon + [CleanAirForumBrand.title] wordmark lockup shown top-left on the
 /// selfie filter card: logo mark, a vertical divider, then the title/edition
 /// text — matches the Figma "AQ/CAF" header exactly (node 169:538).
 ///
@@ -98,7 +101,7 @@ class CleanAirForumBrandHeader extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Text(
-                'Clean Air Forum',
+                CleanAirForumBrand.title,
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,
                 style: TextStyle(


### PR DESCRIPTION
## Summary
- Update selfie filter wordmark from "Clean Air Forum" to "Africa CLEAN - Air Forum" via new `CleanAirForumBrand.title` constant
- Update event date range from "13TH-16TH JULY" to "14TH-16TH JULY"

## Test plan
- [ ] Run mobile app with `--flavor airqodev` and open the Clean Air Forum selfie filter card
- [ ] Confirm the header shows "Africa CLEAN - Air Forum"
- [ ] Confirm the date range shows "14TH-16TH JULY"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the Clean Air Forum branding shown in the app with a shared title label.
  * Adjusted the displayed event dates to reflect the latest schedule.

* **Bug Fixes**
  * Replaced a hardcoded forum name with the shared branding value so the displayed title stays consistent across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->