### PR TITLE
Fix silent certificate share failures and ambiguous forecast day labels

### DIFF
--- a/src/mobile/lib/src/app/dashboard/widgets/analytics_forecast_widget.dart
+++ b/src/mobile/lib/src/app/dashboard/widgets/analytics_forecast_widget.dart
@@ -152,7 +152,7 @@ class _AnalyticsForecastWidgetState extends State<AnalyticsForecastWidget> with 
                           
                           return ForeCastChip(
                             active: isCurrentDay,
-                            day: DateFormat.E().format(e.time)[0],
+                            day: DateFormat.E().format(e.time).substring(0, 2),
                             imagePath:
                                 getForecastAirQualityIcon(e.aqiCategory),
                             height: _getResponsiveHeight(context),

--- a/src/mobile/lib/src/app/dashboard/widgets/forecast_day_selector.dart
+++ b/src/mobile/lib/src/app/dashboard/widgets/forecast_day_selector.dart
@@ -69,7 +69,7 @@ class ForecastDaySelector extends StatelessWidget {
                 mainAxisSize: MainAxisSize.min,
                 children: [
                   Text(
-                    isToday ? 'T' : DateFormat.E().format(f.time)[0],
+                    DateFormat.E().format(f.time).substring(0, 2),
                     style: TextStyle(
                       fontSize: 12,
                       fontWeight: FontWeight.w700,

--- a/src/mobile/lib/src/app/learn/widgets/experience/learn_course_certificate.dart
+++ b/src/mobile/lib/src/app/learn/widgets/experience/learn_course_certificate.dart
@@ -63,6 +63,11 @@ class _LearnCourseCertificatePaneState extends State<LearnCourseCertificatePane>
       final sharePositionOrigin =
           box != null ? box.localToGlobal(Offset.zero) & box.size : null;
 
+      // Only the capture phase should hold the button in "Preparing...";
+      // once the OS share sheet takes over, its future may not resolve
+      // promptly (or at all on some platforms) after sharing completes.
+      setState(() => _sharing = false);
+
       await Share.shareXFiles(
         [
           XFile.fromData(

--- a/src/mobile/lib/src/app/learn/widgets/experience/learn_course_certificate.dart
+++ b/src/mobile/lib/src/app/learn/widgets/experience/learn_course_certificate.dart
@@ -1,6 +1,4 @@
-import 'dart:io';
-import 'dart:ui' as ui;
-
+import 'package:airqo/src/app/dashboard/widgets/share_sheet_widgets.dart';
 import 'package:airqo/src/app/learn/formatting/learn_display_text.dart';
 import 'package:airqo/src/app/learn/models/learn_course_structure.dart';
 import 'package:airqo/src/app/learn/theme/learn_design_tokens.dart';
@@ -8,8 +6,7 @@ import 'package:airqo/src/app/learn/widgets/learn_completion_sheet.dart';
 import 'package:airqo/src/app/learn/widgets/learn_sheet_button_styles.dart';
 import 'package:airqo/src/app/shared/widgets/translated_text.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
-import 'package:path_provider/path_provider.dart';
+import 'package:loggy/loggy.dart';
 import 'package:share_plus/share_plus.dart';
 
 class LearnCourseCertificatePane extends StatefulWidget {
@@ -31,37 +28,59 @@ class LearnCourseCertificatePane extends StatefulWidget {
       _LearnCourseCertificatePaneState();
 }
 
-class _LearnCourseCertificatePaneState extends State<LearnCourseCertificatePane> {
+class _LearnCourseCertificatePaneState extends State<LearnCourseCertificatePane>
+    with UiLoggy {
   static const _appDownloadUrl = 'https://airqo.net/explore-data';
 
   final _certificateKey = GlobalKey();
   bool _sharing = false;
+  String? _shareError;
 
   String get _shareMessage =>
       'I completed ${learnDisplayTitle(widget.course.plainTitleKey)} course on AirQo Learn! '
       'Download the AirQo app and complete the course yourself: $_appDownloadUrl';
 
   Future<void> _shareCertificate() async {
-    setState(() => _sharing = true);
+    if (_sharing) return;
+    setState(() {
+      _sharing = true;
+      _shareError = null;
+    });
     try {
-      final boundary = _certificateKey.currentContext?.findRenderObject()
-          as RenderRepaintBoundary?;
-      if (boundary == null) return;
-      final image = await boundary.toImage(pixelRatio: 3);
-      final byteData = await image.toByteData(format: ui.ImageByteFormat.png);
-      if (byteData == null) return;
-      final pngBytes = byteData.buffer.asUint8List();
+      final pngBytes = await captureShareBoundary(context, _certificateKey);
+      if (pngBytes == null || !mounted) {
+        if (mounted) {
+          setState(
+            () => _shareError = "Couldn't prepare the certificate. Try again.",
+          );
+        }
+        return;
+      }
 
-      final dir = await getTemporaryDirectory();
-      final file = File(
-        '${dir.path}/airqo_course_${widget.course.id}_certificate.png',
-      );
-      await file.writeAsBytes(pngBytes);
+      // iPadOS requires an anchor rect for its share popover; share_plus
+      // throws without one.
+      final box = context.findRenderObject() as RenderBox?;
+      final sharePositionOrigin =
+          box != null ? box.localToGlobal(Offset.zero) & box.size : null;
 
       await Share.shareXFiles(
-        [XFile(file.path)],
+        [
+          XFile.fromData(
+            pngBytes,
+            mimeType: 'image/png',
+            name: 'airqo_course_${widget.course.id}_certificate.png',
+          ),
+        ],
         text: _shareMessage,
+        sharePositionOrigin: sharePositionOrigin,
       );
+    } catch (error) {
+      loggy.error('Failed to share course certificate: $error');
+      if (mounted) {
+        setState(
+          () => _shareError = "Couldn't share the certificate. Try again.",
+        );
+      }
     } finally {
       if (mounted) setState(() => _sharing = false);
     }
@@ -112,6 +131,17 @@ class _LearnCourseCertificatePaneState extends State<LearnCourseCertificatePane>
             textAlign: TextAlign.center,
             style: LearnDesignTokens.completionCaption(context),
           ),
+          if (_shareError != null) ...[
+            const SizedBox(height: 8),
+            TranslatedText(
+              _shareError!,
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                fontSize: 12,
+                color: Theme.of(context).colorScheme.error,
+              ),
+            ),
+          ],
         ],
       ),
       actions: [


### PR DESCRIPTION
- Share certificate: use captureShareBoundary and XFile.fromData, anchor the iPad share popover, and surface errors inline instead of swallowing them in a catch-less try/finally
- Forecast chips: show two-letter day labels so 'T' no longer conflates Today with Tuesday/Thursday

