### PR TITLE
Fix Near You tab flashing empty state before cards load

### DIFF
--- a/src/mobile/lib/src/app/dashboard/widgets/nearby_view.dart
+++ b/src/mobile/lib/src/app/dashboard/widgets/nearby_view.dart
@@ -88,13 +88,12 @@ class _NearbyViewState extends State<NearbyView> with UiLoggy {
       if (position != null && mounted) {
         setState(() {
           _userPosition = position;
-          _isLoading = false;
         });
-        
+
         // Update nearby locations with this position
         await _updateNearbyLocations();
       }
-      
+
       // Then get current position for more accuracy
       try {
         position = await Geolocator.getCurrentPosition(
@@ -103,11 +102,10 @@ class _NearbyViewState extends State<NearbyView> with UiLoggy {
             timeLimit: Duration(seconds: 5),
           ),
         );
-        
+
         if (mounted) {
           setState(() {
             _userPosition = position;
-            _isLoading = false;
           });
         }
         
@@ -210,6 +208,13 @@ class _NearbyViewState extends State<NearbyView> with UiLoggy {
     
     final state = context.read<DashboardBloc>().state;
     if (state is! DashboardLoaded || state.response.measurements == null) {
+      // Dashboard loaded but has no measurements: nothing to filter, stop
+      // showing the loading skeleton so the empty state can render.
+      if (state is DashboardLoaded && mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+      }
       return;
     }
     
@@ -279,6 +284,7 @@ class _NearbyViewState extends State<NearbyView> with UiLoggy {
     if (mounted) {
       setState(() {
         _nearbyMeasurementsWithDistance = visibleMeasurements;
+        _isLoading = false;
       });
     }
   }
@@ -349,6 +355,10 @@ class _NearbyViewState extends State<NearbyView> with UiLoggy {
   }
 
   void _retry() {
+    setState(() {
+      _isLoading = true;
+      _errorMessage = null;
+    });
     _initializeLocationAndData();
   }
 
@@ -377,32 +387,26 @@ class _NearbyViewState extends State<NearbyView> with UiLoggy {
           }
         }
       },
-      child: BlocSelector<DashboardBloc, DashboardState, dynamic>(
-        selector: (state) {
+      child: BlocBuilder<DashboardBloc, DashboardState>(
+        builder: (context, state) {
+          // Local init (cache read, location fetch, distance filtering) may
+          // still be running even though the dashboard data is already
+          // loaded; keep showing the skeleton until it produces a result.
+          // This must be computed in the builder (not a BlocSelector) so
+          // local setState calls re-evaluate it against current fields.
+          final bool isLoading;
           if (state is DashboardLoaded) {
-            return {
-              'isLoading': false,
-              'error': null,
-            };
+            isLoading = _isLoading && _nearbyMeasurementsWithDistance.isEmpty;
           } else if (state is DashboardLoadingError) {
-            return {
-              'isLoading': false,
-              'error': state.message,
-            };
+            isLoading = false;
           } else if (state is DashboardLoading) {
-            return {
-              'isLoading': _nearbyMeasurementsWithDistance.isEmpty,
-              'error': null,
-            };
+            isLoading = _nearbyMeasurementsWithDistance.isEmpty;
+          } else {
+            isLoading = _isLoading && _nearbyMeasurementsWithDistance.isEmpty;
           }
-          return {
-            'isLoading': _isLoading && _nearbyMeasurementsWithDistance.isEmpty,
-            'error': _errorMessage,
-          };
-        },
-        builder: (context, selectedState) {
-          final isLoading = selectedState['isLoading'] as bool;
-          final error = selectedState['error'] as String? ?? _errorMessage;
+          final error =
+              (state is DashboardLoadingError ? state.message : null) ??
+                  _errorMessage;
 
           if (error != null && error.contains('permission') && _nearbyMeasurementsWithDistance.isEmpty) {
             return NearbyViewEmptyState(

--- a/src/mobile/lib/src/app/dashboard/widgets/nearby_view.dart
+++ b/src/mobile/lib/src/app/dashboard/widgets/nearby_view.dart
@@ -400,7 +400,7 @@ class _NearbyViewState extends State<NearbyView> with UiLoggy {
           } else if (state is DashboardLoadingError) {
             isLoading = false;
           } else if (state is DashboardLoading) {
-            isLoading = _nearbyMeasurementsWithDistance.isEmpty;
+            isLoading = _isLoading && _nearbyMeasurementsWithDistance.isEmpty;
           } else {
             isLoading = _isLoading && _nearbyMeasurementsWithDistance.isEmpty;
           }


### PR DESCRIPTION
The BlocSelector reported isLoading=false whenever the dashboard bloc was already DashboardLoaded, ignoring the widget's own async init (cache read, location fetch, distance filtering). Since NearbyView only mounts once the dashboard is loaded, the first frame skipped the skeleton and rendered the 'No stations nearby' empty state, which was replaced by cards a few frames later once the cache read completed.

- Compute isLoading in a BlocBuilder from the live local fields; a BlocSelector only re-runs its selector on bloc emissions, so local setState updates were invisible to it (and the selector returned a fresh Map each time, defeating memoization anyway).
- Keep _isLoading true until _updateNearbyLocations actually filters measurements (or determines there are none), instead of clearing it as soon as a position is obtained.
- Reset _isLoading/_errorMessage on retry so the skeleton shows again.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed nearby dashboard loading so the UI stops showing “loading” at the correct time after location updates and filtering.
  * Resolved cases where nearby data could stay in a loading state when there were no available measurements.
  * Improved retry behavior by clearing prior errors and restarting loading before reloading nearby results.
  * Refined how loading and error UI are derived from a combination of dashboard state and local widget updates, improving refresh reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->