### PR TITLE
fix(vertex): install.sh fails to resolve download URL and crashes on cleanup

### DIFF
--- a/src/vertex/app/changelog.md
+++ b/src/vertex/app/changelog.md
@@ -13,7 +13,7 @@ A live user report surfaced two bugs in the `install.sh` terminal installer (add
 <summary><strong>Broken download URL lookup (<code>public/install.sh</code>)</strong></summary>
 
 - A follow-up commit after 2.0.17 shipped replaced direct URL construction with an `awk`-based lookup of `browser_download_url` from the GitHub API response, parsed as a two-line state machine (match `"name":`, then expect `"browser_download_url":` on a later line). That only works on pretty-printed JSON.
-- The actual response the script receives (`Accept: application/vnd.github+json`) is **compact, single-line JSON** — confirmed directly (`wc -l` returns `0` with that header vs `583` without it) — so the lookup silently returned empty for every user since that commit merged.
+- The actual response the script receives (`Accept: application/vnd.github+json`) is **compact JSON with no line breaks** — confirmed directly (`wc -l`, which counts newline characters, returns `0` with that header vs `583` without it, i.e. the whole payload is one line rather than an empty response) — so the lookup silently returned empty for every user since that commit merged.
 - Reverted to constructing the download URL directly from the release tag and asset name, GitHub's documented, stable release-asset URL pattern, which doesn't depend on API response formatting at all.
 
 </details>
@@ -22,7 +22,7 @@ A live user report surfaced two bugs in the `install.sh` terminal installer (add
 <summary><strong>Unbound variable on cleanup</strong></summary>
 
 - The `workdir` cleanup trap used late variable expansion (`trap 'rm -rf "${workdir}"' EXIT`), referencing a `local` variable from `main()`. If a later step failed (e.g. `sudo` unavailable) and `set -e` unwound out of `main()`, that local was out of scope by the time the `EXIT` trap fired, so `set -u` threw `unbound variable` instead of cleaning up.
-- Fixed with early expansion, baking the literal path into the trap command at registration time — the same pattern already used correctly elsewhere in this file.
+- Fixed with early expansion, baking the literal path into the trap command at registration time.
 
 </details>
 

--- a/src/vertex/app/changelog.md
+++ b/src/vertex/app/changelog.md
@@ -2,6 +2,39 @@
 
 > **Note**: This changelog consolidates all recent improvements, features, and fixes to the AirQo Vertex frontend.
 
+## Version 2.0.19
+**Released:** July 9, 2026
+
+### Fix: Terminal Installer Failed to Resolve Download URL
+
+A live user report surfaced two bugs in the `install.sh` terminal installer (added in 2.0.17): every run failed with `error: Could not determine the download URL for <asset>`, and a separate crash could occur during cleanup after a failed step.
+
+<details>
+<summary><strong>Broken download URL lookup (<code>public/install.sh</code>)</strong></summary>
+
+- A follow-up commit after 2.0.17 shipped replaced direct URL construction with an `awk`-based lookup of `browser_download_url` from the GitHub API response, parsed as a two-line state machine (match `"name":`, then expect `"browser_download_url":` on a later line). That only works on pretty-printed JSON.
+- The actual response the script receives (`Accept: application/vnd.github+json`) is **compact, single-line JSON** — confirmed directly (`wc -l` returns `0` with that header vs `583` without it) — so the lookup silently returned empty for every user since that commit merged.
+- Reverted to constructing the download URL directly from the release tag and asset name, GitHub's documented, stable release-asset URL pattern, which doesn't depend on API response formatting at all.
+
+</details>
+
+<details>
+<summary><strong>Unbound variable on cleanup</strong></summary>
+
+- The `workdir` cleanup trap used late variable expansion (`trap 'rm -rf "${workdir}"' EXIT`), referencing a `local` variable from `main()`. If a later step failed (e.g. `sudo` unavailable) and `set -e` unwound out of `main()`, that local was out of scope by the time the `EXIT` trap fired, so `set -u` threw `unbound variable` instead of cleaning up.
+- Fixed with early expansion, baking the literal path into the trap command at registration time — the same pattern already used correctly elsewhere in this file.
+
+</details>
+
+<details>
+<summary><strong>Files Modified (1)</strong></summary>
+
+- `src/vertex/public/install.sh` [MODIFIED]
+
+</details>
+
+---
+
 ## Version 2.0.18
 **Released:** July 9, 2026
 

--- a/src/vertex/public/install.sh
+++ b/src/vertex/public/install.sh
@@ -77,30 +77,6 @@ json_string_field() {
   sed -n "s/.*\"${key}\"[[:space:]]*:[[:space:]]*\"\\([^\"]*\\)\".*/\\1/p" | head -n1
 }
 
-# Looks up the browser_download_url for the release asset whose "name" field
-# exactly matches $1. Used instead of hand-constructing the GitHub download
-# URL from the tag and asset name, since the asset name is derived from the
-# app's product name and isn't guaranteed to be URL-safe (e.g. no spaces).
-asset_download_url() {
-  local name="$1"
-  awk -v name="$name" '
-    /"name"[[:space:]]*:/ {
-      line = $0
-      sub(/.*"name"[[:space:]]*:[[:space:]]*"/, "", line)
-      sub(/".*/, "", line)
-      matched = (line == name)
-      next
-    }
-    matched && /"browser_download_url"[[:space:]]*:/ {
-      line = $0
-      sub(/.*"browser_download_url"[[:space:]]*:[[:space:]]*"/, "", line)
-      sub(/".*/, "", line)
-      print line
-      exit
-    }
-  '
-}
-
 verify_checksum() {
   local tag="$1" asset_name="$2" file_path="$3"
 
@@ -208,13 +184,18 @@ main() {
 
   log "Latest release: ${tag} (${asset_name})"
 
-  local asset_url
-  asset_url="$(printf '%s' "$release_json" | asset_download_url "$asset_name")"
-  [ -n "$asset_url" ] || err "Could not determine the download URL for ${asset_name}."
+  # GitHub's release download URLs follow this stable, documented pattern;
+  # no need to look up browser_download_url from the API response for it.
+  # (asset_name comes from electron-builder's artifact naming, which is
+  # already URL-safe - e.g. "AirQo-Vertex-0.1.11.AppImage", no raw spaces.)
+  local asset_url="https://github.com/${REPO}/releases/download/${tag}/${asset_name}"
 
   local workdir
   workdir="$(mktemp -d)"
-  trap 'rm -rf "${workdir}"' EXIT
+  # Early-expand $workdir into the trap command itself: if the script exits
+  # via `set -e` while unwinding out of main(), this local variable would
+  # otherwise be out of scope by the time the EXIT trap actually runs.
+  trap "rm -rf '${workdir}'" EXIT
 
   log "Downloading ${asset_name}..."
   curl -fsSL -A "$USER_AGENT" -o "${workdir}/${asset_name}" "$asset_url" ||


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

Fixes a **live bug** reported by a real user running the deployed installer (`curl -fsSL https://vertex.airqo.net/install.sh | bash`), who got:

```
error: Could not determine the download URL for vertex-desktop_0.1.11_amd64.deb.
```

**Root cause 1 — broken since the follow-up commit after #3764 merged:**

`asset_download_url()` parsed the GitHub API's release JSON as a two-line `awk` state machine: match a `"name":` line, then expect `"browser_download_url":` on a *later* line. That only works if the response is pretty-printed. The actual response our script receives (we send `Accept: application/vnd.github+json`) is **compact, single-line JSON** — confirmed directly:

```bash
$ curl -s -H "Accept: application/vnd.github+json" ".../releases/latest" | wc -l
0
$ curl -s ".../releases/latest" | wc -l   # no special Accept header
583
```

So the lookup has silently returned empty for every user since that commit merged. Reverted to directly constructing the URL from the tag + asset name — GitHub's documented, stable release-asset URL pattern, which doesn't depend on API response formatting at all. Confirmed none of our real asset filenames need URL-encoding (electron-builder already sanitizes `productName` — `"AirQo Vertex"` → `AirQo-Vertex-...` — no raw spaces in any actual artifact).

**Root cause 2 — found while fixing #1:** the `workdir` cleanup trap used late variable expansion (`trap 'rm -rf "${workdir}"' EXIT`), referencing a `local` variable from `main()`. If a later step fails (e.g. `sudo` unavailable) and `set -e` unwinds out of `main()`, that local is out of scope by the time the `EXIT` trap actually fires, so `set -u` throws `unbound variable` instead of cleaning up. Fixed with early expansion (bakes in the literal path at trap-registration time) — the same pattern already used correctly elsewhere in this same file.

Both were reproduced by running the actual deployed script end-to-end, not just by inspection.

#### Status of maturity (all need to be checked before merging):

- [x] I've tested this locally
- [ ] I consider this code done
- [ ] This change ready to hit production in its current state
- [x] The title of the PR states what changed and the related issues number (used for the release note).
- [ ] I've included issue number in the "Closes #ISSUE-NUMBER" part of the "[What are the relevant tickets?](#what-are-the-relevant-tickets)" section to [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [ ] I've updated corresponding documentation for the changes in this PR.
- [ ] I have written unit and/or e2e tests for my change(s).

#### How should this be manually tested?

```bash
curl -fsSL https://raw.githubusercontent.com/airqo-platform/AirQo-frontend/fix-vertex-install-script-download-url/src/vertex/public/install.sh | bash
```
Confirm it prints "Latest release: ..." and "Downloading ..." and actually starts downloading (no "Could not determine the download URL" error), then verifies the checksum successfully.

#### What are the relevant tickets?

- Closes #<enter issue number here>

#### Screenshots (optional)

N/A — CLI script fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the installer’s handling of Linux downloads, making release fetching more reliable.
  * Updated temporary file cleanup during installation to reduce the chance of leftover files after failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->