### PR TITLE
Chore/organization col

### DIFF
--- a/src/vertex/app/(authenticated)/devices/my-devices/page.tsx
+++ b/src/vertex/app/(authenticated)/devices/my-devices/page.tsx
@@ -209,6 +209,7 @@ const MyDevicesPage = () => {
           isLoading={isLoading}
           error={error}
           multiSelect={true}
+          hiddenColumns={['groups']}
         />
 
         {/* Modals */}

--- a/src/vertex/app/changelog.md
+++ b/src/vertex/app/changelog.md
@@ -2,6 +2,13 @@
 
 > **Note**: This changelog consolidates all recent improvements, features, and fixes to the AirQo Vertex frontend.
 
+## Version 2.0.26
+**Released:** July 16, 2026
+
+### Chore: hide redundant Organization column on My Devices table
+
+The **Organization** column is no longer shown on the My Devices table (`/devices/my-devices`). The active organization is already visible in the top-bar org picker, making the column redundant — for personal devices it rendered a dash, and it added unnecessary horizontal width to an already wide table. The existing `hiddenColumns` prop on `ClientPaginatedDevicesTable` is used; no changes to the table component or column definitions were needed. Tables on other pages are unaffected.
+
 ## Version 2.0.24
 **Released:** July 12, 2026
 


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

Hides the redundant **Organization** column from the My Devices table (`/devices/my-devices`) by passing `hiddenColumns={['groups']}` to `ClientPaginatedDevicesTable`. The `hiddenColumns` prop already existed on the table component — this is a one-line change to the page.

The column is redundant on this page because the active organization is already shown in the top-bar org picker, and for personal devices it renders a dash. All other tables that reuse `ClientPaginatedDevicesTable` are unaffected.

**Files changed (1):**

- `src/vertex/app/(authenticated)/devices/my-devices/page.tsx` — added `hiddenColumns={['groups']}` to `<ClientPaginatedDevicesTable />`

#### Status of maturity (all need to be checked before merging):

- [x] I've tested this locally
- [x] I consider this code done
- [x] This change ready to hit production in its current state
- [x] The title of the PR states what changed and the related issues number (used for the release note).
- [x] I've included issue number in the "Closes #3810" part of the "[What are the relevant tickets?](#what-are-the-relevant-tickets)" section to [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] I've updated corresponding documentation for the changes in this PR.
- [ ] I have written unit and/or e2e tests for my change(s).

#### How should this be manually tested?

1. Run `npm run dev` inside `src/vertex`.
2. Navigate to **My Devices** (`/devices/my-devices`).
3. Confirm the **Organization** column is no longer visible in the table — including when logged in as an AirQo-internal user in personal context (where it previously appeared).
4. Confirm all other columns (Device Name, Device Status, Site, Deployment Status, Created On, etc.) are still present and render correctly.
5. Navigate to another page that uses the same table (e.g. a site detail page or cohort detail page) and confirm the Organization column is still shown there — the `hiddenColumns` prop is only passed on My Devices.

#### What are the relevant tickets?

- Closes #3810

#### Screenshots (optional)
