### PR TITLE
Hotfix for Vertex desktop social window

### DIFF
--- a/src/vertex-desktop/main/auth-window.ts
+++ b/src/vertex-desktop/main/auth-window.ts
@@ -21,7 +21,10 @@ const isOAuthUrl = (url: string): boolean => {
     const trustedOrigin = apiOrigin
       ? parsed.origin === apiOrigin
       : parsed.hostname === "airqo.net" || parsed.hostname.endsWith(".airqo.net");
-    return trustedOrigin && parsed.pathname.startsWith("/users/auth/");
+    return trustedOrigin && (
+      parsed.pathname.startsWith("/users/auth/") ||
+      parsed.pathname.includes("/users/auth/")
+    );
   } catch {
     return false;
   }

--- a/src/vertex-desktop/main/auth-window.ts
+++ b/src/vertex-desktop/main/auth-window.ts
@@ -21,10 +21,7 @@ const isOAuthUrl = (url: string): boolean => {
     const trustedOrigin = apiOrigin
       ? parsed.origin === apiOrigin
       : parsed.hostname === "airqo.net" || parsed.hostname.endsWith(".airqo.net");
-    return trustedOrigin && (
-      parsed.pathname.startsWith("/users/auth/") ||
-      parsed.pathname.includes("/users/auth/")
-    );
+    return trustedOrigin && /^\/(?:api\/v\d+\/)?users\/auth\//i.test(parsed.pathname);
   } catch {
     return false;
   }


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

- Fixes social OAuth (Google, GitHub, LinkedIn, X) opening in the system browser instead of an in-app Electron child window in Vertex Desktop.
- Root cause: `isOAuthUrl()` in `auth-window.ts` checked `pathname.startsWith("/users/auth/")` but the actual URL built by `buildOAuthInitiationUrl` includes the API version prefix — `/api/v2/users/auth/<provider>`. The `startsWith` check rejected every OAuth URL, causing all social sign-in attempts to fall through to `shell.openExternal()`.
- Fix: changed the path check to `pathname.includes("/users/auth/")` so versioned paths (`/api/v2/users/auth/*`) are matched correctly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded sign-in URL matching to recognize trusted authentication pages more reliably, including OAuth URLs where the auth path appears deeper in supported API routes.
  * Improved OAuth redirect handling for valid URLs that previously weren’t detected due to case/path variations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->