### PR TITLE
feat(vertex): add topbar Settings link to Nexus profile and rename An…

### DIFF
--- a/src/vertex/app/changelog.md
+++ b/src/vertex/app/changelog.md
@@ -2,6 +2,35 @@
 
 > **Note**: This changelog consolidates all recent improvements, features, and fixes to the AirQo Vertex frontend.
 
+## Version 2.0.31
+**Released:** July 29, 2026
+
+### Feat: Settings shortcut to the Nexus profile page, and the "Analytics" app tile renamed to "Nexus"
+
+Vertex had no entry point for account/profile settings — account management lives in the Nexus web app. A Settings icon in the topbar now hands off to the Nexus profile page in a new tab. The app-launcher tile is renamed to match the app's new name.
+
+<details>
+<summary><strong>New: Settings icon in the topbar linking to the Nexus profile page</strong></summary>
+
+- `profileSettingsUrl` added to `core/urls.tsx`, derived from the existing env-aware `ANALYTICS_BASE_URL` (`NEXT_PUBLIC_ANALYTICS_URL`, falling back to staging/production by environment) alongside `forgotPasswordUrl` / `signUpUrl` — the URL is not hardcoded in the component.
+- The button sits between `<OrganizationPicker />` and Help & Feedback, reusing the Help button's exact `variant`, `className`, and `iconClassName="!h-7 !w-7"` so size, spacing, hover, and dark-mode styling match the adjacent icons (both use the `text-muted-foreground` / `hover:text-foreground` semantic tokens).
+- Opens in a new tab via `window.open(profileSettingsUrl, '_blank', 'noopener,noreferrer')` — it navigates to a different application, so users shouldn't lose their Vertex context. Carries both `aria-label="Settings"` and a `title` tooltip.
+
+</details>
+
+<details>
+<summary><strong>Chore: app-launcher tile renamed "Analytics" → "Nexus"</strong></summary>
+
+- The Analytics app was renamed to Nexus; the `AppDropdown` tile still carried the old name.
+- Name only — the tile's `href` and the `ANALYTICS_BASE_URL` fallbacks still resolve to `analytics.airqo.net` / `staging-analytics.airqo.net`. Switching those needs the staging hostname confirmed (`staging-nexus.airqo.net` appears nowhere in the repo) and a coordinated deployment-config change for `NEXT_PUBLIC_ANALYTICS_URL`, so it is deliberate follow-up.
+
+</details>
+
+**Files changed:**
+- `core/urls.tsx` — `profileSettingsUrl` export
+- `components/layout/topbar.tsx` — Settings `ReusableButton` + `handleSettingsClick` handler
+- `components/layout/AppDropdown.tsx` — tile renamed to "Nexus"
+
 ## Version 2.0.30
 **Released:** July 28, 2026
 

--- a/src/vertex/components/layout/AppDropdown.tsx
+++ b/src/vertex/components/layout/AppDropdown.tsx
@@ -50,7 +50,7 @@ const AppDropdown: React.FC<AppDropdownProps> = ({ className = '' }) => {
 
     const apps: App[] = [
         {
-            name: 'Analytics',
+            name: 'Nexus',
             description: 'View air quality dashboards',
             icon: AqBarChartSquarePlus,
             href: getUrl('https://analytics.airqo.net/'),

--- a/src/vertex/components/layout/topbar.tsx
+++ b/src/vertex/components/layout/topbar.tsx
@@ -3,7 +3,7 @@
 import type React from 'react';
 import { useState, useEffect, useCallback } from 'react';
 import { Moon, Sun } from 'lucide-react';
-import { AqHelpCircle, AqMenu01 } from '@airqo/icons-react';
+import { AqHelpCircle, AqMenu01, AqSettings01 } from '@airqo/icons-react';
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
@@ -27,6 +27,7 @@ import { useSession } from 'next-auth/react';
 import type { UserDetails } from '@/app/types/users';
 import { useTheme } from "next-themes";
 import { vertexConfig } from '@/vertex.config';
+import { profileSettingsUrl } from '@/core/urls';
 
 interface TopbarProps {
   onMenuClick: () => void;
@@ -59,6 +60,10 @@ const Topbar: React.FC<TopbarProps> = ({ onMenuClick }) => {
   const handleLogoClick = useCallback(() => {
     router.push('/home');
   }, [router]);
+
+  const handleSettingsClick = useCallback(() => {
+    window.open(profileSettingsUrl, '_blank', 'noopener,noreferrer');
+  }, []);
 
   const LogoComponent = useCallback(
     ({ className = '', buttonProps = {} }) => (
@@ -129,6 +134,16 @@ const Topbar: React.FC<TopbarProps> = ({ onMenuClick }) => {
 
           <div className="flex items-center gap-x-1 ml-auto">
             <OrganizationPicker />
+
+            <ReusableButton
+              variant="text"
+              onClick={handleSettingsClick}
+              className="text-muted-foreground hover:text-foreground rounded-full p-2"
+              title="Settings"
+              aria-label="Settings"
+              Icon={AqSettings01}
+              iconClassName="!h-7 !w-7"
+            />
 
             <ReusableButton
               variant="text"

--- a/src/vertex/core/urls.tsx
+++ b/src/vertex/core/urls.tsx
@@ -19,4 +19,5 @@ export const ANALYTICS_BASE_URL = stripTrailingSlash(
   process.env.NEXT_PUBLIC_ANALYTICS_URL || DEFAULT_ANALYTICS_BASE_URL
 );
 export const forgotPasswordUrl = `${ANALYTICS_BASE_URL}/user/forgotPwd`;
+export const profileSettingsUrl = `${ANALYTICS_BASE_URL}/user/profile`;
 export const signUpUrl = `${ANALYTICS_BASE_URL}/user/creation/individual/register`;


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

Vertex has no entry point for account/profile settings — account management lives in the Nexus web app. This adds a Settings icon to the Vertex topbar that hands off to the Nexus profile page.

- **`core/urls.tsx`** — adds `profileSettingsUrl`, derived from the existing env-aware `ANALYTICS_BASE_URL` (`NEXT_PUBLIC_ANALYTICS_URL`, falling back to staging/production by environment) alongside `forgotPasswordUrl` / `signUpUrl`. The URL is not hardcoded in the component.
- **`components/layout/topbar.tsx`** — adds a `ReusableButton` with `Icon={AqSettings01}` between `<OrganizationPicker />` and the Help & Feedback button. It reuses the Help button's exact `variant`, `className`, and `iconClassName="!h-7 !w-7"`, so size, spacing, hover, and dark-mode styling match the adjacent icons (both use the `text-muted-foreground` / `hover:text-foreground` semantic tokens). Clicking opens `profileSettingsUrl` via `window.open(..., '_blank', 'noopener,noreferrer')` — a new tab, since it navigates to a different application and users shouldn't lose their Vertex context. The button carries both `aria-label="Settings"` and a `title` tooltip.
- **`components/layout/AppDropdown.tsx`** — renames the app-launcher tile "Analytics" → "Nexus" to match the app's new name.

Automated checks run: `tsc --noEmit` clean across app source (remaining errors are pre-existing — `@playwright/test` and `dotenv` aren't installed, affecting `e2e/` and `playwright.config.ts` only); `next lint` passes on all three changed files; `vitest run components/layout` passes (3 files, 16 tests).

No dependencies required. Follow-up left out of scope: the Nexus tile's `href` and the `ANALYTICS_BASE_URL` fallbacks still resolve to `analytics.airqo.net` / `staging-analytics.airqo.net`. Switching those needs the staging hostname confirmed (`staging-nexus.airqo.net` appears nowhere in the repo) and a coordinated deployment-config change for `NEXT_PUBLIC_ANALYTICS_URL`, so it belongs in its own PR.

#### Status of maturity (all need to be checked before merging):

- [x] I've tested this locally
- [x] I consider this code done
- [ ] This change ready to hit production in its current state
- [x] The title of the PR states what changed and the related issues number (used for the release note).
- [ ] I've included issue number in the "Closes #3813" part of the "[What are the relevant tickets?](#what-are-the-relevant-tickets)" section to [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [ ] I've updated corresponding documentation for the changes in this PR.
- [ ] I have written unit and/or e2e tests for my change(s).

#### How should this be manually tested?

```bash
cd src/vertex
npm install
npm run dev
```

1. Sign in and look at the topbar's right-hand cluster. Confirm the Settings gear appears **between** the organization picker and the Help & Feedback icon.
2. Confirm it renders at the same size as the Help icon and picks up the same hover treatment. Check in **both light and dark mode** (toggle via the avatar menu → Dark/Light Mode).
3. Hover it — tooltip reads "Settings". Tab to it with the keyboard — it takes focus and shows the focus ring.
4. Click it. A **new tab** should open at `https://staging-analytics.airqo.net/user/profile` (unless `NEXT_PUBLIC_ANALYTICS_URL` is set locally, which overrides it). The Vertex tab should stay exactly where it was.
5. Open the app-launcher (grid icon) and confirm the first tile now reads **"Nexus"**.

#### What are the relevant tickets?

- Closes #3813

#### Screenshots (optional)

<img width="305" height="271" alt="image" src="https://github.com/user-attachments/assets/dc3bc245-c38c-4aaf-832f-67b1c3d4e5d6" />
