### PR TITLE
Fix map marker icons rendering at device pixel ratio scale

### DIFF
--- a/src/mobile/lib/src/app/map/utils/map_marker_builder.dart
+++ b/src/mobile/lib/src/app/map/utils/map_marker_builder.dart
@@ -7,10 +7,8 @@ import 'package:flutter/painting.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 
 class MapMarkerBuilder {
-  /// Rasterized marker icon size, in logical pixels. The air quality badge
-  /// SVGs are 96x96 circular icons — 10x10 (the previous value) rendered
-  /// as little more than a dot on the map.
-  static const Size _markerIconSize = Size(44, 44);
+  /// Rasterized marker icon size, in logical pixels.
+  static const Size _markerIconSize = Size(28, 28);
 
   Future<List<Marker>> buildMarkers({
     required List<Measurement> measurements,

--- a/src/mobile/lib/src/meta/utils/widget_to_map_icon.dart
+++ b/src/mobile/lib/src/meta/utils/widget_to_map_icon.dart
@@ -50,5 +50,8 @@ Future<BitmapDescriptor> _rasterizeSvgAsset(
     return BitmapDescriptor.defaultMarker;
   }
 
-  return BitmapDescriptor.bytes(bytes.buffer.asUint8List());
+  return BitmapDescriptor.bytes(
+    bytes.buffer.asUint8List(),
+    imagePixelRatio: devicePixelRatio,
+  );
 }


### PR DESCRIPTION
Marker bitmaps are rasterized at size * devicePixelRatio for crispness, but BitmapDescriptor.bytes() defaults to an imagePixelRatio of 1.0, so markers drew devicePixelRatio times larger than intended (the old fromBytes API handled this implicitly). Pass the actual pixel ratio and restore the pre-regression 28x28 logical icon size.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed map marker icons so they display at the correct size and scale on Google Maps.
  * Improved marker rendering consistency on different device pixel ratios, reducing blurry or oversized icons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->