### PR TITLE
Fix/vertex self redirect

### DIFF
--- a/src/vertex/app/changelog.md
+++ b/src/vertex/app/changelog.md
@@ -2,6 +2,42 @@
 
 > **Note**: This changelog consolidates all recent improvements, features, and fixes to the AirQo Vertex frontend.
 
+## Version 2.0.33
+**Released:** July 30, 2026
+
+### Fix: app launcher sent staging users to production apps
+
+The launcher's links resolved to production hosts when Vertex itself was running on staging, so switching apps silently moved users from staging into live production. The Vertex tile — a link to the app you are already in — is also gone.
+
+<details>
+<summary><strong>Fix: staging detection used `NODE_ENV`, which is "production" on staging too</strong></summary>
+
+- The staging deployment is a production Next.js build, so `process.env.NODE_ENV === 'production'` is true there. The launcher's `getUrl` helper took that as "we are in production" and returned production URLs unchanged — meaning every cross-app link on staging pointed at the live apps.
+- Detection now keys off the **runtime hostname** instead: URLs are rewritten when the current host contains `staging`, or when running locally. This is what Nexus and the website already do (`getEnvironmentAwareUrl` in `nexus/src/shared/utils/url.ts` and `website/src/lib/environmentAwareUrl.ts`).
+
+</details>
+
+<details>
+<summary><strong>Fix: staging hostnames were guessed by prefixing, which is wrong for some apps</strong></summary>
+
+- The old helper derived staging hosts as `staging-${hostname}` for everything. The convention is not uniform — most apps take the `staging-` prefix (`staging-analytics.airqo.net`, `staging-vertex.airqo.net`) but the marketing site is a subdomain (`staging.airqo.net`), which the prefix would have turned into the nonexistent `staging-airqo.net`. Latent rather than live, since the Website tile did not use the helper.
+- Replaced with an explicit production → staging map. Hosts absent from the map are returned unchanged rather than given a guessed prefix: `ai.airqo.net` and `airqalibrate.airqo.net` have no staging deployment anywhere in the repo, and all four frontends link to them bare, so they are deliberately unmapped.
+- `getEnvironmentAwareUrl` lives in `core/urls.tsx` alongside `ANALYTICS_BASE_URL` and is SSR-safe — with no `window` to inspect it returns the URL as written.
+
+</details>
+
+<details>
+<summary><strong>Chore: removed the Vertex tile from the launcher</strong></summary>
+
+- The launcher listed Vertex itself, offering a link to the app the user is already using. Removed, along with its now-unused `AqServer03` icon import. Six tiles instead of seven.
+
+</details>
+
+**Files changed:**
+- `core/urls.tsx` — new `getEnvironmentAwareUrl` export + `STAGING_HOSTS` map
+- `core/urls.test.ts` [NEW] — 8 cases covering SSR, production, staging, localhost, the subdomain-vs-prefix distinction, path/query preservation, unmapped hosts, and unparseable input
+- `components/layout/AppDropdown.tsx` — uses the shared helper; local `getUrl`/`isProduction` and the Vertex tile removed
+
 ## Version 2.0.32
 **Released:** July 30, 2026
 

--- a/src/vertex/components/layout/AppDropdown.tsx
+++ b/src/vertex/components/layout/AppDropdown.tsx
@@ -10,7 +10,6 @@ import {
     AqPhone01,
     AqArrowNarrowLeft,
     AqCpuChip01,
-    AqServer03,
     AqBarChartSquarePlus,
 } from '@airqo/icons-react';
 import { Smartphone } from 'lucide-react';
@@ -19,6 +18,7 @@ import {
     DropdownMenuTrigger,
     DropdownMenuContent,
 } from '@/components/ui/dropdown-menu';
+import { getEnvironmentAwareUrl } from '@/core/urls';
 
 interface App {
     name: string;
@@ -35,32 +35,20 @@ interface AppDropdownProps {
 
 const AppDropdown: React.FC<AppDropdownProps> = ({ className = '' }) => {
     const [showQRCode, setShowQRCode] = useState(false);
-    const isProduction = process.env.NODE_ENV === 'production';
-
-    const getUrl = (baseUrl: string): string => {
-        if (isProduction) return baseUrl;
-        try {
-            const url = new URL(baseUrl);
-            url.hostname = `staging-${url.hostname}`;
-            return url.toString();
-        } catch {
-            return baseUrl;
-        }
-    };
 
     const apps: App[] = [
         {
             name: 'Nexus',
             description: 'View air quality dashboards',
             icon: AqBarChartSquarePlus,
-            href: getUrl('https://analytics.airqo.net/'),
+            href: getEnvironmentAwareUrl('https://analytics.airqo.net/'),
             color: 'bg-green-500',
         },
         {
             name: 'Calibrate',
             description: 'Calibrate low-cost sensors',
             icon: AqCalibration,
-            href: getUrl('https://airqalibrate.airqo.net/'),
+            href: getEnvironmentAwareUrl('https://airqalibrate.airqo.net/'),
             color: 'bg-blue-500',
         },
         {
@@ -69,13 +57,6 @@ const AppDropdown: React.FC<AppDropdownProps> = ({ className = '' }) => {
             icon: AqGlobe02Maps_Travel,
             href: 'https://airqo.net/',
             color: 'bg-purple-500',
-        },
-        {
-            name: 'Vertex',
-            description: 'Manage device deployment',
-            icon: AqServer03,
-            href: getUrl('https://vertex.airqo.net/'),
-            color: 'bg-yellow-600',
         },
         {
             name: 'API Docs',

--- a/src/vertex/core/urls.test.ts
+++ b/src/vertex/core/urls.test.ts
@@ -49,6 +49,18 @@ describe('getEnvironmentAwareUrl', () => {
     );
   });
 
+  // `location.hostname` keeps IPv6 brackets — http://[::1]:3000 reports "[::1]",
+  // never a bare "::1" — so the bracketed form is what must be matched.
+  it.each(['127.0.0.1', '[::1]', '0.0.0.0'])(
+    'treats %s as local and rewrites to staging',
+    (hostname) => {
+      setHostname(hostname);
+      expect(getEnvironmentAwareUrl('https://analytics.airqo.net/')).toBe(
+        'https://staging-analytics.airqo.net/'
+      );
+    }
+  );
+
   // Not every app uses the `staging-` prefix — the marketing site is a
   // `staging.` subdomain, which a blind prefix would have turned into the
   // nonexistent `staging-airqo.net`.

--- a/src/vertex/core/urls.test.ts
+++ b/src/vertex/core/urls.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { getEnvironmentAwareUrl } from './urls';
+
+/**
+ * `getEnvironmentAwareUrl` keys off the *runtime* hostname rather than NODE_ENV,
+ * because the staging deployment is a production Next.js build. These tests stub
+ * window.location.hostname to stand in for each environment.
+ */
+const setHostname = (hostname: string | undefined) => {
+  if (hostname === undefined) {
+    vi.stubGlobal('window', undefined);
+    return;
+  }
+  vi.stubGlobal('window', { location: { hostname } });
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('getEnvironmentAwareUrl', () => {
+  it('leaves the URL untouched during SSR, when there is no window', () => {
+    setHostname(undefined);
+    expect(getEnvironmentAwareUrl('https://analytics.airqo.net/')).toBe(
+      'https://analytics.airqo.net/'
+    );
+  });
+
+  it('leaves production URLs untouched when serving from a production host', () => {
+    setHostname('vertex.airqo.net');
+    expect(getEnvironmentAwareUrl('https://analytics.airqo.net/')).toBe(
+      'https://analytics.airqo.net/'
+    );
+  });
+
+  // The regression this function exists for: the staging deployment is a
+  // production build, so a NODE_ENV check handed out production links there.
+  it('rewrites to staging when serving from the staging host', () => {
+    setHostname('staging-vertex.airqo.net');
+    expect(getEnvironmentAwareUrl('https://analytics.airqo.net/')).toBe(
+      'https://staging-analytics.airqo.net/'
+    );
+  });
+
+  it('rewrites to staging when running locally', () => {
+    setHostname('localhost');
+    expect(getEnvironmentAwareUrl('https://analytics.airqo.net/')).toBe(
+      'https://staging-analytics.airqo.net/'
+    );
+  });
+
+  // Not every app uses the `staging-` prefix — the marketing site is a
+  // `staging.` subdomain, which a blind prefix would have turned into the
+  // nonexistent `staging-airqo.net`.
+  it('maps the marketing site to a staging subdomain, not a prefix', () => {
+    setHostname('localhost');
+    expect(getEnvironmentAwareUrl('https://airqo.net/')).toBe(
+      'https://staging.airqo.net/'
+    );
+    expect(getEnvironmentAwareUrl('https://www.airqo.net/')).toBe(
+      'https://staging.airqo.net/'
+    );
+  });
+
+  it('preserves path and query when rewriting', () => {
+    setHostname('localhost');
+    expect(
+      getEnvironmentAwareUrl('https://analytics.airqo.net/user/profile?tab=api')
+    ).toBe('https://staging-analytics.airqo.net/user/profile?tab=api');
+  });
+
+  it('leaves hosts with no known staging deployment unchanged', () => {
+    setHostname('localhost');
+    expect(getEnvironmentAwareUrl('https://ai.airqo.net')).toBe(
+      'https://ai.airqo.net'
+    );
+    expect(getEnvironmentAwareUrl('https://example.com/x')).toBe(
+      'https://example.com/x'
+    );
+  });
+
+  it('returns unparseable input as-is rather than throwing', () => {
+    setHostname('localhost');
+    expect(getEnvironmentAwareUrl('not-a-url')).toBe('not-a-url');
+  });
+});

--- a/src/vertex/core/urls.tsx
+++ b/src/vertex/core/urls.tsx
@@ -38,7 +38,16 @@ const STAGING_HOSTS: Readonly<Record<string, string>> = {
   "www.airqo.net": "staging.airqo.net",
 };
 
-const LOCAL_HOSTNAMES = ["localhost", "127.0.0.1", "::1", "0.0.0.0"];
+// `location.hostname` serialises IPv6 hosts *with* brackets per the URL spec, so
+// `http://[::1]:3000` reports "[::1]" — the bracketed form is the one that actually
+// occurs. The bare form is kept only to guard non-browser callers.
+const LOCAL_HOSTNAMES = [
+  "localhost",
+  "127.0.0.1",
+  "[::1]",
+  "::1",
+  "0.0.0.0",
+];
 
 /**
  * Rewrites a production cross-app URL to its staging equivalent when the current

--- a/src/vertex/core/urls.tsx
+++ b/src/vertex/core/urls.tsx
@@ -21,3 +21,51 @@ export const ANALYTICS_BASE_URL = stripTrailingSlash(
 export const forgotPasswordUrl = `${ANALYTICS_BASE_URL}/user/forgotPwd`;
 export const profileSettingsUrl = `${ANALYTICS_BASE_URL}/user/profile`;
 export const signUpUrl = `${ANALYTICS_BASE_URL}/user/creation/individual/register`;
+
+/**
+ * Production host -> staging host for cross-app links.
+ *
+ * The mapping is explicit because the convention is not uniform: most apps take
+ * a `staging-` prefix, while the marketing site uses a `staging.` subdomain.
+ * Hosts absent from this table are left alone (no known staging deployment).
+ */
+const STAGING_HOSTS: Readonly<Record<string, string>> = {
+  "analytics.airqo.net": "staging-analytics.airqo.net",
+  "vertex.airqo.net": "staging-vertex.airqo.net",
+  "beacon.airqo.net": "staging-beacon.airqo.net",
+  "platform.airqo.net": "staging-platform.airqo.net",
+  "airqo.net": "staging.airqo.net",
+  "www.airqo.net": "staging.airqo.net",
+};
+
+const LOCAL_HOSTNAMES = ["localhost", "127.0.0.1", "::1", "0.0.0.0"];
+
+/**
+ * Rewrites a production cross-app URL to its staging equivalent when the current
+ * page is itself on staging (or running locally).
+ *
+ * Detection is by runtime hostname rather than `NODE_ENV`: the staging deployment
+ * is a production Next.js build, so `NODE_ENV === "production"` there too and
+ * would incorrectly hand out production links.
+ */
+export const getEnvironmentAwareUrl = (baseUrl: string): string => {
+  // Server-side render: no hostname to inspect, so emit the URL as written.
+  if (typeof window === "undefined") return baseUrl;
+
+  try {
+    const currentHost = (window.location?.hostname || "").toLowerCase();
+    const isLocalhost = LOCAL_HOSTNAMES.includes(currentHost);
+    const isStaging = currentHost.includes("staging");
+
+    if (!isStaging && !isLocalhost) return baseUrl;
+
+    const parsed = new URL(baseUrl);
+    const stagingHost = STAGING_HOSTS[parsed.hostname.toLowerCase()];
+    if (!stagingHost) return baseUrl;
+
+    parsed.hostname = stagingHost;
+    return parsed.toString();
+  } catch {
+    return baseUrl;
+  }
+};


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

The app launcher sent staging users into production. Opening another AirQo app from staging Vertex landed the user on the live production deployment — with live data — instead of that app's staging instance. This fixes the environment detection, replaces the staging-hostname guessing with an explicit map, and drops the launcher's link to Vertex itself.

**Bug 1 — staging detection used `NODE_ENV` (live)**

`AppDropdown`'s local `getUrl` helper treated `process.env.NODE_ENV === 'production'` as "we are in production" and returned production URLs untouched. But the staging deployment *is* a production Next.js build, so `NODE_ENV` is `'production'` there too — every cross-app link on staging pointed at the live apps. Detection now keys off the **runtime hostname**: URLs are rewritten when the current host contains `staging`, or when running locally.

**Bug 2 — staging hostnames were derived by prefixing (latent)**

The old helper built staging hosts as `staging-${hostname}` for everything. The convention is not uniform: most apps take the `staging-` prefix (`staging-analytics.airqo.net`, `staging-vertex.airqo.net`) but the marketing site is a subdomain (`staging.airqo.net`), which prefixing would have turned into the nonexistent `staging-airqo.net`. Not currently triggered — the Website tile did not route through the helper — but it would have broken the moment anyone wrapped it. Replaced with an explicit production → staging map.

**Approach**

`getEnvironmentAwareUrl` now lives in `core/urls.tsx` beside `ANALYTICS_BASE_URL`. It is SSR-safe (no `window` → URL returned as written), and hosts absent from the map are returned unchanged rather than given a guessed prefix. This matches the implementations already in Nexus (`nexus/src/shared/utils/url.ts`) and the website (`website/src/lib/environmentAwareUrl.ts`) — same function name, same hostname-based detection, same explicit table.

`ai.airqo.net` and `airqalibrate.airqo.net` are **deliberately unmapped**. Neither has a staging URL anywhere in the repo (18 references to `ai.airqo.net` across four frontends and the docs site, all bare production), and none of the three existing helper implementations maps either host.

**Also in this PR:** the launcher no longer lists Vertex — a link to the app the user is already in — along with its now-unused `AqServer03` icon import. Six tiles instead of seven.

Automated checks: `tsc --noEmit` clean across app source (the only errors are pre-existing — `@playwright/test` and `dotenv` are not installed, affecting `e2e/` and `playwright.config.ts` only); `next lint` clean on both changed files; the new `core/urls.test.ts` passes 8/8.

No new dependencies. Changelog entry added as **Version 2.0.33**.

#### Status of maturity (all need to be checked before merging):

- [x] I've tested this locally
- [x] I consider this code done
- [x] This change ready to hit production in its current state
- [x] The title of the PR states what changed and the related issues number (used for the release note).
- [ ] I've included issue number in the "Closes #ISSUE-NUMBER" part of the "[What are the relevant tickets?](#what-are-the-relevant-tickets)" section to [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] I've updated corresponding documentation for the changes in this PR.
- [x] I have written unit and/or e2e tests for my change(s).

Unit tests cover the logic, but the fix has **not** been exercised in a browser, and the behaviour that matters most — links resolving correctly *from a real staging deployment* — can only be confirmed once this is deployed to staging. See step 4 below.

One open question for the reviewer: **is there a staging Calibrate?** `airqalibrate.airqo.net` is unmapped here, matching Nexus and the website. Before this change, Vertex's blind prefix produced `staging-airqalibrate.airqo.net` in local/dev. If that host exists, add `"airqalibrate.airqo.net": "staging-airqalibrate.airqo.net"` to `STAGING_HOSTS`. If it does not, the old local behaviour was pointing at a dead host.

#### How should this be manually tested?

```bash
cd src/vertex
npm install
npm run dev
```

**Locally (treated as staging)**

1. Open the app launcher (grid icon in the topbar). Confirm there are **six** tiles and **no Vertex tile**.
2. Check the Nexus tile's target — it should be `https://staging-analytics.airqo.net/`, not `analytics.airqo.net`.
3. Confirm Website (`airqo.net`), API Docs (`docs.airqo.net`), and AI Platform (`ai.airqo.net`) still point at production — none of them routes through the helper or is in the map.

**On staging — the case this PR exists for**

4. After deploying to `staging-vertex.airqo.net`, open the launcher and confirm the Nexus tile resolves to `staging-analytics.airqo.net`. Before this change it resolved to production `analytics.airqo.net`. This is the regression being fixed and cannot be verified from localhost.

**On production**

5. Confirm links are unchanged — production hostname contains neither `staging` nor localhost, so `getEnvironmentAwareUrl` returns every URL as written.

**Unit tests**

```bash
cd src/vertex
npx vitest run core/urls.test.ts
```

Eight cases: SSR (no `window`), production host, staging host, localhost, the subdomain-vs-prefix distinction for `airqo.net`, path/query preservation, unmapped hosts, and unparseable input.

#### What are the relevant tickets?

- Closes #<enter issue number here>


#### Screenshots (optional)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cross-app launcher links now automatically point to the appropriate staging destinations when running in staging or locally.
  * URL paths and query parameters are preserved when links are rewritten.
  * Added safe handling for unknown hosts, invalid URLs, and server-rendered pages.

* **Bug Fixes**
  * Corrected staging link generation for supported applications.
  * Removed the Vertex tile from the application launcher.

* **Documentation**
  * Added release notes for version 2.0.33.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->