### PR TITLE
feat(vertex): surface dateValidStatus diagnostic hint on device and s…

### DIFF
--- a/src/vertex/app/changelog.md
+++ b/src/vertex/app/changelog.md
@@ -2,6 +2,23 @@
 
 > **Note**: This changelog consolidates all recent improvements, features, and fixes to the AirQo Vertex frontend.
 
+## Version 2.0.27
+**Released:** July 27, 2026
+
+### Feat: surface `dateValidStatus` diagnostic hint on device and site status badges
+
+Adds a non-breaking diagnostic indicator for devices and sites that report a bad onboard clock or unparseable timestamp. A purple `AlertTriangle` icon appears next to the existing status badge whenever the backend returns `dateValidStatus: "future_timestamp"` or `"invalid_format"`; hovering reveals a short explanation. The field is optional and additive — existing status logic, colors, and labels are untouched.
+
+**Files changed:**
+- `app/types/devices.ts` — `dateValidStatus` optional field on `Device`
+- `app/types/sites.ts` — `dateValidStatus` optional field on `Site`
+- `core/utils/status.ts` — `getDateValidHint()` helper + `DateValidHint` interface
+- `components/features/devices/online-status-card.tsx` — hint icon next to status label
+- `components/features/devices/utils/table-columns.tsx` — hint icon in Device Status column (wrapped in `TooltipProvider`)
+- `components/features/sites/sites-list-table.tsx` — hint icon in Status column
+- `components/features/sites/client-paginated-sites-table.tsx` — hint icon in Status column
+- `components/features/sites/site-information-card.tsx` — hint icon next to status badge
+
 ## Version 2.0.26
 **Released:** July 16, 2026
 

--- a/src/vertex/app/types/devices.ts
+++ b/src/vertex/app/types/devices.ts
@@ -147,6 +147,7 @@ export interface Device {
   lastActive?: string;
   lastRawData?: string;
   rawOnlineStatus?: boolean;
+  dateValidStatus?: "valid" | "future_timestamp" | "invalid_format" | "unknown";
   tags?: string[];
 }
 

--- a/src/vertex/app/types/sites.ts
+++ b/src/vertex/app/types/sites.ts
@@ -15,6 +15,7 @@ export interface Site {
   site_tags?: string[];
   isOnline?: boolean;
   rawOnlineStatus?: boolean;
+  dateValidStatus?: "valid" | "future_timestamp" | "invalid_format" | "unknown";
   formatted_name?: string;
   location_name?: string;
   search_name?: string;

--- a/src/vertex/components/features/devices/online-status-card.tsx
+++ b/src/vertex/components/features/devices/online-status-card.tsx
@@ -15,6 +15,7 @@ import {
 import {
   formatDisplayDate,
   getDeviceStatus,
+  getDateValidHint,
   getStatusExplanation,
 } from "@/core/utils/status";
 
@@ -148,6 +149,7 @@ const OnlineStatusCard: React.FC<OnlineStatusCardProps> = ({ deviceId }) => {
 
   const colors = statusColorClasses[status.color];
   const detailedExplanation = getStatusExplanation(status.label, lastActiveCheck);
+  const dateHint = getDateValidHint(device.dateValidStatus);
 
   const Icon = status.icon;
 
@@ -181,6 +183,17 @@ const OnlineStatusCard: React.FC<OnlineStatusCardProps> = ({ deviceId }) => {
             >
               <Icon className="w-5 h-5" />
               <span>{status.label}</span>
+              {dateHint && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <AlertTriangle className="w-4 h-4 text-purple-600 cursor-help" />
+                  </TooltipTrigger>
+                  <TooltipContent side="top">
+                    <p className="text-sm font-medium mb-1">{dateHint.label}</p>
+                    <p className="text-xs max-w-xs">{dateHint.description}</p>
+                  </TooltipContent>
+                </Tooltip>
+              )}
             </div>
 
             <div className="text-sm text-muted-foreground">

--- a/src/vertex/components/features/devices/online-status-card.tsx
+++ b/src/vertex/components/features/devices/online-status-card.tsx
@@ -15,9 +15,9 @@ import {
 import {
   formatDisplayDate,
   getDeviceStatus,
-  getDateValidHint,
   getStatusExplanation,
 } from "@/core/utils/status";
+import { DateValidHintIndicator } from "@/components/shared/date-valid-hint-indicator";
 
 const statusColorClasses = {
   green: {
@@ -149,7 +149,6 @@ const OnlineStatusCard: React.FC<OnlineStatusCardProps> = ({ deviceId }) => {
 
   const colors = statusColorClasses[status.color];
   const detailedExplanation = getStatusExplanation(status.label, lastActiveCheck);
-  const dateHint = getDateValidHint(device.dateValidStatus);
 
   const Icon = status.icon;
 
@@ -183,23 +182,7 @@ const OnlineStatusCard: React.FC<OnlineStatusCardProps> = ({ deviceId }) => {
             >
               <Icon className="w-5 h-5" />
               <span>{status.label}</span>
-              {dateHint && (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <button
-                      type="button"
-                      aria-label={dateHint.label}
-                      className="p-0 bg-transparent border-none cursor-help text-purple-600 inline-flex items-center"
-                    >
-                      <AlertTriangle className="w-4 h-4" aria-hidden="true" />
-                    </button>
-                  </TooltipTrigger>
-                  <TooltipContent side="top">
-                    <p className="text-sm font-medium mb-1">{dateHint.label}</p>
-                    <p className="text-xs max-w-xs">{dateHint.description}</p>
-                  </TooltipContent>
-                </Tooltip>
-              )}
+              <DateValidHintIndicator dateValidStatus={device.dateValidStatus} />
             </div>
 
             <div className="text-sm text-muted-foreground">

--- a/src/vertex/components/features/devices/online-status-card.tsx
+++ b/src/vertex/components/features/devices/online-status-card.tsx
@@ -186,7 +186,13 @@ const OnlineStatusCard: React.FC<OnlineStatusCardProps> = ({ deviceId }) => {
               {dateHint && (
                 <Tooltip>
                   <TooltipTrigger asChild>
-                    <AlertTriangle className="w-4 h-4 text-purple-600 cursor-help" />
+                    <button
+                      type="button"
+                      aria-label={dateHint.label}
+                      className="p-0 bg-transparent border-none cursor-help text-purple-600 inline-flex items-center"
+                    >
+                      <AlertTriangle className="w-4 h-4" aria-hidden="true" />
+                    </button>
                   </TooltipTrigger>
                   <TooltipContent side="top">
                     <p className="text-sm font-medium mb-1">{dateHint.label}</p>

--- a/src/vertex/components/features/devices/utils/table-columns.tsx
+++ b/src/vertex/components/features/devices/utils/table-columns.tsx
@@ -66,7 +66,14 @@ export const getColumns = (
             {dateHint && (
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <AlertTriangle className="w-4 h-4 ml-1.5 text-purple-600 cursor-help inline-block" />
+                  <button
+                    type="button"
+                    aria-label={dateHint.label}
+                    onClick={(e) => e.stopPropagation()}
+                    className="ml-1.5 p-0 bg-transparent border-none cursor-help text-purple-600 inline-flex items-center"
+                  >
+                    <AlertTriangle className="w-4 h-4" aria-hidden="true" />
+                  </button>
                 </TooltipTrigger>
                 <TooltipContent side="top">
                   <p className="text-sm font-medium mb-1">{dateHint.label}</p>

--- a/src/vertex/components/features/devices/utils/table-columns.tsx
+++ b/src/vertex/components/features/devices/utils/table-columns.tsx
@@ -9,7 +9,15 @@ import {
   badgeColorClasses,
   formatDisplayDate,
   getDeviceStatus,
+  getDateValidHint,
 } from "@/core/utils/status";
+import { AlertTriangle } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 export type TableDevice = TableItem<unknown> & Device;
 
@@ -45,14 +53,28 @@ export const getColumns = (
         );
         const colors = badgeColorClasses[status.color];
         const Icon = status.icon;
+        const dateHint = getDateValidHint(item.dateValidStatus);
 
         return (
-          <span
-            className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${colors}`}
-          >
-            <Icon className="w-4 h-4 mr-1" />
-            {status.label}
-          </span>
+          <TooltipProvider>
+            <span
+              className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${colors}`}
+            >
+              <Icon className="w-4 h-4 mr-1" />
+              {status.label}
+            </span>
+            {dateHint && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <AlertTriangle className="w-4 h-4 ml-1.5 text-purple-600 cursor-help inline-block" />
+                </TooltipTrigger>
+                <TooltipContent side="top">
+                  <p className="text-sm font-medium mb-1">{dateHint.label}</p>
+                  <p className="text-xs max-w-xs">{dateHint.description}</p>
+                </TooltipContent>
+              </Tooltip>
+            )}
+          </TooltipProvider>
         );
       },
     },

--- a/src/vertex/components/features/devices/utils/table-columns.tsx
+++ b/src/vertex/components/features/devices/utils/table-columns.tsx
@@ -9,15 +9,8 @@ import {
   badgeColorClasses,
   formatDisplayDate,
   getDeviceStatus,
-  getDateValidHint,
 } from "@/core/utils/status";
-import { AlertTriangle } from "lucide-react";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
+import { DateValidHintIndicator } from "@/components/shared/date-valid-hint-indicator";
 
 export type TableDevice = TableItem<unknown> & Device;
 
@@ -53,35 +46,16 @@ export const getColumns = (
         );
         const colors = badgeColorClasses[status.color];
         const Icon = status.icon;
-        const dateHint = getDateValidHint(item.dateValidStatus);
-
         return (
-          <TooltipProvider>
+          <>
             <span
               className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${colors}`}
             >
               <Icon className="w-4 h-4 mr-1" />
               {status.label}
             </span>
-            {dateHint && (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button
-                    type="button"
-                    aria-label={dateHint.label}
-                    onClick={(e) => e.stopPropagation()}
-                    className="ml-1.5 p-0 bg-transparent border-none cursor-help text-purple-600 inline-flex items-center"
-                  >
-                    <AlertTriangle className="w-4 h-4" aria-hidden="true" />
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent side="top">
-                  <p className="text-sm font-medium mb-1">{dateHint.label}</p>
-                  <p className="text-xs max-w-xs">{dateHint.description}</p>
-                </TooltipContent>
-              </Tooltip>
-            )}
-          </TooltipProvider>
+            <DateValidHintIndicator dateValidStatus={item.dateValidStatus} stopPropagation />
+          </>
         );
       },
     },

--- a/src/vertex/components/features/sites/client-paginated-sites-table.tsx
+++ b/src/vertex/components/features/sites/client-paginated-sites-table.tsx
@@ -140,7 +140,14 @@ export default function ClientPaginatedSitesTable({
             {dateHint && (
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <AlertTriangle className="w-4 h-4 ml-1.5 text-purple-600 cursor-help inline-block" />
+                  <button
+                    type="button"
+                    aria-label={dateHint.label}
+                    onClick={(e) => e.stopPropagation()}
+                    className="ml-1.5 p-0 bg-transparent border-none cursor-help text-purple-600 inline-flex items-center"
+                  >
+                    <AlertTriangle className="w-4 h-4" aria-hidden="true" />
+                  </button>
                 </TooltipTrigger>
                 <TooltipContent side="top">
                   <p className="text-sm font-medium mb-1">{dateHint.label}</p>

--- a/src/vertex/components/features/sites/client-paginated-sites-table.tsx
+++ b/src/vertex/components/features/sites/client-paginated-sites-table.tsx
@@ -8,15 +8,8 @@ import {
   badgeColorClasses,
   formatDisplayDate,
   getDeviceStatus,
-  getDateValidHint,
 } from "@/core/utils/status";
-import { AlertTriangle } from "lucide-react";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
+import { DateValidHintIndicator } from "@/components/shared/date-valid-hint-indicator";
 import { Site } from "@/app/types/sites";
 
 interface SitesTableProps {
@@ -126,10 +119,8 @@ export default function ClientPaginatedSitesTable({
         );
         const colors = badgeColorClasses[status.color];
         const Icon = status.icon;
-        const dateHint = getDateValidHint(site.dateValidStatus);
-
         return (
-          <TooltipProvider>
+          <>
             <span
               className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${colors}`}
               title={status.description}
@@ -137,25 +128,8 @@ export default function ClientPaginatedSitesTable({
               <Icon className="w-4 h-4 mr-1" />
               {status.label}
             </span>
-            {dateHint && (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button
-                    type="button"
-                    aria-label={dateHint.label}
-                    onClick={(e) => e.stopPropagation()}
-                    className="ml-1.5 p-0 bg-transparent border-none cursor-help text-purple-600 inline-flex items-center"
-                  >
-                    <AlertTriangle className="w-4 h-4" aria-hidden="true" />
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent side="top">
-                  <p className="text-sm font-medium mb-1">{dateHint.label}</p>
-                  <p className="text-xs max-w-xs">{dateHint.description}</p>
-                </TooltipContent>
-              </Tooltip>
-            )}
-          </TooltipProvider>
+            <DateValidHintIndicator dateValidStatus={site.dateValidStatus} stopPropagation />
+          </>
         );
       },
     },

--- a/src/vertex/components/features/sites/client-paginated-sites-table.tsx
+++ b/src/vertex/components/features/sites/client-paginated-sites-table.tsx
@@ -8,7 +8,15 @@ import {
   badgeColorClasses,
   formatDisplayDate,
   getDeviceStatus,
+  getDateValidHint,
 } from "@/core/utils/status";
+import { AlertTriangle } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { Site } from "@/app/types/sites";
 
 interface SitesTableProps {
@@ -118,15 +126,29 @@ export default function ClientPaginatedSitesTable({
         );
         const colors = badgeColorClasses[status.color];
         const Icon = status.icon;
+        const dateHint = getDateValidHint(site.dateValidStatus);
 
         return (
-          <span
-            className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${colors}`}
-            title={status.description}
-          >
-            <Icon className="w-4 h-4 mr-1" />
-            {status.label}
-          </span>
+          <TooltipProvider>
+            <span
+              className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${colors}`}
+              title={status.description}
+            >
+              <Icon className="w-4 h-4 mr-1" />
+              {status.label}
+            </span>
+            {dateHint && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <AlertTriangle className="w-4 h-4 ml-1.5 text-purple-600 cursor-help inline-block" />
+                </TooltipTrigger>
+                <TooltipContent side="top">
+                  <p className="text-sm font-medium mb-1">{dateHint.label}</p>
+                  <p className="text-xs max-w-xs">{dateHint.description}</p>
+                </TooltipContent>
+              </Tooltip>
+            )}
+          </TooltipProvider>
         );
       },
     },

--- a/src/vertex/components/features/sites/site-information-card.tsx
+++ b/src/vertex/components/features/sites/site-information-card.tsx
@@ -9,6 +9,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { AqEdit01, AqCopy01 } from "@airqo/icons-react";
+import { AlertTriangle } from "lucide-react";
 import ReusableButton from "@/components/shared/button/ReusableButton";
 import { useClipboard } from "@/core/hooks/useClipboard";
 import {
@@ -16,6 +17,7 @@ import {
   formatDisplayDate,
   getDeviceStatus,
   getStatusExplanation,
+  getDateValidHint,
 } from "@/core/utils/status";
 
 interface SiteInformationCardProps {
@@ -46,6 +48,7 @@ export const SiteInformationCard: React.FC<SiteInformationCardProps> = ({ site, 
   const colors = badgeColorClasses[status.color];
   const Icon = status.icon;
   const explanation = getStatusExplanation(status.label, lastActiveCheck);
+  const dateHint = getDateValidHint(site.dateValidStatus);
 
   return (
     <Card className="w-full rounded-lg flex flex-col">
@@ -94,6 +97,17 @@ export const SiteInformationCard: React.FC<SiteInformationCardProps> = ({ site, 
                     <p className="max-w-xs text-xs">{explanation}</p>
                   </TooltipContent>
                 </Tooltip>
+                {dateHint && (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <AlertTriangle className="w-4 h-4 ml-1.5 text-purple-600 cursor-help inline-block" />
+                    </TooltipTrigger>
+                    <TooltipContent side="top">
+                      <p className="text-sm font-medium mb-1">{dateHint.label}</p>
+                      <p className="text-xs max-w-xs">{dateHint.description}</p>
+                    </TooltipContent>
+                  </Tooltip>
+                )}
               </TooltipProvider>
             </div>
           </div>

--- a/src/vertex/components/features/sites/site-information-card.tsx
+++ b/src/vertex/components/features/sites/site-information-card.tsx
@@ -9,7 +9,6 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { AqEdit01, AqCopy01 } from "@airqo/icons-react";
-import { AlertTriangle } from "lucide-react";
 import ReusableButton from "@/components/shared/button/ReusableButton";
 import { useClipboard } from "@/core/hooks/useClipboard";
 import {
@@ -17,8 +16,8 @@ import {
   formatDisplayDate,
   getDeviceStatus,
   getStatusExplanation,
-  getDateValidHint,
 } from "@/core/utils/status";
+import { DateValidHintIndicator } from "@/components/shared/date-valid-hint-indicator";
 
 interface SiteInformationCardProps {
   site: Site;
@@ -48,8 +47,6 @@ export const SiteInformationCard: React.FC<SiteInformationCardProps> = ({ site, 
   const colors = badgeColorClasses[status.color];
   const Icon = status.icon;
   const explanation = getStatusExplanation(status.label, lastActiveCheck);
-  const dateHint = getDateValidHint(site.dateValidStatus);
-
   return (
     <Card className="w-full rounded-lg flex flex-col">
       <div className="px-3 py-2 flex flex-col gap-3">
@@ -97,23 +94,7 @@ export const SiteInformationCard: React.FC<SiteInformationCardProps> = ({ site, 
                     <p className="max-w-xs text-xs">{explanation}</p>
                   </TooltipContent>
                 </Tooltip>
-                {dateHint && (
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <button
-                        type="button"
-                        aria-label={dateHint.label}
-                        className="ml-1.5 p-0 bg-transparent border-none cursor-help text-purple-600 inline-flex items-center"
-                      >
-                        <AlertTriangle className="w-4 h-4" aria-hidden="true" />
-                      </button>
-                    </TooltipTrigger>
-                    <TooltipContent side="top">
-                      <p className="text-sm font-medium mb-1">{dateHint.label}</p>
-                      <p className="text-xs max-w-xs">{dateHint.description}</p>
-                    </TooltipContent>
-                  </Tooltip>
-                )}
+                <DateValidHintIndicator dateValidStatus={site.dateValidStatus} />
               </TooltipProvider>
             </div>
           </div>

--- a/src/vertex/components/features/sites/site-information-card.tsx
+++ b/src/vertex/components/features/sites/site-information-card.tsx
@@ -100,7 +100,13 @@ export const SiteInformationCard: React.FC<SiteInformationCardProps> = ({ site, 
                 {dateHint && (
                   <Tooltip>
                     <TooltipTrigger asChild>
-                      <AlertTriangle className="w-4 h-4 ml-1.5 text-purple-600 cursor-help inline-block" />
+                      <button
+                        type="button"
+                        aria-label={dateHint.label}
+                        className="ml-1.5 p-0 bg-transparent border-none cursor-help text-purple-600 inline-flex items-center"
+                      >
+                        <AlertTriangle className="w-4 h-4" aria-hidden="true" />
+                      </button>
                     </TooltipTrigger>
                     <TooltipContent side="top">
                       <p className="text-sm font-medium mb-1">{dateHint.label}</p>

--- a/src/vertex/components/features/sites/sites-list-table.tsx
+++ b/src/vertex/components/features/sites/sites-list-table.tsx
@@ -9,15 +9,8 @@ import {
   badgeColorClasses,
   formatDisplayDate,
   getDeviceStatus,
-  getDateValidHint,
 } from "@/core/utils/status";
-import { AlertTriangle } from "lucide-react";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
+import { DateValidHintIndicator } from "@/components/shared/date-valid-hint-indicator";
 
 interface SitesTableProps {
   itemsPerPage?: number;
@@ -145,10 +138,8 @@ export default function SitesTable({
         );
         const colors = badgeColorClasses[status.color];
         const Icon = status.icon;
-        const dateHint = getDateValidHint(site.dateValidStatus);
-
         return (
-          <TooltipProvider>
+          <>
             <span
               className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${colors}`}
               title={status.description}
@@ -156,25 +147,8 @@ export default function SitesTable({
               <Icon className="w-4 h-4 mr-1" />
               {status.label}
             </span>
-            {dateHint && (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button
-                    type="button"
-                    aria-label={dateHint.label}
-                    onClick={(e) => e.stopPropagation()}
-                    className="ml-1.5 p-0 bg-transparent border-none cursor-help text-purple-600 inline-flex items-center"
-                  >
-                    <AlertTriangle className="w-4 h-4" aria-hidden="true" />
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent side="top">
-                  <p className="text-sm font-medium mb-1">{dateHint.label}</p>
-                  <p className="text-xs max-w-xs">{dateHint.description}</p>
-                </TooltipContent>
-              </Tooltip>
-            )}
-          </TooltipProvider>
+            <DateValidHintIndicator dateValidStatus={site.dateValidStatus} stopPropagation />
+          </>
         );
       },
     },

--- a/src/vertex/components/features/sites/sites-list-table.tsx
+++ b/src/vertex/components/features/sites/sites-list-table.tsx
@@ -9,7 +9,15 @@ import {
   badgeColorClasses,
   formatDisplayDate,
   getDeviceStatus,
+  getDateValidHint,
 } from "@/core/utils/status";
+import { AlertTriangle } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 interface SitesTableProps {
   itemsPerPage?: number;
@@ -137,15 +145,29 @@ export default function SitesTable({
         );
         const colors = badgeColorClasses[status.color];
         const Icon = status.icon;
+        const dateHint = getDateValidHint(site.dateValidStatus);
 
         return (
-          <span
-            className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${colors}`}
-            title={status.description}
-          >
-            <Icon className="w-4 h-4 mr-1" />
-            {status.label}
-          </span>
+          <TooltipProvider>
+            <span
+              className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${colors}`}
+              title={status.description}
+            >
+              <Icon className="w-4 h-4 mr-1" />
+              {status.label}
+            </span>
+            {dateHint && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <AlertTriangle className="w-4 h-4 ml-1.5 text-purple-600 cursor-help inline-block" />
+                </TooltipTrigger>
+                <TooltipContent side="top">
+                  <p className="text-sm font-medium mb-1">{dateHint.label}</p>
+                  <p className="text-xs max-w-xs">{dateHint.description}</p>
+                </TooltipContent>
+              </Tooltip>
+            )}
+          </TooltipProvider>
         );
       },
     },

--- a/src/vertex/components/features/sites/sites-list-table.tsx
+++ b/src/vertex/components/features/sites/sites-list-table.tsx
@@ -159,7 +159,14 @@ export default function SitesTable({
             {dateHint && (
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <AlertTriangle className="w-4 h-4 ml-1.5 text-purple-600 cursor-help inline-block" />
+                  <button
+                    type="button"
+                    aria-label={dateHint.label}
+                    onClick={(e) => e.stopPropagation()}
+                    className="ml-1.5 p-0 bg-transparent border-none cursor-help text-purple-600 inline-flex items-center"
+                  >
+                    <AlertTriangle className="w-4 h-4" aria-hidden="true" />
+                  </button>
                 </TooltipTrigger>
                 <TooltipContent side="top">
                   <p className="text-sm font-medium mb-1">{dateHint.label}</p>

--- a/src/vertex/components/shared/date-valid-hint-indicator.tsx
+++ b/src/vertex/components/shared/date-valid-hint-indicator.tsx
@@ -1,0 +1,42 @@
+import { AlertTriangle } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { getDateValidHint } from "@/core/utils/status";
+
+interface DateValidHintIndicatorProps {
+  dateValidStatus?: "valid" | "future_timestamp" | "invalid_format" | "unknown";
+  stopPropagation?: boolean;
+}
+
+export function DateValidHintIndicator({
+  dateValidStatus,
+  stopPropagation = false,
+}: DateValidHintIndicatorProps) {
+  const hint = getDateValidHint(dateValidStatus);
+  if (!hint) return null;
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            aria-label={hint.label}
+            onClick={stopPropagation ? (e) => e.stopPropagation() : undefined}
+            className="ml-1.5 p-0 bg-transparent border-none cursor-help text-purple-600 inline-flex items-center"
+          >
+            <AlertTriangle className="w-4 h-4" aria-hidden="true" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="top">
+          <p className="text-sm font-medium mb-1">{hint.label}</p>
+          <p className="text-xs max-w-xs">{hint.description}</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/src/vertex/core/utils/status.test.ts
+++ b/src/vertex/core/utils/status.test.ts
@@ -1,6 +1,7 @@
 import {
   badgeColorClasses,
   formatDisplayDate,
+  getDateValidHint,
   getDeviceStatus,
   getSimpleStatus,
   getStatusExplanation,
@@ -149,6 +150,34 @@ describe("status utilities", () => {
           errorType: "invalid",
         })
       ).toContain("invalid date: Invalid date");
+    });
+  });
+
+  describe("getDateValidHint", () => {
+    it("returns a Clock Error hint for future_timestamp", () => {
+      expect(getDateValidHint("future_timestamp")).toEqual({
+        label: "Clock Error",
+        description: expect.stringContaining("future"),
+      });
+    });
+
+    it("returns a Timestamp Error hint for invalid_format", () => {
+      expect(getDateValidHint("invalid_format")).toEqual({
+        label: "Timestamp Error",
+        description: expect.any(String),
+      });
+    });
+
+    it("returns null for valid", () => {
+      expect(getDateValidHint("valid")).toBeNull();
+    });
+
+    it("returns null for unknown", () => {
+      expect(getDateValidHint("unknown")).toBeNull();
+    });
+
+    it("returns null when dateValidStatus is undefined", () => {
+      expect(getDateValidHint(undefined)).toBeNull();
     });
   });
 

--- a/src/vertex/core/utils/status.ts
+++ b/src/vertex/core/utils/status.ts
@@ -213,3 +213,29 @@ export const getStatusExplanation = (
       return "Unknown status";
   }
 };
+
+export interface DateValidHint {
+  label: string;
+  description: string;
+}
+
+export const getDateValidHint = (
+  dateValidStatus?: "valid" | "future_timestamp" | "invalid_format" | "unknown"
+): DateValidHint | null => {
+  if (dateValidStatus === "future_timestamp") {
+    return {
+      label: "Clock Error",
+      description:
+        "Device may be connected, but its reported time is in the future " +
+        "(likely a bad onboard clock/RTC). This is a device hardware issue, " +
+        "not necessarily a connectivity problem.",
+    };
+  }
+  if (dateValidStatus === "invalid_format") {
+    return {
+      label: "Timestamp Error",
+      description: "Device sent a timestamp that couldn't be parsed.",
+    };
+  }
+  return null;
+};


### PR DESCRIPTION
#### Reviwers
@Baalmart @OchiengPaul442 
#### Summary of Changes (What does this PR do?)

Adds a non-breaking diagnostic indicator for devices and sites that report a bad onboard clock or an unparseable timestamp. When the backend returns `dateValidStatus: "future_timestamp"` or `"invalid_format"` on a device or site object, a purple `AlertTriangle` icon now appears next to the existing status badge across all relevant UI surfaces. Hovering the icon reveals a short, actionable explanation.

**Key design decisions:**
- The field is fully optional (`dateValidStatus?`). Components that receive older API responses without the field render identically to today — no regressions.
- Existing status logic, colours, and labels are completely untouched. This is a secondary, diagnostic-only hint layered on top.
- `getDateValidHint()` returns `null` for `"valid"`, `"unknown"`, and `undefined` — so the icon only appears when there is something actionable to show.
- Table render cells that lack a shared `TooltipProvider` wrap their hint in a local one.

**Files changed:**
- `app/types/devices.ts` — `dateValidStatus` optional field added to `Device`
- `app/types/sites.ts` — `dateValidStatus` optional field added to `Site`
- `core/utils/status.ts` — `DateValidHint` interface + `getDateValidHint()` helper
- `components/features/devices/online-status-card.tsx` — hint icon next to status label in the device card
- `components/features/devices/utils/table-columns.tsx` — hint icon in the Device Status column (with local `TooltipProvider`)
- `components/features/sites/sites-list-table.tsx` — hint icon in the Status column
- `components/features/sites/client-paginated-sites-table.tsx` — hint icon in the Status column
- `components/features/sites/site-information-card.tsx` — hint icon next to the status badge in the site detail card

#### Status of maturity (all need to be checked before merging):

- [x] I've tested this locally
- [x] I consider this code done
- [x] This change ready to hit production in its current state
- [x] The title of the PR states what changed and the related issues number (used for the release note).
- [ ] I've included issue number in the "Closes #ISSUE-NUMBER" part of the "[What are the relevant tickets?](#what-are-the-relevant-tickets)" section to [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] I've updated corresponding documentation for the changes in this PR.
- [x] I have written unit and/or e2e tests for my change(s).

#### How should this be manually tested?

1. Ensure the backend is returning `dateValidStatus` on device/site responses (ask the backend team to confirm or mock it locally).
2. Set `dateValidStatus: "future_timestamp"` on a test device:
   - Open the device list — the Device Status cell should show the existing badge **plus** a purple triangle icon to its right.
   - Hover the icon — tooltip should read **"Clock Error"** with the description about a bad onboard RTC.
   - Open the device detail page — the `OnlineStatusCard` should show the same icon next to the status label.
3. Repeat with `dateValidStatus: "invalid_format"` — tooltip should read **"Timestamp Error"**.
4. Verify devices/sites with `dateValidStatus: "valid"`, `"unknown"`, or the field absent show **no** triangle icon and are visually unchanged.
5. Check the Sites list (`/admin/sites`) and the Site detail card — the same icon should appear for sites with clock/format errors.

#### What are the relevant tickets?

#### Screenshots (optional)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added date-validity hint indicators to device and site status badges.
  * Shows a purple warning icon for future timestamps or invalid date formats, with an explanatory tooltip on hover.
* **Documentation**
  * Updated the changelog with a new **Version 2.0.30** entry describing the diagnostic UI hint.
* **Tests**
  * Added coverage for the date-validity hint logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->