### PR TITLE
Fix iOS camera permission denial in Clean Air Forum live filter

### DIFF
--- a/src/mobile/ios/Podfile
+++ b/src/mobile/ios/Podfile
@@ -41,5 +41,15 @@ end
 post_install do |installer|
   installer.pods_project.targets.each do |target|
     flutter_additional_ios_build_settings(target)
+    target.build_configurations.each do |config|
+      # permission_handler compiles out each permission unless enabled here;
+      # without these, Permission.camera/notification report "denied" on iOS
+      # without ever prompting.
+      config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= [
+        '$(inherited)',
+        'PERMISSION_CAMERA=1',
+        'PERMISSION_NOTIFICATIONS=1',
+      ]
+    end
   end
 end


### PR DESCRIPTION
## Problem
The Clean Air Forum live filter preview always showed "Camera permission was denied" on iOS, even when the app's camera permission was granted at the OS level (e.g. via the profile-picture flow). Android was unaffected.

## Root cause
`permission_handler` on iOS compiles out each permission handler unless its preprocessor macro is defined in the Podfile (`PERMISSION_CAMERA` defaults to `0` in `permission_handler_apple`). Our Podfile defined no macros, so `Permission.camera.request()` returned a hardcoded denial without ever prompting or checking the real permission state. The same applies to `Permission.notification`, which is used in 4 places.

## Fix
Define `PERMISSION_CAMERA=1` and `PERMISSION_NOTIFICATIONS=1` in the Podfile's `post_install` hook.

## Testing
- Verified on a physical iPhone: the forum filter now opens the live camera preview (previously showed the denial error).
- The profile-picture flow (image_picker) is unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enabled camera and notification permissions to be correctly recognized during iOS app builds.
  * Preserved inherited build settings while applying the required permission configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->