### PR TITLE
fix(mobile): skip current day forecast period

### DIFF
--- a/src/mobile/lib/src/app/dashboard/models/forecast_guidance.dart
+++ b/src/mobile/lib/src/app/dashboard/models/forecast_guidance.dart
@@ -75,13 +75,24 @@ class ForecastReadingSnapshot {
 
 List<HourlyForecastEntry> hourlyEntriesForDate(
   HourlyForecastResponse? response,
-  DateTime date,
-) {
+  DateTime date, {
+  bool skipCurrentHour = false,
+}) {
   if (response == null) return [];
   final dateStr = _fmtDate(date.toLocal());
-  return response.forecasts
+  final entries = response.forecasts
       .where((e) => _fmtDate(e.time.toLocal()) == dateStr)
       .toList();
+
+  if (!skipCurrentHour) return entries;
+
+  final now = DateTime.now();
+  if (dateStr != _fmtDate(now)) return entries;
+
+  final nextHour = DateTime(now.year, now.month, now.day, now.hour).add(
+    const Duration(hours: 1),
+  );
+  return entries.where((e) => !e.time.toLocal().isBefore(nextHour)).toList();
 }
 
 String _fmtDate(DateTime dt) {
@@ -90,7 +101,8 @@ String _fmtDate(DateTime dt) {
       '${dt.day.toString().padLeft(2, '0')}';
 }
 
-int defaultHourlyIndex(List<HourlyForecastEntry> entries, DateTime selectedDay) {
+int defaultHourlyIndex(
+    List<HourlyForecastEntry> entries, DateTime selectedDay) {
   if (entries.isEmpty) return 0;
   final now = DateTime.now();
   final todayStr = _fmtDate(now);

--- a/src/mobile/lib/src/app/dashboard/models/forecast_guidance.dart
+++ b/src/mobile/lib/src/app/dashboard/models/forecast_guidance.dart
@@ -77,6 +77,7 @@ List<HourlyForecastEntry> hourlyEntriesForDate(
   HourlyForecastResponse? response,
   DateTime date, {
   bool skipCurrentHour = false,
+  DateTime? now,
 }) {
   if (response == null) return [];
   final dateStr = _fmtDate(date.toLocal());
@@ -86,10 +87,15 @@ List<HourlyForecastEntry> hourlyEntriesForDate(
 
   if (!skipCurrentHour) return entries;
 
-  final now = DateTime.now();
-  if (dateStr != _fmtDate(now)) return entries;
+  final currentTime = now ?? DateTime.now();
+  if (dateStr != _fmtDate(currentTime)) return entries;
 
-  final nextHour = DateTime(now.year, now.month, now.day, now.hour).add(
+  final nextHour = DateTime(
+    currentTime.year,
+    currentTime.month,
+    currentTime.day,
+    currentTime.hour,
+  ).add(
     const Duration(hours: 1),
   );
   return entries.where((e) => !e.time.toLocal().isBefore(nextHour)).toList();

--- a/src/mobile/lib/src/app/dashboard/pages/forecast_overview_page.dart
+++ b/src/mobile/lib/src/app/dashboard/pages/forecast_overview_page.dart
@@ -134,17 +134,24 @@ class _ForecastOverviewPageState extends State<ForecastOverviewPage> {
     }
   }
 
-  void _syncTodayIndex(List<Forecast> forecasts) {
-    if (_selectedDayIndex == 0) {
-      final todayIdx =
-          forecasts.indexWhere((f) => _fmtDate(f.time) == _todayStr);
-      if (todayIdx > 0) {
-        WidgetsBinding.instance.addPostFrameCallback((_) {
-          if (!mounted) return;
-          setState(() => _selectedDayIndex = todayIdx);
-        });
-      }
-    }
+  List<Forecast> _futureDailyForecasts(List<Forecast> forecasts) {
+    final today = _dateOnly(DateTime.now());
+    return forecasts
+        .where((f) => _dateOnly(f.time.toLocal()).isAfter(today))
+        .toList();
+  }
+
+  List<HourlyForecastEntry> _futureHourlyEntriesForDate(
+    HourlyForecastResponse? response,
+    DateTime date,
+  ) {
+    final entries = hourlyEntriesForDate(response, date);
+    final now = DateTime.now();
+    final selectedDateStr = _fmtDate(date.toLocal());
+    if (selectedDateStr != _fmtDate(now)) return entries;
+
+    final nextHour = DateTime(now.year, now.month, now.day, now.hour + 1);
+    return entries.where((e) => !e.time.toLocal().isBefore(nextHour)).toList();
   }
 
   void _syncHourIndex(List<HourlyForecastEntry> entries, DateTime day) {
@@ -356,17 +363,16 @@ class _ForecastOverviewPageState extends State<ForecastOverviewPage> {
     bool hourlyLoading = false,
     String? hourlyError,
   }) {
-    final forecasts = state.response.forecasts;
+    final forecasts = _futureDailyForecasts(state.response.forecasts);
     if (forecasts.isEmpty) {
       return const Center(child: Text('No forecast data available.'));
     }
 
-    _syncTodayIndex(forecasts);
-
     final idx = _selectedDayIndex.clamp(0, forecasts.length - 1);
     final day = forecasts[idx];
     final selectedDateLabel = DateFormat('EEEE, MMMM d').format(day.time);
-    final hourEntries = hourlyEntriesForDate(state.hourlyResponse, day.time);
+    final hourEntries =
+        _futureHourlyEntriesForDate(state.hourlyResponse, day.time);
     _syncHourIndex(hourEntries, day.time);
 
     final hourIdx = hourEntries.isEmpty
@@ -428,6 +434,7 @@ class _ForecastOverviewPageState extends State<ForecastOverviewPage> {
                 onInsetPanel: true,
                 selectedHourIndex: hourIdx,
                 onHourSelected: _selectHour,
+                skipCurrentHour: true,
               ),
             ),
             if (selectedHour != null) ...[
@@ -524,4 +531,6 @@ class _ForecastOverviewPageState extends State<ForecastOverviewPage> {
   }
 
   String _fmtDate(DateTime dt) => DateFormat('yyyy-MM-dd').format(dt);
+
+  DateTime _dateOnly(DateTime dt) => DateTime(dt.year, dt.month, dt.day);
 }

--- a/src/mobile/lib/src/app/dashboard/pages/forecast_overview_page.dart
+++ b/src/mobile/lib/src/app/dashboard/pages/forecast_overview_page.dart
@@ -141,19 +141,6 @@ class _ForecastOverviewPageState extends State<ForecastOverviewPage> {
         .toList();
   }
 
-  List<HourlyForecastEntry> _futureHourlyEntriesForDate(
-    HourlyForecastResponse? response,
-    DateTime date,
-  ) {
-    final entries = hourlyEntriesForDate(response, date);
-    final now = DateTime.now();
-    final selectedDateStr = _fmtDate(date.toLocal());
-    if (selectedDateStr != _fmtDate(now)) return entries;
-
-    final nextHour = DateTime(now.year, now.month, now.day, now.hour + 1);
-    return entries.where((e) => !e.time.toLocal().isBefore(nextHour)).toList();
-  }
-
   void _syncHourIndex(List<HourlyForecastEntry> entries, DateTime day) {
     if (_timeScope != ForecastTimeScope.hourly || entries.isEmpty) return;
     final defaultIdx = defaultHourlyIndex(entries, day);
@@ -368,16 +355,19 @@ class _ForecastOverviewPageState extends State<ForecastOverviewPage> {
       return const Center(child: Text('No forecast data available.'));
     }
 
-    final idx = _selectedDayIndex.clamp(0, forecasts.length - 1);
+    final idx = _selectedDayIndex.clamp(0, forecasts.length - 1).toInt();
     final day = forecasts[idx];
     final selectedDateLabel = DateFormat('EEEE, MMMM d').format(day.time);
-    final hourEntries =
-        _futureHourlyEntriesForDate(state.hourlyResponse, day.time);
+    final hourEntries = hourlyEntriesForDate(
+      state.hourlyResponse,
+      day.time,
+      skipCurrentHour: true,
+    );
     _syncHourIndex(hourEntries, day.time);
 
     final hourIdx = hourEntries.isEmpty
         ? 0
-        : _selectedHourIndex.clamp(0, hourEntries.length - 1);
+        : _selectedHourIndex.clamp(0, hourEntries.length - 1).toInt();
     final selectedHour = hourEntries.isNotEmpty ? hourEntries[hourIdx] : null;
 
     return SingleChildScrollView(
@@ -529,8 +519,6 @@ class _ForecastOverviewPageState extends State<ForecastOverviewPage> {
       ),
     );
   }
-
-  String _fmtDate(DateTime dt) => DateFormat('yyyy-MM-dd').format(dt);
 
   DateTime _dateOnly(DateTime dt) => DateTime(dt.year, dt.month, dt.day);
 }

--- a/src/mobile/lib/src/app/dashboard/pages/forecast_overview_page.dart
+++ b/src/mobile/lib/src/app/dashboard/pages/forecast_overview_page.dart
@@ -358,10 +358,12 @@ class _ForecastOverviewPageState extends State<ForecastOverviewPage> {
     final idx = _selectedDayIndex.clamp(0, forecasts.length - 1).toInt();
     final day = forecasts[idx];
     final selectedDateLabel = DateFormat('EEEE, MMMM d').format(day.time);
+    final now = DateTime.now();
     final hourEntries = hourlyEntriesForDate(
       state.hourlyResponse,
       day.time,
       skipCurrentHour: true,
+      now: now,
     );
     _syncHourIndex(hourEntries, day.time);
 

--- a/src/mobile/lib/src/app/dashboard/widgets/forecast_hourly_section.dart
+++ b/src/mobile/lib/src/app/dashboard/widgets/forecast_hourly_section.dart
@@ -18,6 +18,7 @@ class ForecastHourlySection extends StatelessWidget {
   final bool onInsetPanel;
   final int selectedHourIndex;
   final ValueChanged<int>? onHourSelected;
+  final bool skipCurrentHour;
 
   const ForecastHourlySection({
     super.key,
@@ -30,6 +31,7 @@ class ForecastHourlySection extends StatelessWidget {
     this.onInsetPanel = false,
     this.selectedHourIndex = 0,
     this.onHourSelected,
+    this.skipCurrentHour = false,
   });
 
   @override
@@ -49,8 +51,8 @@ class ForecastHourlySection extends StatelessWidget {
               itemCount: 8,
               itemBuilder: (_, i) => Padding(
                 padding: const EdgeInsets.only(right: 8),
-                child: ShimmerContainer(
-                    width: 64, height: 100, borderRadius: 12),
+                child:
+                    ShimmerContainer(width: 64, height: 100, borderRadius: 12),
               ),
             ),
           )
@@ -64,6 +66,7 @@ class ForecastHourlySection extends StatelessWidget {
             onInsetPanel: onInsetPanel,
             selectedHourIndex: selectedHourIndex,
             onHourSelected: onHourSelected,
+            skipCurrentHour: skipCurrentHour,
           ),
       ],
     );
@@ -92,8 +95,8 @@ class _ErrorRow extends StatelessWidget {
           Expanded(
             child: Text(
               'Hourly data unavailable',
-              style: TextStyle(
-                  fontSize: 13, color: AppTextColors.muted(context)),
+              style:
+                  TextStyle(fontSize: 13, color: AppTextColors.muted(context)),
             ),
           ),
           TextButton(
@@ -115,6 +118,7 @@ class _HourlyList extends StatelessWidget {
   final bool onInsetPanel;
   final int selectedHourIndex;
   final ValueChanged<int>? onHourSelected;
+  final bool skipCurrentHour;
 
   const _HourlyList({
     required this.hourlyResponse,
@@ -123,6 +127,7 @@ class _HourlyList extends StatelessWidget {
     this.onInsetPanel = false,
     required this.selectedHourIndex,
     this.onHourSelected,
+    this.skipCurrentHour = false,
   });
 
   Color _surfaceColor(BuildContext context) => onInsetPanel
@@ -133,9 +138,17 @@ class _HourlyList extends StatelessWidget {
   Widget build(BuildContext context) {
     final selectedDateStr =
         DateFormat('yyyy-MM-dd').format(selectedDate.toLocal());
+    final now = DateTime.now();
+    final nowStr = DateFormat('yyyy-MM-dd').format(now);
+    final nextHour = DateTime(now.year, now.month, now.day, now.hour + 1);
     final dayEntries = hourlyResponse.forecasts
         .where((e) =>
-            DateFormat('yyyy-MM-dd').format(e.time.toLocal()) == selectedDateStr)
+            DateFormat('yyyy-MM-dd').format(e.time.toLocal()) ==
+            selectedDateStr)
+        .where((e) =>
+            !skipCurrentHour ||
+            selectedDateStr != nowStr ||
+            !e.time.toLocal().isBefore(nextHour))
         .toList();
 
     if (dayEntries.isEmpty) {
@@ -153,16 +166,14 @@ class _HourlyList extends StatelessWidget {
             const SizedBox(width: 8),
             Text(
               'No hourly data available for this day.',
-              style: TextStyle(
-                  fontSize: 13, color: AppTextColors.muted(context)),
+              style:
+                  TextStyle(fontSize: 13, color: AppTextColors.muted(context)),
             ),
           ],
         ),
       );
     }
 
-    final now = DateTime.now();
-    final nowStr = DateFormat('yyyy-MM-dd').format(now);
     return SizedBox(
       height: 100,
       child: ListView.builder(

--- a/src/mobile/lib/src/app/dashboard/widgets/forecast_hourly_section.dart
+++ b/src/mobile/lib/src/app/dashboard/widgets/forecast_hourly_section.dart
@@ -142,6 +142,7 @@ class _HourlyList extends StatelessWidget {
       hourlyResponse,
       selectedDate,
       skipCurrentHour: skipCurrentHour,
+      now: now,
     );
 
     if (dayEntries.isEmpty) {

--- a/src/mobile/lib/src/app/dashboard/widgets/forecast_hourly_section.dart
+++ b/src/mobile/lib/src/app/dashboard/widgets/forecast_hourly_section.dart
@@ -1,4 +1,5 @@
 import 'package:airqo/src/app/dashboard/bloc/forecast/forecast_bloc.dart';
+import 'package:airqo/src/app/dashboard/models/forecast_guidance.dart';
 import 'package:airqo/src/app/dashboard/models/forecast_response.dart';
 import 'package:airqo/src/app/shared/widgets/loading_widget.dart';
 import 'package:airqo/src/meta/utils/colors.dart';
@@ -136,20 +137,12 @@ class _HourlyList extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final selectedDateStr =
-        DateFormat('yyyy-MM-dd').format(selectedDate.toLocal());
     final now = DateTime.now();
-    final nowStr = DateFormat('yyyy-MM-dd').format(now);
-    final nextHour = DateTime(now.year, now.month, now.day, now.hour + 1);
-    final dayEntries = hourlyResponse.forecasts
-        .where((e) =>
-            DateFormat('yyyy-MM-dd').format(e.time.toLocal()) ==
-            selectedDateStr)
-        .where((e) =>
-            !skipCurrentHour ||
-            selectedDateStr != nowStr ||
-            !e.time.toLocal().isBefore(nextHour))
-        .toList();
+    final dayEntries = hourlyEntriesForDate(
+      hourlyResponse,
+      selectedDate,
+      skipCurrentHour: skipCurrentHour,
+    );
 
     if (dayEntries.isEmpty) {
       return Container(
@@ -181,10 +174,13 @@ class _HourlyList extends StatelessWidget {
         itemCount: dayEntries.length,
         itemBuilder: (context, i) {
           final entry = dayEntries[i];
+          final entryTime = entry.time.toLocal();
           final isNow = entry.time.toLocal().hour == now.hour &&
-              selectedDateStr == nowStr;
+              entryTime.year == now.year &&
+              entryTime.month == now.month &&
+              entryTime.day == now.day;
           final isSelected = onHourSelected != null
-              ? i == selectedHourIndex.clamp(0, dayEntries.length - 1)
+              ? i == selectedHourIndex.clamp(0, dayEntries.length - 1).toInt()
               : isNow;
           return _HourlyChip(
             entry: entry,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Forecast overviews now display only upcoming days.
  - Hourly forecasts begin with the next available hour, excluding outdated entries from the current hour.
  - Date and hour selection now stays aligned with local time for more consistent navigation.
- **Style**
  - Refined loading, empty-state, and error-message formatting without changing displayed content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->