### PR TITLE
Fix docs sidebar text clipping and hidden dropdown/caret icons

### DIFF
--- a/src/docs-website/src/components/ProductDropdown/styles.module.css
+++ b/src/docs-website/src/components/ProductDropdown/styles.module.css
@@ -29,6 +29,17 @@
   display: flex;
   align-items: center;
   gap: 0.75rem;
+  /* Allow the title to shrink/truncate instead of pushing the arrow
+     (below) out past the button's edge. */
+  min-width: 0;
+  flex: 1;
+}
+
+.productInfo span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
 }
 
 .productIcon {
@@ -36,6 +47,7 @@
   align-items: center;
   justify-content: center;
   color: var(--ifm-color-primary);
+  flex-shrink: 0;
 }
 
 .productIcon svg {
@@ -47,6 +59,7 @@
   color: var(--ifm-color-emphasis-600);
   display: flex;
   align-items: center;
+  flex-shrink: 0;
 }
 
 .dropdownMenu {
@@ -82,6 +95,13 @@
   font-family: inherit;
 }
 
+.dropdownItem span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
 .dropdownItem:hover {
   background-color: var(--ifm-color-emphasis-100);
   color: var(--ifm-color-primary);
@@ -94,6 +114,7 @@
 
 .checkIcon {
   margin-left: auto;
+  flex-shrink: 0;
   color: var(--ifm-color-primary);
 }
 

--- a/src/docs-website/src/css/custom.css
+++ b/src/docs-website/src/css/custom.css
@@ -81,6 +81,14 @@
   --font-mono: 'SF Mono', 'Monaco', 'Inconsolata', 'Roboto Mono', 'Source Code Pro', monospace;
 }
 
+/* Widen the default sidebar so longer category/section titles have more
+   room to wrap before hitting the edge. */
+@media (min-width: 997px) {
+  :root {
+    --doc-sidebar-width: 340px;
+  }
+}
+
 body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -330,11 +338,25 @@ pre code {
   margin-right: 0.5rem;
   margin-left: 0.5rem;
   padding-right: 1rem;
-  
+
   /* Match p element typography */
   font-size: 0.875rem;
   font-weight: 400;
   line-height: calc(1.25 / 0.875);
+
+  /* .menu__link is itself a flex container (label text + caret pseudo-element).
+     Flex items default to min-width: auto, which stops long labels from
+     wrapping in some browsers (notably Safari) and lets them overflow past
+     the sidebar's clipped edge instead - taking the caret icon with them. */
+  min-width: 0;
+  white-space: normal;
+  word-break: break-word;
+}
+
+/* Never let the expand/collapse caret shrink or get pushed out of view by a
+   long label sharing its flex row. */
+.menu__link--sublist-caret:after {
+  flex-shrink: 0;
 }
 
 .menu__link:hover {

--- a/src/docs-website/src/css/custom.css
+++ b/src/docs-website/src/css/custom.css
@@ -350,7 +350,7 @@ pre code {
      the sidebar's clipped edge instead - taking the caret icon with them. */
   min-width: 0;
   white-space: normal;
-  word-break: break-word;
+  overflow-wrap: anywhere;
 }
 
 /* Never let the expand/collapse caret shrink or get pushed out of view by a


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Fixes the docs site sidebar so long section/subsection titles (e.g. in the Researchers' Guide) no longer get clipped, and ensures the collapse/expand caret icons and the product-switcher dropdown arrow are never pushed out of view. Also widens the default sidebar from 300px to 340px for more breathing room.

### Why is this change needed?
Sidebar links and the product-switcher dropdown are internally `display: flex` (label text + arrow icon as flex items), but neither had `min-width: 0` on the text or `flex-shrink: 0` on the icons. Combined with `overflow-x: hidden` on the sidebar (used to hide the scrollbar), long titles could overflow instead of wrapping — silently clipping the text and pushing the caret/arrow icon out past the visible edge in some browsers/viewports (e.g. Safari, browser zoom, smaller laptop screens).

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [x] :bug: Bug fix
- [ ] :sparkles: New feature
- [x] :wrench: Enhancement/improvement
- [ ] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `docs-website` (Docusaurus documentation site)

---

## :test_tube: Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
Ran the docs site locally via `docusaurus start` and took headless-Chrome screenshots of `/docs/data-access/researchers-guide/` at 1400px, 1024px, and the 997px desktop breakpoint edge before and after the fix. Confirmed long sidebar labels (e.g. "5. Monitor Coverage & Representativeness", "Appendix: Quick Reference Checklist") now wrap cleanly instead of overflowing, and that the category caret and product-dropdown arrow remain fully visible at every width tested.

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes
This Docusaurus version (3.9.2) does not ship a drag-to-resize sidebar handle, so the width fix is a static CSS increase (300px → 340px) rather than a user-adjustable control. Building an actual resize handle was scoped out as a separate, larger enhancement.

---

## :white_check_mark: Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dropdown and sidebar text handling so long labels no longer overflow or push icons out of place.
  * Added truncation and wrapping behavior for lengthy product names and menu items, with icons staying properly aligned.
  * Widened the documentation sidebar on desktop for better readability of longer entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->