### PR TITLE
docs(vertex): mention Linux, macOS, and Windows in Desktop quickstart

### DIFF
--- a/src/docs-website/docs/vertex/quickstart.md
+++ b/src/docs-website/docs/vertex/quickstart.md
@@ -30,7 +30,7 @@ Vertex is designed to be accessible from multiple environments to suit your work
     Use the dedicated Vertex Desktop client, optimized for field engineers and offline management.
     
     ### 1. Download Vertex Desktop
-    Download the Windows application from [vertex.airqo.net/download](https://vertex.airqo.net/download).
+    Download the application for Linux, macOS, or Windows from [vertex.airqo.net/download](https://vertex.airqo.net/download)
     
     ### 2. Install and open the application
     Run the installer and open Vertex Desktop. It is built for local-network use and times when you don't have reliable internet access.

--- a/src/docs-website/docs/vertex/quickstart.md
+++ b/src/docs-website/docs/vertex/quickstart.md
@@ -13,47 +13,46 @@ Vertex is designed to be accessible from multiple environments to suit your work
 ## Setup
 
 <Tabs groupId="operating-systems">
-<TabItem value="web" label="Web" default>
-Access the Vertex platform directly from your browser.
-
-### 1. Navigate to Vertex Web
-Open your browser and head to [vertex.airqo.net](https://vertex.airqo.net).
-
-### 2. Sign in to your workspace
-Use your AirQo account credentials to log in.
-
-### 3. Explore your devices
-Once logged in, you can view your cohorts, sites, and manage your device inventory.
-</TabItem>
-
-<TabItem value="desktop" label="Desktop">
-Use the dedicated Vertex Desktop client, optimized for field engineers and offline management.
-
-### 1. Download Vertex Desktop
-Download the application for Linux, macOS, or Windows from [vertex.airqo.net/download](https://vertex.airqo.net/download).
-
-### 2. Install and open the application
-Run the installer and open Vertex Desktop. It is built for local-network use and times when you don't have reliable internet access.
-
-### 3. Sign in and sync
-Sign in with your credentials to sync your device configurations and cohorts for field work.
-</TabItem>
-
-<TabItem value="toolkit" label="Developer Toolkit">
-Scaffold and build custom IoT applications tailored to your specific sensor networks.
-
-### 1. Vertex IoT Kit (Coming Soon)
-*Coming soon!* The `vertex-iot-kit` is a powerful command-line scaffolding tool that allows developers to instantly bootstrap a fully configured boilerplate, making it easy to start building custom IoT sensor management applications right away.
-</TabItem>
+  <TabItem value="web" label="Web" default>
+    Access the Vertex platform directly from your browser.
+    
+    ### 1. Navigate to Vertex Web
+    Open your browser and head to [vertex.airqo.net](https://vertex.airqo.net).
+    
+    ### 2. Sign in to your workspace
+    Use your AirQo account credentials to log in.
+    
+    ### 3. Explore your devices
+    Once logged in, you can view your cohorts, sites, and manage your device inventory.
+  </TabItem>
+  
+  <TabItem value="desktop" label="Desktop">
+    Use the dedicated Vertex Desktop client, optimized for field engineers and offline management.
+    
+    ### 1. Download Vertex Desktop
+    Download the application for Linux, macOS, or Windows from [vertex.airqo.net/download](https://vertex.airqo.net/download).
+    
+    ### 2. Install and open the application
+    Run the installer and open Vertex Desktop. It is built for local-network use and times when you don't have reliable internet access.
+    
+    ### 3. Sign in and sync
+    Sign in with your credentials to sync your device configurations and cohorts for field work.
+  </TabItem>
+  
+  <TabItem value="toolkit" label="Developer Toolkit">
+    Scaffold and build custom IoT applications tailored to your specific sensor networks.
+    
+    ### 1. Vertex IoT Kit (Coming Soon)
+    *Coming soon!* The `vertex-iot-kit` is a powerful command-line scaffolding tool that allows developers to instantly bootstrap a fully configured boilerplate, making it easy to start building custom IoT sensor management applications right away.
+  </TabItem>
 </Tabs>
 
 <br />
 
 ## Next steps
 
-- [**For Organizations**](./getting-started/for-organizations.md)
-- Learn how to coordinate multiple devices across various regions, manage cohorts, and oversee complex deployments.
+- [**For Organizations**](./getting-started/for-organizations.md)  
+  Learn how to coordinate multiple devices across various regions, manage cohorts, and oversee complex deployments.
 
-- - [**For Individuals**](./getting-started/for-individuals.md)
-  - Discover how to deploy a single device at home and contribute to the global air quality network.
-  - 
+- [**For Individuals**](./getting-started/for-individuals.md)  
+  Discover how to deploy a single device at home and contribute to the global air quality network.

--- a/src/docs-website/docs/vertex/quickstart.md
+++ b/src/docs-website/docs/vertex/quickstart.md
@@ -13,46 +13,47 @@ Vertex is designed to be accessible from multiple environments to suit your work
 ## Setup
 
 <Tabs groupId="operating-systems">
-  <TabItem value="web" label="Web" default>
-    Access the Vertex platform directly from your browser.
-    
-    ### 1. Navigate to Vertex Web
-    Open your browser and head to [vertex.airqo.net](https://vertex.airqo.net).
-    
-    ### 2. Sign in to your workspace
-    Use your AirQo account credentials to log in.
-    
-    ### 3. Explore your devices
-    Once logged in, you can view your cohorts, sites, and manage your device inventory.
-  </TabItem>
-  
-  <TabItem value="desktop" label="Desktop">
-    Use the dedicated Vertex Desktop client, optimized for field engineers and offline management.
-    
-    ### 1. Download Vertex Desktop
-    Download the application for Linux, macOS, or Windows from [vertex.airqo.net/download](https://vertex.airqo.net/download)
-    
-    ### 2. Install and open the application
-    Run the installer and open Vertex Desktop. It is built for local-network use and times when you don't have reliable internet access.
-    
-    ### 3. Sign in and sync
-    Sign in with your credentials to sync your device configurations and cohorts for field work.
-  </TabItem>
-  
-  <TabItem value="toolkit" label="Developer Toolkit">
-    Scaffold and build custom IoT applications tailored to your specific sensor networks.
-    
-    ### 1. Vertex IoT Kit (Coming Soon)
-    *Coming soon!* The `vertex-iot-kit` is a powerful command-line scaffolding tool that allows developers to instantly bootstrap a fully configured boilerplate, making it easy to start building custom IoT sensor management applications right away.
-  </TabItem>
+<TabItem value="web" label="Web" default>
+Access the Vertex platform directly from your browser.
+
+### 1. Navigate to Vertex Web
+Open your browser and head to [vertex.airqo.net](https://vertex.airqo.net).
+
+### 2. Sign in to your workspace
+Use your AirQo account credentials to log in.
+
+### 3. Explore your devices
+Once logged in, you can view your cohorts, sites, and manage your device inventory.
+</TabItem>
+
+<TabItem value="desktop" label="Desktop">
+Use the dedicated Vertex Desktop client, optimized for field engineers and offline management.
+
+### 1. Download Vertex Desktop
+Download the application for Linux, macOS, or Windows from [vertex.airqo.net/download](https://vertex.airqo.net/download).
+
+### 2. Install and open the application
+Run the installer and open Vertex Desktop. It is built for local-network use and times when you don't have reliable internet access.
+
+### 3. Sign in and sync
+Sign in with your credentials to sync your device configurations and cohorts for field work.
+</TabItem>
+
+<TabItem value="toolkit" label="Developer Toolkit">
+Scaffold and build custom IoT applications tailored to your specific sensor networks.
+
+### 1. Vertex IoT Kit (Coming Soon)
+*Coming soon!* The `vertex-iot-kit` is a powerful command-line scaffolding tool that allows developers to instantly bootstrap a fully configured boilerplate, making it easy to start building custom IoT sensor management applications right away.
+</TabItem>
 </Tabs>
 
 <br />
 
 ## Next steps
 
-- [**For Organizations**](./getting-started/for-organizations.md)  
-  Learn how to coordinate multiple devices across various regions, manage cohorts, and oversee complex deployments.
+- [**For Organizations**](./getting-started/for-organizations.md)
+- Learn how to coordinate multiple devices across various regions, manage cohorts, and oversee complex deployments.
 
-- [**For Individuals**](./getting-started/for-individuals.md)  
-  Discover how to deploy a single device at home and contribute to the global air quality network.
+- - [**For Individuals**](./getting-started/for-individuals.md)
+  - Discover how to deploy a single device at home and contribute to the global air quality network.
+  - 


### PR DESCRIPTION
Closes #3806.

## Problem
The Vertex Quickstart docs (Desktop tab) said "Download the Windows application", implying the Vertex Desktop app is Windows-only. It's actually available for Linux, macOS, and Windows.

## Fix
Updated the download instructions in `src/docs-website/docs/vertex/quickstart.md` to mention all three supported platforms. I also scanned the rest of `src/docs-website/docs/vertex/` for similar Windows-only wording and didn't find any other occurrences.

## Checklist
- [x] Confirmed supported platforms against `src/vertex/app/download/page.tsx`
- [x] Download link unchanged (still points to vertex.airqo.net/download)
- [x] Scanned the rest of the Vertex docs for the same issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Vertex quickstart to include download instructions for Linux, macOS, and Windows desktop applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->