### PR TITLE
fix(vertex-desktop): bump to v0.1.12

### DIFF
--- a/src/vertex-desktop/CHANGELOG.md
+++ b/src/vertex-desktop/CHANGELOG.md
@@ -4,6 +4,30 @@
 
 ---
 
+## Version 0.1.12
+**Released:** July 10, 2026
+
+### Hotfix: Social OAuth Opens in System Browser
+
+Fixed social sign-in (Google, GitHub, LinkedIn, X) opening in the system browser instead of the in-app Electron child window.
+
+<details>
+<summary><strong>Root Cause & Fix (<code>main/auth-window.ts</code>)</strong></summary>
+
+- `isOAuthUrl()` checked `pathname.startsWith("/users/auth/")` but the OAuth initiation URL includes the versioned API prefix — `/api/v2/users/auth/<provider>` — so every URL was rejected and fell through to `shell.openExternal()` (system browser).
+- Fixed by replacing the path check with an anchored regex `/^\/(?:api\/v\d+\/)?users\/auth\//i` that matches both unversioned and versioned paths without being overly broad.
+
+</details>
+
+<details>
+<summary><strong>Files Modified (1)</strong></summary>
+
+- `main/auth-window.ts` [MODIFIED]
+
+</details>
+
+---
+
 ## Version 0.1.11
 **Released:** July 06, 2026
 

--- a/src/vertex-desktop/package.json
+++ b/src/vertex-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vertex-desktop",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "private": true,
   "author": "AirQo <airqo.analytics@gmail.com>",
   "repository": {


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

- Bumped version to `0.1.12` so the auto-tag workflow picks up and cuts a new desktop release.

#### Status of maturity (all need to be checked before merging):

- [ ] I've tested this locally
- [ ] I consider this code done
- [ ] This change ready to hit production in its current state
- [ ] The title of the PR states what changed and the related issues number (used for the release note).
- [ ] I've included issue number in the "Closes #ISSUE-NUMBER" part of the "[What are the relevant tickets?](#what-are-the-relevant-tickets)" section to [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] I've updated corresponding documentation for the changes in this PR.
- [ ] I have written unit and/or e2e tests for my change(s).

#### How should this be manually tested?

1. From `src/vertex-desktop`, run `npm install` then `npm run dev`.
2. On the login page click any social sign-in button (Google, GitHub, LinkedIn, X).
3. Verify a **480×680 in-app child window** opens — not the system browser.
4. Complete sign-in and confirm the child window closes and the main window session is active.
5. Verify non-OAuth external links still open in the system browser.

#### Reviewers
@Baalmart 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed social sign-in links being incorrectly rejected and opened outside the app.
  * Social OAuth authentication now opens correctly in the system browser for both standard and versioned sign-in URLs.

* **Chores**
  * Updated the desktop app to version 0.1.12.
  * Added release notes documenting the authentication fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->