### PR TITLE
Add Per os download section

### DIFF
--- a/src/vertex/app/api/latest-release/route.ts
+++ b/src/vertex/app/api/latest-release/route.ts
@@ -1,0 +1,65 @@
+import { NextResponse } from 'next/server';
+
+interface GitHubAsset {
+  name: string;
+  browser_download_url: string;
+}
+
+interface GitHubRelease {
+  tag_name: string;
+  assets: GitHubAsset[];
+}
+
+export const revalidate = 3600;
+
+export async function GET() {
+  try {
+    const res = await fetch(
+      'https://api.github.com/repos/airqo-platform/AirQo-frontend/releases?per_page=20',
+      {
+        headers: {
+          Accept: 'application/vnd.github+json',
+          ...(process.env.GITHUB_TOKEN
+            ? { Authorization: `Bearer ${process.env.GITHUB_TOKEN}` }
+            : {}),
+        },
+        next: { revalidate: 3600 },
+      }
+    );
+
+    if (!res.ok) {
+      return NextResponse.json({ error: 'Failed to fetch releases' }, { status: 502 });
+    }
+
+    const releases: GitHubRelease[] = await res.json();
+
+    // Desktop releases are identified by having a .exe asset (v0.x.y series)
+    const desktop = releases.find((r) => r.assets.some((a) => a.name.endsWith('.exe')));
+
+    if (!desktop) {
+      return NextResponse.json({ error: 'No desktop release found' }, { status: 404 });
+    }
+
+    const find = (match: (name: string) => boolean) =>
+      desktop.assets.find((a) => match(a.name))?.browser_download_url ?? null;
+
+    return NextResponse.json({
+      version: desktop.tag_name,
+      windows: {
+        exe: find((n) => n.endsWith('.exe')),
+      },
+      mac: {
+        arm64Dmg: find((n) => n.includes('arm64') && n.endsWith('.dmg')),
+        arm64Zip: find((n) => n.includes('arm64') && n.endsWith('.zip')),
+        intelDmg: find((n) => !n.includes('arm64') && n.endsWith('.dmg')),
+        intelZip: find((n) => !n.includes('arm64') && n.endsWith('.zip')),
+      },
+      linux: {
+        appImage: find((n) => n.endsWith('.AppImage')),
+        deb: find((n) => n.endsWith('.deb')),
+      },
+    });
+  } catch {
+    return NextResponse.json({ error: 'Internal error' }, { status: 500 });
+  }
+}

--- a/src/vertex/app/changelog.md
+++ b/src/vertex/app/changelog.md
@@ -2,6 +2,17 @@
 
 > **Note**: This changelog consolidates all recent improvements, features, and fixes to the AirQo Vertex frontend.
 
+## Version 2.0.21
+**Released:** July 9, 2026
+
+### Chore: Increase Bundle Size Limit to 205 kB
+
+Raised the `size-limit` threshold in `package.json` from `200 kB` to `205 kB` to accommodate the new platform-aware download page, OS detection utilities, logout confirmation dialog, and sidebar CTA — features added across versions 2.0.18–2.0.20 that collectively pushed the brotlied app chunk total to ~202 kB.
+
+- `src/vertex/package.json` [MODIFIED] — `"limit": "200 kB"` → `"limit": "205 kB"`
+
+---
+
 ## Version 2.0.20
 **Released:** July 9, 2026
 

--- a/src/vertex/app/changelog.md
+++ b/src/vertex/app/changelog.md
@@ -2,6 +2,77 @@
 
 > **Note**: This changelog consolidates all recent improvements, features, and fixes to the AirQo Vertex frontend.
 
+## Version 2.0.19
+**Released:** July 9, 2026
+
+### Platform-Aware Download Page with Dynamic GitHub Release Fetching
+
+Redesigned the `/download` page with a dynamic primary download button that detects the visitor's OS, a multi-platform release card section (macOS, Windows, Linux), and a server-side Route Handler that fetches the latest desktop release from GitHub automatically — no more hardcoded version URLs.
+
+<details>
+<summary><strong>New: Route Handler — <code>app/api/latest-release/route.ts</code></strong></summary>
+
+- Fetches the GitHub Releases API (`/repos/airqo-platform/AirQo-frontend/releases`) server-side.
+- Identifies desktop releases (v0.x.y) by the presence of a `.exe` asset, distinguishing them from web releases (v2.x.x) which have zero assets.
+- Returns parsed download URLs per platform/format: Windows `.exe`, macOS Apple Silicon `.dmg`, macOS Intel `.dmg`, Linux `.AppImage`, Linux `.deb`.
+- `export const revalidate = 3600` — Next.js ISR caches the response for 1 hour so GitHub is not hit on every page load.
+- Optional `GITHUB_TOKEN` environment variable to avoid anonymous rate limits.
+
+</details>
+
+<details>
+<summary><strong>New: OS detection utilities</strong></summary>
+
+- `core/utils/platform.ts` — added `getDetectedPlatform()` (returns `'win' | 'mac' | 'linux' | 'other'`) and `getIsElectron()` as pure functions alongside the existing `getMacArchitecture()`.
+- `core/hooks/useDetectedPlatform.ts` [NEW] — React hook wrapping the above pure functions; uses `useEffect` to avoid SSR hydration mismatches. Returns `{ platform, isElectron }`.
+
+</details>
+
+<details>
+<summary><strong>DownloadHero — <code>components/features/download/DownloadHero.tsx</code></strong></summary>
+
+- **Primary button**: dynamically labelled ("Download for Windows / macOS / Linux" or "Get Desktop app") and linked based on the detected OS. Defaults to best format per platform: Apple Silicon `.dmg` for macOS, `.AppImage` for Linux.
+- **Fallback**: starts with hardcoded v0.1.11 URLs from `app-downloads.ts`; swaps to live data once the Route Handler responds.
+- **Platform cards**: three cards (macOS, Windows, Linux) each listing their available formats as download links. Linux card includes a terminal install snippet (`curl -fsSL https://vertex.airqo.net/install.sh | bash`) with an inline copy button.
+- Detected OS card gets a subtle primary-coloured ring highlight.
+- Dark mode: cards use `bg-card`; hero section uses `bg-primary-50 dark:bg-background`.
+
+</details>
+
+<details>
+<summary><strong>Sidebar & Login — non-Electron CTA</strong></summary>
+
+- `components/layout/secondary-sidebar.tsx` — replaced inline OS detection with `useDetectedPlatform`; CTA ("Get Desktop app") now shows for all non-Electron users, not just Windows.
+- `app/login/page.tsx` — same: removed manual state/effect OS detection, now uses `useDetectedPlatform`; CTA shows for all non-Electron users.
+- `components/features/auth/social-auth-section.tsx` — replaced inline `window.navigator.userAgent` check with `useDetectedPlatform`.
+
+</details>
+
+<details>
+<summary><strong>Download page scroll fix (<code>app/download/page.tsx</code>)</strong></summary>
+
+- `globals.css` sets `html { overflow: hidden }` globally; the download page (a public route with no authenticated shell) had no scroll container of its own. Fixed by making the page wrapper `h-screen overflow-y-auto`.
+
+</details>
+
+<details>
+<summary><strong>Files Modified &amp; Added (8)</strong></summary>
+
+- `src/vertex/app/api/latest-release/route.ts` [NEW]
+- `src/vertex/core/hooks/useDetectedPlatform.ts` [NEW]
+- `src/vertex/core/utils/platform.ts` [MODIFIED]
+- `src/vertex/core/constants/app-downloads.ts` [MODIFIED]
+- `src/vertex/components/features/download/DownloadHero.tsx` [MODIFIED]
+- `src/vertex/components/features/download/PlatformInfo.tsx` [MODIFIED]
+- `src/vertex/app/download/page.tsx` [MODIFIED]
+- `src/vertex/components/layout/secondary-sidebar.tsx` [MODIFIED]
+- `src/vertex/app/login/page.tsx` [MODIFIED]
+- `src/vertex/components/features/auth/social-auth-section.tsx` [MODIFIED]
+
+</details>
+
+---
+
 ## Version 2.0.18
 **Released:** July 9, 2026
 

--- a/src/vertex/app/changelog.md
+++ b/src/vertex/app/changelog.md
@@ -56,7 +56,7 @@ Redesigned the `/download` page with a dynamic primary download button that dete
 </details>
 
 <details>
-<summary><strong>Files Modified &amp; Added (8)</strong></summary>
+<summary><strong>Files Modified &amp; Added (10)</strong></summary>
 
 - `src/vertex/app/api/latest-release/route.ts` [NEW]
 - `src/vertex/core/hooks/useDetectedPlatform.ts` [NEW]

--- a/src/vertex/app/download/page.tsx
+++ b/src/vertex/app/download/page.tsx
@@ -7,12 +7,12 @@ import DownloadTopbar from '@/components/layout/DownloadTopbar';
 export const metadata: Metadata = {
   title: 'Download Vertex Desktop',
   description:
-    'Download the AirQo Vertex Desktop application for Windows and manage device deployment workflows from your desktop.',
+    'Download the AirQo Vertex Desktop application for macOS, Windows, and Linux. Manage device deployment workflows from your desktop.',
 };
 
 export default function DownloadPage() {
   return (
-    <div className="min-h-screen bg-background text-foreground">
+    <div className="h-screen overflow-y-auto bg-background text-foreground">
       <DownloadTopbar />
       <main>
         <DownloadHero />

--- a/src/vertex/app/login/page.tsx
+++ b/src/vertex/app/login/page.tsx
@@ -27,6 +27,7 @@ import { ROUTE_LINKS } from "@/core/routes";
 import SocialAuthSection from "@/components/features/auth/social-auth-section";
 import { motion, AnimatePresence } from "framer-motion";
 import { vertexConfig } from "@/vertex.config";
+import { useDetectedPlatform } from "@/core/hooks/useDetectedPlatform";
 
 
 const loginSchema = z.object({
@@ -84,8 +85,7 @@ export default function LoginPage() {
   const dispatch = useAppDispatch();
   const isMounted = useRef(true);
 
-  const [platform, setPlatform] = useState<'win' | 'linux' | 'other' | null>(null);
-  const [isElectron, setIsElectron] = useState(false);
+  const { isElectron } = useDetectedPlatform();
 
   useEffect(() => {
     isMounted.current = true;
@@ -114,20 +114,6 @@ export default function LoginPage() {
       }
     };
     checkExistingSession();
-
-    // OS Detection for download link and platform check
-    const userAgent = window.navigator.userAgent.toLowerCase();
-    const isWin = userAgent.includes('win');
-    const isLinux = userAgent.includes('linux');
-    setIsElectron(userAgent.includes('electron'));
-    
-    if (isWin) {
-      setPlatform('win');
-    } else if (isLinux) {
-      setPlatform('linux');
-    } else {
-      setPlatform('other');
-    }
 
     const authError = searchParams.get('error');
     if (authError === 'oauth_failed') {
@@ -257,7 +243,7 @@ export default function LoginPage() {
             />
           </div>
           
-          {!isElectron && platform === 'win' && (
+          {!isElectron && (
             <div className="flex items-center">
               <Link
                 href={ROUTE_LINKS.DOWNLOAD}
@@ -265,10 +251,7 @@ export default function LoginPage() {
                 rel="noopener noreferrer"
                 className="inline-flex items-center gap-2 rounded-md border border-border bg-primary px-4 py-2 text-sm font-medium text-white transition-all hover:bg-primary/80 hover:border-foreground/20 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
               >
-                <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor">
-                  <path d="M0 3.449L9.75 2.1V11.7H0V3.449zm0 9.151h9.75v9.6L0 20.551V12.6zm10.55-10.701L24 0v11.7h-13.45V1.899zm0 10.701H24V24l-13.45-1.899V12.6z"/>
-                </svg>
-                Download for Windows
+                Get Desktop app
               </Link>
             </div>
           )}

--- a/src/vertex/components/features/auth/social-auth-section.tsx
+++ b/src/vertex/components/features/auth/social-auth-section.tsx
@@ -15,6 +15,7 @@ import {
 import { cn } from '@/lib/utils';
 import { useBanner } from '@/context/banner-context';
 import { getLastActiveModule } from '@/core/utils/userPreferences';
+import { useDetectedPlatform } from '@/core/hooks/useDetectedPlatform';
 
 interface SocialAuthSectionProps {
   mode: 'login' | 'register';
@@ -83,9 +84,7 @@ export default function SocialAuthSection({
       ]
     : SOCIAL_PROVIDERS;
 
-  const isElectron =
-    typeof window !== 'undefined' &&
-    window.navigator.userAgent.toLowerCase().includes('electron');
+  const { isElectron } = useDetectedPlatform();
 
   const handleSocialAuth = useCallback(
     (provider: SupportedSocialAuthProvider) => {

--- a/src/vertex/components/features/download/DownloadHero.tsx
+++ b/src/vertex/components/features/download/DownloadHero.tsx
@@ -128,9 +128,9 @@ export default function DownloadHero() {
                 rel="noopener noreferrer"
                 variant="filled"
                 Icon={primary.Icon}
-                iconClassName="h-3.5 w-3.5"
-                className="inline-flex w-full justify-center gap-2 rounded-md border-border bg-primary text-sm font-medium text-white shadow-none transition-all hover:border-foreground/20 hover:bg-primary/80 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 sm:w-auto"
-                padding="px-4 py-2"
+                iconClassName="h-5 w-5"
+                className="inline-flex w-full justify-center gap-2 rounded-lg border-border bg-primary text-base font-semibold text-white shadow-none transition-all hover:border-foreground/20 hover:bg-primary/80 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 sm:w-auto"
+                padding="px-8 py-4"
               >
                 {primary.label}
               </ReusableButton>

--- a/src/vertex/components/features/download/DownloadHero.tsx
+++ b/src/vertex/components/features/download/DownloadHero.tsx
@@ -1,10 +1,16 @@
 'use client';
 
-import { Monitor, ShieldCheck } from 'lucide-react';
+import { Monitor, ShieldCheck, Copy, Check, Download } from 'lucide-react';
+import { FaLinux } from 'react-icons/fa';
 import { useEffect, useState } from 'react';
 
 import ReusableButton from '@/components/shared/button/ReusableButton';
-import { VERTEX_DESKTOP_DOWNLOADS } from '@/core/constants/app-downloads';
+import {
+  VERTEX_DESKTOP_DOWNLOAD_FALLBACKS,
+  LINUX_INSTALL_COMMAND,
+  type DesktopReleaseUrls,
+} from '@/core/constants/app-downloads';
+import { useDetectedPlatform } from '@/core/hooks/useDetectedPlatform';
 import { vertexConfig } from '@/vertex.config';
 
 const WindowsIcon = ({ className }: { className?: string }) => (
@@ -13,112 +19,241 @@ const WindowsIcon = ({ className }: { className?: string }) => (
   </svg>
 );
 
+const AppleIcon = ({ className }: { className?: string }) => (
+  <svg className={className} viewBox="0 0 24 24" fill="currentColor">
+    <path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.8-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z" />
+  </svg>
+);
+
+function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <button
+      onClick={handleCopy}
+      className="shrink-0 p-1.5 rounded hover:bg-background/80 text-muted-foreground hover:text-foreground transition-colors"
+      aria-label="Copy install command"
+    >
+      {copied ? <Check className="h-4 w-4 text-emerald-500" /> : <Copy className="h-4 w-4" />}
+    </button>
+  );
+}
+
+function getPrimaryRelease(platform: string, release: DesktopReleaseUrls) {
+  switch (platform) {
+    case 'win':
+      return { label: 'Download for Windows', href: release.windows.exe, Icon: WindowsIcon };
+    case 'mac':
+      return { label: 'Download for macOS', href: release.mac.arm64Dmg, Icon: AppleIcon };
+    case 'linux':
+      return { label: 'Download for Linux', href: release.linux.appImage, Icon: FaLinux };
+    default:
+      return { label: 'Get Desktop app', href: '#releases', Icon: Download };
+  }
+}
+
 export default function DownloadHero() {
   const [mounted, setMounted] = useState(false);
+  const [release, setRelease] = useState<DesktopReleaseUrls>(VERTEX_DESKTOP_DOWNLOAD_FALLBACKS);
+  const { platform } = useDetectedPlatform();
 
   useEffect(() => {
     const timer = setTimeout(() => setMounted(true), 100);
     return () => clearTimeout(timer);
   }, []);
 
-  return (
-    <section className="bg-primary-50 px-4 py-10 sm:px-6 sm:py-16 lg:px-8">
-      <div className="mx-auto grid w-full max-w-7xl items-center gap-10 lg:min-h-[calc(100vh-5rem)] lg:grid-cols-[minmax(0,0.95fr)_minmax(420px,1.05fr)]">
-        <div className="max-w-3xl">
-          <h1 className="max-w-2xl text-3xl font-semibold leading-tight tracking-normal text-heading sm:text-5xl lg:text-6xl">
-            Deploy Devices. Share Air Data
-          </h1>
-          <p className="mt-5 max-w-2xl text-sm leading-6 text-muted-foreground sm:mt-6 sm:text-lg sm:leading-7">
-            Install {vertexConfig.org.name} Desktop for a focused workspace built around field
-            deployment, device visibility, and trusted air quality data
-            workflows.
-          </p>
+  useEffect(() => {
+    fetch('/api/latest-release')
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => { if (data && !data.error) setRelease(data); })
+      .catch(() => {});
+  }, []);
 
-          <div className="mt-7 flex flex-col gap-3 sm:mt-8 sm:flex-row sm:items-center">
-            <ReusableButton
-              path={VERTEX_DESKTOP_DOWNLOADS.windows}
-              target="_blank"
-              rel="noopener noreferrer"
-              variant="filled"
-              Icon={WindowsIcon}
-              iconClassName="h-3 w-3"
-              className="inline-flex w-full justify-center gap-2 rounded-md border-border bg-primary text-sm font-medium text-white shadow-none transition-all hover:border-foreground/20 hover:bg-primary/80 hover:shadow-none focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 sm:w-auto"
-              padding="px-4 py-2"
-            >
-              Download for Windows
-            </ReusableButton>
-            <span className="text-sm leading-6 text-muted-foreground">
-              Windows is the currently supported platform.
-            </span>
+  const primary = getPrimaryRelease(platform, release);
+
+  const platformCards = [
+    {
+      id: 'mac',
+      label: 'macOS',
+      Icon: AppleIcon,
+      links: [
+        { label: 'Apple Silicon', suffix: '.dmg', href: release.mac.arm64Dmg },
+        { label: 'Intel', suffix: '.dmg', href: release.mac.intelDmg },
+      ],
+    },
+    {
+      id: 'win',
+      label: 'Windows',
+      Icon: WindowsIcon,
+      links: [
+        { label: 'Installer', suffix: '.exe', href: release.windows.exe },
+      ],
+    },
+    {
+      id: 'linux',
+      label: 'Linux',
+      Icon: FaLinux,
+      links: [
+        { label: 'AppImage', suffix: '', href: release.linux.appImage },
+        { label: 'Debian / Ubuntu', suffix: '.deb', href: release.linux.deb },
+      ],
+      terminal: true,
+    },
+  ];
+
+  return (
+    <section className="bg-primary-50 dark:bg-background px-4 py-10 sm:px-6 sm:py-16 lg:px-8">
+      <div className="mx-auto w-full max-w-7xl">
+        {/* Hero row */}
+        <div className="grid items-center gap-10 lg:min-h-[calc(60vh)] lg:grid-cols-[minmax(0,0.95fr)_minmax(420px,1.05fr)]">
+          <div className="max-w-3xl">
+            <h1 className="max-w-2xl text-3xl font-semibold leading-tight tracking-normal text-heading sm:text-5xl lg:text-6xl">
+              Deploy Devices. Share Air Data
+            </h1>
+            <p className="mt-5 max-w-2xl text-sm leading-6 text-muted-foreground sm:mt-6 sm:text-lg sm:leading-7">
+              Install {vertexConfig.org.name} Desktop for a focused workspace built around field
+              deployment, device visibility, and trusted air quality data workflows.
+            </p>
+
+            <div className="mt-7 flex flex-col gap-3 sm:mt-8 sm:flex-row sm:items-center">
+              <ReusableButton
+                path={primary.href ?? '#releases'}
+                target={primary.href?.startsWith('http') ? '_blank' : undefined}
+                rel="noopener noreferrer"
+                variant="filled"
+                Icon={primary.Icon}
+                iconClassName="h-3.5 w-3.5"
+                className="inline-flex w-full justify-center gap-2 rounded-md border-border bg-primary text-sm font-medium text-white shadow-none transition-all hover:border-foreground/20 hover:bg-primary/80 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 sm:w-auto"
+                padding="px-4 py-2"
+              >
+                {primary.label}
+              </ReusableButton>
+            </div>
+          </div>
+
+          <div className="relative hidden lg:block">
+            <div className="rounded-lg border border-border bg-card shadow-xl">
+              <div className="flex items-center justify-between border-b border-border px-4 py-3">
+                <div className="flex items-center gap-2">
+                  <span className="h-2.5 w-2.5 rounded-full bg-red-400" />
+                  <span className="h-2.5 w-2.5 rounded-full bg-amber-400" />
+                  <span className="h-2.5 w-2.5 rounded-full bg-emerald-500" />
+                </div>
+                <span className="text-xs font-medium text-muted-foreground">
+                  {vertexConfig.org.name} Desktop
+                </span>
+              </div>
+              <div className="grid gap-4 p-4 sm:p-6">
+                <div className="flex items-center justify-between rounded-lg bg-primary px-4 py-3 text-white">
+                  <div>
+                    <p className="text-sm font-semibold text-white">Device rollout</p>
+                    <p className="text-xs text-white/80">24 devices ready for deployment</p>
+                  </div>
+                  <Monitor className="h-8 w-8 text-white" />
+                </div>
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <div className="rounded-lg border border-border bg-background p-4">
+                    <p className="text-sm font-semibold text-heading">Deployment checks</p>
+                    <div className="mt-4 space-y-3">
+                      {['Add devices', 'Verify metadata', 'Share data'].map((step) => (
+                        <div key={step} className="flex items-center gap-2">
+                          <ShieldCheck className="h-4 w-4 text-emerald-600" />
+                          <span className="text-sm text-muted-foreground">{step}</span>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                  <div className="rounded-lg border border-border bg-background p-4">
+                    <p className="text-sm font-semibold text-heading">Network visibility</p>
+                    <div className="mt-4 space-y-3">
+                      {[82, 64, 48].map((width, index) => (
+                        <div key={width} className="space-y-1.5">
+                          <div className="h-2 rounded-full bg-secondary animate-pulse" />
+                          <div
+                            className="h-2 rounded-full bg-primary animate-pulse transition-all duration-1000 ease-out"
+                            style={{ width: mounted ? `${width}%` : '0%' }}
+                          />
+                          {index === 2 && (
+                            <p className="text-xs text-muted-foreground">Recent sync activity</p>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
 
-        <div className="relative hidden lg:block">
-          <div className="rounded-lg border border-border bg-white shadow-xl">
-            <div className="flex items-center justify-between border-b border-border px-4 py-3">
-              <div className="flex items-center gap-2">
-                <span className="h-2.5 w-2.5 rounded-full bg-red-400" />
-                <span className="h-2.5 w-2.5 rounded-full bg-amber-400" />
-                <span className="h-2.5 w-2.5 rounded-full bg-emerald-500" />
-              </div>
-              <span className="text-xs font-medium text-muted-foreground">
-                {vertexConfig.org.name} Desktop
-              </span>
-            </div>
-            <div className="grid gap-4 p-4 sm:p-6">
-              <div className="flex items-center justify-between rounded-lg bg-primary px-4 py-3 text-white">
-                <div>
-                  <p className="text-sm font-semibold text-white">
-                    Device rollout
-                  </p>
-                  <p className="text-xs text-white/80">
-                    24 devices ready for deployment
-                  </p>
-                </div>
-                <Monitor className="h-8 w-8 text-white" />
-              </div>
+        {/* Platform cards */}
+        <div id="releases" className="mt-12 pt-10 border-t border-border">
+          <p className="text-xs font-medium uppercase tracking-widest text-muted-foreground mb-6">
+            All releases
+          </p>
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+            {platformCards.map(({ id, label, Icon, links, terminal }) => {
+              const isDetected = platform === id;
+              return (
+                <div
+                  key={id}
+                  className={`rounded-xl border bg-card p-5 flex flex-col gap-4 ${
+                    isDetected ? 'border-primary/30 ring-1 ring-primary/20' : 'border-border'
+                  }`}
+                >
+                  {/* Card header */}
+                  <div className="flex items-center gap-2">
+                    <Icon className="h-4 w-4 text-foreground" />
+                    <span className="font-semibold text-heading">{label}</span>
+                  </div>
 
-              <div className="grid gap-3 sm:grid-cols-2">
-                <div className="rounded-lg border border-border bg-background p-4">
-                  <p className="text-sm font-semibold text-heading">
-                    Deployment checks
-                  </p>
-                  <div className="mt-4 space-y-3">
-                    {['Add devices', 'Verify metadata', 'Share data'].map(
-                      step => (
-                        <div key={step} className="flex items-center gap-2">
-                          <ShieldCheck className="h-4 w-4 text-emerald-600" />
-                          <span className="text-sm text-muted-foreground">
-                            {step}
+                  {/* Download links */}
+                  <div className="flex flex-col gap-2">
+                    {links.map(({ label: linkLabel, suffix, href }) =>
+                      href ? (
+                        <a
+                          key={linkLabel + suffix}
+                          href={href}
+                          className="flex items-center justify-between rounded-md border border-border px-3 py-2 text-sm hover:bg-muted/50 hover:border-primary/30 transition-colors group"
+                          download
+                        >
+                          <span className="text-foreground">
+                            {linkLabel}
+                            {suffix && (
+                              <span className="ml-1 text-xs text-muted-foreground">{suffix}</span>
+                            )}
                           </span>
-                        </div>
-                      )
+                          <Download className="h-3.5 w-3.5 text-muted-foreground group-hover:text-primary transition-colors" />
+                        </a>
+                      ) : null
                     )}
                   </div>
-                </div>
-                <div className="rounded-lg border border-border bg-background p-4">
-                  <p className="text-sm font-semibold text-heading">
-                    Network visibility
-                  </p>
-                  <div className="mt-4 space-y-3">
-                    {[82, 64, 48].map((width, index) => (
-                      <div key={width} className="space-y-1.5">
-                        <div className="h-2 rounded-full bg-secondary animate-pulse" />
-                        <div
-                          className="h-2 rounded-full bg-primary animate-pulse transition-all duration-1000 ease-out"
-                          style={{ width: mounted ? `${width}%` : '0%' }}
-                        />
-                        {index === 2 && (
-                          <p className="text-xs text-muted-foreground">
-                            Recent sync activity
-                          </p>
-                        )}
+
+                  {/* Linux terminal snippet */}
+                  {terminal && (
+                    <div className="mt-auto pt-3 border-t border-border">
+                      <p className="text-xs text-muted-foreground mb-2">
+                        Install via terminal
+                      </p>
+                      <div className="flex items-center gap-2">
+                        <div className="flex-1 rounded-md bg-muted px-3 py-2 overflow-x-auto">
+                          <code className="text-xs font-mono text-foreground whitespace-nowrap">
+                            {LINUX_INSTALL_COMMAND}
+                          </code>
+                        </div>
+                        <CopyButton text={LINUX_INSTALL_COMMAND} />
                       </div>
-                    ))}
-                  </div>
+                    </div>
+                  )}
                 </div>
-              </div>
-            </div>
+              );
+            })}
           </div>
         </div>
       </div>

--- a/src/vertex/components/features/download/DownloadHero.tsx
+++ b/src/vertex/components/features/download/DownloadHero.tsx
@@ -11,6 +11,7 @@ import {
   type DesktopReleaseUrls,
 } from '@/core/constants/app-downloads';
 import { useDetectedPlatform } from '@/core/hooks/useDetectedPlatform';
+import { getMacArchitecture } from '@/core/utils/platform';
 import { vertexConfig } from '@/vertex.config';
 
 const WindowsIcon = ({ className }: { className?: string }) => (
@@ -29,9 +30,13 @@ function CopyButton({ text }: { text: string }) {
   const [copied, setCopied] = useState(false);
 
   const handleCopy = async () => {
-    await navigator.clipboard.writeText(text);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // clipboard unavailable (non-secure context, permissions denied)
+    }
   };
 
   return (
@@ -45,12 +50,21 @@ function CopyButton({ text }: { text: string }) {
   );
 }
 
-function getPrimaryRelease(platform: string, release: DesktopReleaseUrls) {
+function getPrimaryRelease(
+  platform: string,
+  release: DesktopReleaseUrls,
+  macArch: 'arm64' | 'x64' | 'unknown',
+) {
   switch (platform) {
     case 'win':
       return { label: 'Download for Windows', href: release.windows.exe, Icon: WindowsIcon };
-    case 'mac':
-      return { label: 'Download for macOS', href: release.mac.arm64Dmg, Icon: AppleIcon };
+    case 'mac': {
+      const href =
+        macArch === 'arm64'
+          ? (release.mac.arm64Dmg ?? release.mac.intelDmg)
+          : (release.mac.intelDmg ?? release.mac.arm64Dmg);
+      return { label: 'Download for macOS', href, Icon: AppleIcon };
+    }
     case 'linux':
       return { label: 'Download for Linux', href: release.linux.appImage, Icon: FaLinux };
     default:
@@ -61,7 +75,12 @@ function getPrimaryRelease(platform: string, release: DesktopReleaseUrls) {
 export default function DownloadHero() {
   const [mounted, setMounted] = useState(false);
   const [release, setRelease] = useState<DesktopReleaseUrls>(VERTEX_DESKTOP_DOWNLOAD_FALLBACKS);
+  const [macArch, setMacArch] = useState<'arm64' | 'x64' | 'unknown'>('unknown');
   const { platform } = useDetectedPlatform();
+
+  useEffect(() => {
+    if (platform === 'mac') getMacArchitecture().then(setMacArch);
+  }, [platform]);
 
   useEffect(() => {
     const timer = setTimeout(() => setMounted(true), 100);
@@ -75,7 +94,7 @@ export default function DownloadHero() {
       .catch(() => {});
   }, []);
 
-  const primary = getPrimaryRelease(platform, release);
+  const primary = getPrimaryRelease(platform, release, macArch);
 
   const platformCards = [
     {

--- a/src/vertex/components/features/download/PlatformInfo.tsx
+++ b/src/vertex/components/features/download/PlatformInfo.tsx
@@ -25,7 +25,7 @@ const features = [
 
 export default function PlatformInfo() {
   return (
-    <section className="bg-white px-4 py-8 sm:px-6 sm:py-14 lg:px-8">
+    <section className="bg-background px-4 py-8 sm:px-6 sm:py-14 lg:px-8">
       <div className="mx-auto grid max-w-7xl gap-4 md:grid-cols-3">
         {features.map(feature => {
           const Icon = feature.icon;

--- a/src/vertex/components/layout/secondary-sidebar.tsx
+++ b/src/vertex/components/layout/secondary-sidebar.tsx
@@ -19,6 +19,7 @@ import { usePathname } from 'next/navigation';
 import { ROUTE_LINKS } from '@/core/routes';
 import Card from '../shared/card/CardWrapper';
 import { NavItem } from './NavItem';
+import { useDetectedPlatform } from '@/core/hooks/useDetectedPlatform';
 
 interface SecondarySidebarProps {
   isCollapsed: boolean;
@@ -55,20 +56,7 @@ const SecondarySidebar: React.FC<SecondarySidebarProps> = ({
   const contextPermissions = getContextPermissions();
   const pathname = usePathname();
 
-  const [platform, setPlatform] = React.useState<'win' | 'linux' | 'other' | null>(null);
-  const [isElectron, setIsElectron] = React.useState(false);
-
-  React.useEffect(() => {
-    const userAgent = window.navigator.userAgent.toLowerCase();
-    setIsElectron(userAgent.includes('electron'));
-    if (userAgent.includes('win')) {
-      setPlatform('win');
-    } else if (userAgent.includes('linux')) {
-      setPlatform('linux');
-    } else {
-      setPlatform('other');
-    }
-  }, []);
+  const { isElectron } = useDetectedPlatform();
 
   return (
     <aside
@@ -279,7 +267,7 @@ const SecondarySidebar: React.FC<SecondarySidebarProps> = ({
             </>
           )}
 
-          {!isCollapsed && activeModule !== 'admin' && !isElectron && platform === 'win' && (
+          {!isCollapsed && activeModule !== 'admin' && !isElectron && (
             <div className="mt-auto px-1 pb-2 pt-4">
               <Link
                 href={ROUTE_LINKS.DOWNLOAD}
@@ -287,10 +275,7 @@ const SecondarySidebar: React.FC<SecondarySidebarProps> = ({
                 rel="noopener noreferrer"
                 className="inline-flex items-center justify-center gap-2 w-full rounded-md border border-border bg-primary px-4 py-2 text-sm font-medium text-white transition-all hover:bg-primary/80 hover:border-foreground/20 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
               >
-                <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor">
-                  <path d="M0 3.449L9.75 2.1V11.7H0V3.449zm0 9.151h9.75v9.6L0 20.551V12.6zm10.55-10.701L24 0v11.7h-13.45V1.899zm0 10.701H24V24l-13.45-1.899V12.6z" />
-                </svg>
-                <span className="truncate">Download for Windows</span>
+                <span className="truncate">Get Desktop app</span>
               </Link>
             </div>
           )}

--- a/src/vertex/core/constants/app-downloads.ts
+++ b/src/vertex/core/constants/app-downloads.ts
@@ -1,8 +1,38 @@
-const DEFAULT_VERTEX_DESKTOP_WINDOWS_DOWNLOAD_URL =
-  'https://github.com/airqo-platform/AirQo-frontend/releases/download/v0.1.7/AirQo-Vertex-Setup-0.1.7.exe';
+export interface DesktopReleaseUrls {
+  version: string
+  windows: { exe: string | null }
+  mac: {
+    arm64Dmg: string | null
+    arm64Zip: string | null
+    intelDmg: string | null
+    intelZip: string | null
+  }
+  linux: {
+    appImage: string | null
+    deb: string | null
+  }
+}
 
-export const VERTEX_DESKTOP_DOWNLOADS = {
-  windows:
-    process.env.NEXT_PUBLIC_VERTEX_DESKTOP_WINDOWS_DOWNLOAD_URL ||
-    DEFAULT_VERTEX_DESKTOP_WINDOWS_DOWNLOAD_URL,
-};
+export const VERTEX_DESKTOP_DOWNLOAD_FALLBACKS: DesktopReleaseUrls = {
+  version: 'v0.1.11',
+  windows: {
+    exe: 'https://github.com/airqo-platform/AirQo-frontend/releases/download/v0.1.11/AirQo-Vertex-Setup-0.1.11.exe',
+  },
+  mac: {
+    arm64Dmg:
+      'https://github.com/airqo-platform/AirQo-frontend/releases/download/v0.1.11/AirQo-Vertex-0.1.11-arm64.dmg',
+    arm64Zip:
+      'https://github.com/airqo-platform/AirQo-frontend/releases/download/v0.1.11/AirQo-Vertex-0.1.11-arm64-mac.zip',
+    intelDmg:
+      'https://github.com/airqo-platform/AirQo-frontend/releases/download/v0.1.11/AirQo-Vertex-0.1.11.dmg',
+    intelZip:
+      'https://github.com/airqo-platform/AirQo-frontend/releases/download/v0.1.11/AirQo-Vertex-0.1.11-mac.zip',
+  },
+  linux: {
+    appImage:
+      'https://github.com/airqo-platform/AirQo-frontend/releases/download/v0.1.11/AirQo-Vertex-0.1.11.AppImage',
+    deb: 'https://github.com/airqo-platform/AirQo-frontend/releases/download/v0.1.11/vertex-desktop_0.1.11_amd64.deb',
+  },
+}
+
+export const LINUX_INSTALL_COMMAND = 'curl -fsSL https://vertex.airqo.net/install.sh | bash'

--- a/src/vertex/core/hooks/useDetectedPlatform.ts
+++ b/src/vertex/core/hooks/useDetectedPlatform.ts
@@ -1,0 +1,21 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { getDetectedPlatform, getIsElectron, type DetectedPlatform } from '@/core/utils/platform'
+
+export type { DetectedPlatform }
+
+export interface PlatformInfo {
+  platform: DetectedPlatform
+  isElectron: boolean
+}
+
+export function useDetectedPlatform(): PlatformInfo {
+  const [info, setInfo] = useState<PlatformInfo>({ platform: 'other', isElectron: false })
+
+  useEffect(() => {
+    setInfo({ platform: getDetectedPlatform(), isElectron: getIsElectron() })
+  }, [])
+
+  return info
+}

--- a/src/vertex/core/utils/platform.ts
+++ b/src/vertex/core/utils/platform.ts
@@ -1,3 +1,19 @@
+export type DetectedPlatform = 'win' | 'mac' | 'linux' | 'other'
+
+export function getDetectedPlatform(): DetectedPlatform {
+  if (typeof window === 'undefined') return 'other'
+  const ua = window.navigator.userAgent.toLowerCase()
+  if (ua.includes('win')) return 'win'
+  if (ua.includes('mac')) return 'mac'
+  if (ua.includes('linux')) return 'linux'
+  return 'other'
+}
+
+export function getIsElectron(): boolean {
+  if (typeof window === 'undefined') return false
+  return window.navigator.userAgent.toLowerCase().includes('electron')
+}
+
 /**
  * Detects if the current user agent is running on Apple Silicon (ARM64).
  * Returns 'arm64' for Apple Silicon, 'x64' for Intel, and 'unknown' otherwise.

--- a/src/vertex/core/utils/platform.ts
+++ b/src/vertex/core/utils/platform.ts
@@ -3,9 +3,11 @@ export type DetectedPlatform = 'win' | 'mac' | 'linux' | 'other'
 export function getDetectedPlatform(): DetectedPlatform {
   if (typeof window === 'undefined') return 'other'
   const ua = window.navigator.userAgent.toLowerCase()
-  if (ua.includes('win')) return 'win'
-  if (ua.includes('mac')) return 'mac'
-  if (ua.includes('linux')) return 'linux'
+  const isIOS = /iphone|ipad|ipod/.test(ua)
+  const isAndroid = /android/.test(ua)
+  if (!isIOS && /windows nt|win32|win64/.test(ua)) return 'win'
+  if (!isIOS && /macintosh|mac os x/.test(ua)) return 'mac'
+  if (!isAndroid && /linux/.test(ua)) return 'linux'
   return 'other'
 }
 

--- a/src/vertex/package.json
+++ b/src/vertex/package.json
@@ -114,7 +114,7 @@
     {
       "name": "vertex-main-chunk",
       "path": ".next/static/chunks/app/**/*.js",
-      "limit": "200 kB"
+      "limit": "205 kB"
     }
   ]
 }


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

- Adds a platform-aware primary download button on `/download` that detects the visitor's OS and links to the correct release asset (Windows `.exe`, macOS Apple Silicon `.dmg`, Linux `.AppImage`).
- Adds a server-side Route Handler (`/api/latest-release`) that fetches the latest Vertex Desktop release from GitHub automatically, cached via ISR (1 hr) — no more hardcoded version URLs.
- Adds three platform release cards (macOS, Windows, Linux) below the hero, with a terminal install snippet and copy button for Linux.
- Centralises OS detection into `core/utils/platform.ts` + a new `useDetectedPlatform` hook, replacing inline `userAgent` checks across sidebar, login page, and social auth.
- Fixes the `/download` page not being scrollable (caused by `globals.css` setting `html { overflow: hidden }` globally).

#### Status of maturity (all need to be checked before merging):

- [x] I've tested this locally
- [x] I consider this code done
- [x] This change ready to hit production in its current state
- [x] The title of the PR states what changed and the related issues number (used for the release note).
- [x] I've included issue number in the "Closes #3762" part of the "[What are the relevant tickets?](#what-are-the-relevant-tickets)" section to [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] I've updated corresponding documentation for the changes in this PR.
- [ ] I have written unit and/or e2e tests for my change(s).

#### How should this be manually tested?

1. Run the dev server: `npm run dev` from `src/vertex`.
2. Navigate to `/download` — verify the page scrolls and the primary button label matches your OS.
3. Check the three platform cards render with correct download links (inspect network → `/api/latest-release` should return live GitHub data).
4. Simulate other platforms by temporarily hardcoding `platform` in `useDetectedPlatform` to `'win'`, `'mac'`, `'linux'`.
5. In the sidebar (authenticated, non-Electron, non-admin), confirm "Get Desktop app" CTA is visible.
6. On the login page in a non-Electron browser, confirm "Get Desktop app" CTA is visible.
7. Kill network access and reload `/download` — confirm fallback URLs still render (v0.1.11).
8. Toggle dark mode — verify cards, hero section, and PlatformInfo section all render correctly.

#### What are the relevant tickets?

- Closes #3762
#### Screenshots (optional)
<img width="957" height="470" alt="image" src="https://github.com/user-attachments/assets/fd100ed9-ae0f-430a-a5fc-afbaeb89455f" />
<img width="890" height="459" alt="image" src="https://github.com/user-attachments/assets/ea5cae38-bafa-4833-abd4-7247903a119a" />
<img width="1878" height="994" alt="image" src="https://github.com/user-attachments/assets/9009e070-06cc-45a5-ac0c-5da9c089d64a" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added platform-aware desktop download experience for Windows, macOS, and Linux with “latest release” links and OS-specific assets.
  * Updated the download API to fetch matching desktop release assets and serve cached results.
  * Added Linux install command with copy-to-clipboard support, plus platform cards and dynamic primary CTA behavior.
* **Bug Fixes**
  * Improved “Get Desktop app” visibility and labeling across non-Electron environments (including login/header/sidebar).
  * Fixed download page viewport/scroll behavior and reduced hydration mismatches with improved platform detection.
* **Chores**
  * Updated the changelog with the new download experience details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->