### PR TITLE
fix: improve data download preview UX with pre-fetch validation and professional empty states

### DIFF
--- a/src/nexus/src/modules/data-download/DataExportPage.tsx
+++ b/src/nexus/src/modules/data-download/DataExportPage.tsx
@@ -244,23 +244,23 @@ const DataExportPage = () => {
         ? 'raw'
         : (dataType as 'calibrated' | 'raw');
 
-    const previewRequest: DataDownloadRequest = buildDataDownloadRequest({
-      dateRange,
-      activeTab,
-      selectedSites,
-      selectedDeviceIds,
-      selectedDeviceNames: selectedDevices,
-      selectedGridIds,
-      selectedGridSites,
-      selectedGridSiteIds,
-      selectedPollutants,
-      dataType: effectiveDataType,
-      fileType: 'csv',
-      frequency,
-      deviceCategory,
-    });
-
     try {
+      const previewRequest: DataDownloadRequest = buildDataDownloadRequest({
+        dateRange,
+        activeTab,
+        selectedSites,
+        selectedDeviceIds,
+        selectedDeviceNames: selectedDevices,
+        selectedGridIds,
+        selectedGridSites,
+        selectedGridSiteIds,
+        selectedPollutants,
+        dataType: effectiveDataType,
+        fileType: 'csv',
+        frequency,
+        deviceCategory,
+      });
+
       const response = await fetchPreviewData(previewRequest);
 
       if (abortController.signal.aborted) return;

--- a/src/nexus/src/modules/data-download/DataExportPage.tsx
+++ b/src/nexus/src/modules/data-download/DataExportPage.tsx
@@ -1,4 +1,10 @@
-import React, { useMemo, useEffect, useCallback, useRef, useState } from 'react';
+import React, {
+  useMemo,
+  useEffect,
+  useCallback,
+  useRef,
+  useState,
+} from 'react';
 import { usePostHog } from 'posthog-js/react';
 import { usePathname } from 'next/navigation';
 import PageHeading from '@/shared/components/ui/page-heading';
@@ -20,6 +26,7 @@ import {
   CohortDevicesResponse,
   Grid,
   DataDownloadRequest,
+  DataDownloadResponse,
 } from '@/shared/types/api';
 import {
   DataType,
@@ -34,17 +41,21 @@ import { useDataExportState } from './hooks/useDataExportState';
 import {
   type PreparedDownloadResult,
   useDataExportActions,
-  buildPartialDataWarning,
   getGridSiteNames,
 } from './hooks/useDataExportActions';
+import { getDataAvailability } from './utils/dataAvailability';
 import { useDataExportData } from './hooks/useDataExportData';
 import { useDownloadData } from '@/shared/hooks/useAnalytics';
-import { buildDataDownloadRequest } from './utils/dataExportRequest';
+import {
+  buildDataDownloadRequest,
+  resolveGridSitesForDownload,
+} from './utils/dataExportRequest';
+import { getSiteDisplayName } from './utils/dataExportUtils';
 import {
   buildDownloadFileContent,
   buildDownloadPdfBlob,
   buildDownloadXlsxBlob,
-  parseDownloadCsvRows,
+  parseDownloadResponseRecords,
 } from './utils/dataExportFile';
 import MoreInsights from '@/modules/location-insights/more-insights';
 import AddLocation from '@/modules/location-insights/add-location';
@@ -102,6 +113,72 @@ const rebuildSelectionCache = (
   return nextCache;
 };
 
+type PreviewData = Record<string, string | number | null>;
+
+const getPreviewField = (
+  record: Record<string, unknown>,
+  aliases: string[]
+): unknown => {
+  const normalizedAliases = new Set(
+    aliases.map(alias => alias.toLowerCase().replace(/[\s-]+/g, '_'))
+  );
+
+  const entry = Object.entries(record).find(([key]) =>
+    normalizedAliases.has(key.toLowerCase().replace(/[\s-]+/g, '_'))
+  );
+
+  return entry?.[1];
+};
+
+const buildPreviewRows = (
+  response: DataDownloadResponse | string,
+  activeTab: TabType,
+  countriesData: TableItem[],
+  citiesData: TableItem[]
+): PreviewData[] => {
+  const records = parseDownloadResponseRecords(response);
+  const gridData = activeTab === 'countries' ? countriesData : citiesData;
+  const siteIdToName = new Map<string, string>();
+
+  if (activeTab === 'countries' || activeTab === 'cities') {
+    gridData.forEach(grid => {
+      const sites = grid.sites as
+        | Array<{ _id?: string; name?: string }>
+        | undefined;
+
+      sites?.forEach(site => {
+        if (site._id && site.name) {
+          siteIdToName.set(String(site._id), String(site.name));
+        }
+      });
+    });
+  }
+
+  return records.slice(0, 5).map(record => {
+    const row: PreviewData = {};
+
+    Object.entries(record).forEach(([key, value]) => {
+      row[key] =
+        typeof value === 'number'
+          ? value
+          : value == null
+            ? null
+            : String(value);
+    });
+
+    if (activeTab === 'countries' || activeTab === 'cities') {
+      const siteId = getPreviewField(record, ['site_id', 'siteId']);
+      const siteName = siteId ? siteIdToName.get(String(siteId)) : undefined;
+
+      if (siteName) {
+        row.site_name = siteName;
+      }
+    }
+
+    return row;
+  });
+};
+
 const DataExportPage = () => {
   const pathname = usePathname();
   const posthog = usePostHog();
@@ -152,7 +229,6 @@ const DataExportPage = () => {
     fileType,
     selectedPollutants,
     selectedSites,
-    selectedDevices,
     selectedSiteIds,
     selectedDeviceIds,
     selectedGridIds,
@@ -264,7 +340,6 @@ const DataExportPage = () => {
   }, [isOrgFlow, activeTab, handleTabChange]);
 
   // Preview state — fetched before dialog opens
-  type PreviewData = Record<string, string | number | null>;
   const [previewRows, setPreviewRows] = useState<PreviewData[]>([]);
   const [isPreviewLoading, setIsPreviewLoading] = useState(false);
   const [previewError, setPreviewError] = useState<string | null>(null);
@@ -273,6 +348,31 @@ const DataExportPage = () => {
     | undefined
   >(undefined);
   const previewAbortRef = useRef<AbortController | null>(null);
+
+  const clearPreviewState = useCallback(() => {
+    previewAbortRef.current?.abort();
+    previewAbortRef.current = null;
+    setPreviewRows([]);
+    setPreviewError(null);
+    setPreviewPartialWarning(undefined);
+    setIsPreviewLoading(false);
+    setPreviewOpen(false);
+  }, [setPreviewOpen]);
+
+  const clearSelectionState = useCallback(() => {
+    handleClearSelections();
+    setSelectedSitesCache({});
+    setSelectedDevicesCache({});
+    setSelectedCountriesCache({});
+    setSelectedCitiesCache({});
+    setSelectedGridForSites(null);
+    setSiteSelectionDialogOpen(false);
+    setSiteSelectionDownloading(false);
+    setPendingDownload(null);
+    setSaveFormatDialogOpen(false);
+    setSavingFormat(null);
+    clearPreviewState();
+  }, [clearPreviewState, handleClearSelections]);
 
   // Wrap handleTabChange to prevent org flow from accessing countries/cities
   const wrappedHandleTabChange = useCallback(
@@ -301,6 +401,8 @@ const DataExportPage = () => {
           return;
         }
 
+        clearSelectionState();
+
         trackFeatureUsage(posthog, 'data_export', 'tab_changed', {
           from_tab: activeTab,
           to_tab: tab,
@@ -315,21 +417,24 @@ const DataExportPage = () => {
 
       handleTabChange(tab);
     },
-    [activeTab, isGroupSyncing, isOrgFlow, handleTabChange, posthog, selectedSiteIds, selectedDeviceIds, selectedGridIds]
+    [
+      activeTab,
+      clearSelectionState,
+      handleTabChange,
+      isGroupSyncing,
+      isOrgFlow,
+      posthog,
+      selectedDeviceIds,
+      selectedGridIds,
+      selectedSiteIds,
+    ]
   );
 
   const confirmTabChange = useCallback(() => {
     const { targetTab } = tabChangeConfirm;
     setTabChangeConfirm(prev => ({ ...prev, isOpen: false }));
 
-    // Clear preview state to prevent stale data
-    setPreviewRows([]);
-    setPreviewError(null);
-    setPreviewPartialWarning(undefined);
-    setPreviewOpen(false);
-    if (previewAbortRef.current) {
-      previewAbortRef.current.abort();
-    }
+    clearSelectionState();
 
     trackFeatureUsage(posthog, 'data_export', 'tab_changed', {
       from_tab: activeTab,
@@ -343,7 +448,14 @@ const DataExportPage = () => {
     });
 
     handleTabChange(targetTab);
-  }, [tabChangeConfirm, activeTab, isOrgFlow, handleTabChange, posthog, setPreviewOpen, setPreviewRows, setPreviewError, setPreviewPartialWarning]);
+  }, [
+    tabChangeConfirm,
+    activeTab,
+    isOrgFlow,
+    handleTabChange,
+    posthog,
+    clearSelectionState,
+  ]);
 
   // Data fetching and processing (initial call with empty array)
   const selectedDevicesForActions = useMemo(
@@ -397,21 +509,34 @@ const DataExportPage = () => {
     isOrgContextReady
   );
 
+  const selectedDeviceNamesForExport = useMemo(() => {
+    const source = [...selectedDevicesForActions, ...processedDevicesData];
+    const names = selectedDeviceIds.map(id => {
+      const device = source.find(item => String(item.id) === id);
+      const name = device?.name ?? device?.device_name;
+      return typeof name === 'string' && name.trim() && name !== '--'
+        ? name.trim()
+        : null;
+    });
+
+    return names.every(Boolean) ? (names as string[]) : [];
+  }, [processedDevicesData, selectedDeviceIds, selectedDevicesForActions]);
+
   // Compute site names from cache to avoid stale state issues
   const selectedSiteNames = useMemo(
     () =>
       selectedSiteIds.map(id => {
         const cached = selectedSitesCache[id];
         if (cached) {
-          return String(
-            cached.name || cached.search_name || cached.location_name || id
-          );
+          const displayName = getSiteDisplayName(cached);
+          return displayName === '--' ? id : displayName;
         }
         // Fallback: find in current page data
         const site = processedSitesData.find(item => String(item.id) === id);
-        return site
-          ? String(site.name || site.search_name || site.location_name || id)
-          : id;
+        if (!site) return id;
+
+        const displayName = getSiteDisplayName(site);
+        return displayName === '--' ? id : displayName;
       }),
     [selectedSiteIds, selectedSitesCache, processedSitesData]
   );
@@ -443,8 +568,9 @@ const DataExportPage = () => {
         dateRange,
         activeTab,
         selectedSites,
+        selectedSiteIds,
         selectedDeviceIds,
-        selectedDeviceNames: selectedDevices,
+        selectedDeviceNames: selectedDeviceNamesForExport,
         selectedGridIds,
         selectedGridSites,
         selectedGridSiteIds,
@@ -459,94 +585,53 @@ const DataExportPage = () => {
 
       if (abortController.signal.aborted) return;
 
+      const selectedAvailabilityIds =
+        activeTab === 'sites'
+          ? selectedSiteIds
+          : activeTab === 'devices'
+            ? selectedDeviceIds
+            : resolveGridSitesForDownload(
+                selectedGridIds,
+                selectedGridSites,
+                selectedGridSiteIds
+              );
+      const selectedAvailabilityLabels =
+        activeTab === 'sites'
+          ? selectedSiteNames
+          : activeTab === 'devices'
+            ? selectedDeviceNamesForExport
+            : getGridSiteNames(
+                activeTab,
+                selectedGridIds,
+                selectedGridSiteIds,
+                selectedGridSites,
+                activeTab === 'countries'
+                  ? processedCountriesData
+                  : processedCitiesData
+              );
+      const previewAvailability = getDataAvailability(
+        response,
+        activeTab,
+        selectedAvailabilityIds,
+        selectedAvailabilityLabels,
+        selectedPollutants
+      );
+
       if (typeof response === 'string') {
-        const parsedRows = parseDownloadCsvRows(response);
-        if (parsedRows.length > 1) {
-          const headers = parsedRows[0];
-          const rows: PreviewData[] = parsedRows.slice(1, 6).map((values: string[]) => {
-            const row: PreviewData = {};
-            headers.forEach((header, index) => {
-              const val = values[index];
-              if (val === '' || val === undefined) {
-                row[header] = null;
-              } else {
-                const num = Number(val);
-                row[header] = isNaN(num) ? val : num;
-              }
-            });
-            return row;
-          });
-
-          // For countries/cities, backfill site_name from grid.sites data
-          if (activeTab === 'countries' || activeTab === 'cities') {
-            const gridData = activeTab === 'countries' ? processedCountriesData : processedCitiesData;
-
-            // Build siteId → siteName lookup from all selected grids' sites
-            const siteIdToName = new Map<string, string>();
-            gridData.forEach(grid => {
-              if (grid.sites) {
-                const sites = grid.sites as Array<{ _id: string; name: string }>;
-                sites.forEach(site => {
-                  if (site._id && site.name) {
-                    siteIdToName.set(site._id, site.name);
-                  }
-                });
-              }
-            });
-
-            // Backfill site_name for each row using site_id lookup
-            rows.forEach(row => {
-              const siteId = row.site_id ? String(row.site_id) : null;
-              if (siteId) {
-                const siteName = siteIdToName.get(siteId);
-                if (siteName) {
-                  row.site_name = siteName;
-                }
-              }
-            });
-          }
-
+        const rows = buildPreviewRows(
+          response,
+          activeTab,
+          processedCountriesData,
+          processedCitiesData
+        );
+        if (rows.length > 0) {
+          // Site names are normalized in buildPreviewRows.
+          // Build siteId → siteName lookup from all selected grids' sites
           setPreviewRows(rows);
-          const countriesCitiesGridData =
-            activeTab === 'countries' ? processedCountriesData : processedCitiesData;
-          const gridSiteNames =
-            activeTab === 'countries' || activeTab === 'cities'
-              ? getGridSiteNames(
-                  activeTab,
-                  selectedGridIds,
-                  selectedGridSiteIds,
-                  selectedGridSites,
-                  countriesCitiesGridData
-                )
-              : [];
-          const gridSiteIds =
-            activeTab === 'countries' || activeTab === 'cities'
-              ? (() => {
-                  const custom = Object.values(selectedGridSiteIds).flat();
-                  return custom.length > 0
-                    ? custom
-                    : Object.values(selectedGridSites).flat();
-                })()
-              : [];
-          setPreviewPartialWarning(
-            buildPartialDataWarning(
-              response,
-              activeTab,
-              activeTab === 'sites'
-                ? selectedSiteIds
-                : activeTab === 'devices'
-                  ? selectedDeviceIds
-                  : gridSiteIds,
-              activeTab === 'sites'
-                ? selectedSiteNames
-                : activeTab === 'devices'
-                  ? selectedDevices
-                  : gridSiteNames
-            )
-          );
+          setPreviewPartialWarning(previewAvailability);
         } else {
           setPreviewRows([]);
-          setPreviewPartialWarning(undefined);
+          setPreviewPartialWarning(previewAvailability);
         }
       } else if (
         response &&
@@ -554,88 +639,18 @@ const DataExportPage = () => {
         'data' in response &&
         Array.isArray((response as { data: unknown }).data)
       ) {
-        const responseData = (
-          response as unknown as { data: Record<string, unknown>[] }
-        ).data;
-        const rows: PreviewData[] = responseData.slice(0, 5).map(item => {
-          const row: PreviewData = {};
-          Object.entries(item).forEach(([key, value]) => {
-            row[key] =
-              typeof value === 'number'
-                ? value
-                : value != null
-                  ? String(value)
-                  : null;
-          });
-          return row;
-        });
-
-        // For countries/cities, backfill site_name from grid.sites data
-        if (activeTab === 'countries' || activeTab === 'cities') {
-          const gridData = activeTab === 'countries' ? processedCountriesData : processedCitiesData;
-          const siteIdToName = new Map<string, string>();
-          gridData.forEach(grid => {
-            if (grid.sites) {
-              const sites = grid.sites as Array<{ _id: string; name: string }>;
-              sites.forEach(site => {
-                if (site._id && site.name) {
-                  siteIdToName.set(site._id, site.name);
-                }
-              });
-            }
-          });
-          rows.forEach(row => {
-            const siteId = row.site_id ? String(row.site_id) : null;
-            if (siteId) {
-              const siteName = siteIdToName.get(siteId);
-              if (siteName) {
-                row.site_name = siteName;
-              }
-            }
-          });
-        }
+        const rows = buildPreviewRows(
+          response,
+          activeTab,
+          processedCountriesData,
+          processedCitiesData
+        );
 
         setPreviewRows(rows);
-        const countriesCitiesGridDataObj =
-          activeTab === 'countries' ? processedCountriesData : processedCitiesData;
-        const gridSiteNamesObj =
-          activeTab === 'countries' || activeTab === 'cities'
-            ? getGridSiteNames(
-                activeTab,
-                selectedGridIds,
-                selectedGridSiteIds,
-                selectedGridSites,
-                countriesCitiesGridDataObj
-              )
-            : [];
-        const gridSiteIdsObj =
-          activeTab === 'countries' || activeTab === 'cities'
-            ? (() => {
-                const custom = Object.values(selectedGridSiteIds).flat();
-                return custom.length > 0
-                  ? custom
-                  : Object.values(selectedGridSites).flat();
-              })()
-            : [];
-        setPreviewPartialWarning(
-          buildPartialDataWarning(
-            response,
-            activeTab,
-            activeTab === 'sites'
-              ? selectedSiteIds
-              : activeTab === 'devices'
-                ? selectedDeviceIds
-                : gridSiteIdsObj,
-            activeTab === 'sites'
-              ? selectedSiteNames
-              : activeTab === 'devices'
-                ? selectedDevices
-                : gridSiteNamesObj
-          )
-        );
+        setPreviewPartialWarning(previewAvailability);
       } else {
         setPreviewRows([]);
-        setPreviewPartialWarning(undefined);
+        setPreviewPartialWarning(previewAvailability);
       }
     } catch {
       if (abortController.signal.aborted) return;
@@ -659,7 +674,7 @@ const DataExportPage = () => {
     activeTab,
     selectedSites,
     selectedSiteNames,
-    selectedDevices,
+    selectedDeviceNamesForExport,
     selectedSiteIds,
     selectedDeviceIds,
     selectedGridIds,
@@ -671,6 +686,35 @@ const DataExportPage = () => {
     setPreviewOpen,
   ]);
 
+  // A preview is a snapshot of the current export configuration. Close and
+  // discard it as soon as a filter or selection changes so stale rows cannot
+  // be mistaken for the next export.
+  const previewFromTimestamp = dateRange?.from?.getTime();
+  const previewToTimestamp = dateRange?.to?.getTime();
+
+  useEffect(() => {
+    if (previewOpen) {
+      clearPreviewState();
+    }
+    // previewOpen is intentionally omitted: this effect reacts only to
+    // configuration changes, not to opening the preview itself.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    activeTab,
+    clearPreviewState,
+    dataType,
+    previewFromTimestamp,
+    previewToTimestamp,
+    deviceCategory,
+    frequency,
+    selectedDeviceIds,
+    selectedGridIds,
+    selectedGridSiteIds,
+    selectedGridSites,
+    selectedPollutants,
+    selectedSiteIds,
+  ]);
+
   useEffect(() => {
     return () => {
       if (previewAbortRef.current) {
@@ -680,12 +724,12 @@ const DataExportPage = () => {
   }, []);
 
   // Actions and event handlers
-  const { handleDownload, handleVisualizeData, isDownloading } =
+  const { handleDownload, handleVisualizeData, isDownloading, cancelDownload } =
     useDataExportActions(
       dateRange,
       activeTab,
       selectedSiteNames,
-      selectedDevices,
+      selectedDeviceNamesForExport,
       selectedSiteIds,
       selectedDeviceIds,
       selectedGridIds,
@@ -781,32 +825,17 @@ const DataExportPage = () => {
       previousGroupId &&
       currentGroupId !== previousGroupId
     ) {
-      resetGroupScopedState(!siteSelectionDownloading);
-      setPendingDownload(null);
-      setSaveFormatDialogOpen(false);
-      setSavingFormat(null);
-      setSelectedSitesCache({});
-      setSelectedDevicesCache({});
-      setSelectedCountriesCache({});
-      setSelectedCitiesCache({});
-      setSelectedGridForSites(null);
-      setSiteSelectionDialogOpen(false);
-      setSiteSelectionDownloading(false);
+      cancelDownload();
+      resetGroupScopedState(true);
+      clearSelectionState();
     }
 
     previousGroupIdRef.current = currentGroupId;
   }, [
     activeGroup?.id,
+    cancelDownload,
+    clearSelectionState,
     resetGroupScopedState,
-    setPendingDownload,
-    setSaveFormatDialogOpen,
-    setSavingFormat,
-    setSelectedDevicesCache,
-    setSelectedGridForSites,
-    setSelectedSitesCache,
-    setSiteSelectionDialogOpen,
-    setSiteSelectionDownloading,
-    siteSelectionDownloading,
   ]);
 
   // Handle sidebar visibility based on screen size
@@ -822,6 +851,16 @@ const DataExportPage = () => {
   }, [setSidebarOpen]);
 
   // Check if download is ready
+  const selectedGridSiteCount = useMemo(
+    () =>
+      resolveGridSitesForDownload(
+        selectedGridIds,
+        selectedGridSites,
+        selectedGridSiteIds
+      ).length,
+    [selectedGridIds, selectedGridSites, selectedGridSiteIds]
+  );
+
   const isDownloadReady = useMemo(() => {
     const hasDateRange = dateRange?.from && dateRange?.to;
     const hasSelections =
@@ -829,8 +868,7 @@ const DataExportPage = () => {
         ? selectedSiteIds.length > 0
         : activeTab === 'devices'
           ? selectedDeviceIds.length > 0
-          : Object.keys(selectedGridSiteIds).length > 0 ||
-            Object.keys(selectedGridSites).length > 0; // countries and cities use custom or default site selections
+          : selectedGridSiteCount > 0;
     const hasPollutants = selectedPollutants.length > 0;
 
     return Boolean(hasDateRange && hasSelections && hasPollutants);
@@ -839,8 +877,7 @@ const DataExportPage = () => {
     activeTab,
     selectedSiteIds,
     selectedDeviceIds,
-    selectedGridSiteIds,
-    selectedGridSites,
+    selectedGridSiteCount,
     selectedPollutants,
   ]);
 
@@ -852,7 +889,9 @@ const DataExportPage = () => {
       // For sites, get human-readable names from processedSitesData
       const siteNames = stringIds.map(id => {
         const site = processedSitesData.find(item => String(item.id) === id);
-        return site ? String(site.name || site.search_name || site.location_name || id) : id;
+        return site
+          ? String(site.name || site.search_name || site.location_name || id)
+          : id;
       });
       setSelectedSites(siteNames);
       setSelectedSitesCache(prevCache =>
@@ -866,7 +905,9 @@ const DataExportPage = () => {
     } else if (activeTab === 'countries' || activeTab === 'cities') {
       // For countries/cities, select all sites by default
       setSelectedGridIds(stringIds);
-      const newSelectedGridSites: Record<string, string[]> = {};
+      const newSelectedGridSites: Record<string, string[]> = {
+        ...selectedGridSites,
+      };
       if (stringIds.length > 0) {
         const gridData =
           activeTab === 'countries'
@@ -878,13 +919,26 @@ const DataExportPage = () => {
             const sites = grid.sites as Array<{ _id: string }>;
             const siteIds = sites.map(site => site._id);
             newSelectedGridSites[id] = siteIds;
-          } else {
+          } else if (
+            !Object.prototype.hasOwnProperty.call(newSelectedGridSites, id)
+          ) {
             newSelectedGridSites[id] = [];
           }
         });
       }
+      Object.keys(newSelectedGridSites).forEach(gridId => {
+        if (!stringIds.includes(gridId)) {
+          delete newSelectedGridSites[gridId];
+        }
+      });
       setSelectedGridSites(newSelectedGridSites);
-      setSelectedGridSiteIds({}); // Reset custom selection
+      const selectedGridIdSet = new Set(stringIds);
+      const retainedCustomSelections = Object.fromEntries(
+        Object.entries(selectedGridSiteIds).filter(([gridId]) =>
+          selectedGridIdSet.has(gridId)
+        )
+      );
+      setSelectedGridSiteIds(retainedCustomSelections);
 
       if (activeTab === 'countries') {
         setSelectedCountriesCache(prevCache =>
@@ -948,11 +1002,15 @@ const DataExportPage = () => {
 
   // Handle site selection dialog
   const handleSiteSelectionConfirm = async (selectedSiteIds: string[]) => {
+    if (!selectedGridForSites) {
+      return;
+    }
+
     setSiteSelectionDownloading(true);
     try {
       const nextSelectedGridSiteIds = {
         ...selectedGridSiteIds,
-        [selectedGridForSites!.grid._id]: selectedSiteIds,
+        [selectedGridForSites.grid._id]: selectedSiteIds,
       };
       setSelectedGridSiteIds(nextSelectedGridSiteIds);
 
@@ -1238,6 +1296,7 @@ const DataExportPage = () => {
               selectedSiteIds={selectedSiteIds}
               selectedDeviceIds={selectedDeviceIds}
               selectedGridIds={selectedGridIds}
+              selectedGridSiteCount={selectedGridSiteCount}
               selectedPollutants={selectedPollutants}
               deviceCategory={deviceCategory}
               isDownloadReady={isDownloadReady}
@@ -1267,6 +1326,7 @@ const DataExportPage = () => {
                       ? (processedCountriesData as unknown as Grid[])
                       : (processedCitiesData as unknown as Grid[])
                   }
+                  selectedGridSites={selectedGridSites}
                   selectedGridSiteIds={selectedGridSiteIds}
                   onCustomizeSites={(grid: Grid) => {
                     setSelectedGridForSites({ grid, gridType: activeTab });
@@ -1289,7 +1349,7 @@ const DataExportPage = () => {
               onRefresh={handleRefreshCurrentTab}
               isRefreshing={isRefreshing}
               onTabChange={wrappedHandleTabChange}
-              onClearSelections={handleClearSelections}
+              onClearSelections={clearSelectionState}
               onVisualizeData={handleVisualizeData}
               onDownload={handleOpenPreview}
               onToggleSidebar={() => setSidebarOpen(!sidebarOpen)}
@@ -1362,7 +1422,7 @@ const DataExportPage = () => {
         dateRange={dateRange}
         activeTab={activeTab}
         selectedSites={selectedSites}
-        selectedDevices={selectedDevices}
+        selectedDevices={selectedDeviceNamesForExport}
         selectedGridSites={selectedGridSites}
         selectedGridSiteIds={selectedGridSiteIds}
       />
@@ -1420,7 +1480,9 @@ const DataExportPage = () => {
       {/* Tab Change Confirmation Dialog */}
       <Dialog
         isOpen={tabChangeConfirm.isOpen}
-        onClose={() => setTabChangeConfirm(prev => ({ ...prev, isOpen: false }))}
+        onClose={() =>
+          setTabChangeConfirm(prev => ({ ...prev, isOpen: false }))
+        }
         title="Switch Tab?"
         subtitle="Your current selections will be cleared"
         icon={AqAlertTriangle}
@@ -1433,13 +1495,15 @@ const DataExportPage = () => {
         }}
         secondaryAction={{
           label: 'Cancel',
-          onClick: () => setTabChangeConfirm(prev => ({ ...prev, isOpen: false })),
+          onClick: () =>
+            setTabChangeConfirm(prev => ({ ...prev, isOpen: false })),
         }}
         size="md"
       >
         <p className="text-sm text-gray-600 dark:text-gray-400">
-          You have {tabChangeConfirm.selectionCount} item{tabChangeConfirm.selectionCount !== 1 ? 's' : ''} selected.
-          Switching tabs will clear all current selections. Do you want to continue?
+          You have {tabChangeConfirm.selectionCount} item
+          {tabChangeConfirm.selectionCount !== 1 ? 's' : ''} selected. Switching
+          tabs will clear all current selections. Do you want to continue?
         </p>
       </Dialog>
     </div>

--- a/src/nexus/src/modules/data-download/DataExportPage.tsx
+++ b/src/nexus/src/modules/data-download/DataExportPage.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useEffect, useCallback } from 'react';
+import React, { useMemo, useEffect, useCallback, useRef, useState } from 'react';
 import { usePostHog } from 'posthog-js/react';
 import { usePathname } from 'next/navigation';
 import PageHeading from '@/shared/components/ui/page-heading';
@@ -17,6 +17,7 @@ import {
   CohortSitesResponse,
   CohortDevicesResponse,
   Grid,
+  DataDownloadRequest,
 } from '@/shared/types/api';
 import {
   DataType,
@@ -33,6 +34,8 @@ import {
   useDataExportActions,
 } from './hooks/useDataExportActions';
 import { useDataExportData } from './hooks/useDataExportData';
+import { useDownloadData } from '@/shared/hooks/useAnalytics';
+import { buildDataDownloadRequest } from './utils/dataExportRequest';
 import {
   buildDownloadFileContent,
   buildDownloadPdfBlob,
@@ -214,6 +217,161 @@ const DataExportPage = () => {
     return true;
   });
   const previousGroupIdRef = React.useRef<string | null>(null);
+
+  // Preview state — fetched before dialog opens
+  type PreviewData = Record<string, string | number | null>;
+  const [previewRows, setPreviewRows] = useState<PreviewData[]>([]);
+  const [isPreviewLoading, setIsPreviewLoading] = useState(false);
+  const [previewError, setPreviewError] = useState<string | null>(null);
+  const previewAbortRef = useRef<AbortController | null>(null);
+  const { trigger: fetchPreviewData } = useDownloadData();
+
+  const handleOpenPreview = useCallback(async () => {
+    if (isPreviewLoading) return;
+
+    setIsPreviewLoading(true);
+    setPreviewError(null);
+    setPreviewRows([]);
+
+    if (previewAbortRef.current) {
+      previewAbortRef.current.abort();
+    }
+    const abortController = new AbortController();
+    previewAbortRef.current = abortController;
+
+    const effectiveDataType: 'calibrated' | 'raw' =
+      activeTab === 'devices' && deviceCategory === 'bam'
+        ? 'raw'
+        : (dataType as 'calibrated' | 'raw');
+
+    const previewRequest: DataDownloadRequest = buildDataDownloadRequest({
+      dateRange,
+      activeTab,
+      selectedSites,
+      selectedDeviceIds,
+      selectedDeviceNames: selectedDevices,
+      selectedGridIds,
+      selectedGridSites,
+      selectedGridSiteIds,
+      selectedPollutants,
+      dataType: effectiveDataType,
+      fileType: 'csv',
+      frequency,
+      deviceCategory,
+    });
+
+    try {
+      const response = await fetchPreviewData(previewRequest);
+
+      if (abortController.signal.aborted) return;
+
+      if (typeof response === 'string') {
+        const parseCsvLine = (line: string): string[] => {
+          const fields: string[] = [];
+          let current = '';
+          let inQuotes = false;
+          for (let i = 0; i < line.length; i++) {
+            const char = line[i];
+            if (inQuotes) {
+              if (char === '"') {
+                if (i + 1 < line.length && line[i + 1] === '"') {
+                  current += '"';
+                  i++;
+                } else {
+                  inQuotes = false;
+                }
+              } else {
+                current += char;
+              }
+            } else {
+              if (char === '"') {
+                inQuotes = true;
+              } else if (char === ',') {
+                fields.push(current.trim());
+                current = '';
+              } else {
+                current += char;
+              }
+            }
+          }
+          fields.push(current.trim());
+          return fields;
+        };
+
+        const lines = response.split('\n').filter((line: string) => line.trim());
+        if (lines.length > 1) {
+          const headers = parseCsvLine(lines[0]);
+          const rows: PreviewData[] = lines.slice(1, 6).map((line: string) => {
+            const values = parseCsvLine(line);
+            const row: PreviewData = {};
+            headers.forEach((header, index) => {
+              const val = values[index];
+              if (val === '' || val === undefined) {
+                row[header] = null;
+              } else {
+                const num = Number(val);
+                row[header] = isNaN(num) ? val : num;
+              }
+            });
+            return row;
+          });
+          setPreviewRows(rows);
+        } else {
+          setPreviewRows([]);
+        }
+      } else if (
+        response &&
+        typeof response === 'object' &&
+        'data' in response &&
+        Array.isArray((response as { data: unknown }).data)
+      ) {
+        const responseData = (
+          response as unknown as { data: Record<string, unknown>[] }
+        ).data;
+        const rows: PreviewData[] = responseData.slice(0, 5).map(item => {
+          const row: PreviewData = {};
+          Object.entries(item).forEach(([key, value]) => {
+            row[key] =
+              typeof value === 'number'
+                ? value
+                : value != null
+                  ? String(value)
+                  : null;
+          });
+          return row;
+        });
+        setPreviewRows(rows);
+      } else {
+        setPreviewRows([]);
+      }
+    } catch {
+      if (abortController.signal.aborted) return;
+      setPreviewError(
+        'Unable to load data preview. You can retry or proceed with the download.'
+      );
+    } finally {
+      if (!abortController.signal.aborted) {
+        setIsPreviewLoading(false);
+        setPreviewOpen(true);
+      }
+    }
+  }, [
+    isPreviewLoading,
+    fetchPreviewData,
+    dataType,
+    frequency,
+    selectedPollutants,
+    dateRange,
+    activeTab,
+    selectedSites,
+    selectedDevices,
+    selectedDeviceIds,
+    selectedGridIds,
+    selectedGridSites,
+    selectedGridSiteIds,
+    deviceCategory,
+    setPreviewOpen,
+  ]);
 
   useEffect(() => {
     isMountedRef.current = true;
@@ -912,6 +1070,7 @@ const DataExportPage = () => {
               selectedGridSiteIds={selectedGridSiteIds}
               isDownloadReady={isDownloadReady}
               isDownloading={isDownloading}
+              isPreviewLoading={isPreviewLoading}
               isGroupSyncing={isGroupSyncing}
               canDownload={canDownload}
               onRefresh={handleRefreshCurrentTab}
@@ -919,7 +1078,7 @@ const DataExportPage = () => {
               onTabChange={wrappedHandleTabChange}
               onClearSelections={handleClearSelections}
               onVisualizeData={handleVisualizeData}
-              onDownload={() => setPreviewOpen(true)}
+              onDownload={handleOpenPreview}
               onToggleSidebar={() => setSidebarOpen(!sidebarOpen)}
               sidebarOpen={sidebarOpen}
               isOrgFlow={isOrgFlow}
@@ -974,7 +1133,11 @@ const DataExportPage = () => {
             console.error('Unexpected download confirmation error:', error);
           }
         }}
+        onRetryPreview={handleOpenPreview}
         isDownloading={isDownloading}
+        previewRows={previewRows}
+        isFetchingPreview={isPreviewLoading}
+        previewError={previewError}
         dataType={dataType}
         frequency={frequency}
         fileType={fileType}
@@ -983,11 +1146,8 @@ const DataExportPage = () => {
         activeTab={activeTab}
         selectedSites={selectedSites}
         selectedDevices={selectedDevices}
-        selectedDeviceIds={selectedDeviceIds}
-        selectedGridIds={selectedGridIds}
         selectedGridSites={selectedGridSites}
         selectedGridSiteIds={selectedGridSiteIds}
-        deviceCategory={deviceCategory}
       />
 
       {/* More Insights Dialog */}

--- a/src/nexus/src/modules/data-download/DataExportPage.tsx
+++ b/src/nexus/src/modules/data-download/DataExportPage.tsx
@@ -267,7 +267,20 @@ const DataExportPage = () => {
         return;
       }
 
+      // Warn user before switching tabs if they have active selections
       if (tab !== activeTab) {
+        const hasActiveSelections =
+          selectedSiteIds.length > 0 ||
+          selectedDeviceIds.length > 0 ||
+          selectedGridIds.length > 0;
+
+        if (hasActiveSelections) {
+          const confirmed = window.confirm(
+            'Switching tabs will clear your current selections. Do you want to continue?'
+          );
+          if (!confirmed) return;
+        }
+
         trackFeatureUsage(posthog, 'data_export', 'tab_changed', {
           from_tab: activeTab,
           to_tab: tab,
@@ -282,7 +295,7 @@ const DataExportPage = () => {
 
       handleTabChange(tab);
     },
-    [activeTab, isGroupSyncing, isOrgFlow, handleTabChange, posthog]
+    [activeTab, isGroupSyncing, isOrgFlow, handleTabChange, posthog, selectedSiteIds, selectedDeviceIds, selectedGridIds]
   );
 
   // Data fetching and processing (initial call with empty array)
@@ -449,6 +462,15 @@ const DataExportPage = () => {
                   countriesCitiesGridData
                 )
               : [];
+          const gridSiteIds =
+            activeTab === 'countries' || activeTab === 'cities'
+              ? (() => {
+                  const custom = Object.values(selectedGridSiteIds).flat();
+                  return custom.length > 0
+                    ? custom
+                    : Object.values(selectedGridSites).flat();
+                })()
+              : [];
           setPreviewPartialWarning(
             buildPartialDataWarning(
               response,
@@ -457,9 +479,7 @@ const DataExportPage = () => {
                 ? selectedSiteIds
                 : activeTab === 'devices'
                   ? selectedDeviceIds
-                  : selectedGridSiteIds
-                    ? Object.values(selectedGridSiteIds).flat()
-                    : [],
+                  : gridSiteIds,
               activeTab === 'sites'
                 ? selectedSites
                 : activeTab === 'devices'
@@ -532,6 +552,15 @@ const DataExportPage = () => {
                 countriesCitiesGridDataObj
               )
             : [];
+        const gridSiteIdsObj =
+          activeTab === 'countries' || activeTab === 'cities'
+            ? (() => {
+                const custom = Object.values(selectedGridSiteIds).flat();
+                return custom.length > 0
+                  ? custom
+                  : Object.values(selectedGridSites).flat();
+              })()
+            : [];
         setPreviewPartialWarning(
           buildPartialDataWarning(
             response,
@@ -540,9 +569,7 @@ const DataExportPage = () => {
               ? selectedSiteIds
               : activeTab === 'devices'
                 ? selectedDeviceIds
-                : selectedGridSiteIds
-                  ? Object.values(selectedGridSiteIds).flat()
-                  : [],
+                : gridSiteIdsObj,
             activeTab === 'sites'
               ? selectedSites
               : activeTab === 'devices'
@@ -681,6 +708,10 @@ const DataExportPage = () => {
       dataType !== 'raw'
     ) {
       setDataType('raw');
+      toast.info(
+        'Data Type Updated',
+        'Reference monitors only provide raw data. Data type has been set to Raw.'
+      );
     }
   }, [activeTab, deviceCategory, dataType, setDataType]);
 
@@ -1022,7 +1053,6 @@ const DataExportPage = () => {
 
       return true;
     } catch (error) {
-      console.error('Failed to save export:', error);
       const errorMessage = error instanceof Error ? error.message : '';
 
       if (format === 'pdf' && /export too large for pdf/i.test(errorMessage)) {
@@ -1030,14 +1060,13 @@ const DataExportPage = () => {
       } else {
         toast.error(
           'Save Failed',
-          errorMessage || 'We could not save the file. Please try again.'
+          `${errorMessage || 'We could not save the file.'} Click a format button to retry.`
         );
       }
 
-      if (format === 'json') {
-        setSaveFormatDialogOpen(false);
-        setPendingDownload(null);
-      }
+      // Clear dialog state on all formats so user can retry
+      setSaveFormatDialogOpen(false);
+      setPendingDownload(null);
 
       return false;
     }
@@ -1052,8 +1081,7 @@ const DataExportPage = () => {
 
     try {
       await savePreparedDownload(pendingDownload, format);
-    } catch (error) {
-      console.error('Failed to save export:', error);
+    } catch {
       toast.error(
         'Save Failed',
         'We could not save the file. Please try again.'
@@ -1069,6 +1097,24 @@ const DataExportPage = () => {
       localStorage.setItem('hideDataExportHelpBanner', 'true');
     }
   };
+
+  const handleToggleHelpBanner = () => {
+    setShowHelpBanner(prev => {
+      const next = !prev;
+      if (typeof window !== 'undefined') {
+        localStorage.setItem('hideDataExportHelpBanner', String(!next));
+      }
+      return next;
+    });
+  };
+
+  // Compute the total selection count for the current tab
+  const selectionCount = useMemo(() => {
+    if (activeTab === 'sites') return selectedSiteIds.length;
+    if (activeTab === 'devices') return selectedDeviceIds.length;
+    // countries/cities: count selected grid IDs
+    return selectedGridIds.length;
+  }, [activeTab, selectedSiteIds, selectedDeviceIds, selectedGridIds]);
 
   if (isOrgUnresolved) {
     return (
@@ -1189,6 +1235,9 @@ const DataExportPage = () => {
               onToggleSidebar={() => setSidebarOpen(!sidebarOpen)}
               sidebarOpen={sidebarOpen}
               isOrgFlow={isOrgFlow}
+              showHelpBanner={showHelpBanner}
+              onToggleHelpBanner={handleToggleHelpBanner}
+              selectionCount={selectionCount}
             />
 
             <DataExportTable

--- a/src/nexus/src/modules/data-download/DataExportPage.tsx
+++ b/src/nexus/src/modules/data-download/DataExportPage.tsx
@@ -218,161 +218,6 @@ const DataExportPage = () => {
   });
   const previousGroupIdRef = React.useRef<string | null>(null);
 
-  // Preview state — fetched before dialog opens
-  type PreviewData = Record<string, string | number | null>;
-  const [previewRows, setPreviewRows] = useState<PreviewData[]>([]);
-  const [isPreviewLoading, setIsPreviewLoading] = useState(false);
-  const [previewError, setPreviewError] = useState<string | null>(null);
-  const previewAbortRef = useRef<AbortController | null>(null);
-  const { trigger: fetchPreviewData } = useDownloadData();
-
-  const handleOpenPreview = useCallback(async () => {
-    if (isPreviewLoading) return;
-
-    setIsPreviewLoading(true);
-    setPreviewError(null);
-    setPreviewRows([]);
-
-    if (previewAbortRef.current) {
-      previewAbortRef.current.abort();
-    }
-    const abortController = new AbortController();
-    previewAbortRef.current = abortController;
-
-    const effectiveDataType: 'calibrated' | 'raw' =
-      activeTab === 'devices' && deviceCategory === 'bam'
-        ? 'raw'
-        : (dataType as 'calibrated' | 'raw');
-
-    try {
-      const previewRequest: DataDownloadRequest = buildDataDownloadRequest({
-        dateRange,
-        activeTab,
-        selectedSites,
-        selectedDeviceIds,
-        selectedDeviceNames: selectedDevices,
-        selectedGridIds,
-        selectedGridSites,
-        selectedGridSiteIds,
-        selectedPollutants,
-        dataType: effectiveDataType,
-        fileType: 'csv',
-        frequency,
-        deviceCategory,
-      });
-
-      const response = await fetchPreviewData(previewRequest);
-
-      if (abortController.signal.aborted) return;
-
-      if (typeof response === 'string') {
-        const parseCsvLine = (line: string): string[] => {
-          const fields: string[] = [];
-          let current = '';
-          let inQuotes = false;
-          for (let i = 0; i < line.length; i++) {
-            const char = line[i];
-            if (inQuotes) {
-              if (char === '"') {
-                if (i + 1 < line.length && line[i + 1] === '"') {
-                  current += '"';
-                  i++;
-                } else {
-                  inQuotes = false;
-                }
-              } else {
-                current += char;
-              }
-            } else {
-              if (char === '"') {
-                inQuotes = true;
-              } else if (char === ',') {
-                fields.push(current.trim());
-                current = '';
-              } else {
-                current += char;
-              }
-            }
-          }
-          fields.push(current.trim());
-          return fields;
-        };
-
-        const lines = response.split('\n').filter((line: string) => line.trim());
-        if (lines.length > 1) {
-          const headers = parseCsvLine(lines[0]);
-          const rows: PreviewData[] = lines.slice(1, 6).map((line: string) => {
-            const values = parseCsvLine(line);
-            const row: PreviewData = {};
-            headers.forEach((header, index) => {
-              const val = values[index];
-              if (val === '' || val === undefined) {
-                row[header] = null;
-              } else {
-                const num = Number(val);
-                row[header] = isNaN(num) ? val : num;
-              }
-            });
-            return row;
-          });
-          setPreviewRows(rows);
-        } else {
-          setPreviewRows([]);
-        }
-      } else if (
-        response &&
-        typeof response === 'object' &&
-        'data' in response &&
-        Array.isArray((response as { data: unknown }).data)
-      ) {
-        const responseData = (
-          response as unknown as { data: Record<string, unknown>[] }
-        ).data;
-        const rows: PreviewData[] = responseData.slice(0, 5).map(item => {
-          const row: PreviewData = {};
-          Object.entries(item).forEach(([key, value]) => {
-            row[key] =
-              typeof value === 'number'
-                ? value
-                : value != null
-                  ? String(value)
-                  : null;
-          });
-          return row;
-        });
-        setPreviewRows(rows);
-      } else {
-        setPreviewRows([]);
-      }
-    } catch {
-      if (abortController.signal.aborted) return;
-      setPreviewError(
-        'Unable to load data preview. You can retry or proceed with the download.'
-      );
-    } finally {
-      if (!abortController.signal.aborted) {
-        setIsPreviewLoading(false);
-        setPreviewOpen(true);
-      }
-    }
-  }, [
-    isPreviewLoading,
-    fetchPreviewData,
-    dataType,
-    frequency,
-    selectedPollutants,
-    dateRange,
-    activeTab,
-    selectedSites,
-    selectedDevices,
-    selectedDeviceIds,
-    selectedGridIds,
-    selectedGridSites,
-    selectedGridSiteIds,
-    deviceCategory,
-    setPreviewOpen,
-  ]);
-
   useEffect(() => {
     isMountedRef.current = true;
     return () => {
@@ -488,6 +333,191 @@ const DataExportPage = () => {
     setSelectedDevices,
     isOrgContextReady
   );
+
+  // Preview state — fetched before dialog opens
+  type PreviewData = Record<string, string | number | null>;
+  const [previewRows, setPreviewRows] = useState<PreviewData[]>([]);
+  const [isPreviewLoading, setIsPreviewLoading] = useState(false);
+  const [previewError, setPreviewError] = useState<string | null>(null);
+  const previewAbortRef = useRef<AbortController | null>(null);
+  const { trigger: fetchPreviewData } = useDownloadData();
+
+  const handleOpenPreview = useCallback(async () => {
+    if (isPreviewLoading) return;
+
+    setIsPreviewLoading(true);
+    setPreviewError(null);
+    setPreviewRows([]);
+
+    if (previewAbortRef.current) {
+      previewAbortRef.current.abort();
+    }
+    const abortController = new AbortController();
+    previewAbortRef.current = abortController;
+
+    const effectiveDataType: 'calibrated' | 'raw' =
+      activeTab === 'devices' && deviceCategory === 'bam'
+        ? 'raw'
+        : (dataType as 'calibrated' | 'raw');
+
+    try {
+      const previewRequest: DataDownloadRequest = buildDataDownloadRequest({
+        dateRange,
+        activeTab,
+        selectedSites,
+        selectedDeviceIds,
+        selectedDeviceNames: selectedDevices,
+        selectedGridIds,
+        selectedGridSites,
+        selectedGridSiteIds,
+        selectedPollutants,
+        dataType: effectiveDataType,
+        fileType: 'csv',
+        frequency,
+        deviceCategory,
+      });
+
+      const response = await fetchPreviewData(previewRequest);
+
+      if (abortController.signal.aborted) return;
+
+      if (typeof response === 'string') {
+        const parseCsvLine = (line: string): string[] => {
+          const fields: string[] = [];
+          let current = '';
+          let inQuotes = false;
+          for (let i = 0; i < line.length; i++) {
+            const char = line[i];
+            if (inQuotes) {
+              if (char === '"') {
+                if (i + 1 < line.length && line[i + 1] === '"') {
+                  current += '"';
+                  i++;
+                } else {
+                  inQuotes = false;
+                }
+              } else {
+                current += char;
+              }
+            } else {
+              if (char === '"') {
+                inQuotes = true;
+              } else if (char === ',') {
+                fields.push(current.trim());
+                current = '';
+              } else {
+                current += char;
+              }
+            }
+          }
+          fields.push(current.trim());
+          return fields;
+        };
+
+        const lines = response.split('\n').filter((line: string) => line.trim());
+        if (lines.length > 1) {
+          const headers = parseCsvLine(lines[0]);
+          const rows: PreviewData[] = lines.slice(1, 6).map((line: string) => {
+            const values = parseCsvLine(line);
+            const row: PreviewData = {};
+            headers.forEach((header, index) => {
+              const val = values[index];
+              if (val === '' || val === undefined) {
+                row[header] = null;
+              } else {
+                const num = Number(val);
+                row[header] = isNaN(num) ? val : num;
+              }
+            });
+            return row;
+          });
+
+          // For countries/cities, fill in the grid name column from processed grid data
+          if (activeTab === 'countries' || activeTab === 'cities') {
+            const locationKey = activeTab === 'countries' ? 'country_name' : 'city_name';
+            const gridData = activeTab === 'countries' ? processedCountriesData : processedCitiesData;
+
+            // Build siteId → gridName lookup
+            const siteToGrid = new Map<string, string>();
+            gridData.forEach(grid => {
+              if (grid.sites) {
+                const sites = grid.sites as Array<{ _id: string }>;
+                sites.forEach(site => {
+                  siteToGrid.set(site._id, grid.name as string);
+                });
+              }
+            });
+
+            rows.forEach(row => {
+              const siteId = row.site_id ? String(row.site_id) : null;
+              if (siteId && !row[locationKey]) {
+                const gridName = siteToGrid.get(siteId);
+                if (gridName) {
+                  row[locationKey] = gridName;
+                }
+              }
+            });
+          }
+
+          setPreviewRows(rows);
+        } else {
+          setPreviewRows([]);
+        }
+      } else if (
+        response &&
+        typeof response === 'object' &&
+        'data' in response &&
+        Array.isArray((response as { data: unknown }).data)
+      ) {
+        const responseData = (
+          response as unknown as { data: Record<string, unknown>[] }
+        ).data;
+        const rows: PreviewData[] = responseData.slice(0, 5).map(item => {
+          const row: PreviewData = {};
+          Object.entries(item).forEach(([key, value]) => {
+            row[key] =
+              typeof value === 'number'
+                ? value
+                : value != null
+                  ? String(value)
+                  : null;
+          });
+          return row;
+        });
+        setPreviewRows(rows);
+      } else {
+        setPreviewRows([]);
+      }
+    } catch {
+      if (abortController.signal.aborted) return;
+      setPreviewError(
+        'Unable to load data preview. You can retry or proceed with the download.'
+      );
+    } finally {
+      if (!abortController.signal.aborted) {
+        setIsPreviewLoading(false);
+        setPreviewOpen(true);
+      }
+    }
+  }, [
+    isPreviewLoading,
+    fetchPreviewData,
+    dataType,
+    frequency,
+    selectedPollutants,
+    dateRange,
+    activeTab,
+    selectedSites,
+    selectedDevices,
+    selectedDeviceIds,
+    selectedGridIds,
+    selectedGridSites,
+    selectedGridSiteIds,
+    deviceCategory,
+    processedCountriesData,
+    processedCitiesData,
+    setPreviewOpen,
+  ]);
 
   // Actions and event handlers
   const { handleDownload, handleVisualizeData, isDownloading } =

--- a/src/nexus/src/modules/data-download/DataExportPage.tsx
+++ b/src/nexus/src/modules/data-download/DataExportPage.tsx
@@ -2,7 +2,6 @@ import React, {
   useMemo,
   useEffect,
   useCallback,
-  useRef,
   useState,
 } from 'react';
 import { usePostHog } from 'posthog-js/react';
@@ -25,8 +24,6 @@ import {
   CohortSitesResponse,
   CohortDevicesResponse,
   Grid,
-  DataDownloadRequest,
-  DataDownloadResponse,
 } from '@/shared/types/api';
 import {
   DataType,
@@ -41,13 +38,9 @@ import { useDataExportState } from './hooks/useDataExportState';
 import {
   type PreparedDownloadResult,
   useDataExportActions,
-  getGridSiteNames,
 } from './hooks/useDataExportActions';
-import { getDataAvailability } from './utils/dataAvailability';
 import { useDataExportData } from './hooks/useDataExportData';
-import { useDownloadData } from '@/shared/hooks/useAnalytics';
 import {
-  buildDataDownloadRequest,
   resolveGridSitesForDownload,
 } from './utils/dataExportRequest';
 import { getSiteDisplayName } from './utils/dataExportUtils';
@@ -55,8 +48,8 @@ import {
   buildDownloadFileContent,
   buildDownloadPdfBlob,
   buildDownloadXlsxBlob,
-  parseDownloadResponseRecords,
 } from './utils/dataExportFile';
+import { FREQUENCY_LABELS } from '@/shared/components/charts/constants';
 import MoreInsights from '@/modules/location-insights/more-insights';
 import AddLocation from '@/modules/location-insights/add-location';
 import { trackEvent } from '@/shared/utils/analytics';
@@ -114,70 +107,6 @@ const rebuildSelectionCache = (
 };
 
 type PreviewData = Record<string, string | number | null>;
-
-const getPreviewField = (
-  record: Record<string, unknown>,
-  aliases: string[]
-): unknown => {
-  const normalizedAliases = new Set(
-    aliases.map(alias => alias.toLowerCase().replace(/[\s-]+/g, '_'))
-  );
-
-  const entry = Object.entries(record).find(([key]) =>
-    normalizedAliases.has(key.toLowerCase().replace(/[\s-]+/g, '_'))
-  );
-
-  return entry?.[1];
-};
-
-const buildPreviewRows = (
-  response: DataDownloadResponse | string,
-  activeTab: TabType,
-  countriesData: TableItem[],
-  citiesData: TableItem[]
-): PreviewData[] => {
-  const records = parseDownloadResponseRecords(response);
-  const gridData = activeTab === 'countries' ? countriesData : citiesData;
-  const siteIdToName = new Map<string, string>();
-
-  if (activeTab === 'countries' || activeTab === 'cities') {
-    gridData.forEach(grid => {
-      const sites = grid.sites as
-        | Array<{ _id?: string; name?: string }>
-        | undefined;
-
-      sites?.forEach(site => {
-        if (site._id && site.name) {
-          siteIdToName.set(String(site._id), String(site.name));
-        }
-      });
-    });
-  }
-
-  return records.slice(0, 5).map(record => {
-    const row: PreviewData = {};
-
-    Object.entries(record).forEach(([key, value]) => {
-      row[key] =
-        typeof value === 'number'
-          ? value
-          : value == null
-            ? null
-            : String(value);
-    });
-
-    if (activeTab === 'countries' || activeTab === 'cities') {
-      const siteId = getPreviewField(record, ['site_id', 'siteId']);
-      const siteName = siteId ? siteIdToName.get(String(siteId)) : undefined;
-
-      if (siteName) {
-        row.site_name = siteName;
-      }
-    }
-
-    return row;
-  });
-};
 
 const DataExportPage = () => {
   const pathname = usePathname();
@@ -281,6 +210,9 @@ const DataExportPage = () => {
   const [selectedCitiesCache, setSelectedCitiesCache] = React.useState<
     Record<string, TableItem>
   >({});
+  const [pendingColumnKeys, setPendingColumnKeys] = React.useState<
+    string[] | null
+  >(null);
   const [pendingDownload, setPendingDownload] =
     React.useState<PreparedDownloadResult | null>(null);
   const [saveFormatDialogOpen, setSaveFormatDialogOpen] = React.useState(false);
@@ -339,22 +271,14 @@ const DataExportPage = () => {
     }
   }, [isOrgFlow, activeTab, handleTabChange]);
 
-  // Preview state — fetched before dialog opens
+  // Preview state — built from cached data (no API call needed)
   const [previewRows, setPreviewRows] = useState<PreviewData[]>([]);
   const [isPreviewLoading, setIsPreviewLoading] = useState(false);
   const [previewError, setPreviewError] = useState<string | null>(null);
-  const [previewPartialWarning, setPreviewPartialWarning] = useState<
-    | { totalSelected: number; withData: number; missingNames: string[] }
-    | undefined
-  >(undefined);
-  const previewAbortRef = useRef<AbortController | null>(null);
 
   const clearPreviewState = useCallback(() => {
-    previewAbortRef.current?.abort();
-    previewAbortRef.current = null;
     setPreviewRows([]);
     setPreviewError(null);
-    setPreviewPartialWarning(undefined);
     setIsPreviewLoading(false);
     setPreviewOpen(false);
   }, [setPreviewOpen]);
@@ -368,6 +292,7 @@ const DataExportPage = () => {
     setSelectedGridForSites(null);
     setSiteSelectionDialogOpen(false);
     setSiteSelectionDownloading(false);
+    setPendingColumnKeys(null);
     setPendingDownload(null);
     setSaveFormatDialogOpen(false);
     setSavingFormat(null);
@@ -541,146 +466,145 @@ const DataExportPage = () => {
     [selectedSiteIds, selectedSitesCache, processedSitesData]
   );
 
-  // Preview state — fetched before dialog opens
-  const { trigger: fetchPreviewData } = useDownloadData();
-
-  const handleOpenPreview = useCallback(async () => {
+  // Build preview rows from cached data (no API call needed)
+  const handleOpenPreview = useCallback(() => {
     if (isPreviewLoading) return;
 
     setIsPreviewLoading(true);
     setPreviewError(null);
     setPreviewRows([]);
-    setPreviewPartialWarning(undefined);
-
-    if (previewAbortRef.current) {
-      previewAbortRef.current.abort();
-    }
-    const abortController = new AbortController();
-    previewAbortRef.current = abortController;
-
-    const effectiveDataType: 'calibrated' | 'raw' =
-      activeTab === 'devices' && deviceCategory === 'bam'
-        ? 'raw'
-        : (dataType as 'calibrated' | 'raw');
 
     try {
-      const previewRequest: DataDownloadRequest = buildDataDownloadRequest({
-        dateRange,
-        activeTab,
-        selectedSites,
-        selectedSiteIds,
-        selectedDeviceIds,
-        selectedDeviceNames: selectedDeviceNamesForExport,
-        selectedGridIds,
-        selectedGridSites,
-        selectedGridSiteIds,
-        selectedPollutants,
-        dataType: effectiveDataType,
-        fileType: 'csv',
-        frequency,
-        deviceCategory,
-      });
+      let rows: PreviewData[] = [];
 
-      const response = await fetchPreviewData(previewRequest);
+      // Derive config-based field values for the preview
+      const frequencyLabel =
+        FREQUENCY_LABELS[frequency as keyof typeof FREQUENCY_LABELS] || frequency;
+      const formatNetwork = (val: unknown): string | null => {
+        if (typeof val !== 'string' || !val.trim()) return null;
+        return val.trim().toUpperCase();
+      };
+      const formattedDate = (() => {
+        if (!dateRange?.from || !dateRange?.to) return 'Not selected';
+        const fmt = (d: Date) =>
+          d.toLocaleDateString('en-US', {
+            year: 'numeric',
+            month: 'short',
+            day: 'numeric',
+          });
+        return `${fmt(dateRange.from)} – ${fmt(dateRange.to)}`;
+      })();
 
-      if (abortController.signal.aborted) return;
-
-      const selectedAvailabilityIds =
-        activeTab === 'sites'
-          ? selectedSiteIds
-          : activeTab === 'devices'
-            ? selectedDeviceIds
-            : resolveGridSitesForDownload(
-                selectedGridIds,
-                selectedGridSites,
-                selectedGridSiteIds
-              );
-      const selectedAvailabilityLabels =
-        activeTab === 'sites'
-          ? selectedSiteNames
-          : activeTab === 'devices'
-            ? selectedDeviceNamesForExport
-            : getGridSiteNames(
-                activeTab,
-                selectedGridIds,
-                selectedGridSiteIds,
-                selectedGridSites,
-                activeTab === 'countries'
-                  ? processedCountriesData
-                  : processedCitiesData
-              );
-      const previewAvailability = getDataAvailability(
-        response,
-        activeTab,
-        selectedAvailabilityIds,
-        selectedAvailabilityLabels,
-        selectedPollutants
-      );
-
-      if (typeof response === 'string') {
-        const rows = buildPreviewRows(
-          response,
-          activeTab,
-          processedCountriesData,
-          processedCitiesData
+      if (activeTab === 'sites') {
+        rows = selectedSiteIds.map(id => {
+          const site = selectedSitesCache[id];
+          const name = site
+            ? (site.name ?? site.site_name ?? id)
+            : id;
+          const row: PreviewData = {
+            id: site?.id ?? id,
+            site_name: name as string,
+            datetime: formattedDate,
+            frequency: frequencyLabel,
+            network:
+              formatNetwork(site?.network ?? site?.sensor_manufacturer ?? site?.data_provider),
+            latitude: (site?.latitude ?? site?.lat ?? null) as string | number | null,
+            longitude: (site?.longitude ?? site?.lng ?? site?.lon ?? null) as string | number | null,
+            site_id: (site?.site_id ?? site?.id ?? id) as string,
+          };
+          if (site?.search_name) row.search_name = site.search_name as string;
+          if (site?.formatted_name) row.formatted_name = site.formatted_name as string;
+          if (site?.location_name) row.location_name = site.location_name as string;
+          if (site?.city) row.city = site.city as string;
+          if (site?.country) row.country = site.country as string;
+          if (site?.data_provider) row.data_provider = site.data_provider as string;
+          return row;
+        });
+      } else if (activeTab === 'devices') {
+        rows = selectedDeviceIds.map(id => {
+          const device = selectedDevicesCache[id];
+          const name = device
+            ? (device.name ?? device.device_name ?? id)
+            : id;
+          const row: PreviewData = {
+            id: device?.id ?? id,
+            device_name: name as string,
+            datetime: formattedDate,
+            frequency: frequencyLabel,
+            network:
+              formatNetwork(device?.network ?? device?.sensor_manufacturer ?? device?.manufacturer),
+            device_id: (device?.device_id ?? device?.id ?? id) as string,
+            latitude: (device?.latitude ?? device?.lat ?? null) as string | number | null,
+            longitude: (device?.longitude ?? device?.lng ?? device?.lon ?? null) as string | number | null,
+          };
+          if (device?.site_name) row.site_name = device.site_name as string;
+          if (device?.category) row.category = device.category as string;
+          return row;
+        });
+      } else if (activeTab === 'countries' || activeTab === 'cities') {
+        // For countries/cities, build preview from selected grid sites
+        const gridIds = Array.from(
+          new Set([
+            ...Object.keys(selectedGridSites),
+            ...Object.keys(selectedGridSiteIds),
+          ])
         );
-        if (rows.length > 0) {
-          // Site names are normalized in buildPreviewRows.
-          // Build siteId → siteName lookup from all selected grids' sites
-          setPreviewRows(rows);
-          setPreviewPartialWarning(previewAvailability);
-        } else {
-          setPreviewRows([]);
-          setPreviewPartialWarning(previewAvailability);
-        }
-      } else if (
-        response &&
-        typeof response === 'object' &&
-        'data' in response &&
-        Array.isArray((response as { data: unknown }).data)
-      ) {
-        const rows = buildPreviewRows(
-          response,
-          activeTab,
-          processedCountriesData,
-          processedCitiesData
+        const resolvedSiteIds = resolveGridSitesForDownload(
+          gridIds,
+          selectedGridSites,
+          selectedGridSiteIds
         );
+        const gridData =
+          activeTab === 'countries' ? processedCountriesData : processedCitiesData;
 
-        setPreviewRows(rows);
-        setPreviewPartialWarning(previewAvailability);
-      } else {
-        setPreviewRows([]);
-        setPreviewPartialWarning(previewAvailability);
+        // Build siteId → siteName and siteId → network lookups from grid data
+        const siteIdToName = new Map<string, string>();
+        const siteIdToNetwork = new Map<string, string | null>();
+        gridData.forEach(grid => {
+          const gridNetwork = formatNetwork(grid.network ?? grid.sensor_manufacturer);
+          const sites = grid.sites as
+            | Array<{ _id?: string; name?: string }>
+            | undefined;
+          sites?.forEach(site => {
+            if (site._id) {
+              siteIdToName.set(String(site._id), String(site.name ?? site._id));
+              siteIdToNetwork.set(String(site._id), gridNetwork);
+            }
+          });
+        });
+
+        rows = resolvedSiteIds.map(siteId => ({
+          id: siteId,
+          site_id: siteId,
+          site_name: siteIdToName.get(siteId) ?? siteId,
+          datetime: formattedDate,
+          frequency: frequencyLabel,
+          network: siteIdToNetwork.get(siteId) ?? null,
+          latitude: null,
+          longitude: null,
+        }));
       }
+
+      setPreviewRows(rows);
     } catch {
-      if (abortController.signal.aborted) return;
       setPreviewError(
-        'Unable to load data preview. You can retry or proceed with the download.'
+        'Unable to build data preview. Please try again.'
       );
-      setPreviewPartialWarning(undefined);
     } finally {
-      if (!abortController.signal.aborted) {
-        setIsPreviewLoading(false);
-        setPreviewOpen(true);
-      }
+      setIsPreviewLoading(false);
+      setPreviewOpen(true);
     }
   }, [
     isPreviewLoading,
-    fetchPreviewData,
-    dataType,
-    frequency,
-    selectedPollutants,
-    dateRange,
     activeTab,
-    selectedSites,
-    selectedSiteNames,
-    selectedDeviceNamesForExport,
+    dateRange,
+    frequency,
     selectedSiteIds,
     selectedDeviceIds,
-    selectedGridIds,
+    selectedSitesCache,
+    selectedDevicesCache,
     selectedGridSites,
     selectedGridSiteIds,
-    deviceCategory,
     processedCountriesData,
     processedCitiesData,
     setPreviewOpen,
@@ -714,14 +638,6 @@ const DataExportPage = () => {
     selectedPollutants,
     selectedSiteIds,
   ]);
-
-  useEffect(() => {
-    return () => {
-      if (previewAbortRef.current) {
-        previewAbortRef.current.abort();
-      }
-    };
-  }, []);
 
   // Actions and event handlers
   const { handleDownload, handleVisualizeData, isDownloading, cancelDownload } =
@@ -1019,11 +935,12 @@ const DataExportPage = () => {
         customSelectedGridSiteIds: nextSelectedGridSiteIds,
       });
 
-      // Close dialog only on successful download preparation
+      // Store prepared download and open format dialog directly
       if (preparedDownload) {
         setSiteSelectionDialogOpen(false);
         setSelectedGridForSites(null);
-        openSaveFormatDialog(preparedDownload);
+        setPendingDownload(preparedDownload);
+        setSaveFormatDialogOpen(true);
       }
     } catch (error) {
       // Error is already handled in handleDownload
@@ -1059,17 +976,6 @@ const DataExportPage = () => {
       }
     }
   }, [currentHook, isGroupSyncing, isRefreshing]);
-
-  const openSaveFormatDialog = (download: PreparedDownloadResult) => {
-    if (fileType === 'json') {
-      void savePreparedDownload(download, 'json');
-      return;
-    }
-
-    setPendingDownload(download);
-    setSavingFormat(null);
-    setSaveFormatDialogOpen(true);
-  };
 
   const savePreparedDownload = async (
     download: PreparedDownloadResult,
@@ -1167,7 +1073,6 @@ const DataExportPage = () => {
 
       toast.success(`Saved as ${savedLabel}`, savedMessage);
       setSaveFormatDialogOpen(false);
-      setPendingDownload(null);
 
       return true;
     } catch (error) {
@@ -1182,30 +1087,37 @@ const DataExportPage = () => {
         );
       }
 
-      // Clear dialog state on all formats so user can retry
       setSaveFormatDialogOpen(false);
-      setPendingDownload(null);
 
       return false;
     }
   };
 
   const handleSaveFormatSelection = async (format: SaveFormat) => {
-    if (!pendingDownload) {
-      return;
-    }
-
     setSavingFormat(format);
 
     try {
-      await savePreparedDownload(pendingDownload, format);
+      // Use pendingDownload if already prepared (from grid site selection),
+      // otherwise make the API call now that user has chosen a format
+      const preparedDownload = pendingDownload ?? (await handleDownload({
+        exportColumnKeys: pendingColumnKeys ?? undefined,
+      }));
+
+      if (!preparedDownload) {
+        setSavingFormat(null);
+        return;
+      }
+
+      await savePreparedDownload(preparedDownload, format);
     } catch {
       toast.error(
-        'Save Failed',
-        'We could not save the file. Please try again.'
+        'Download Failed',
+        'We could not complete your download. Please try again.'
       );
     } finally {
       setSavingFormat(null);
+      setPendingDownload(null);
+      setPendingColumnKeys(null);
     }
   };
 
@@ -1395,26 +1307,16 @@ const DataExportPage = () => {
       <DataExportPreview
         isOpen={previewOpen}
         onClose={() => setPreviewOpen(false)}
-        onConfirm={async (selectedColumnKeys: string[]) => {
-          try {
-            const preparedDownload = await handleDownload({
-              exportColumnKeys: selectedColumnKeys,
-            });
-
-            if (preparedDownload) {
-              setPreviewOpen(false);
-              openSaveFormatDialog(preparedDownload);
-            }
-          } catch (error) {
-            console.error('Unexpected download confirmation error:', error);
-          }
+        onConfirm={(selectedColumnKeys: string[]) => {
+          setPendingColumnKeys(selectedColumnKeys);
+          setPreviewOpen(false);
+          setSaveFormatDialogOpen(true);
         }}
         onRetryPreview={handleOpenPreview}
         isDownloading={isDownloading}
         previewRows={previewRows}
         isFetchingPreview={isPreviewLoading}
         previewError={previewError}
-        partialDataWarning={previewPartialWarning}
         dataType={dataType}
         frequency={frequency}
         fileType={fileType}
@@ -1471,10 +1373,11 @@ const DataExportPage = () => {
           if (!savingFormat) {
             setSaveFormatDialogOpen(false);
             setPendingDownload(null);
+            setPendingColumnKeys(null);
           }
         }}
         onSave={handleSaveFormatSelection}
-        locationCount={pendingDownload?.locationCount || 0}
+        locationCount={selectionCount}
       />
 
       {/* Tab Change Confirmation Dialog */}

--- a/src/nexus/src/modules/data-download/DataExportPage.tsx
+++ b/src/nexus/src/modules/data-download/DataExportPage.tsx
@@ -13,6 +13,8 @@ import { DataExportBanner } from './components/DataExportBanner';
 import { DataExportHelpBanner } from './components/DataExportHelpBanner';
 import { VideoTutorialDialog } from './components/VideoTutorialDialog';
 import { toast } from '@/shared/components/ui/toast';
+import Dialog from '@/shared/components/ui/dialog';
+import { AqAlertTriangle } from '@airqo/icons-react';
 import {
   CohortSitesResponse,
   CohortDevicesResponse,
@@ -220,6 +222,11 @@ const DataExportPage = () => {
     return true;
   });
   const previousGroupIdRef = React.useRef<string | null>(null);
+  const [tabChangeConfirm, setTabChangeConfirm] = React.useState<{
+    isOpen: boolean;
+    targetTab: TabType;
+    selectionCount: number;
+  }>({ isOpen: false, targetTab: 'sites', selectionCount: 0 });
 
   useEffect(() => {
     isMountedRef.current = true;
@@ -256,6 +263,17 @@ const DataExportPage = () => {
     }
   }, [isOrgFlow, activeTab, handleTabChange]);
 
+  // Preview state — fetched before dialog opens
+  type PreviewData = Record<string, string | number | null>;
+  const [previewRows, setPreviewRows] = useState<PreviewData[]>([]);
+  const [isPreviewLoading, setIsPreviewLoading] = useState(false);
+  const [previewError, setPreviewError] = useState<string | null>(null);
+  const [previewPartialWarning, setPreviewPartialWarning] = useState<
+    | { totalSelected: number; withData: number; missingNames: string[] }
+    | undefined
+  >(undefined);
+  const previewAbortRef = useRef<AbortController | null>(null);
+
   // Wrap handleTabChange to prevent org flow from accessing countries/cities
   const wrappedHandleTabChange = useCallback(
     (tab: TabType) => {
@@ -269,16 +287,18 @@ const DataExportPage = () => {
 
       // Warn user before switching tabs if they have active selections
       if (tab !== activeTab) {
-        const hasActiveSelections =
-          selectedSiteIds.length > 0 ||
-          selectedDeviceIds.length > 0 ||
-          selectedGridIds.length > 0;
+        const selectionCount =
+          selectedSiteIds.length +
+          selectedDeviceIds.length +
+          selectedGridIds.length;
 
-        if (hasActiveSelections) {
-          const confirmed = window.confirm(
-            'Switching tabs will clear your current selections. Do you want to continue?'
-          );
-          if (!confirmed) return;
+        if (selectionCount > 0) {
+          setTabChangeConfirm({
+            isOpen: true,
+            targetTab: tab,
+            selectionCount,
+          });
+          return;
         }
 
         trackFeatureUsage(posthog, 'data_export', 'tab_changed', {
@@ -297,6 +317,33 @@ const DataExportPage = () => {
     },
     [activeTab, isGroupSyncing, isOrgFlow, handleTabChange, posthog, selectedSiteIds, selectedDeviceIds, selectedGridIds]
   );
+
+  const confirmTabChange = useCallback(() => {
+    const { targetTab } = tabChangeConfirm;
+    setTabChangeConfirm(prev => ({ ...prev, isOpen: false }));
+
+    // Clear preview state to prevent stale data
+    setPreviewRows([]);
+    setPreviewError(null);
+    setPreviewPartialWarning(undefined);
+    setPreviewOpen(false);
+    if (previewAbortRef.current) {
+      previewAbortRef.current.abort();
+    }
+
+    trackFeatureUsage(posthog, 'data_export', 'tab_changed', {
+      from_tab: activeTab,
+      to_tab: targetTab,
+      is_org_flow: isOrgFlow,
+    });
+    trackEvent('data_export_tab_changed', {
+      from_tab: activeTab,
+      to_tab: targetTab,
+      is_org_flow: isOrgFlow,
+    });
+
+    handleTabChange(targetTab);
+  }, [tabChangeConfirm, activeTab, isOrgFlow, handleTabChange, posthog, setPreviewOpen, setPreviewRows, setPreviewError, setPreviewPartialWarning]);
 
   // Data fetching and processing (initial call with empty array)
   const selectedDevicesForActions = useMemo(
@@ -350,16 +397,26 @@ const DataExportPage = () => {
     isOrgContextReady
   );
 
+  // Compute site names from cache to avoid stale state issues
+  const selectedSiteNames = useMemo(
+    () =>
+      selectedSiteIds.map(id => {
+        const cached = selectedSitesCache[id];
+        if (cached) {
+          return String(
+            cached.name || cached.search_name || cached.location_name || id
+          );
+        }
+        // Fallback: find in current page data
+        const site = processedSitesData.find(item => String(item.id) === id);
+        return site
+          ? String(site.name || site.search_name || site.location_name || id)
+          : id;
+      }),
+    [selectedSiteIds, selectedSitesCache, processedSitesData]
+  );
+
   // Preview state — fetched before dialog opens
-  type PreviewData = Record<string, string | number | null>;
-  const [previewRows, setPreviewRows] = useState<PreviewData[]>([]);
-  const [isPreviewLoading, setIsPreviewLoading] = useState(false);
-  const [previewError, setPreviewError] = useState<string | null>(null);
-  const [previewPartialWarning, setPreviewPartialWarning] = useState<
-    | { totalSelected: number; withData: number; missingNames: string[] }
-    | undefined
-  >(undefined);
-  const previewAbortRef = useRef<AbortController | null>(null);
   const { trigger: fetchPreviewData } = useDownloadData();
 
   const handleOpenPreview = useCallback(async () => {
@@ -481,11 +538,10 @@ const DataExportPage = () => {
                   ? selectedDeviceIds
                   : gridSiteIds,
               activeTab === 'sites'
-                ? selectedSites
+                ? selectedSiteNames
                 : activeTab === 'devices'
                   ? selectedDevices
-                  : gridSiteNames,
-              countriesCitiesGridData
+                  : gridSiteNames
             )
           );
         } else {
@@ -571,11 +627,10 @@ const DataExportPage = () => {
                 ? selectedDeviceIds
                 : gridSiteIdsObj,
             activeTab === 'sites'
-              ? selectedSites
+              ? selectedSiteNames
               : activeTab === 'devices'
                 ? selectedDevices
-                : gridSiteNamesObj,
-            countriesCitiesGridDataObj
+                : gridSiteNamesObj
           )
         );
       } else {
@@ -603,6 +658,7 @@ const DataExportPage = () => {
     dateRange,
     activeTab,
     selectedSites,
+    selectedSiteNames,
     selectedDevices,
     selectedSiteIds,
     selectedDeviceIds,
@@ -628,7 +684,7 @@ const DataExportPage = () => {
     useDataExportActions(
       dateRange,
       activeTab,
-      selectedSites,
+      selectedSiteNames,
       selectedDevices,
       selectedSiteIds,
       selectedDeviceIds,
@@ -793,8 +849,12 @@ const DataExportPage = () => {
     const stringIds = selectedIds.map(id => String(id));
     if (activeTab === 'sites') {
       setSelectedSiteIds(stringIds);
-      // For sites, IDs are the same as names for the API
-      setSelectedSites(stringIds);
+      // For sites, get human-readable names from processedSitesData
+      const siteNames = stringIds.map(id => {
+        const site = processedSitesData.find(item => String(item.id) === id);
+        return site ? String(site.name || site.search_name || site.location_name || id) : id;
+      });
+      setSelectedSites(siteNames);
       setSelectedSitesCache(prevCache =>
         rebuildSelectionCache(stringIds, processedSitesData, prevCache)
       );
@@ -1356,6 +1416,32 @@ const DataExportPage = () => {
         onSave={handleSaveFormatSelection}
         locationCount={pendingDownload?.locationCount || 0}
       />
+
+      {/* Tab Change Confirmation Dialog */}
+      <Dialog
+        isOpen={tabChangeConfirm.isOpen}
+        onClose={() => setTabChangeConfirm(prev => ({ ...prev, isOpen: false }))}
+        title="Switch Tab?"
+        subtitle="Your current selections will be cleared"
+        icon={AqAlertTriangle}
+        iconColor="text-amber-600"
+        iconBgColor="bg-amber-100"
+        primaryAction={{
+          label: 'Switch Tab',
+          onClick: confirmTabChange,
+          className: 'bg-amber-600 hover:bg-amber-700 text-white',
+        }}
+        secondaryAction={{
+          label: 'Cancel',
+          onClick: () => setTabChangeConfirm(prev => ({ ...prev, isOpen: false })),
+        }}
+        size="md"
+      >
+        <p className="text-sm text-gray-600 dark:text-gray-400">
+          You have {tabChangeConfirm.selectionCount} item{tabChangeConfirm.selectionCount !== 1 ? 's' : ''} selected.
+          Switching tabs will clear all current selections. Do you want to continue?
+        </p>
+      </Dialog>
     </div>
   );
 };

--- a/src/nexus/src/modules/data-download/DataExportPage.tsx
+++ b/src/nexus/src/modules/data-download/DataExportPage.tsx
@@ -7,6 +7,7 @@ import React, {
 import { usePostHog } from 'posthog-js/react';
 import { usePathname } from 'next/navigation';
 import PageHeading from '@/shared/components/ui/page-heading';
+import { SuccessBanner } from '@/shared/components/ui/banner';
 import { DataExportSidebar } from './components/DataExportSidebar';
 import { SiteSelectionDialog } from './components/SiteSelectionDialog';
 import { DownloadFormatDialog } from './components/DownloadFormatDialog';
@@ -219,6 +220,10 @@ const DataExportPage = () => {
   const [savingFormat, setSavingFormat] = React.useState<SaveFormat | null>(
     null
   );
+  const [downloadSuccess, setDownloadSuccess] = React.useState<{
+    format: string;
+    message: string;
+  } | null>(null);
   const [isRefreshing, setIsRefreshing] = React.useState(false);
   const refreshInFlightRef = React.useRef(false);
   const isMountedRef = React.useRef(true);
@@ -242,6 +247,13 @@ const DataExportPage = () => {
       isMountedRef.current = false;
     };
   }, []);
+
+  // Auto-dismiss success banner after 10 seconds
+  useEffect(() => {
+    if (!downloadSuccess) return;
+    const timer = setTimeout(() => setDownloadSuccess(null), 10000);
+    return () => clearTimeout(timer);
+  }, [downloadSuccess]);
 
   useEffect(() => {
     if (!isOrgFlow) {
@@ -296,6 +308,7 @@ const DataExportPage = () => {
     setPendingDownload(null);
     setSaveFormatDialogOpen(false);
     setSavingFormat(null);
+    setDownloadSuccess(null);
     clearPreviewState();
   }, [clearPreviewState, handleClearSelections]);
 
@@ -1071,7 +1084,7 @@ const DataExportPage = () => {
               ? 'Your CSV file has been saved.'
               : 'Your JSON file has been saved.';
 
-      toast.success(`Saved as ${savedLabel}`, savedMessage);
+      setDownloadSuccess({ format: savedLabel, message: savedMessage });
       setSaveFormatDialogOpen(false);
 
       return true;
@@ -1271,6 +1284,17 @@ const DataExportPage = () => {
               onToggleHelpBanner={handleToggleHelpBanner}
               selectionCount={selectionCount}
             />
+
+            {/* Download Success Banner */}
+            {downloadSuccess && (
+              <SuccessBanner
+                dense
+                dismissible
+                onDismiss={() => setDownloadSuccess(null)}
+                title={`Saved as ${downloadSuccess.format}`}
+                message={downloadSuccess.message}
+              />
+            )}
 
             <DataExportTable
               activeTab={activeTab}

--- a/src/nexus/src/modules/data-download/DataExportPage.tsx
+++ b/src/nexus/src/modules/data-download/DataExportPage.tsx
@@ -432,28 +432,30 @@ const DataExportPage = () => {
             return row;
           });
 
-          // For countries/cities, fill in the grid name column from processed grid data
+          // For countries/cities, backfill site_name from grid.sites data
           if (activeTab === 'countries' || activeTab === 'cities') {
-            const locationKey = activeTab === 'countries' ? 'country_name' : 'city_name';
             const gridData = activeTab === 'countries' ? processedCountriesData : processedCitiesData;
 
-            // Build siteId → gridName lookup
-            const siteToGrid = new Map<string, string>();
+            // Build siteId → siteName lookup from all selected grids' sites
+            const siteIdToName = new Map<string, string>();
             gridData.forEach(grid => {
               if (grid.sites) {
-                const sites = grid.sites as Array<{ _id: string }>;
+                const sites = grid.sites as Array<{ _id: string; name: string }>;
                 sites.forEach(site => {
-                  siteToGrid.set(site._id, grid.name as string);
+                  if (site._id && site.name) {
+                    siteIdToName.set(site._id, site.name);
+                  }
                 });
               }
             });
 
+            // Backfill site_name for each row using site_id lookup
             rows.forEach(row => {
               const siteId = row.site_id ? String(row.site_id) : null;
-              if (siteId && !row[locationKey]) {
-                const gridName = siteToGrid.get(siteId);
-                if (gridName) {
-                  row[locationKey] = gridName;
+              if (siteId) {
+                const siteName = siteIdToName.get(siteId);
+                if (siteName) {
+                  row.site_name = siteName;
                 }
               }
             });
@@ -484,6 +486,32 @@ const DataExportPage = () => {
           });
           return row;
         });
+
+        // For countries/cities, backfill site_name from grid.sites data
+        if (activeTab === 'countries' || activeTab === 'cities') {
+          const gridData = activeTab === 'countries' ? processedCountriesData : processedCitiesData;
+          const siteIdToName = new Map<string, string>();
+          gridData.forEach(grid => {
+            if (grid.sites) {
+              const sites = grid.sites as Array<{ _id: string; name: string }>;
+              sites.forEach(site => {
+                if (site._id && site.name) {
+                  siteIdToName.set(site._id, site.name);
+                }
+              });
+            }
+          });
+          rows.forEach(row => {
+            const siteId = row.site_id ? String(row.site_id) : null;
+            if (siteId) {
+              const siteName = siteIdToName.get(siteId);
+              if (siteName) {
+                row.site_name = siteName;
+              }
+            }
+          });
+        }
+
         setPreviewRows(rows);
       } else {
         setPreviewRows([]);

--- a/src/nexus/src/modules/data-download/DataExportPage.tsx
+++ b/src/nexus/src/modules/data-download/DataExportPage.tsx
@@ -983,9 +983,11 @@ const DataExportPage = () => {
         activeTab={activeTab}
         selectedSites={selectedSites}
         selectedDevices={selectedDevices}
+        selectedDeviceIds={selectedDeviceIds}
         selectedGridIds={selectedGridIds}
         selectedGridSites={selectedGridSites}
         selectedGridSiteIds={selectedGridSiteIds}
+        deviceCategory={deviceCategory}
       />
 
       {/* More Insights Dialog */}

--- a/src/nexus/src/modules/data-download/DataExportPage.tsx
+++ b/src/nexus/src/modules/data-download/DataExportPage.tsx
@@ -32,6 +32,8 @@ import { useDataExportState } from './hooks/useDataExportState';
 import {
   type PreparedDownloadResult,
   useDataExportActions,
+  buildPartialDataWarning,
+  getGridSiteNames,
 } from './hooks/useDataExportActions';
 import { useDataExportData } from './hooks/useDataExportData';
 import { useDownloadData } from '@/shared/hooks/useAnalytics';
@@ -40,6 +42,7 @@ import {
   buildDownloadFileContent,
   buildDownloadPdfBlob,
   buildDownloadXlsxBlob,
+  parseDownloadCsvRows,
 } from './utils/dataExportFile';
 import MoreInsights from '@/modules/location-insights/more-insights';
 import AddLocation from '@/modules/location-insights/add-location';
@@ -339,6 +342,10 @@ const DataExportPage = () => {
   const [previewRows, setPreviewRows] = useState<PreviewData[]>([]);
   const [isPreviewLoading, setIsPreviewLoading] = useState(false);
   const [previewError, setPreviewError] = useState<string | null>(null);
+  const [previewPartialWarning, setPreviewPartialWarning] = useState<
+    | { totalSelected: number; withData: number; missingNames: string[] }
+    | undefined
+  >(undefined);
   const previewAbortRef = useRef<AbortController | null>(null);
   const { trigger: fetchPreviewData } = useDownloadData();
 
@@ -348,6 +355,7 @@ const DataExportPage = () => {
     setIsPreviewLoading(true);
     setPreviewError(null);
     setPreviewRows([]);
+    setPreviewPartialWarning(undefined);
 
     if (previewAbortRef.current) {
       previewAbortRef.current.abort();
@@ -382,43 +390,10 @@ const DataExportPage = () => {
       if (abortController.signal.aborted) return;
 
       if (typeof response === 'string') {
-        const parseCsvLine = (line: string): string[] => {
-          const fields: string[] = [];
-          let current = '';
-          let inQuotes = false;
-          for (let i = 0; i < line.length; i++) {
-            const char = line[i];
-            if (inQuotes) {
-              if (char === '"') {
-                if (i + 1 < line.length && line[i + 1] === '"') {
-                  current += '"';
-                  i++;
-                } else {
-                  inQuotes = false;
-                }
-              } else {
-                current += char;
-              }
-            } else {
-              if (char === '"') {
-                inQuotes = true;
-              } else if (char === ',') {
-                fields.push(current.trim());
-                current = '';
-              } else {
-                current += char;
-              }
-            }
-          }
-          fields.push(current.trim());
-          return fields;
-        };
-
-        const lines = response.split('\n').filter((line: string) => line.trim());
-        if (lines.length > 1) {
-          const headers = parseCsvLine(lines[0]);
-          const rows: PreviewData[] = lines.slice(1, 6).map((line: string) => {
-            const values = parseCsvLine(line);
+        const parsedRows = parseDownloadCsvRows(response);
+        if (parsedRows.length > 1) {
+          const headers = parsedRows[0];
+          const rows: PreviewData[] = parsedRows.slice(1, 6).map((values: string[]) => {
             const row: PreviewData = {};
             headers.forEach((header, index) => {
               const val = values[index];
@@ -462,8 +437,40 @@ const DataExportPage = () => {
           }
 
           setPreviewRows(rows);
+          const countriesCitiesGridData =
+            activeTab === 'countries' ? processedCountriesData : processedCitiesData;
+          const gridSiteNames =
+            activeTab === 'countries' || activeTab === 'cities'
+              ? getGridSiteNames(
+                  activeTab,
+                  selectedGridIds,
+                  selectedGridSiteIds,
+                  selectedGridSites,
+                  countriesCitiesGridData
+                )
+              : [];
+          setPreviewPartialWarning(
+            buildPartialDataWarning(
+              response,
+              activeTab,
+              activeTab === 'sites'
+                ? selectedSiteIds
+                : activeTab === 'devices'
+                  ? selectedDeviceIds
+                  : selectedGridSiteIds
+                    ? Object.values(selectedGridSiteIds).flat()
+                    : [],
+              activeTab === 'sites'
+                ? selectedSites
+                : activeTab === 'devices'
+                  ? selectedDevices
+                  : gridSiteNames,
+              countriesCitiesGridData
+            )
+          );
         } else {
           setPreviewRows([]);
+          setPreviewPartialWarning(undefined);
         }
       } else if (
         response &&
@@ -513,14 +520,47 @@ const DataExportPage = () => {
         }
 
         setPreviewRows(rows);
+        const countriesCitiesGridDataObj =
+          activeTab === 'countries' ? processedCountriesData : processedCitiesData;
+        const gridSiteNamesObj =
+          activeTab === 'countries' || activeTab === 'cities'
+            ? getGridSiteNames(
+                activeTab,
+                selectedGridIds,
+                selectedGridSiteIds,
+                selectedGridSites,
+                countriesCitiesGridDataObj
+              )
+            : [];
+        setPreviewPartialWarning(
+          buildPartialDataWarning(
+            response,
+            activeTab,
+            activeTab === 'sites'
+              ? selectedSiteIds
+              : activeTab === 'devices'
+                ? selectedDeviceIds
+                : selectedGridSiteIds
+                  ? Object.values(selectedGridSiteIds).flat()
+                  : [],
+            activeTab === 'sites'
+              ? selectedSites
+              : activeTab === 'devices'
+                ? selectedDevices
+                : gridSiteNamesObj,
+            countriesCitiesGridDataObj
+          )
+        );
       } else {
         setPreviewRows([]);
+        setPreviewPartialWarning(undefined);
       }
     } catch {
       if (abortController.signal.aborted) return;
       setPreviewError(
         'Unable to load data preview. You can retry or proceed with the download.'
       );
+      setPreviewPartialWarning(undefined);
     } finally {
       if (!abortController.signal.aborted) {
         setIsPreviewLoading(false);
@@ -537,6 +577,7 @@ const DataExportPage = () => {
     activeTab,
     selectedSites,
     selectedDevices,
+    selectedSiteIds,
     selectedDeviceIds,
     selectedGridIds,
     selectedGridSites,
@@ -546,6 +587,14 @@ const DataExportPage = () => {
     processedCitiesData,
     setPreviewOpen,
   ]);
+
+  useEffect(() => {
+    return () => {
+      if (previewAbortRef.current) {
+        previewAbortRef.current.abort();
+      }
+    };
+  }, []);
 
   // Actions and event handlers
   const { handleDownload, handleVisualizeData, isDownloading } =
@@ -1196,6 +1245,7 @@ const DataExportPage = () => {
         previewRows={previewRows}
         isFetchingPreview={isPreviewLoading}
         previewError={previewError}
+        partialDataWarning={previewPartialWarning}
         dataType={dataType}
         frequency={frequency}
         fileType={fileType}

--- a/src/nexus/src/modules/data-download/DataExportPage.tsx
+++ b/src/nexus/src/modules/data-download/DataExportPage.tsx
@@ -556,14 +556,8 @@ const DataExportPage = () => {
         });
       } else if (activeTab === 'countries' || activeTab === 'cities') {
         // For countries/cities, build preview from selected grid sites
-        const gridIds = Array.from(
-          new Set([
-            ...Object.keys(selectedGridSites),
-            ...Object.keys(selectedGridSiteIds),
-          ])
-        );
         const resolvedSiteIds = resolveGridSitesForDownload(
-          gridIds,
+          selectedGridIds,
           selectedGridSites,
           selectedGridSiteIds
         );
@@ -616,6 +610,7 @@ const DataExportPage = () => {
     selectedDeviceIds,
     selectedSitesCache,
     selectedDevicesCache,
+    selectedGridIds,
     selectedGridSites,
     selectedGridSiteIds,
     processedCountriesData,
@@ -1100,8 +1095,6 @@ const DataExportPage = () => {
         );
       }
 
-      setSaveFormatDialogOpen(false);
-
       return false;
     }
   };
@@ -1121,7 +1114,12 @@ const DataExportPage = () => {
         return;
       }
 
-      await savePreparedDownload(preparedDownload, format);
+      const saved = await savePreparedDownload(preparedDownload, format);
+
+      if (saved) {
+        setPendingDownload(null);
+        setPendingColumnKeys(null);
+      }
     } catch {
       toast.error(
         'Download Failed',
@@ -1129,8 +1127,6 @@ const DataExportPage = () => {
       );
     } finally {
       setSavingFormat(null);
-      setPendingDownload(null);
-      setPendingColumnKeys(null);
     }
   };
 
@@ -1158,6 +1154,13 @@ const DataExportPage = () => {
     // countries/cities: count selected grid IDs
     return selectedGridIds.length;
   }, [activeTab, selectedSiteIds, selectedDeviceIds, selectedGridIds]);
+
+  // Export location count — on grid tabs a "location" is a monitoring site
+  const exportLocationCount = useMemo(() => {
+    if (activeTab === 'sites') return selectedSiteIds.length;
+    if (activeTab === 'devices') return selectedDeviceIds.length;
+    return selectedGridSiteCount;
+  }, [activeTab, selectedSiteIds, selectedDeviceIds, selectedGridSiteCount]);
 
   if (isOrgUnresolved) {
     return (
@@ -1349,6 +1352,7 @@ const DataExportPage = () => {
         activeTab={activeTab}
         selectedSites={selectedSites}
         selectedDevices={selectedDeviceNamesForExport}
+        selectedGridIds={selectedGridIds}
         selectedGridSites={selectedGridSites}
         selectedGridSiteIds={selectedGridSiteIds}
       />
@@ -1401,7 +1405,7 @@ const DataExportPage = () => {
           }
         }}
         onSave={handleSaveFormatSelection}
-        locationCount={selectionCount}
+        locationCount={exportLocationCount}
       />
 
       {/* Tab Change Confirmation Dialog */}

--- a/src/nexus/src/modules/data-download/components/DataExportBanner.tsx
+++ b/src/nexus/src/modules/data-download/components/DataExportBanner.tsx
@@ -10,6 +10,7 @@ interface DataExportBannerProps {
   selectedSiteIds: string[];
   selectedDeviceIds: string[];
   selectedGridIds: string[];
+  selectedGridSiteCount: number;
   selectedPollutants: string[];
   deviceCategory: DeviceCategory;
   isDownloadReady: boolean;
@@ -29,6 +30,7 @@ export const DataExportBanner: React.FC<DataExportBannerProps> = ({
   selectedSiteIds,
   selectedDeviceIds,
   selectedGridIds,
+  selectedGridSiteCount,
   selectedPollutants,
   deviceCategory,
   isDownloadReady,
@@ -44,6 +46,7 @@ export const DataExportBanner: React.FC<DataExportBannerProps> = ({
     selectedSiteIds,
     selectedDeviceIds,
     selectedGridIds,
+    selectedGridSiteCount,
     selectedPollutants,
     deviceCategory,
     isDownloadReady,

--- a/src/nexus/src/modules/data-download/components/DataExportHeader.tsx
+++ b/src/nexus/src/modules/data-download/components/DataExportHeader.tsx
@@ -5,6 +5,7 @@ import {
   AqAnnotationX,
   AqDownload01,
   AqRefreshCcw01,
+  AqHelpCircle,
 } from '@airqo/icons-react';
 import { TabType } from '../types/dataExportTypes';
 
@@ -28,6 +29,9 @@ interface DataExportHeaderProps {
   onToggleSidebar?: () => void;
   sidebarOpen?: boolean;
   isOrgFlow?: boolean;
+  showHelpBanner?: boolean;
+  onToggleHelpBanner?: () => void;
+  selectionCount?: number;
 }
 
 /**
@@ -53,12 +57,30 @@ export const DataExportHeader: React.FC<DataExportHeaderProps> = ({
   onToggleSidebar,
   sidebarOpen = false,
   isOrgFlow = false,
+  showHelpBanner = true,
+  onToggleHelpBanner,
+  selectionCount = 0,
 }) => {
   const hasSelections =
     selectedSiteIds.length > 0 ||
     selectedDeviceIds.length > 0 ||
     selectedGridIds.length > 0 ||
     Object.keys(selectedGridSiteIds).length > 0;
+
+  const totalSelectionCount =
+    selectedSiteIds.length +
+    selectedDeviceIds.length +
+    selectedGridIds.length;
+
+  const handleClearClick = () => {
+    if (totalSelectionCount > 5) {
+      const confirmed = window.confirm(
+        `You have ${totalSelectionCount} items selected. Are you sure you want to clear all selections?`
+      );
+      if (!confirmed) return;
+    }
+    onClearSelections();
+  };
 
   const reviewDownloadTooltip = isDownloadReady
     ? 'Preview your export before downloading'
@@ -126,6 +148,21 @@ export const DataExportHeader: React.FC<DataExportHeaderProps> = ({
       </div>
 
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 xl:flex xl:flex-wrap gap-2 w-full min-w-0 xl:w-auto mt-3 xl:mt-0">
+        {!showHelpBanner && onToggleHelpBanner && (
+          <Tooltip content="Show getting-started tips" placement="top">
+            <span className="inline-flex w-full xl:w-auto">
+              <Button
+                variant="outlined"
+                onClick={onToggleHelpBanner}
+                Icon={AqHelpCircle}
+                size="sm"
+                className="px-4 py-2 w-full xl:w-auto"
+              >
+                Show Tips
+              </Button>
+            </span>
+          </Tooltip>
+        )}
         {onRefresh && (
           <Button
             variant="outlined"
@@ -142,7 +179,7 @@ export const DataExportHeader: React.FC<DataExportHeaderProps> = ({
         {hasSelections && (
           <Button
             variant="outlined"
-            onClick={onClearSelections}
+            onClick={handleClearClick}
             Icon={AqAnnotationX}
             disabled={isGroupSyncing}
             className="px-4 py-2 w-full xl:w-auto"
@@ -180,7 +217,9 @@ export const DataExportHeader: React.FC<DataExportHeaderProps> = ({
                   ? 'Loading preview...'
                   : isDownloading
                     ? 'Downloading...'
-                    : 'Review & Download'}
+                    : selectionCount > 0
+                      ? `Review & Download (${selectionCount})`
+                      : 'Review & Download'}
               </Button>
             </span>
           </Tooltip>

--- a/src/nexus/src/modules/data-download/components/DataExportHeader.tsx
+++ b/src/nexus/src/modules/data-download/components/DataExportHeader.tsx
@@ -77,11 +77,7 @@ export const DataExportHeader: React.FC<DataExportHeaderProps> = ({
     selectedGridIds.length;
 
   const handleClearClick = () => {
-    if (totalSelectionCount > 5) {
-      setShowClearConfirm(true);
-    } else {
-      onClearSelections();
-    }
+    setShowClearConfirm(true);
   };
 
   const confirmClear = () => {
@@ -154,18 +150,17 @@ export const DataExportHeader: React.FC<DataExportHeaderProps> = ({
         </div>
       </div>
 
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 xl:flex xl:flex-wrap gap-2 w-full min-w-0 xl:w-auto mt-3 xl:mt-0">
+      <div className="flex flex-wrap items-center gap-2 w-full min-w-0 xl:w-auto mt-3 xl:mt-0">
         {!showHelpBanner && onToggleHelpBanner && (
           <Tooltip content="Show getting-started tips" placement="top">
-            <span className="inline-flex w-full xl:w-auto">
+            <span className="inline-flex">
               <Button
                 variant="outlined"
                 onClick={onToggleHelpBanner}
                 Icon={AqHelpCircle}
                 size="sm"
-                className="px-4 py-2 w-full xl:w-auto"
               >
-                Show Tips
+                Tips
               </Button>
             </span>
           </Tooltip>
@@ -178,7 +173,6 @@ export const DataExportHeader: React.FC<DataExportHeaderProps> = ({
             loading={isRefreshing}
             disabled={isGroupSyncing || isRefreshing}
             size="sm"
-            className="px-4 py-2 w-full xl:w-auto"
           >
             Refresh
           </Button>
@@ -189,7 +183,7 @@ export const DataExportHeader: React.FC<DataExportHeaderProps> = ({
             onClick={handleClearClick}
             Icon={AqAnnotationX}
             disabled={isGroupSyncing}
-            className="px-4 py-2 w-full xl:w-auto"
+            size="sm"
           >
             Clear All
           </Button>
@@ -204,24 +198,25 @@ export const DataExportHeader: React.FC<DataExportHeaderProps> = ({
             ((activeTab === 'countries' || activeTab === 'cities') &&
               selectedGridIds.length === 0)
           }
-          className="px-4 py-2 w-full xl:w-auto"
+          size="sm"
         >
           Visualize Data
         </Button>
         {/* Preview button removed: preview shown via Review & Download flow */}
         {canDownload && (
           <Tooltip content={reviewDownloadTooltip} placement="top">
-            <span className="inline-flex w-full xl:w-auto">
+            <span className="inline-flex">
               <Button
                 variant="filled"
                 onClick={onDownload}
                 Icon={AqDownload01}
-                className="px-4 py-2 w-full xl:w-auto"
+                size="sm"
                 disabled={isGroupSyncing || !isDownloadReady || isPreviewLoading || isDownloading}
                 loading={isPreviewLoading || isDownloading}
+                className="whitespace-nowrap"
               >
                 {isPreviewLoading
-                  ? 'Loading preview...'
+                  ? 'Loading...'
                   : isDownloading
                     ? 'Downloading...'
                     : selectionCount > 0

--- a/src/nexus/src/modules/data-download/components/DataExportHeader.tsx
+++ b/src/nexus/src/modules/data-download/components/DataExportHeader.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import { Tooltip } from 'flowbite-react';
 import { Button } from '@/shared/components/ui';
+import Dialog from '@/shared/components/ui/dialog';
 import {
   AqAnnotationX,
   AqDownload01,
   AqRefreshCcw01,
   AqHelpCircle,
+  AqAlertTriangle,
 } from '@airqo/icons-react';
 import { TabType } from '../types/dataExportTypes';
 
@@ -61,6 +63,8 @@ export const DataExportHeader: React.FC<DataExportHeaderProps> = ({
   onToggleHelpBanner,
   selectionCount = 0,
 }) => {
+  const [showClearConfirm, setShowClearConfirm] = React.useState(false);
+
   const hasSelections =
     selectedSiteIds.length > 0 ||
     selectedDeviceIds.length > 0 ||
@@ -74,11 +78,14 @@ export const DataExportHeader: React.FC<DataExportHeaderProps> = ({
 
   const handleClearClick = () => {
     if (totalSelectionCount > 5) {
-      const confirmed = window.confirm(
-        `You have ${totalSelectionCount} items selected. Are you sure you want to clear all selections?`
-      );
-      if (!confirmed) return;
+      setShowClearConfirm(true);
+    } else {
+      onClearSelections();
     }
+  };
+
+  const confirmClear = () => {
+    setShowClearConfirm(false);
     onClearSelections();
   };
 
@@ -225,6 +232,32 @@ export const DataExportHeader: React.FC<DataExportHeaderProps> = ({
           </Tooltip>
         )}
       </div>
+
+      {/* Clear All Confirmation Dialog */}
+      <Dialog
+        isOpen={showClearConfirm}
+        onClose={() => setShowClearConfirm(false)}
+        title="Clear All Selections?"
+        subtitle="This action cannot be undone"
+        icon={AqAlertTriangle}
+        iconColor="text-amber-600"
+        iconBgColor="bg-amber-100"
+        primaryAction={{
+          label: 'Clear All',
+          onClick: confirmClear,
+          className: 'bg-amber-600 hover:bg-amber-700 text-white',
+        }}
+        secondaryAction={{
+          label: 'Cancel',
+          onClick: () => setShowClearConfirm(false),
+        }}
+        size="md"
+      >
+        <p className="text-sm text-gray-600 dark:text-gray-400">
+          You have {totalSelectionCount} item{totalSelectionCount !== 1 ? 's' : ''} selected.
+          Are you sure you want to clear all selections?
+        </p>
+      </Dialog>
     </div>
   );
 };

--- a/src/nexus/src/modules/data-download/components/DataExportHeader.tsx
+++ b/src/nexus/src/modules/data-download/components/DataExportHeader.tsx
@@ -58,12 +58,9 @@ export const DataExportHeader: React.FC<DataExportHeaderProps> = ({
     selectedGridIds.length > 0 ||
     Object.keys(selectedGridSiteIds).length > 0;
 
-  const reviewDownloadTooltip = (
-    <div className="max-w-sm text-sm break-words">
-      Review the export before downloading. If no readings are returned, the
-      download falls back to metadata.
-    </div>
-  );
+  const reviewDownloadTooltip = isDownloadReady
+    ? 'Review the export configuration before downloading. If no readings are returned, the download falls back to location metadata.'
+    : 'To enable download, please select a date range, at least one location, and at least one pollutant.';
 
   return (
     <div className="flex flex-col xl:flex-row justify-between items-stretch xl:items-center gap-4 min-w-0">

--- a/src/nexus/src/modules/data-download/components/DataExportHeader.tsx
+++ b/src/nexus/src/modules/data-download/components/DataExportHeader.tsx
@@ -173,7 +173,7 @@ export const DataExportHeader: React.FC<DataExportHeaderProps> = ({
                 onClick={onDownload}
                 Icon={AqDownload01}
                 className="px-4 py-2 w-full xl:w-auto"
-                disabled={isGroupSyncing || !isDownloadReady || isDownloading}
+                disabled={isGroupSyncing || !isDownloadReady || isPreviewLoading || isDownloading}
                 loading={isPreviewLoading || isDownloading}
               >
                 {isPreviewLoading

--- a/src/nexus/src/modules/data-download/components/DataExportHeader.tsx
+++ b/src/nexus/src/modules/data-download/components/DataExportHeader.tsx
@@ -61,8 +61,8 @@ export const DataExportHeader: React.FC<DataExportHeaderProps> = ({
     Object.keys(selectedGridSiteIds).length > 0;
 
   const reviewDownloadTooltip = isDownloadReady
-    ? 'Review the export configuration before downloading. If no readings are returned, the download falls back to location metadata.'
-    : 'To enable download, please select a date range, at least one location, and at least one pollutant.';
+    ? 'Preview your export before downloading'
+    : 'Select a date range, location, and pollutant to enable download';
 
   return (
     <div className="flex flex-col xl:flex-row justify-between items-stretch xl:items-center gap-4 min-w-0">

--- a/src/nexus/src/modules/data-download/components/DataExportHeader.tsx
+++ b/src/nexus/src/modules/data-download/components/DataExportHeader.tsx
@@ -16,6 +16,7 @@ interface DataExportHeaderProps {
   selectedGridSiteIds: Record<string, string[]>;
   isDownloadReady: boolean;
   isDownloading: boolean;
+  isPreviewLoading?: boolean;
   isGroupSyncing?: boolean;
   canDownload?: boolean;
   onRefresh?: () => void;
@@ -40,6 +41,7 @@ export const DataExportHeader: React.FC<DataExportHeaderProps> = ({
   selectedGridSiteIds,
   isDownloadReady,
   isDownloading,
+  isPreviewLoading = false,
   isGroupSyncing = false,
   canDownload = true,
   onRefresh,
@@ -171,10 +173,14 @@ export const DataExportHeader: React.FC<DataExportHeaderProps> = ({
                 onClick={onDownload}
                 Icon={AqDownload01}
                 className="px-4 py-2 w-full xl:w-auto"
-                disabled={isGroupSyncing || !isDownloadReady}
-                loading={isDownloading}
+                disabled={isGroupSyncing || !isDownloadReady || isDownloading}
+                loading={isPreviewLoading || isDownloading}
               >
-                {isDownloading ? 'Downloading...' : 'Review & Download'}
+                {isPreviewLoading
+                  ? 'Loading preview...'
+                  : isDownloading
+                    ? 'Downloading...'
+                    : 'Review & Download'}
               </Button>
             </span>
           </Tooltip>

--- a/src/nexus/src/modules/data-download/components/DataExportPreview.tsx
+++ b/src/nexus/src/modules/data-download/components/DataExportPreview.tsx
@@ -1,11 +1,6 @@
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import Checkbox from '@/shared/components/ui/checkbox';
+import { Button } from '@/shared/components/ui';
 import ReusableDialog from '@/shared/components/ui/dialog';
 import { DateRange } from '@/shared/components/calendar/types';
 import {
@@ -19,18 +14,22 @@ import {
   getDownloadColumnGroups,
   getDownloadColumnLabelMap,
 } from '../utils/dataExportFile';
-import { Button } from '@/shared/components/ui';
-import { buildDataDownloadRequest } from '../utils/dataExportRequest';
-import { useDownloadData } from '@/shared/hooks/useAnalytics';
-import { DeviceCategory } from '../types/dataExportTypes';
-import type { DataDownloadRequest } from '@/shared/types/api';
+
+type PreviewData = Record<string, string | number | null>;
 
 interface DataExportPreviewProps {
   isOpen: boolean;
   onClose: () => void;
   onConfirm: (selectedColumnKeys: string[]) => void;
+  onRetryPreview: () => void;
   isDownloading: boolean;
 
+  // Preview data fetched by parent before dialog opened
+  previewRows: PreviewData[];
+  isFetchingPreview: boolean;
+  previewError: string | null;
+
+  // Export configuration
   dataType: string;
   frequency: string;
   fileType: string;
@@ -39,20 +38,19 @@ interface DataExportPreviewProps {
   activeTab: 'sites' | 'devices' | 'countries' | 'cities';
   selectedSites: string[];
   selectedDevices: string[];
-  selectedDeviceIds: string[];
-  selectedGridIds: string[];
   selectedGridSites: Record<string, string[]>;
   selectedGridSiteIds: Record<string, string[]>;
-  deviceCategory: DeviceCategory;
 }
-
-type PreviewData = Record<string, string | number | null>;
 
 export const DataExportPreview: React.FC<DataExportPreviewProps> = ({
   isOpen,
   onClose,
   onConfirm,
+  onRetryPreview,
   isDownloading,
+  previewRows,
+  isFetchingPreview,
+  previewError,
   dataType,
   frequency,
   fileType,
@@ -61,30 +59,26 @@ export const DataExportPreview: React.FC<DataExportPreviewProps> = ({
   activeTab,
   selectedSites,
   selectedDevices,
-  selectedDeviceIds,
-  selectedGridIds,
   selectedGridSites,
   selectedGridSiteIds,
-  deviceCategory,
 }) => {
+  const defaultColumnKeys = useMemo(
+    () => getDefaultDownloadColumnKeys(activeTab, selectedPollutants, dataType),
+    [activeTab, dataType, selectedPollutants]
+  );
+
   const [selectedColumnKeys, setSelectedColumnKeys] = useState<string[]>(() =>
     getDefaultDownloadColumnKeys(activeTab, selectedPollutants, dataType)
   );
-  const previousOpenRef = useRef(false);
-  const isMountedRef = useRef(true);
-  const abortControllerRef = useRef<AbortController | null>(null);
-  const { trigger: fetchPreviewData } = useDownloadData();
-  const [previewRows, setPreviewRows] = useState<PreviewData[]>([]);
-  const [isFetchingPreview, setIsFetchingPreview] = useState(false);
-  const [previewError, setPreviewError] = useState<string | null>(null);
-  const previewRequestRef = useRef<DataDownloadRequest | null>(null);
 
-  useEffect(() => {
-    isMountedRef.current = true;
-    return () => {
-      isMountedRef.current = false;
-    };
-  }, []);
+  // Reset column selection when dialog opens with new default columns
+  React.useEffect(() => {
+    if (isOpen) {
+      setSelectedColumnKeys(prev =>
+        areArraysEqual(prev, defaultColumnKeys) ? prev : defaultColumnKeys
+      );
+    }
+  }, [defaultColumnKeys, isOpen]);
 
   const formattedDateRange = useMemo(() => {
     if (!dateRange?.from || !dateRange?.to) return 'Not selected';
@@ -116,11 +110,6 @@ export const DataExportPreview: React.FC<DataExportPreviewProps> = ({
 
   const columnLabelMap = useMemo(
     () => getDownloadColumnLabelMap(activeTab, selectedPollutants, dataType),
-    [activeTab, dataType, selectedPollutants]
-  );
-
-  const defaultColumnKeys = useMemo(
-    () => getDefaultDownloadColumnKeys(activeTab, selectedPollutants, dataType),
     [activeTab, dataType, selectedPollutants]
   );
 
@@ -163,184 +152,6 @@ export const DataExportPreview: React.FC<DataExportPreviewProps> = ({
     }
   }, [activeTab]);
 
-  const parseCsvLine = useCallback((line: string): string[] => {
-    const fields: string[] = [];
-    let current = '';
-    let inQuotes = false;
-
-    for (let i = 0; i < line.length; i++) {
-      const char = line[i];
-
-      if (inQuotes) {
-        if (char === '"') {
-          if (i + 1 < line.length && line[i + 1] === '"') {
-            current += '"';
-            i++;
-          } else {
-            inQuotes = false;
-          }
-        } else {
-          current += char;
-        }
-      } else {
-        if (char === '"') {
-          inQuotes = true;
-        } else if (char === ',') {
-          fields.push(current.trim());
-          current = '';
-        } else {
-          current += char;
-        }
-      }
-    }
-
-    fields.push(current.trim());
-    return fields;
-  }, []);
-
-  const doFetchPreview = useCallback(
-    (request: DataDownloadRequest, controller: AbortController) => {
-      fetchPreviewData(request)
-        .then(response => {
-          if (!isMountedRef.current || controller.signal.aborted) return;
-
-          if (typeof response === 'string') {
-            const lines = response.split('\n').filter(line => line.trim());
-            if (lines.length > 1) {
-              const headers = parseCsvLine(lines[0]);
-              const rows = lines.slice(1, 6).map(line => {
-                const values = parseCsvLine(line);
-                const row: PreviewData = {};
-                headers.forEach((header, index) => {
-                  const val = values[index];
-                  if (val === '' || val === undefined) {
-                    row[header] = null;
-                  } else {
-                    const num = Number(val);
-                    row[header] = isNaN(num) ? val : num;
-                  }
-                });
-                return row;
-              });
-              setPreviewRows(rows);
-            } else {
-              setPreviewRows([]);
-            }
-          } else if (
-            response &&
-            typeof response === 'object' &&
-            'data' in response &&
-            Array.isArray((response as { data: unknown }).data)
-          ) {
-            const responseData = (
-              response as unknown as { data: Record<string, unknown>[] }
-            ).data;
-            const rows: PreviewData[] = responseData.slice(0, 5).map(item => {
-              const row: PreviewData = {};
-              Object.entries(item).forEach(([key, value]) => {
-                row[key] =
-                  typeof value === 'number'
-                    ? value
-                    : value != null
-                      ? String(value)
-                      : null;
-              });
-              return row;
-            });
-            setPreviewRows(rows);
-          } else {
-            setPreviewRows([]);
-          }
-        })
-        .catch(() => {
-          if (!isMountedRef.current || controller.signal.aborted) return;
-          setPreviewError(
-            'Unable to load data preview. You can retry or proceed with the download.'
-          );
-        })
-        .finally(() => {
-          if (isMountedRef.current && !controller.signal.aborted) {
-            setIsFetchingPreview(false);
-          }
-        });
-    },
-    [fetchPreviewData, parseCsvLine]
-  );
-
-  useEffect(() => {
-    if (isOpen && !previousOpenRef.current) {
-      setSelectedColumnKeys(prev =>
-        areArraysEqual(prev, defaultColumnKeys) ? prev : defaultColumnKeys
-      );
-      setPreviewRows([]);
-      setPreviewError(null);
-      setIsFetchingPreview(true);
-
-      if (abortControllerRef.current) {
-        abortControllerRef.current.abort();
-      }
-      const abortController = new AbortController();
-      abortControllerRef.current = abortController;
-
-      const effectiveDataType: 'calibrated' | 'raw' =
-        activeTab === 'devices' && deviceCategory === 'bam'
-          ? 'raw'
-          : (dataType as 'calibrated' | 'raw');
-
-      const previewRequest: DataDownloadRequest = buildDataDownloadRequest({
-        dateRange,
-        activeTab,
-        selectedSites,
-        selectedDeviceIds,
-        selectedDeviceNames: selectedDevices,
-        selectedGridIds,
-        selectedGridSites,
-        selectedGridSiteIds,
-        selectedPollutants,
-        dataType: effectiveDataType,
-        fileType: 'csv',
-        frequency,
-        deviceCategory,
-      });
-
-      previewRequestRef.current = previewRequest;
-      doFetchPreview(previewRequest, abortController);
-    }
-
-    previousOpenRef.current = isOpen;
-  }, [
-    defaultColumnKeys,
-    isOpen,
-    doFetchPreview,
-    dataType,
-    frequency,
-    selectedPollutants,
-    dateRange,
-    activeTab,
-    selectedSites,
-    selectedDevices,
-    selectedDeviceIds,
-    selectedGridIds,
-    selectedGridSites,
-    selectedGridSiteIds,
-    deviceCategory,
-  ]);
-
-  const handleRetryPreview = useCallback(() => {
-    if (!previewRequestRef.current) return;
-    setPreviewError(null);
-    setPreviewRows([]);
-    setIsFetchingPreview(true);
-
-    if (abortControllerRef.current) {
-      abortControllerRef.current.abort();
-    }
-    const abortController = new AbortController();
-    abortControllerRef.current = abortController;
-
-    doFetchPreview(previewRequestRef.current, abortController);
-  }, [doFetchPreview]);
-
   const handleColumnToggle = useCallback((key: string, checked: boolean) => {
     setSelectedColumnKeys(prev => {
       if (checked) {
@@ -376,6 +187,12 @@ export const DataExportPreview: React.FC<DataExportPreviewProps> = ({
     });
   }, [previewRows, selectedColumnKeys]);
 
+  const hasNoData =
+    !isFetchingPreview &&
+    !previewError &&
+    previewRows.length === 0 &&
+    selectedColumnKeys.length > 0;
+
   return (
     <ReusableDialog
       isOpen={isOpen}
@@ -384,7 +201,11 @@ export const DataExportPreview: React.FC<DataExportPreviewProps> = ({
       subtitle="Choose the columns you want to keep before downloading."
       size="2xl"
       primaryAction={{
-        label: isDownloading ? 'Downloading...' : 'Confirm & Download',
+        label: isDownloading
+          ? 'Downloading...'
+          : hasNoData
+            ? 'Download Metadata Only'
+            : 'Confirm & Download',
         onClick: () => onConfirm(selectedColumnKeys),
         disabled: isDownloading || selectedColumnKeys.length === 0,
         loading: isDownloading,
@@ -397,7 +218,115 @@ export const DataExportPreview: React.FC<DataExportPreviewProps> = ({
       }}
     >
       <div className="space-y-6">
+        {/* Data Preview — at top so loading/empty/error states are immediately visible */}
+        <div>
+          <h3 className="text-sm text-gray-900 dark:text-gray-100 mb-3">
+            Data Preview
+          </h3>
+
+          {isFetchingPreview ? (
+            <div className="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden p-8 text-center">
+              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary mx-auto mb-4"></div>
+              <p className="text-sm text-gray-600 dark:text-gray-400">
+                Fetching data preview...
+              </p>
+            </div>
+          ) : previewError ? (
+            <div className="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden p-6 text-center">
+              <div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-amber-100 dark:bg-amber-900/30 mb-3">
+                <span className="text-amber-600 dark:text-amber-400 text-xl">
+                  &#9888;
+                </span>
+              </div>
+              <h4 className="text-sm font-medium text-gray-900 dark:text-gray-100 mb-1">
+                Unable to Load Preview
+              </h4>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mb-4 max-w-sm mx-auto">
+                {previewError}
+              </p>
+              <Button
+                variant="outlined"
+                size="sm"
+                onClick={onRetryPreview}
+              >
+                Retry
+              </Button>
+            </div>
+          ) : previewData.length > 0 ? (
+            <div className="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
+              <div className="max-h-64 overflow-auto">
+                <table className="w-full text-sm">
+                  <thead className="bg-gray-50 dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700">
+                    <tr>
+                      {previewColumns.map(column => (
+                        <th
+                          key={column.key}
+                          className="px-3 py-2 text-left font-medium text-gray-700 dark:text-gray-300 border-r border-gray-200 dark:border-gray-700 last:border-r-0"
+                        >
+                          {column.label}
+                        </th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {previewData.map((row, rowIndex) => (
+                      <tr
+                        key={rowIndex}
+                        className="border-b border-gray-100 dark:border-gray-700 last:border-b-0"
+                      >
+                        {previewColumns.map(column => (
+                          <td
+                            key={column.key}
+                            className="px-3 py-2 text-gray-900 dark:text-gray-100 border-r border-gray-200 dark:border-gray-700 last:border-r-0"
+                          >
+                            {typeof row[column.key] === 'number'
+                              ? Number.isInteger(row[column.key])
+                                ? String(row[column.key])
+                                : Number(row[column.key]).toFixed(2)
+                              : String(row[column.key] ?? '')}
+                          </td>
+                        ))}
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          ) : hasNoData ? (
+            <div className="border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-900/20 rounded-lg p-5 text-center">
+              <div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-amber-100 dark:bg-amber-900/40 mb-3">
+                <span className="text-amber-600 dark:text-amber-400 text-xl">
+                  &#128269;
+                </span>
+              </div>
+              <h4 className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-1">
+                No Measurement Data Found
+              </h4>
+              <p className="text-xs text-gray-600 dark:text-gray-400 max-w-md mx-auto mb-3">
+                There are no readings available for the selected time period,
+                locations, and pollutants. You can adjust your filters above and
+                the preview will update automatically.
+              </p>
+              <div className="inline-flex items-center gap-2 rounded-full bg-amber-100 dark:bg-amber-900/40 px-3 py-1.5">
+                <span className="text-amber-700 dark:text-amber-300 text-xs font-medium">
+                  If you proceed, you will receive a metadata-only file (location
+                  names, coordinates, and device info) with no measurement
+                  values.
+                </span>
+              </div>
+            </div>
+          ) : (
+            <div className="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden p-8 text-center">
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                No preview data available.
+              </p>
+            </div>
+          )}
+        </div>
+
+        {/* Info banner */}
         <InfoBanner
+          dense
           title="Metadata fallback enabled"
           message="If the selected filters return no readings, the download automatically falls back to metadata for the selected locations."
         />
@@ -502,95 +431,10 @@ export const DataExportPreview: React.FC<DataExportPreviewProps> = ({
           </div>
         </div>
 
-        {/* Data Preview */}
-        <div>
-          <h3 className="text-sm text-gray-900 dark:text-gray-100 mb-3">
-            Data Preview (First 5 Rows)
-          </h3>
-
-          {selectedColumnKeys.length === 0 ? (
-            <InfoBanner
-              title="Preview Unavailable"
-              message="Select at least one column above to preview the export output."
-            />
-          ) : isFetchingPreview ? (
-            <div className="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden p-8 text-center">
-              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary mx-auto mb-4"></div>
-              <p className="text-sm text-gray-600 dark:text-gray-400">Loading data preview...</p>
-            </div>
-          ) : previewError ? (
-            <div className="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden p-6 text-center">
-              <div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-amber-100 dark:bg-amber-900/30 mb-3">
-                <span className="text-amber-600 dark:text-amber-400 text-xl">&#9888;</span>
-              </div>
-              <h4 className="text-sm font-medium text-gray-900 dark:text-gray-100 mb-1">
-                Unable to Load Preview
-              </h4>
-              <p className="text-xs text-gray-500 dark:text-gray-400 mb-4 max-w-sm mx-auto">
-                {previewError}
-              </p>
-              <Button
-                variant="outlined"
-                size="sm"
-                onClick={handleRetryPreview}
-                disabled={isFetchingPreview}
-                loading={isFetchingPreview}
-              >
-                Retry
-              </Button>
-            </div>
-          ) : previewData.length > 0 ? (
-            <div className="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
-              <div className="max-h-64 overflow-auto">
-                <table className="w-full text-sm">
-                  <thead className="bg-gray-50 dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700">
-                    <tr>
-                      {previewColumns.map(column => (
-                        <th
-                          key={column.key}
-                          className="px-3 py-2 text-left font-medium text-gray-700 dark:text-gray-300 border-r border-gray-200 dark:border-gray-700 last:border-r-0"
-                        >
-                          {column.label}
-                        </th>
-                      ))}
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {previewData.map((row, rowIndex) => (
-                      <tr
-                        key={rowIndex}
-                        className="border-b border-gray-100 dark:border-gray-700 last:border-b-0"
-                      >
-                        {previewColumns.map(column => (
-                          <td
-                            key={column.key}
-                            className="px-3 py-2 text-gray-900 dark:text-gray-100 border-r border-gray-200 dark:border-gray-700 last:border-r-0"
-                          >
-                            {typeof row[column.key] === 'number'
-                              ? Number.isInteger(row[column.key])
-                                ? String(row[column.key])
-                                : Number(row[column.key]).toFixed(2)
-                              : String(row[column.key] ?? '')}
-                          </td>
-                        ))}
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            </div>
-          ) : (
-            <InfoBanner
-              title="No Data Available"
-              message="The current filter settings did not return any data. Please try adjusting your date range, locations, or pollutants. The download will still provide metadata for the selected items."
-            />
-          )}
-        </div>
-
         {/* Export Notes */}
         <InfoBanner
           dense
-          message={`Preview shows the first 5 rows of your export. Your download will include all matching data with only the columns selected above.`}
+          message="Preview shows the first 5 rows of your export. Your download will include all matching data with only the columns selected above."
         />
       </div>
     </ReusableDialog>

--- a/src/nexus/src/modules/data-download/components/DataExportPreview.tsx
+++ b/src/nexus/src/modules/data-download/components/DataExportPreview.tsx
@@ -310,16 +310,29 @@ export const DataExportPreview: React.FC<DataExportPreviewProps> = ({
                 </div>
               </div>
               {partialDataWarning && (
-                <div className="mt-3 p-3 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg">
-                  <p className="text-xs text-amber-700 dark:text-amber-300">
-                    <span className="font-medium">
-                      {partialDataWarning.withData} of {partialDataWarning.totalSelected} selected locations returned data.
-                    </span>{' '}
-                    No readings found for:{' '}
-                    {partialDataWarning.missingNames.slice(0, 3).join(', ')}
-                    {partialDataWarning.missingNames.length > 3 &&
-                      ` and ${partialDataWarning.missingNames.length - 3} more`}
-                  </p>
+                <div className="mt-3 p-4 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg">
+                  <div className="flex items-start gap-3">
+                    <AqAlertTriangle className="w-5 h-5 text-amber-600 dark:text-amber-400 flex-shrink-0 mt-0.5" />
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm font-medium text-amber-800 dark:text-amber-200">
+                        Partial Data Available
+                      </p>
+                      <p className="text-xs text-amber-700 dark:text-amber-300 mt-1">
+                        {partialDataWarning.withData} of {partialDataWarning.totalSelected} selected {locationType.toLowerCase()} have data.
+                        {partialDataWarning.missingNames.length > 0 && (
+                          <>
+                            {' '}No readings found for:{' '}
+                            {partialDataWarning.missingNames.slice(0, 3).join(', ')}
+                            {partialDataWarning.missingNames.length > 3 &&
+                              ` and ${partialDataWarning.missingNames.length - 3} more`}
+                          </>
+                        )}
+                      </p>
+                      <p className="text-xs text-amber-600 dark:text-amber-400 mt-1">
+                        Your download will include metadata for all locations, but only those with data will have measurement values.
+                      </p>
+                    </div>
+                  </div>
                 </div>
               )}
             </>
@@ -404,10 +417,49 @@ export const DataExportPreview: React.FC<DataExportPreviewProps> = ({
           </div>
 
           {selectedColumnKeys.length === 0 && (
-            <p className="text-sm text-red-600 dark:text-red-400">
-              Select at least one column to enable the download.
-            </p>
+            <div className="p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg">
+              <p className="text-sm font-medium text-red-700 dark:text-red-300">
+                No columns selected
+              </p>
+              <p className="text-xs text-red-600 dark:text-red-400 mt-1">
+                Enable at least one column above to continue. Without columns, the download button will remain disabled.
+              </p>
+            </div>
           )}
+        </div>
+
+        {/* What You Will Download - Summary before confirmation */}
+        <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-4">
+          <h3 className="text-sm font-medium text-blue-800 dark:text-blue-200 mb-2">
+            What You Will Download
+          </h3>
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 text-sm">
+            <div>
+              <span className="text-blue-600 dark:text-blue-400">Locations:</span>
+              <p className="text-blue-900 dark:text-blue-100 font-medium">{selectedLocations.length}</p>
+            </div>
+            <div>
+              <span className="text-blue-600 dark:text-blue-400">With data:</span>
+              <p className="text-blue-900 dark:text-blue-100 font-medium">
+                {partialDataWarning ? partialDataWarning.withData : selectedLocations.length}
+              </p>
+            </div>
+            <div>
+              <span className="text-blue-600 dark:text-blue-400">Without data:</span>
+              <p className="text-blue-900 dark:text-blue-100 font-medium">
+                {partialDataWarning ? partialDataWarning.totalSelected - partialDataWarning.withData : 0}
+              </p>
+            </div>
+            <div>
+              <span className="text-blue-600 dark:text-blue-400">Columns:</span>
+              <p className="text-blue-900 dark:text-blue-100 font-medium">{selectedColumnKeys.length}</p>
+            </div>
+          </div>
+          <p className="text-xs text-blue-600 dark:text-blue-400 mt-2">
+            {hasNoData
+              ? 'Download includes location metadata only (names, coordinates, device info).'
+              : 'Preview shows first 5 rows. Full download includes all matching data.'}
+          </p>
         </div>
 
         {/* Configuration Summary */}

--- a/src/nexus/src/modules/data-download/components/DataExportPreview.tsx
+++ b/src/nexus/src/modules/data-download/components/DataExportPreview.tsx
@@ -13,12 +13,11 @@ import {
   FREQUENCY_LABELS,
   DATA_TYPE_LABELS,
 } from '@/shared/components/charts/constants';
-import { InfoBanner } from '@/shared/components/ui/banner';
+import { WarningBanner, InfoBanner } from '@/shared/components/ui/banner';
 import { areArraysEqual } from '@/shared/utils/arrays';
 import {
   AqAlertTriangle,
   AqLoading02,
-  AqSearchMd,
   AqSettings01,
 } from '@airqo/icons-react';
 import {
@@ -30,12 +29,6 @@ import { resolveGridSitesForDownload } from '../utils/dataExportRequest';
 
 type PreviewData = Record<string, string | number | null>;
 
-export interface PartialDataWarning {
-  totalSelected: number;
-  withData: number;
-  missingNames: string[];
-}
-
 interface DataExportPreviewProps {
   isOpen: boolean;
   onClose: () => void;
@@ -43,11 +36,10 @@ interface DataExportPreviewProps {
   onRetryPreview: () => void;
   isDownloading: boolean;
 
-  // Preview data fetched by parent before dialog opened
+  // Preview data built from cached data (no API call)
   previewRows: PreviewData[];
   isFetchingPreview: boolean;
   previewError: string | null;
-  partialDataWarning?: PartialDataWarning;
 
   // Export configuration
   dataType: string;
@@ -71,7 +63,6 @@ export const DataExportPreview: React.FC<DataExportPreviewProps> = ({
   previewRows,
   isFetchingPreview,
   previewError,
-  partialDataWarning,
   dataType,
   frequency,
   fileType,
@@ -225,14 +216,13 @@ export const DataExportPreview: React.FC<DataExportPreviewProps> = ({
     !previewError &&
     previewRows.length === 0 &&
     selectedColumnKeys.length > 0;
-  const hasMissingData = Boolean(partialDataWarning?.missingNames.length);
 
   return (
     <ReusableDialog
       isOpen={isOpen}
       onClose={onClose}
       title="Export Preview"
-      subtitle="Choose the columns you want to keep before downloading."
+      subtitle={`Review the ${selectedLocations.length} selected ${locationType.toLowerCase()} below. Choose the columns you want to keep before downloading.`}
       size="2xl"
       className="max-w-[95vw] sm:max-w-4xl lg:max-w-5xl"
       maxHeight="max-h-[90vh] sm:max-h-[85vh]"
@@ -333,7 +323,7 @@ export const DataExportPreview: React.FC<DataExportPreviewProps> = ({
                 <AqLoading02 className="w-8 h-8 text-primary animate-spin" />
               </div>
               <p className="text-sm text-gray-600 dark:text-gray-400">
-                Fetching data preview...
+                Building preview...
               </p>
             </div>
           ) : previewError ? (
@@ -392,61 +382,16 @@ export const DataExportPreview: React.FC<DataExportPreviewProps> = ({
                   </table>
                 </div>
               </div>
-              {hasMissingData && partialDataWarning && (
-                <div className="mt-3 p-4 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg">
-                  <div className="flex items-start gap-3">
-                    <AqAlertTriangle className="w-5 h-5 text-amber-600 dark:text-amber-400 flex-shrink-0 mt-0.5" />
-                    <div className="flex-1 min-w-0">
-                      <p className="text-sm font-medium text-amber-800 dark:text-amber-200">
-                        Partial Data Available
-                      </p>
-                      <p className="text-xs text-amber-700 dark:text-amber-300 mt-1">
-                        {partialDataWarning.withData === 0
-                          ? `No readings were found for the selected ${locationType.toLowerCase()} for these filters.`
-                          : `Readings were found for ${partialDataWarning.withData} of ${partialDataWarning.totalSelected} selected ${locationType.toLowerCase()} for these filters.`}
-                        {partialDataWarning.missingNames.length > 0 && (
-                          <>
-                            {' '}
-                            No readings found for:{' '}
-                            {partialDataWarning.missingNames
-                              .slice(0, 3)
-                              .join(', ')}
-                            {partialDataWarning.missingNames.length > 3 &&
-                              ` and ${partialDataWarning.missingNames.length - 3} more`}
-                          </>
-                        )}
-                      </p>
-                      <p className="text-xs text-amber-600 dark:text-amber-400 mt-1">
-                        The download will include metadata for every selected
-                        location; measurement values will be present only where
-                        readings were found.
-                      </p>
-                    </div>
-                  </div>
-                </div>
-              )}
+              <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">
+                Showing metadata for all {selectedLocations.length} selected {locationType.toLowerCase()}. The actual download will include measurement data for these locations based on your export configuration.
+              </p>
             </>
           ) : hasNoData ? (
-            <div className="border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-900/20 rounded-lg p-5 text-center">
-              <div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-amber-100 dark:bg-amber-900/40 mb-3">
-                <AqSearchMd className="w-6 h-6 text-amber-600 dark:text-amber-400" />
-              </div>
-              <h4 className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-1">
-                No Measurement Data Found
-              </h4>
-              <p className="text-xs text-gray-600 dark:text-gray-400 max-w-md mx-auto mb-3">
-                There are no readings available for the selected time period,
-                locations, and pollutants. Cancel this dialog to adjust your
-                filters, then run the export again.
-              </p>
-              <div className="inline-flex items-center gap-2 rounded-full bg-amber-100 dark:bg-amber-900/40 px-3 py-1.5">
-                <span className="text-amber-700 dark:text-amber-300 text-xs font-medium">
-                  If you proceed, you will receive a metadata-only file
-                  (location names, coordinates, and device info) with no
-                  measurement values.
-                </span>
-              </div>
-            </div>
+            <WarningBanner
+              dense
+              title="No Measurement Data Found"
+              message="There are no readings available for the selected time period, locations, and pollutants. If you proceed, you will receive a metadata-only file (location names, coordinates, and device info) with no measurement values."
+            />
           ) : (
             <div className="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden p-8 text-center">
               <p className="text-sm text-gray-500 dark:text-gray-400">
@@ -456,61 +401,12 @@ export const DataExportPreview: React.FC<DataExportPreviewProps> = ({
           )}
         </div>
 
-        {/* Keep the general guidance only when there is no more specific warning. */}
-        {!hasMissingData && (
-          <InfoBanner
-            dense
-            title="What happens when readings are unavailable"
-            message="If no readings match the selected filters, the download provides metadata for the selected locations so you can still identify them."
-          />
-        )}
-
-        {/* What You Will Download - Summary before confirmation */}
-        <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-4">
-          <h3 className="text-sm font-medium text-blue-800 dark:text-blue-200 mb-2">
-            What You Will Download
-          </h3>
-          <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 text-sm">
-            <div>
-              <span className="text-blue-600 dark:text-blue-400">
-                Locations:
-              </span>
-              <p className="text-blue-900 dark:text-blue-100 font-medium">
-                {selectedLocations.length}
-              </p>
-            </div>
-            <div>
-              <span className="text-blue-600 dark:text-blue-400">
-                With data:
-              </span>
-              <p className="text-blue-900 dark:text-blue-100 font-medium">
-                {partialDataWarning ? partialDataWarning.withData : '—'}
-              </p>
-            </div>
-            <div>
-              <span className="text-blue-600 dark:text-blue-400">
-                Without data:
-              </span>
-              <p className="text-blue-900 dark:text-blue-100 font-medium">
-                {partialDataWarning
-                  ? partialDataWarning.totalSelected -
-                    partialDataWarning.withData
-                  : '—'}
-              </p>
-            </div>
-            <div>
-              <span className="text-blue-600 dark:text-blue-400">Columns:</span>
-              <p className="text-blue-900 dark:text-blue-100 font-medium">
-                {selectedColumnKeys.length}
-              </p>
-            </div>
-          </div>
-          <p className="text-xs text-blue-600 dark:text-blue-400 mt-2">
-            {hasNoData
-              ? 'Download includes location metadata only (names, coordinates, device info).'
-              : 'Preview shows first 5 rows. Full download includes all matching data.'}
-          </p>
-        </div>
+        {/* Warning banner about potentially missing data */}
+        <WarningBanner
+          dense
+          title="Data May Be Incomplete"
+          message="The data you download may contain missing values or no data at all. If no data is available for your selected filters, you will download the metadata for the selected locations only."
+        />
 
         {/* Configuration Summary */}
         <div className="bg-gray-50 dark:bg-gray-800 rounded-lg p-4">
@@ -565,7 +461,7 @@ export const DataExportPreview: React.FC<DataExportPreviewProps> = ({
         {/* Export Notes */}
         <InfoBanner
           dense
-          message="Preview shows the first 5 rows of your export. Your download will include all matching data with only the columns selected above."
+          message="This preview shows a summary of your selected locations. Your download will include all measurement data matching your export configuration with only the columns selected above."
         />
       </div>
     </ReusableDialog>

--- a/src/nexus/src/modules/data-download/components/DataExportPreview.tsx
+++ b/src/nexus/src/modules/data-download/components/DataExportPreview.tsx
@@ -200,6 +200,8 @@ export const DataExportPreview: React.FC<DataExportPreviewProps> = ({
       title="Export Preview"
       subtitle="Choose the columns you want to keep before downloading."
       size="2xl"
+      className="max-w-[95vw] sm:max-w-4xl lg:max-w-5xl"
+      maxHeight="max-h-[90vh] sm:max-h-[85vh]"
       primaryAction={{
         label: isDownloading
           ? 'Downloading...'
@@ -261,7 +263,7 @@ export const DataExportPreview: React.FC<DataExportPreviewProps> = ({
             </div>
           ) : previewData.length > 0 ? (
             <div className="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
-              <div className="max-h-64 overflow-auto">
+              <div className="max-h-80 overflow-auto">
                 <table className="w-full text-sm">
                   <thead className="bg-gray-50 dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700">
                     <tr>
@@ -349,7 +351,7 @@ export const DataExportPreview: React.FC<DataExportPreviewProps> = ({
             </p>
           </div>
 
-          <div className="grid gap-4 md:grid-cols-2">
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
             {columnGroups.map(group => (
               <div
                 key={group.id}

--- a/src/nexus/src/modules/data-download/components/DataExportPreview.tsx
+++ b/src/nexus/src/modules/data-download/components/DataExportPreview.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/shared/components/charts/constants';
 import { InfoBanner } from '@/shared/components/ui/banner';
 import { areArraysEqual } from '@/shared/utils/arrays';
+import { AqAlertTriangle, AqSearchMd } from '@airqo/icons-react';
 import {
   getDefaultDownloadColumnKeys,
   getDownloadColumnGroups,
@@ -16,6 +17,12 @@ import {
 } from '../utils/dataExportFile';
 
 type PreviewData = Record<string, string | number | null>;
+
+export interface PartialDataWarning {
+  totalSelected: number;
+  withData: number;
+  missingNames: string[];
+}
 
 interface DataExportPreviewProps {
   isOpen: boolean;
@@ -28,6 +35,7 @@ interface DataExportPreviewProps {
   previewRows: PreviewData[];
   isFetchingPreview: boolean;
   previewError: string | null;
+  partialDataWarning?: PartialDataWarning;
 
   // Export configuration
   dataType: string;
@@ -51,6 +59,7 @@ export const DataExportPreview: React.FC<DataExportPreviewProps> = ({
   previewRows,
   isFetchingPreview,
   previewError,
+  partialDataWarning,
   dataType,
   frequency,
   fileType,
@@ -243,9 +252,7 @@ export const DataExportPreview: React.FC<DataExportPreviewProps> = ({
           ) : previewError ? (
             <div className="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden p-6 text-center">
               <div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-amber-100 dark:bg-amber-900/30 mb-3">
-                <span className="text-amber-600 dark:text-amber-400 text-xl">
-                  &#9888;
-                </span>
+                <AqAlertTriangle className="w-6 h-6 text-amber-600 dark:text-amber-400" />
               </div>
               <h4 className="text-sm font-medium text-gray-900 dark:text-gray-100 mb-1">
                 Unable to Load Preview
@@ -262,51 +269,64 @@ export const DataExportPreview: React.FC<DataExportPreviewProps> = ({
               </Button>
             </div>
           ) : previewData.length > 0 ? (
-            <div className="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
-              <div className="max-h-80 overflow-auto">
-                <table className="w-full text-sm">
-                  <thead className="bg-gray-50 dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700">
-                    <tr>
-                      {previewColumns.map(column => (
-                        <th
-                          key={column.key}
-                          className="px-3 py-2 text-left font-medium text-gray-700 dark:text-gray-300 border-r border-gray-200 dark:border-gray-700 last:border-r-0"
-                        >
-                          {column.label}
-                        </th>
-                      ))}
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {previewData.map((row, rowIndex) => (
-                      <tr
-                        key={rowIndex}
-                        className="border-b border-gray-100 dark:border-gray-700 last:border-b-0"
-                      >
+            <>
+              <div className="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
+                <div className="max-h-80 overflow-auto">
+                  <table className="w-full text-sm">
+                    <thead className="bg-gray-50 dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700">
+                      <tr>
                         {previewColumns.map(column => (
-                          <td
+                          <th
                             key={column.key}
-                            className="px-3 py-2 text-gray-900 dark:text-gray-100 border-r border-gray-200 dark:border-gray-700 last:border-r-0"
+                            className="px-3 py-2 text-left font-medium text-gray-700 dark:text-gray-300 border-r border-gray-200 dark:border-gray-700 last:border-r-0"
                           >
-                            {typeof row[column.key] === 'number'
-                              ? Number.isInteger(row[column.key])
-                                ? String(row[column.key])
-                                : Number(row[column.key]).toFixed(2)
-                              : String(row[column.key] ?? '')}
-                          </td>
+                            {column.label}
+                          </th>
                         ))}
                       </tr>
-                    ))}
-                  </tbody>
-                </table>
+                    </thead>
+                    <tbody>
+                      {previewData.map((row, rowIndex) => (
+                        <tr
+                          key={rowIndex}
+                          className="border-b border-gray-100 dark:border-gray-700 last:border-b-0"
+                        >
+                          {previewColumns.map(column => (
+                            <td
+                              key={column.key}
+                              className="px-3 py-2 text-gray-900 dark:text-gray-100 border-r border-gray-200 dark:border-gray-700 last:border-r-0"
+                            >
+                              {typeof row[column.key] === 'number'
+                                ? Number.isInteger(row[column.key])
+                                  ? String(row[column.key])
+                                  : Number(row[column.key]).toFixed(2)
+                                : String(row[column.key] ?? '')}
+                            </td>
+                          ))}
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
               </div>
-            </div>
+              {partialDataWarning && (
+                <div className="mt-3 p-3 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg">
+                  <p className="text-xs text-amber-700 dark:text-amber-300">
+                    <span className="font-medium">
+                      {partialDataWarning.withData} of {partialDataWarning.totalSelected} selected locations returned data.
+                    </span>{' '}
+                    No readings found for:{' '}
+                    {partialDataWarning.missingNames.slice(0, 3).join(', ')}
+                    {partialDataWarning.missingNames.length > 3 &&
+                      ` and ${partialDataWarning.missingNames.length - 3} more`}
+                  </p>
+                </div>
+              )}
+            </>
           ) : hasNoData ? (
             <div className="border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-900/20 rounded-lg p-5 text-center">
               <div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-amber-100 dark:bg-amber-900/40 mb-3">
-                <span className="text-amber-600 dark:text-amber-400 text-xl">
-                  &#128269;
-                </span>
+                <AqSearchMd className="w-6 h-6 text-amber-600 dark:text-amber-400" />
               </div>
               <h4 className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-1">
                 No Measurement Data Found

--- a/src/nexus/src/modules/data-download/components/DataExportPreview.tsx
+++ b/src/nexus/src/modules/data-download/components/DataExportPreview.tsx
@@ -50,6 +50,7 @@ interface DataExportPreviewProps {
   activeTab: 'sites' | 'devices' | 'countries' | 'cities';
   selectedSites: string[];
   selectedDevices: string[];
+  selectedGridIds: string[];
   selectedGridSites: Record<string, string[]>;
   selectedGridSiteIds: Record<string, string[]>;
 }
@@ -71,6 +72,7 @@ export const DataExportPreview: React.FC<DataExportPreviewProps> = ({
   activeTab,
   selectedSites,
   selectedDevices,
+  selectedGridIds,
   selectedGridSites,
   selectedGridSiteIds,
 }) => {
@@ -138,19 +140,12 @@ export const DataExportPreview: React.FC<DataExportPreviewProps> = ({
       case 'devices':
         return selectedDevices;
       case 'countries':
-      case 'cities': {
-        const gridIds = Array.from(
-          new Set([
-            ...Object.keys(selectedGridSites),
-            ...Object.keys(selectedGridSiteIds),
-          ])
-        );
+      case 'cities':
         return resolveGridSitesForDownload(
-          gridIds,
+          selectedGridIds,
           selectedGridSites,
           selectedGridSiteIds
         );
-      }
       default:
         return [];
     }
@@ -158,6 +153,7 @@ export const DataExportPreview: React.FC<DataExportPreviewProps> = ({
     activeTab,
     selectedSites,
     selectedDevices,
+    selectedGridIds,
     selectedGridSites,
     selectedGridSiteIds,
   ]);

--- a/src/nexus/src/modules/data-download/components/DataExportPreview.tsx
+++ b/src/nexus/src/modules/data-download/components/DataExportPreview.tsx
@@ -1,6 +1,12 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import Checkbox from '@/shared/components/ui/checkbox';
 import { Button } from '@/shared/components/ui';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/shared/components/ui/dropdown-menu';
 import ReusableDialog from '@/shared/components/ui/dialog';
 import { DateRange } from '@/shared/components/calendar/types';
 import {
@@ -9,12 +15,18 @@ import {
 } from '@/shared/components/charts/constants';
 import { InfoBanner } from '@/shared/components/ui/banner';
 import { areArraysEqual } from '@/shared/utils/arrays';
-import { AqAlertTriangle, AqSearchMd } from '@airqo/icons-react';
+import {
+  AqAlertTriangle,
+  AqLoading02,
+  AqSearchMd,
+  AqSettings01,
+} from '@airqo/icons-react';
 import {
   getDefaultDownloadColumnKeys,
   getDownloadColumnGroups,
   getDownloadColumnLabelMap,
 } from '../utils/dataExportFile';
+import { resolveGridSitesForDownload } from '../utils/dataExportRequest';
 
 type PreviewData = Record<string, string | number | null>;
 
@@ -117,6 +129,12 @@ export const DataExportPreview: React.FC<DataExportPreviewProps> = ({
     [activeTab, dataType, selectedPollutants]
   );
 
+  const columnOptionCount = useMemo(
+    () =>
+      columnGroups.reduce((count, group) => count + group.options.length, 0),
+    [columnGroups]
+  );
+
   const columnLabelMap = useMemo(
     () => getDownloadColumnLabelMap(activeTab, selectedPollutants, dataType),
     [activeTab, dataType, selectedPollutants]
@@ -130,11 +148,17 @@ export const DataExportPreview: React.FC<DataExportPreviewProps> = ({
         return selectedDevices;
       case 'countries':
       case 'cities': {
-        const customSites = Object.values(selectedGridSiteIds).flat();
-        if (customSites.length > 0) {
-          return customSites;
-        }
-        return Object.values(selectedGridSites).flat();
+        const gridIds = Array.from(
+          new Set([
+            ...Object.keys(selectedGridSites),
+            ...Object.keys(selectedGridSiteIds),
+          ])
+        );
+        return resolveGridSitesForDownload(
+          gridIds,
+          selectedGridSites,
+          selectedGridSiteIds
+        );
       }
       default:
         return [];
@@ -201,6 +225,7 @@ export const DataExportPreview: React.FC<DataExportPreviewProps> = ({
     !previewError &&
     previewRows.length === 0 &&
     selectedColumnKeys.length > 0;
+  const hasMissingData = Boolean(partialDataWarning?.missingNames.length);
 
   return (
     <ReusableDialog
@@ -231,9 +256,72 @@ export const DataExportPreview: React.FC<DataExportPreviewProps> = ({
       <div className="space-y-6">
         {/* Data Preview — at top so loading/empty/error states are immediately visible */}
         <div>
-          <h3 className="text-sm text-gray-900 dark:text-gray-100 mb-3">
-            Data Preview
-          </h3>
+          <div className="mb-3 flex items-center justify-between gap-3">
+            <h3 className="text-sm text-gray-900 dark:text-gray-100">
+              Data Preview
+            </h3>
+
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="outlined"
+                  size="sm"
+                  Icon={AqSettings01}
+                  iconPosition="start"
+                  aria-label={`Configure columns, ${selectedColumnKeys.length} of ${columnOptionCount} selected`}
+                  className="shrink-0"
+                >
+                  <span>Configure columns</span>
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent
+                align="end"
+                className="z-[10002] max-h-[min(70vh,32rem)] w-80 overflow-y-auto p-2"
+              >
+                <div className="px-2 py-1.5">
+                  <p className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                    Configure columns
+                  </p>
+                  <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                    {selectedColumnKeys.length} of {columnOptionCount} selected
+                  </p>
+                </div>
+                <DropdownMenuSeparator />
+
+                {columnGroups.map(group => (
+                  <fieldset key={group.id} className="px-2 py-2">
+                    <legend className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                      {group.title}
+                    </legend>
+                    <div className="space-y-1">
+                      {group.options.map(option => (
+                        <Checkbox
+                          key={option.key}
+                          checked={selectedColumnKeys.includes(option.key)}
+                          onCheckedChange={checked =>
+                            handleColumnToggle(option.key, checked === true)
+                          }
+                          label={
+                            <span className="leading-5 text-gray-900 dark:text-gray-100">
+                              {option.label}
+                            </span>
+                          }
+                          aria-label={option.label}
+                          className="w-full rounded-md px-2 py-2 text-sm hover:bg-gray-100 dark:hover:bg-gray-800"
+                        />
+                      ))}
+                    </div>
+                  </fieldset>
+                ))}
+
+                {selectedColumnKeys.length === 0 && (
+                  <p className="mx-2 mb-2 rounded-md border border-red-200 bg-red-50 p-2 text-xs text-red-700 dark:border-red-800 dark:bg-red-900/20 dark:text-red-300">
+                    Select at least one column to enable download.
+                  </p>
+                )}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
 
           {isFetchingPreview ? (
             <div
@@ -241,10 +329,9 @@ export const DataExportPreview: React.FC<DataExportPreviewProps> = ({
               role="status"
               aria-live="polite"
             >
-              <div
-                aria-hidden="true"
-                className="animate-spin motion-reduce:animate-none rounded-full h-8 w-8 border-b-2 border-primary mx-auto mb-4"
-              ></div>
+              <div aria-hidden="true" className="flex justify-center mb-4">
+                <AqLoading02 className="w-8 h-8 text-primary animate-spin" />
+              </div>
               <p className="text-sm text-gray-600 dark:text-gray-400">
                 Fetching data preview...
               </p>
@@ -260,11 +347,7 @@ export const DataExportPreview: React.FC<DataExportPreviewProps> = ({
               <p className="text-xs text-gray-500 dark:text-gray-400 mb-4 max-w-sm mx-auto">
                 {previewError}
               </p>
-              <Button
-                variant="outlined"
-                size="sm"
-                onClick={onRetryPreview}
-              >
+              <Button variant="outlined" size="sm" onClick={onRetryPreview}>
                 Retry
               </Button>
             </div>
@@ -309,7 +392,7 @@ export const DataExportPreview: React.FC<DataExportPreviewProps> = ({
                   </table>
                 </div>
               </div>
-              {partialDataWarning && (
+              {hasMissingData && partialDataWarning && (
                 <div className="mt-3 p-4 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg">
                   <div className="flex items-start gap-3">
                     <AqAlertTriangle className="w-5 h-5 text-amber-600 dark:text-amber-400 flex-shrink-0 mt-0.5" />
@@ -318,18 +401,25 @@ export const DataExportPreview: React.FC<DataExportPreviewProps> = ({
                         Partial Data Available
                       </p>
                       <p className="text-xs text-amber-700 dark:text-amber-300 mt-1">
-                        {partialDataWarning.withData} of {partialDataWarning.totalSelected} selected {locationType.toLowerCase()} have data.
+                        {partialDataWarning.withData === 0
+                          ? `No readings were found for the selected ${locationType.toLowerCase()} for these filters.`
+                          : `Readings were found for ${partialDataWarning.withData} of ${partialDataWarning.totalSelected} selected ${locationType.toLowerCase()} for these filters.`}
                         {partialDataWarning.missingNames.length > 0 && (
                           <>
-                            {' '}No readings found for:{' '}
-                            {partialDataWarning.missingNames.slice(0, 3).join(', ')}
+                            {' '}
+                            No readings found for:{' '}
+                            {partialDataWarning.missingNames
+                              .slice(0, 3)
+                              .join(', ')}
                             {partialDataWarning.missingNames.length > 3 &&
                               ` and ${partialDataWarning.missingNames.length - 3} more`}
                           </>
                         )}
                       </p>
                       <p className="text-xs text-amber-600 dark:text-amber-400 mt-1">
-                        Your download will include metadata for all locations, but only those with data will have measurement values.
+                        The download will include metadata for every selected
+                        location; measurement values will be present only where
+                        readings were found.
                       </p>
                     </div>
                   </div>
@@ -351,9 +441,9 @@ export const DataExportPreview: React.FC<DataExportPreviewProps> = ({
               </p>
               <div className="inline-flex items-center gap-2 rounded-full bg-amber-100 dark:bg-amber-900/40 px-3 py-1.5">
                 <span className="text-amber-700 dark:text-amber-300 text-xs font-medium">
-                  If you proceed, you will receive a metadata-only file (location
-                  names, coordinates, and device info) with no measurement
-                  values.
+                  If you proceed, you will receive a metadata-only file
+                  (location names, coordinates, and device info) with no
+                  measurement values.
                 </span>
               </div>
             </div>
@@ -366,67 +456,14 @@ export const DataExportPreview: React.FC<DataExportPreviewProps> = ({
           )}
         </div>
 
-        {/* Info banner */}
-        <InfoBanner
-          dense
-          title="Metadata fallback enabled"
-          message="If the selected filters return no readings, the download automatically falls back to metadata for the selected locations."
-        />
-
-        {/* Download Columns */}
-        <div className="space-y-3">
-          <div>
-            <h3 className="text-sm text-gray-900 dark:text-gray-100">
-              Download Columns
-            </h3>
-            <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-              Turn columns on or off to match the file you want.
-            </p>
-          </div>
-
-          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-            {columnGroups.map(group => (
-              <div
-                key={group.id}
-                className="rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800"
-              >
-                <h4 className="text-sm font-medium text-gray-900 dark:text-gray-100">
-                  {group.title}
-                </h4>
-                <div className="mt-3 grid gap-2 sm:grid-cols-2">
-                  {group.options.map(option => (
-                    <label
-                      key={option.key}
-                      className="flex items-start gap-2 rounded-md border border-gray-200 px-3 py-2 text-sm transition-colors hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-700/60"
-                    >
-                      <Checkbox
-                        checked={selectedColumnKeys.includes(option.key)}
-                        onCheckedChange={checked =>
-                          handleColumnToggle(option.key, checked === true)
-                        }
-                        className="mt-0.5"
-                      />
-                      <span className="leading-5 text-gray-900 dark:text-gray-100">
-                        {option.label}
-                      </span>
-                    </label>
-                  ))}
-                </div>
-              </div>
-            ))}
-          </div>
-
-          {selectedColumnKeys.length === 0 && (
-            <div className="p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg">
-              <p className="text-sm font-medium text-red-700 dark:text-red-300">
-                No columns selected
-              </p>
-              <p className="text-xs text-red-600 dark:text-red-400 mt-1">
-                Enable at least one column above to continue. Without columns, the download button will remain disabled.
-              </p>
-            </div>
-          )}
-        </div>
+        {/* Keep the general guidance only when there is no more specific warning. */}
+        {!hasMissingData && (
+          <InfoBanner
+            dense
+            title="What happens when readings are unavailable"
+            message="If no readings match the selected filters, the download provides metadata for the selected locations so you can still identify them."
+          />
+        )}
 
         {/* What You Will Download - Summary before confirmation */}
         <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-4">
@@ -435,24 +472,37 @@ export const DataExportPreview: React.FC<DataExportPreviewProps> = ({
           </h3>
           <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 text-sm">
             <div>
-              <span className="text-blue-600 dark:text-blue-400">Locations:</span>
-              <p className="text-blue-900 dark:text-blue-100 font-medium">{selectedLocations.length}</p>
-            </div>
-            <div>
-              <span className="text-blue-600 dark:text-blue-400">With data:</span>
+              <span className="text-blue-600 dark:text-blue-400">
+                Locations:
+              </span>
               <p className="text-blue-900 dark:text-blue-100 font-medium">
-                {partialDataWarning ? partialDataWarning.withData : selectedLocations.length}
+                {selectedLocations.length}
               </p>
             </div>
             <div>
-              <span className="text-blue-600 dark:text-blue-400">Without data:</span>
+              <span className="text-blue-600 dark:text-blue-400">
+                With data:
+              </span>
               <p className="text-blue-900 dark:text-blue-100 font-medium">
-                {partialDataWarning ? partialDataWarning.totalSelected - partialDataWarning.withData : 0}
+                {partialDataWarning ? partialDataWarning.withData : '—'}
+              </p>
+            </div>
+            <div>
+              <span className="text-blue-600 dark:text-blue-400">
+                Without data:
+              </span>
+              <p className="text-blue-900 dark:text-blue-100 font-medium">
+                {partialDataWarning
+                  ? partialDataWarning.totalSelected -
+                    partialDataWarning.withData
+                  : '—'}
               </p>
             </div>
             <div>
               <span className="text-blue-600 dark:text-blue-400">Columns:</span>
-              <p className="text-blue-900 dark:text-blue-100 font-medium">{selectedColumnKeys.length}</p>
+              <p className="text-blue-900 dark:text-blue-100 font-medium">
+                {selectedColumnKeys.length}
+              </p>
             </div>
           </div>
           <p className="text-xs text-blue-600 dark:text-blue-400 mt-2">

--- a/src/nexus/src/modules/data-download/components/DataExportPreview.tsx
+++ b/src/nexus/src/modules/data-download/components/DataExportPreview.tsx
@@ -19,6 +19,11 @@ import {
   getDownloadColumnGroups,
   getDownloadColumnLabelMap,
 } from '../utils/dataExportFile';
+import { Button } from '@/shared/components/ui';
+import { buildDataDownloadRequest } from '../utils/dataExportRequest';
+import { useDownloadData } from '@/shared/hooks/useAnalytics';
+import { DeviceCategory } from '../types/dataExportTypes';
+import type { DataDownloadRequest } from '@/shared/types/api';
 
 interface DataExportPreviewProps {
   isOpen: boolean;
@@ -26,7 +31,6 @@ interface DataExportPreviewProps {
   onConfirm: (selectedColumnKeys: string[]) => void;
   isDownloading: boolean;
 
-  // Export configuration
   dataType: string;
   frequency: string;
   fileType: string;
@@ -35,21 +39,14 @@ interface DataExportPreviewProps {
   activeTab: 'sites' | 'devices' | 'countries' | 'cities';
   selectedSites: string[];
   selectedDevices: string[];
+  selectedDeviceIds: string[];
   selectedGridIds: string[];
   selectedGridSites: Record<string, string[]>;
   selectedGridSiteIds: Record<string, string[]>;
+  deviceCategory: DeviceCategory;
 }
 
 type PreviewData = Record<string, string | number | null>;
-
-const SAMPLE_POLLUTANT_VALUES: Record<string, [number, number]> = {
-  pm2_5: [36.37, 30.97],
-  pm10: [46.42, 42.11],
-  no2: [18.27, 16.81],
-  so2: [8.12, 7.44],
-  o3: [22.54, 23.71],
-  co: [0.82, 0.74],
-};
 
 export const DataExportPreview: React.FC<DataExportPreviewProps> = ({
   isOpen,
@@ -64,14 +61,30 @@ export const DataExportPreview: React.FC<DataExportPreviewProps> = ({
   activeTab,
   selectedSites,
   selectedDevices,
+  selectedDeviceIds,
   selectedGridIds,
   selectedGridSites,
   selectedGridSiteIds,
+  deviceCategory,
 }) => {
   const [selectedColumnKeys, setSelectedColumnKeys] = useState<string[]>(() =>
     getDefaultDownloadColumnKeys(activeTab, selectedPollutants, dataType)
   );
   const previousOpenRef = useRef(false);
+  const isMountedRef = useRef(true);
+  const abortControllerRef = useRef<AbortController | null>(null);
+  const { trigger: fetchPreviewData } = useDownloadData();
+  const [previewRows, setPreviewRows] = useState<PreviewData[]>([]);
+  const [isFetchingPreview, setIsFetchingPreview] = useState(false);
+  const [previewError, setPreviewError] = useState<string | null>(null);
+  const previewRequestRef = useRef<DataDownloadRequest | null>(null);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
 
   const formattedDateRange = useMemo(() => {
     if (!dateRange?.from || !dateRange?.to) return 'Not selected';
@@ -150,45 +163,183 @@ export const DataExportPreview: React.FC<DataExportPreviewProps> = ({
     }
   }, [activeTab]);
 
-  const locationColumnKey = useMemo(() => {
-    switch (activeTab) {
-      case 'sites':
-        return 'site_name';
-      case 'devices':
-        return 'device_name';
-      case 'countries':
-        return 'country_name';
-      case 'cities':
-        return 'city_name';
-      default:
-        return 'site_name';
-    }
-  }, [activeTab]);
+  const parseCsvLine = useCallback((line: string): string[] => {
+    const fields: string[] = [];
+    let current = '';
+    let inQuotes = false;
 
-  const locationSampleValue = useMemo(() => {
-    switch (activeTab) {
-      case 'sites':
-        return selectedSites[0] || 'Sample Site';
-      case 'devices':
-        return selectedDevices[0] || 'sample_device';
-      case 'countries':
-        return selectedGridIds[0] || 'Sample Country';
-      case 'cities':
-        return selectedGridIds[0] || 'Sample City';
-      default:
-        return 'Sample Location';
+    for (let i = 0; i < line.length; i++) {
+      const char = line[i];
+
+      if (inQuotes) {
+        if (char === '"') {
+          if (i + 1 < line.length && line[i + 1] === '"') {
+            current += '"';
+            i++;
+          } else {
+            inQuotes = false;
+          }
+        } else {
+          current += char;
+        }
+      } else {
+        if (char === '"') {
+          inQuotes = true;
+        } else if (char === ',') {
+          fields.push(current.trim());
+          current = '';
+        } else {
+          current += char;
+        }
+      }
     }
-  }, [activeTab, selectedDevices, selectedGridIds, selectedSites]);
+
+    fields.push(current.trim());
+    return fields;
+  }, []);
+
+  const doFetchPreview = useCallback(
+    (request: DataDownloadRequest, controller: AbortController) => {
+      fetchPreviewData(request)
+        .then(response => {
+          if (!isMountedRef.current || controller.signal.aborted) return;
+
+          if (typeof response === 'string') {
+            const lines = response.split('\n').filter(line => line.trim());
+            if (lines.length > 1) {
+              const headers = parseCsvLine(lines[0]);
+              const rows = lines.slice(1, 6).map(line => {
+                const values = parseCsvLine(line);
+                const row: PreviewData = {};
+                headers.forEach((header, index) => {
+                  const val = values[index];
+                  if (val === '' || val === undefined) {
+                    row[header] = null;
+                  } else {
+                    const num = Number(val);
+                    row[header] = isNaN(num) ? val : num;
+                  }
+                });
+                return row;
+              });
+              setPreviewRows(rows);
+            } else {
+              setPreviewRows([]);
+            }
+          } else if (
+            response &&
+            typeof response === 'object' &&
+            'data' in response &&
+            Array.isArray((response as { data: unknown }).data)
+          ) {
+            const responseData = (
+              response as unknown as { data: Record<string, unknown>[] }
+            ).data;
+            const rows: PreviewData[] = responseData.slice(0, 5).map(item => {
+              const row: PreviewData = {};
+              Object.entries(item).forEach(([key, value]) => {
+                row[key] =
+                  typeof value === 'number'
+                    ? value
+                    : value != null
+                      ? String(value)
+                      : null;
+              });
+              return row;
+            });
+            setPreviewRows(rows);
+          } else {
+            setPreviewRows([]);
+          }
+        })
+        .catch(() => {
+          if (!isMountedRef.current || controller.signal.aborted) return;
+          setPreviewError(
+            'Unable to load data preview. You can retry or proceed with the download.'
+          );
+        })
+        .finally(() => {
+          if (isMountedRef.current && !controller.signal.aborted) {
+            setIsFetchingPreview(false);
+          }
+        });
+    },
+    [fetchPreviewData, parseCsvLine]
+  );
 
   useEffect(() => {
     if (isOpen && !previousOpenRef.current) {
       setSelectedColumnKeys(prev =>
         areArraysEqual(prev, defaultColumnKeys) ? prev : defaultColumnKeys
       );
+      setPreviewRows([]);
+      setPreviewError(null);
+      setIsFetchingPreview(true);
+
+      if (abortControllerRef.current) {
+        abortControllerRef.current.abort();
+      }
+      const abortController = new AbortController();
+      abortControllerRef.current = abortController;
+
+      const effectiveDataType: 'calibrated' | 'raw' =
+        activeTab === 'devices' && deviceCategory === 'bam'
+          ? 'raw'
+          : (dataType as 'calibrated' | 'raw');
+
+      const previewRequest: DataDownloadRequest = buildDataDownloadRequest({
+        dateRange,
+        activeTab,
+        selectedSites,
+        selectedDeviceIds,
+        selectedDeviceNames: selectedDevices,
+        selectedGridIds,
+        selectedGridSites,
+        selectedGridSiteIds,
+        selectedPollutants,
+        dataType: effectiveDataType,
+        fileType: 'csv',
+        frequency,
+        deviceCategory,
+      });
+
+      previewRequestRef.current = previewRequest;
+      doFetchPreview(previewRequest, abortController);
     }
 
     previousOpenRef.current = isOpen;
-  }, [defaultColumnKeys, isOpen]);
+  }, [
+    defaultColumnKeys,
+    isOpen,
+    doFetchPreview,
+    dataType,
+    frequency,
+    selectedPollutants,
+    dateRange,
+    activeTab,
+    selectedSites,
+    selectedDevices,
+    selectedDeviceIds,
+    selectedGridIds,
+    selectedGridSites,
+    selectedGridSiteIds,
+    deviceCategory,
+  ]);
+
+  const handleRetryPreview = useCallback(() => {
+    if (!previewRequestRef.current) return;
+    setPreviewError(null);
+    setPreviewRows([]);
+    setIsFetchingPreview(true);
+
+    if (abortControllerRef.current) {
+      abortControllerRef.current.abort();
+    }
+    const abortController = new AbortController();
+    abortControllerRef.current = abortController;
+
+    doFetchPreview(previewRequestRef.current, abortController);
+  }, [doFetchPreview]);
 
   const handleColumnToggle = useCallback((key: string, checked: boolean) => {
     setSelectedColumnKeys(prev => {
@@ -199,73 +350,6 @@ export const DataExportPreview: React.FC<DataExportPreviewProps> = ({
       return prev.filter(columnKey => columnKey !== key);
     });
   }, []);
-
-  const sampleRows = useMemo<PreviewData[]>(() => {
-    if (!dateRange?.from) {
-      return [];
-    }
-
-    const baseDate = dateRange.from;
-
-    const createSampleDate = (index: number) => {
-      const sampleDate = new Date(baseDate);
-
-      switch (frequency) {
-        case 'raw':
-        case 'hourly':
-          sampleDate.setHours(sampleDate.getHours() + index);
-          break;
-        case 'weekly':
-          sampleDate.setDate(sampleDate.getDate() + index * 7);
-          break;
-        case 'monthly':
-          sampleDate.setMonth(sampleDate.getMonth() + index);
-          break;
-        default:
-          sampleDate.setDate(sampleDate.getDate() + index);
-          break;
-      }
-
-      return sampleDate;
-    };
-
-    return [0, 1].map(index => {
-      const sampleDate = createSampleDate(index);
-
-      const row: PreviewData = {
-        [locationColumnKey]: locationSampleValue,
-        datetime: sampleDate.toISOString().replace('T', ' ').replace('Z', ''),
-        frequency,
-        network: 'airqo',
-        latitude: 0.3244820075131162,
-        longitude: 32.571073376413565,
-        temperature: index === 0 ? 25.83641260890321 : 26.85111111111112,
-        humidity: index === 0 ? 72.06045440983412 : 63.484772961816304,
-      };
-
-      selectedPollutants.forEach(pollutant => {
-        const values = SAMPLE_POLLUTANT_VALUES[pollutant] || [36.37, 30.97];
-        const value = index === 0 ? values[0] : values[1];
-
-        if (dataType === 'calibrated') {
-          row[`${pollutant}_calibrated_value`] = Number(
-            (value * 0.92).toFixed(2)
-          );
-        } else {
-          row[pollutant] = value;
-        }
-      });
-
-      return row;
-    });
-  }, [
-    dateRange?.from,
-    frequency,
-    locationColumnKey,
-    locationSampleValue,
-    dataType,
-    selectedPollutants,
-  ]);
 
   const previewColumns = useMemo(
     () =>
@@ -281,7 +365,7 @@ export const DataExportPreview: React.FC<DataExportPreviewProps> = ({
       return [];
     }
 
-    return sampleRows.map(row => {
+    return previewRows.map(row => {
       const filteredRow: PreviewData = {};
 
       selectedColumnKeys.forEach(key => {
@@ -290,7 +374,7 @@ export const DataExportPreview: React.FC<DataExportPreviewProps> = ({
 
       return filteredRow;
     });
-  }, [sampleRows, selectedColumnKeys]);
+  }, [previewRows, selectedColumnKeys]);
 
   return (
     <ReusableDialog
@@ -421,7 +505,7 @@ export const DataExportPreview: React.FC<DataExportPreviewProps> = ({
         {/* Data Preview */}
         <div>
           <h3 className="text-sm text-gray-900 dark:text-gray-100 mb-3">
-            Data Preview (Sample Rows)
+            Data Preview (First 5 Rows)
           </h3>
 
           {selectedColumnKeys.length === 0 ? (
@@ -429,6 +513,32 @@ export const DataExportPreview: React.FC<DataExportPreviewProps> = ({
               title="Preview Unavailable"
               message="Select at least one column above to preview the export output."
             />
+          ) : isFetchingPreview ? (
+            <div className="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden p-8 text-center">
+              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary mx-auto mb-4"></div>
+              <p className="text-sm text-gray-600 dark:text-gray-400">Loading data preview...</p>
+            </div>
+          ) : previewError ? (
+            <div className="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden p-6 text-center">
+              <div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-amber-100 dark:bg-amber-900/30 mb-3">
+                <span className="text-amber-600 dark:text-amber-400 text-xl">&#9888;</span>
+              </div>
+              <h4 className="text-sm font-medium text-gray-900 dark:text-gray-100 mb-1">
+                Unable to Load Preview
+              </h4>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mb-4 max-w-sm mx-auto">
+                {previewError}
+              </p>
+              <Button
+                variant="outlined"
+                size="sm"
+                onClick={handleRetryPreview}
+                disabled={isFetchingPreview}
+                loading={isFetchingPreview}
+              >
+                Retry
+              </Button>
+            </div>
           ) : previewData.length > 0 ? (
             <div className="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
               <div className="max-h-64 overflow-auto">
@@ -457,7 +567,9 @@ export const DataExportPreview: React.FC<DataExportPreviewProps> = ({
                             className="px-3 py-2 text-gray-900 dark:text-gray-100 border-r border-gray-200 dark:border-gray-700 last:border-r-0"
                           >
                             {typeof row[column.key] === 'number'
-                              ? Number(row[column.key]).toFixed(2)
+                              ? Number.isInteger(row[column.key])
+                                ? String(row[column.key])
+                                : Number(row[column.key]).toFixed(2)
                               : String(row[column.key] ?? '')}
                           </td>
                         ))}
@@ -468,15 +580,17 @@ export const DataExportPreview: React.FC<DataExportPreviewProps> = ({
               </div>
             </div>
           ) : (
-            <div className="text-center py-8 text-sm text-gray-600 dark:text-gray-400">
-              No preview data available
-            </div>
+            <InfoBanner
+              title="No Data Available"
+              message="The current filter settings did not return any data. Please try adjusting your date range, locations, or pollutants. The download will still provide metadata for the selected items."
+            />
           )}
         </div>
 
         {/* Export Notes */}
         <InfoBanner
-          message={`This preview is for the file setup only. Your download will use the same data selection and keep only the columns you choose here.`}
+          dense
+          message={`Preview shows the first 5 rows of your export. Your download will include all matching data with only the columns selected above.`}
         />
       </div>
     </ReusableDialog>

--- a/src/nexus/src/modules/data-download/components/DataExportPreview.tsx
+++ b/src/nexus/src/modules/data-download/components/DataExportPreview.tsx
@@ -225,8 +225,15 @@ export const DataExportPreview: React.FC<DataExportPreviewProps> = ({
           </h3>
 
           {isFetchingPreview ? (
-            <div className="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden p-8 text-center">
-              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary mx-auto mb-4"></div>
+            <div
+              className="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden p-8 text-center"
+              role="status"
+              aria-live="polite"
+            >
+              <div
+                aria-hidden="true"
+                className="animate-spin motion-reduce:animate-none rounded-full h-8 w-8 border-b-2 border-primary mx-auto mb-4"
+              ></div>
               <p className="text-sm text-gray-600 dark:text-gray-400">
                 Fetching data preview...
               </p>
@@ -304,8 +311,8 @@ export const DataExportPreview: React.FC<DataExportPreviewProps> = ({
               </h4>
               <p className="text-xs text-gray-600 dark:text-gray-400 max-w-md mx-auto mb-3">
                 There are no readings available for the selected time period,
-                locations, and pollutants. You can adjust your filters above and
-                the preview will update automatically.
+                locations, and pollutants. Cancel this dialog to adjust your
+                filters, then run the export again.
               </p>
               <div className="inline-flex items-center gap-2 rounded-full bg-amber-100 dark:bg-amber-900/40 px-3 py-1.5">
                 <span className="text-amber-700 dark:text-amber-300 text-xs font-medium">

--- a/src/nexus/src/modules/data-download/components/DataExportSidebar.tsx
+++ b/src/nexus/src/modules/data-download/components/DataExportSidebar.tsx
@@ -129,13 +129,18 @@ export const DataExportSidebar: React.FC<DataExportSidebarProps> = ({
           </h2>
 
           {/* File Title Input - First */}
-          <Input
-            type="text"
-            placeholder="Enter file title"
-            value={fileTitle}
-            onChange={e => setFileTitle(e.target.value)}
-            className="w-full"
-          />
+          <div className="space-y-1">
+            <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+              File Title
+            </label>
+            <Input
+              type="text"
+              placeholder="Enter file title (optional)"
+              value={fileTitle}
+              onChange={e => setFileTitle(e.target.value)}
+              className="w-full"
+            />
+          </div>
 
           {/* Device Category */}
           <CustomField
@@ -264,13 +269,18 @@ export const DataExportSidebar: React.FC<DataExportSidebarProps> = ({
           {/* Mobile Sidebar Content */}
           <div className="flex-1 overflow-y-auto p-4 space-y-4">
             {/* File Title Input - First */}
-            <Input
-              type="text"
-              placeholder="Enter file title"
-              value={fileTitle}
-              onChange={e => setFileTitle(e.target.value)}
-              className="w-full"
-            />
+            <div className="space-y-1">
+              <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                File Title
+              </label>
+              <Input
+                type="text"
+                placeholder="Enter file title (optional)"
+                value={fileTitle}
+                onChange={e => setFileTitle(e.target.value)}
+                className="w-full"
+              />
+            </div>
 
             {/* Device Category */}
             <CustomField

--- a/src/nexus/src/modules/data-download/components/DataExportSidebar.tsx
+++ b/src/nexus/src/modules/data-download/components/DataExportSidebar.tsx
@@ -118,7 +118,7 @@ export const DataExportSidebar: React.FC<DataExportSidebarProps> = ({
     }
   }, [deviceCategory]);
   const showDownloadLimitNotice = useMemo(() => {
-    if (!dateRange?.from || !dateRange?.to) return true;
+    if (!dateRange?.from || !dateRange?.to) return false;
 
     return (
       Math.abs(dateRange.to.getTime() - dateRange.from.getTime()) /
@@ -301,7 +301,7 @@ export const DataExportSidebar: React.FC<DataExportSidebarProps> = ({
 
       {/* Mobile/Tablet Sidebar - Below lg breakpoint */}
       <aside
-        className={`lg:hidden fixed inset-y-0 left-0 z-[60] w-80 bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 transform transition-transform duration-300 ease-in-out overflow-visible ${
+        className={`lg:hidden fixed inset-y-0 left-0 z-[60] w-80 bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 transform transition-transform duration-300 ease-in-out motion-reduce:transition-none overflow-visible ${
           sidebarOpen ? 'translate-x-0' : '-translate-x-full'
         } ${sidebarOpen ? 'flex' : 'hidden'}`}
       >

--- a/src/nexus/src/modules/data-download/components/DataExportSidebar.tsx
+++ b/src/nexus/src/modules/data-download/components/DataExportSidebar.tsx
@@ -130,10 +130,11 @@ export const DataExportSidebar: React.FC<DataExportSidebarProps> = ({
 
           {/* File Title Input - First */}
           <div className="space-y-1">
-            <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+            <label htmlFor="file-title-desktop" className="text-sm font-medium text-gray-700 dark:text-gray-300">
               File Title
             </label>
             <Input
+              id="file-title-desktop"
               type="text"
               placeholder="Enter file title (optional)"
               value={fileTitle}
@@ -270,10 +271,11 @@ export const DataExportSidebar: React.FC<DataExportSidebarProps> = ({
           <div className="flex-1 overflow-y-auto p-4 space-y-4">
             {/* File Title Input - First */}
             <div className="space-y-1">
-              <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+              <label htmlFor="file-title-mobile" className="text-sm font-medium text-gray-700 dark:text-gray-300">
                 File Title
               </label>
               <Input
+                id="file-title-mobile"
                 type="text"
                 placeholder="Enter file title (optional)"
                 value={fileTitle}

--- a/src/nexus/src/modules/data-download/components/DataExportSidebar.tsx
+++ b/src/nexus/src/modules/data-download/components/DataExportSidebar.tsx
@@ -5,6 +5,7 @@ import Checkbox from '@/shared/components/ui/checkbox';
 import { CustomField } from './CustomField';
 import { DateRange } from '@/shared/components/calendar/types';
 import { WarningBanner } from '@/shared/components/ui';
+import { Tooltip } from 'flowbite-react';
 import {
   FREQUENCY_LABELS,
   POLLUTANT_LABELS,
@@ -52,6 +53,37 @@ const deviceCategoryOptions = [
 ];
 
 const pollutants = Object.keys(POLLUTANT_LABELS);
+
+const FieldLabel = ({
+  label,
+  tooltip,
+}: {
+  label: string;
+  tooltip?: string;
+}) => (
+  <span className="inline-flex items-center gap-1.5">
+    <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
+      {label}
+    </span>
+    {tooltip && (
+      <Tooltip content={tooltip} placement="top">
+        <span className="text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 cursor-help">
+          <svg
+            className="w-3.5 h-3.5"
+            fill="currentColor"
+            viewBox="0 0 20 20"
+          >
+            <path
+              fillRule="evenodd"
+              d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z"
+              clipRule="evenodd"
+            />
+          </svg>
+        </span>
+      </Tooltip>
+    )}
+  </span>
+);
 
 export const DataExportSidebar: React.FC<DataExportSidebarProps> = ({
   fileTitle,
@@ -117,11 +149,9 @@ export const DataExportSidebar: React.FC<DataExportSidebarProps> = ({
   );
   return (
     <>
-      {/* Sidebar - Hidden by default, shown when toggled */}
+      {/* Sidebar - Hidden by default on mobile, always visible on desktop */}
       <aside
-        className={`fixed lg:static top-0 left-0 z-[60] w-80 lg:w-64 h-full lg:h-auto bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 p-4 overflow-visible flex-col shadow-lg lg:shadow-sm transition-transform duration-300 ease-in-out ${
-          sidebarOpen ? 'translate-x-0' : '-translate-x-full'
-        } ${sidebarOpen ? 'flex' : 'hidden'}`}
+        className={`hidden lg:flex lg:static top-0 left-0 z-[60] lg:w-64 h-full lg:h-auto bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 p-4 overflow-visible flex-col shadow-lg lg:shadow-sm transition-all duration-300 ease-in-out`}
       >
         <div className="space-y-4">
           <h2 className="text-lg text-gray-900 dark:text-gray-100">
@@ -172,21 +202,34 @@ export const DataExportSidebar: React.FC<DataExportSidebarProps> = ({
             )}
           </div>
 
-          {/* Download Limit Notice */}
-          <WarningBanner
-            title="Download Limit Notice"
-            message="Annual data downloads must be done in batches. Please select shorter date ranges for optimal performance."
-          />
+          {/* Download Limit Notice — only show for large date ranges */}
+          {(!dateRange?.from ||
+            !dateRange?.to ||
+            (dateRange.from && dateRange.to &&
+              Math.abs(dateRange.to.getTime() - dateRange.from.getTime()) /
+                (1000 * 60 * 60 * 24) > 90)) && (
+            <WarningBanner
+              title="Download Limit Notice"
+              message="Annual data downloads must be done in batches. Please select shorter date ranges for optimal performance."
+            />
+          )}
 
           {/* Data Type */}
           {!hideDataTypeSelection && (
-            <CustomField
-              label="Data Type"
-              value={dataType}
-              onChange={setDataType}
-              options={dataTypeOptions}
-              placeholder="Select data type"
-            />
+            <div className="space-y-2">
+              <FieldLabel
+                label="Data Type"
+                tooltip="Calibrated data is quality-assured and adjusted for sensor drift. Raw data is unprocessed sensor output."
+              />
+              <CustomField
+                label="Data Type"
+                value={dataType}
+                onChange={setDataType}
+                options={dataTypeOptions}
+                placeholder="Select data type"
+                showLabel={false}
+              />
+            </div>
           )}
 
           {/* Pollutants */}
@@ -235,21 +278,28 @@ export const DataExportSidebar: React.FC<DataExportSidebarProps> = ({
           />
 
           {/* Frequency */}
-          <CustomField
-            label="Frequency"
-            value={frequency}
-            onChange={setFrequency}
-            options={frequencyOptions}
-            placeholder="Select frequency"
-          />
+          <div className="space-y-2">
+            <FieldLabel
+              label="Frequency"
+              tooltip="How the data is aggregated over time. Hourly gives per-hour readings, Daily averages once per day, Monthly averages once per month."
+            />
+            <CustomField
+              label="Frequency"
+              value={frequency}
+              onChange={setFrequency}
+              options={frequencyOptions}
+              placeholder="Select frequency"
+              showLabel={false}
+            />
+          </div>
         </div>
       </aside>
 
-      {/* Mobile Sidebar - Within Content Area */}
+      {/* Mobile/Tablet Sidebar - Below lg breakpoint */}
       <aside
-        className={`md:hidden fixed inset-y-0 left-0 z-[60] w-80 bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 transform transition-transform duration-300 ease-in-out overflow-visible ${
+        className={`lg:hidden fixed inset-y-0 left-0 z-[60] w-80 bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 transform transition-transform duration-300 ease-in-out overflow-visible ${
           sidebarOpen ? 'translate-x-0' : '-translate-x-full'
-        }`}
+        } ${sidebarOpen ? 'flex' : 'hidden'}`}
       >
         <div className="flex flex-col h-full">
           {/* Mobile Sidebar Header */}
@@ -321,13 +371,20 @@ export const DataExportSidebar: React.FC<DataExportSidebarProps> = ({
 
             {/* Data Type */}
             {!hideDataTypeSelection && (
-              <CustomField
-                label="Data Type"
-                value={dataType}
-                onChange={setDataType}
-                options={dataTypeOptions}
-                placeholder="Select data type"
-              />
+              <div className="space-y-2">
+                <FieldLabel
+                  label="Data Type"
+                  tooltip="Calibrated data is quality-assured and adjusted for sensor drift. Raw data is unprocessed sensor output."
+                />
+                <CustomField
+                  label="Data Type"
+                  value={dataType}
+                  onChange={setDataType}
+                  options={dataTypeOptions}
+                  placeholder="Select data type"
+                  showLabel={false}
+                />
+              </div>
             )}
 
             {/* Pollutants */}
@@ -376,13 +433,20 @@ export const DataExportSidebar: React.FC<DataExportSidebarProps> = ({
             />
 
             {/* Frequency */}
-            <CustomField
-              label="Frequency"
-              value={frequency}
-              onChange={setFrequency}
-              options={frequencyOptions}
-              placeholder="Select frequency"
-            />
+            <div className="space-y-2">
+              <FieldLabel
+                label="Frequency"
+                tooltip="How the data is aggregated over time. Hourly gives per-hour readings, Daily averages once per day, Monthly averages once per month."
+              />
+              <CustomField
+                label="Frequency"
+                value={frequency}
+                onChange={setFrequency}
+                options={frequencyOptions}
+                placeholder="Select frequency"
+                showLabel={false}
+              />
+            </div>
           </div>
         </div>
       </aside>

--- a/src/nexus/src/modules/data-download/components/DataExportSidebar.tsx
+++ b/src/nexus/src/modules/data-download/components/DataExportSidebar.tsx
@@ -68,11 +68,7 @@ const FieldLabel = ({
     {tooltip && (
       <Tooltip content={tooltip} placement="top">
         <span className="text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 cursor-help">
-          <svg
-            className="w-3.5 h-3.5"
-            fill="currentColor"
-            viewBox="0 0 20 20"
-          >
+          <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20">
             <path
               fillRule="evenodd"
               d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z"
@@ -121,6 +117,15 @@ export const DataExportSidebar: React.FC<DataExportSidebarProps> = ({
       return allOptions.filter(option => option.value !== 'raw');
     }
   }, [deviceCategory]);
+  const showDownloadLimitNotice = useMemo(() => {
+    if (!dateRange?.from || !dateRange?.to) return true;
+
+    return (
+      Math.abs(dateRange.to.getTime() - dateRange.from.getTime()) /
+        (1000 * 60 * 60 * 24) >
+      90
+    );
+  }, [dateRange]);
   const [pollutantError, setPollutantError] = useState<string | null>(null);
 
   const handlePollutantChange = useCallback(
@@ -160,7 +165,10 @@ export const DataExportSidebar: React.FC<DataExportSidebarProps> = ({
 
           {/* File Title Input - First */}
           <div className="space-y-1">
-            <label htmlFor="file-title-desktop" className="text-sm font-medium text-gray-700 dark:text-gray-300">
+            <label
+              htmlFor="file-title-desktop"
+              className="text-sm font-medium text-gray-700 dark:text-gray-300"
+            >
               File Title
             </label>
             <Input
@@ -203,11 +211,7 @@ export const DataExportSidebar: React.FC<DataExportSidebarProps> = ({
           </div>
 
           {/* Download Limit Notice — only show for large date ranges */}
-          {(!dateRange?.from ||
-            !dateRange?.to ||
-            (dateRange.from && dateRange.to &&
-              Math.abs(dateRange.to.getTime() - dateRange.from.getTime()) /
-                (1000 * 60 * 60 * 24) > 90)) && (
+          {showDownloadLimitNotice && (
             <WarningBanner
               title="Download Limit Notice"
               message="Annual data downloads must be done in batches. Please select shorter date ranges for optimal performance."
@@ -321,7 +325,10 @@ export const DataExportSidebar: React.FC<DataExportSidebarProps> = ({
           <div className="flex-1 overflow-y-auto p-4 space-y-4">
             {/* File Title Input - First */}
             <div className="space-y-1">
-              <label htmlFor="file-title-mobile" className="text-sm font-medium text-gray-700 dark:text-gray-300">
+              <label
+                htmlFor="file-title-mobile"
+                className="text-sm font-medium text-gray-700 dark:text-gray-300"
+              >
                 File Title
               </label>
               <Input
@@ -364,10 +371,12 @@ export const DataExportSidebar: React.FC<DataExportSidebarProps> = ({
             </div>
 
             {/* Download Limit Notice */}
-            <WarningBanner
-              title="Download Limit Notice"
-              message="Annual data downloads must be done in batches. Please select shorter date ranges for optimal performance."
-            />
+            {showDownloadLimitNotice && (
+              <WarningBanner
+                title="Download Limit Notice"
+                message="Annual data downloads must be done in batches. Please select shorter date ranges for optimal performance."
+              />
+            )}
 
             {/* Data Type */}
             {!hideDataTypeSelection && (

--- a/src/nexus/src/modules/data-download/components/DownloadFormatDialog.tsx
+++ b/src/nexus/src/modules/data-download/components/DownloadFormatDialog.tsx
@@ -46,7 +46,7 @@ const formatCards: Array<{
     title: 'PDF summary',
     actionLabel: 'Download PDF',
     description:
-      'Download a formatted summary with a summary, table, and page numbers.',
+      'Download a formatted summary with an overview, data table, and page numbers.',
     badge: 'Summary',
   },
 ];

--- a/src/nexus/src/modules/data-download/components/SelectedGridsSummary.tsx
+++ b/src/nexus/src/modules/data-download/components/SelectedGridsSummary.tsx
@@ -7,6 +7,7 @@ interface SelectedGridsSummaryProps {
   activeTab: 'countries' | 'cities';
   selectedGridIds: string[];
   processedGridsData: Grid[];
+  selectedGridSites: Record<string, string[]>;
   selectedGridSiteIds: Record<string, string[]>;
   onCustomizeSites: (grid: Grid) => void;
 }
@@ -15,6 +16,7 @@ export const SelectedGridsSummary: React.FC<SelectedGridsSummaryProps> = ({
   activeTab,
   selectedGridIds,
   processedGridsData,
+  selectedGridSites,
   selectedGridSiteIds,
   onCustomizeSites,
 }) => {
@@ -32,8 +34,13 @@ export const SelectedGridsSummary: React.FC<SelectedGridsSummaryProps> = ({
       <div className="space-y-3">
         {selectedGrids.map(grid => {
           const totalSites = grid.sites?.length || 0;
-          const customSites = selectedGridSiteIds[grid._id] || [];
-          const selectedSites = customSites.length;
+          const hasCustomSelection = Object.prototype.hasOwnProperty.call(
+            selectedGridSiteIds,
+            grid._id
+          );
+          const selectedSites = hasCustomSelection
+            ? selectedGridSiteIds[grid._id]?.length || 0
+            : selectedGridSites[grid._id]?.length || 0;
 
           return (
             <div
@@ -47,7 +54,7 @@ export const SelectedGridsSummary: React.FC<SelectedGridsSummaryProps> = ({
                 <div className="text-sm text-gray-600 dark:text-gray-400">
                   {selectedSites > 0
                     ? `${selectedSites} of ${totalSites} sites selected`
-                    : `No sites selected`}
+                    : 'No monitoring sites selected'}
                 </div>
               </div>
               <Button
@@ -56,7 +63,7 @@ export const SelectedGridsSummary: React.FC<SelectedGridsSummaryProps> = ({
                 onClick={() => onCustomizeSites(grid)}
                 className="ml-3"
               >
-                {selectedSites > 0 ? 'Modify Sites' : 'Choose Sites'}
+                {hasCustomSelection ? 'Modify Sites' : 'Customize Sites'}
               </Button>
             </div>
           );
@@ -66,8 +73,8 @@ export const SelectedGridsSummary: React.FC<SelectedGridsSummaryProps> = ({
         <AqLightbulb01 className="w-4 h-4 flex-shrink-0 mt-0.5" />
         <span>
           Tip: Click &quot;Choose Sites&quot; to select specific monitoring
-          locations, or use the main download button to download all sites in your
-          selection.
+          locations, or use the main download button to download all sites in
+          your selection.
         </span>
       </div>
     </div>

--- a/src/nexus/src/modules/data-download/components/SelectedGridsSummary.tsx
+++ b/src/nexus/src/modules/data-download/components/SelectedGridsSummary.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Button } from '@/shared/components/ui';
+import { AqLightbulb01 } from '@airqo/icons-react';
 import { Grid } from '@/shared/types/api';
 
 interface SelectedGridsSummaryProps {
@@ -61,10 +62,13 @@ export const SelectedGridsSummary: React.FC<SelectedGridsSummaryProps> = ({
           );
         })}
       </div>
-      <div className="mt-3 text-xs text-blue-700 dark:text-blue-300">
-        💡 Tip: Click &quot;Choose Sites&quot; to select specific monitoring
-        locations, or use the main download button to download all sites in your
-        selection.
+      <div className="mt-3 text-xs text-blue-700 dark:text-blue-300 flex items-start gap-2">
+        <AqLightbulb01 className="w-4 h-4 flex-shrink-0 mt-0.5" />
+        <span>
+          Tip: Click &quot;Choose Sites&quot; to select specific monitoring
+          locations, or use the main download button to download all sites in your
+          selection.
+        </span>
       </div>
     </div>
   );

--- a/src/nexus/src/modules/data-download/components/SiteSelectionDialog.tsx
+++ b/src/nexus/src/modules/data-download/components/SiteSelectionDialog.tsx
@@ -94,6 +94,9 @@ export const SiteSelectionDialog: React.FC<SiteSelectionDialogProps> = ({
       }}
       title={`Select Sites in ${gridName}`}
       subtitle={`Choose which sites under this ${gridType} to include in your data download.`}
+      size="xl"
+      className="max-w-2xl sm:max-w-3xl"
+      maxHeight="max-h-[80vh]"
       preventBackdropClose={isDownloading}
       showCloseButton={!isDownloading}
       customFooter={

--- a/src/nexus/src/modules/data-download/components/SiteSelectionDialog.tsx
+++ b/src/nexus/src/modules/data-download/components/SiteSelectionDialog.tsx
@@ -148,10 +148,20 @@ export const SiteSelectionDialog: React.FC<SiteSelectionDialogProps> = ({
       <div className="max-h-96 overflow-y-auto">
         <div className="space-y-2">
           {filteredSites.length === 0 ? (
-            <div className="text-center py-8 text-gray-500">
-              {searchTerm
-                ? 'No sites found matching your search.'
-                : 'No sites available.'}
+            <div className="text-center py-8">
+              <div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-gray-100 dark:bg-gray-800 mb-3">
+                <span className="text-gray-400 text-xl">&#128205;</span>
+              </div>
+              <p className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                {searchTerm
+                  ? 'No sites found matching your search.'
+                  : 'No sites available'}
+              </p>
+              {!searchTerm && (
+                <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                  This {gridType} does not have any monitoring sites configured.
+                </p>
+              )}
             </div>
           ) : (
             filteredSites.map(site => (

--- a/src/nexus/src/modules/data-download/components/SiteSelectionDialog.tsx
+++ b/src/nexus/src/modules/data-download/components/SiteSelectionDialog.tsx
@@ -153,11 +153,11 @@ export const SiteSelectionDialog: React.FC<SiteSelectionDialogProps> = ({
                 <span className="text-gray-400 text-xl">&#128205;</span>
               </div>
               <p className="text-sm font-medium text-gray-900 dark:text-gray-100">
-                {searchTerm
+                {searchTerm.trim()
                   ? 'No sites found matching your search.'
                   : 'No sites available'}
               </p>
-              {!searchTerm && (
+              {!searchTerm.trim() && (
                 <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
                   This {gridType} does not have any monitoring sites configured.
                 </p>

--- a/src/nexus/src/modules/data-download/components/SiteSelectionDialog.tsx
+++ b/src/nexus/src/modules/data-download/components/SiteSelectionDialog.tsx
@@ -3,6 +3,7 @@ import ReusableDialog from '@/shared/components/ui/dialog';
 import Checkbox from '@/shared/components/ui/checkbox';
 import { Button } from '@/shared/components/ui';
 import { Input } from '@/shared/components/ui/input';
+import { AqMarkerPin01 } from '@airqo/icons-react';
 import { GridSite } from '@/shared/types/api';
 
 const toNormalizedText = (value: unknown): string =>
@@ -153,7 +154,7 @@ export const SiteSelectionDialog: React.FC<SiteSelectionDialogProps> = ({
           {filteredSites.length === 0 ? (
             <div className="text-center py-8">
               <div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-gray-100 dark:bg-gray-800 mb-3">
-                <span className="text-gray-400 text-xl">&#128205;</span>
+                <AqMarkerPin01 className="w-6 h-6 text-gray-400" />
               </div>
               <p className="text-sm font-medium text-gray-900 dark:text-gray-100">
                 {searchTerm.trim()

--- a/src/nexus/src/modules/data-download/hooks/useDataExportActions.ts
+++ b/src/nexus/src/modules/data-download/hooks/useDataExportActions.ts
@@ -675,7 +675,7 @@ const shouldUseMetadataFallback = (error: unknown): boolean => {
     return false;
   }
 
-  return !status || status === 404 || status >= 500;
+  return status === 404 || (status !== undefined && status >= 500);
 };
 
 const hasDownloadRecords = (response: DataDownloadResponse | string) => {
@@ -1016,6 +1016,10 @@ export const useDataExportActions = (
             : rawResponse;
 
         if (!hasDownloadRecords(normalizedResponse)) {
+          toast.warning(
+            'No measurement data found',
+            'No readings are available for the selected time period and filters. Only location metadata has been included in this export.'
+          );
           return prepareMetadataFallback();
         }
 
@@ -1047,6 +1051,10 @@ export const useDataExportActions = (
         };
       } catch (error) {
         if (shouldUseMetadataFallback(error)) {
+          toast.warning(
+            'No measurement data found',
+            'No readings are available for the selected time period and filters. Only location metadata has been included in this export.'
+          );
           return prepareMetadataFallback();
         }
 

--- a/src/nexus/src/modules/data-download/hooks/useDataExportActions.ts
+++ b/src/nexus/src/modules/data-download/hooks/useDataExportActions.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import React, { useCallback, useRef } from 'react';
 import { useDispatch } from 'react-redux';
 import { usePostHog } from 'posthog-js/react';
 import { openMoreInsights } from '@/shared/store/insightsSlice';
@@ -39,6 +39,11 @@ export interface PreparedDownloadResult {
   activeTab: TabType;
   locationCount: number;
   summaryItems: Array<{ label: string; value: string }>;
+  partialDataWarning?: {
+    totalSelected: number;
+    withData: number;
+    missingNames: string[];
+  };
 }
 
 type MetadataRow = Record<string, unknown>;
@@ -690,6 +695,228 @@ const hasDownloadRecords = (response: DataDownloadResponse | string) => {
   return Array.isArray(response.data) && response.data.length > 0;
 };
 
+const getResponseLocationIds = (
+  response: DataDownloadResponse | string,
+  activeTab: TabType
+): Set<string> => {
+  const ids = new Set<string>();
+
+  if (typeof response === 'string') {
+    const rows = parseDownloadCsvRows(response);
+    if (rows.length < 2) return ids;
+    const headers = rows[0];
+
+    if (activeTab === 'devices') {
+      const deviceIdx = headers.findIndex(
+        h => h === 'device_id' || h === 'device_name'
+      );
+      if (deviceIdx === -1) return ids;
+      for (let i = 1; i < rows.length; i++) {
+        const val = rows[i]?.[deviceIdx]?.trim();
+        if (val) ids.add(val);
+      }
+    } else {
+      // For sites, countries, cities — extract all possible identifiers
+      const siteIdIdx = headers.findIndex(
+        h => h === 'site_id' || h === '_id' || h === 'id'
+      );
+      const siteNameIdx = headers.findIndex(
+        h => h === 'site_name' || h === 'name' || h === 'search_name'
+      );
+      for (let i = 1; i < rows.length; i++) {
+        if (siteIdIdx !== -1) {
+          const val = rows[i]?.[siteIdIdx]?.trim();
+          if (val) ids.add(val);
+        }
+        if (siteNameIdx !== -1) {
+          const val = rows[i]?.[siteNameIdx]?.trim();
+          if (val) ids.add(val);
+        }
+      }
+    }
+    return ids;
+  }
+
+  if (Array.isArray(response.data)) {
+    for (const item of response.data) {
+      if (activeTab === 'devices') {
+        const id = String(item.device_name ?? '').trim();
+        if (id) ids.add(id);
+      } else {
+        // For sites, countries, cities — extract all possible identifiers
+        const itemRecord = item as unknown as Record<string, unknown>;
+        const siteId = String(
+          itemRecord.site_id ?? itemRecord._id ?? itemRecord.id ?? ''
+        ).trim();
+        const siteName = String(
+          item.site_name ?? itemRecord.name ?? itemRecord.search_name ?? ''
+        ).trim();
+        if (siteId) ids.add(siteId);
+        if (siteName) ids.add(siteName);
+      }
+    }
+  }
+
+  return ids;
+};
+
+const buildPartialDataWarning = (
+  response: DataDownloadResponse | string,
+  activeTab: TabType,
+  selectedIds: string[],
+  selectedNames: string[],
+  gridData?: TableItem[]
+): { totalSelected: number; withData: number; missingNames: string[] } | undefined => {
+  if (selectedIds.length === 0) return undefined;
+
+  const responseIds = getResponseLocationIds(response, activeTab);
+  const missingNames: string[] = [];
+
+  // For countries/cities, build a mapping from GridSite._id to response site_name
+  const siteIdToResponseName =
+    activeTab === 'countries' || activeTab === 'cities'
+      ? buildSiteIdToResponseSiteNameMap(response, gridData || [])
+      : new Map<string, string>();
+
+  selectedIds.forEach((id, index) => {
+    const name = selectedNames[index] || id;
+    let hasData = false;
+
+    if (activeTab === 'countries' || activeTab === 'cities') {
+      // For countries/cities, check if the GridSite._id has a matching site_name in the response
+      const responseSiteName = siteIdToResponseName.get(id);
+      hasData =
+        responseIds.has(id) ||
+        responseIds.has(name) ||
+        (responseSiteName !== undefined && responseIds.has(responseSiteName)) ||
+        // Also check by name directly (in case selectedNames contains site names)
+        responseIds.has(name.toLowerCase()) ||
+        responseIds.has(id.toLowerCase());
+    } else {
+      // For sites/devices, direct comparison
+      hasData =
+        responseIds.has(id) ||
+        responseIds.has(name) ||
+        responseIds.has(name.toLowerCase()) ||
+        responseIds.has(id.toLowerCase());
+    }
+
+    if (!hasData) {
+      missingNames.push(name);
+    }
+  });
+
+  if (missingNames.length === 0 || missingNames.length === selectedIds.length) {
+    return undefined;
+  }
+
+  return {
+    totalSelected: selectedIds.length,
+    withData: selectedIds.length - missingNames.length,
+    missingNames,
+  };
+};
+
+export type PartialDataWarning = {
+  totalSelected: number;
+  withData: number;
+  missingNames: string[];
+};
+
+export { buildPartialDataWarning, getGridSiteNames };
+
+const getGridSiteNames = (
+  activeTab: TabType,
+  selectedGridIds: string[],
+  selectedGridSiteIds: Record<string, string[]>,
+  selectedGridSites: Record<string, string[]>,
+  gridData: TableItem[]
+): string[] => {
+  if (activeTab !== 'countries' && activeTab !== 'cities') return [];
+
+  const siteNames: string[] = [];
+  const siteIdToName = new Map<string, string>();
+
+  // Build lookup from grid data
+  gridData.forEach(grid => {
+    const sites = grid.sites as Array<{ _id: string; name: string }> | undefined;
+    if (sites) {
+      sites.forEach(site => {
+        if (site._id && site.name) {
+          siteIdToName.set(site._id, site.name);
+        }
+      });
+    }
+  });
+
+  // Get all selected site IDs and map to names
+  selectedGridIds.forEach(gridId => {
+    const customSites = selectedGridSiteIds[gridId];
+    const defaultSites = selectedGridSites[gridId];
+    const sites = customSites && customSites.length > 0 ? customSites : defaultSites || [];
+    sites.forEach(siteId => {
+      const name = siteIdToName.get(siteId) || siteId;
+      siteNames.push(name);
+    });
+  });
+
+  return siteNames;
+};
+
+const buildGridSiteIdToNameMap = (
+  gridData: TableItem[]
+): Map<string, string> => {
+  const map = new Map<string, string>();
+  gridData.forEach(grid => {
+    const sites = grid.sites as Array<{ _id: string; name: string }> | undefined;
+    if (sites) {
+      sites.forEach(site => {
+        if (site._id && site.name) {
+          map.set(site._id, site.name);
+        }
+      });
+    }
+  });
+  return map;
+};
+
+const buildSiteIdToResponseSiteNameMap = (
+  response: DataDownloadResponse | string,
+  gridData: TableItem[]
+): Map<string, string> => {
+  const gridSiteIdToName = buildGridSiteIdToNameMap(gridData);
+  const responseSiteNames = new Set<string>();
+
+  // Extract site names from response
+  if (typeof response === 'string') {
+    const rows = parseDownloadCsvRows(response);
+    if (rows.length < 2) return new Map();
+    const headers = rows[0];
+    const siteNameIdx = headers.findIndex(h => h === 'site_name');
+    if (siteNameIdx === -1) return new Map();
+    for (let i = 1; i < rows.length; i++) {
+      const val = rows[i]?.[siteNameIdx]?.trim();
+      if (val) responseSiteNames.add(val);
+    }
+  } else if (Array.isArray(response.data)) {
+    for (const item of response.data) {
+      const siteName = String(item.site_name ?? '').trim();
+      if (siteName) responseSiteNames.add(siteName);
+    }
+  }
+
+  // Build mapping: GridSite._id -> response site_name
+  // by matching grid site names against response site names
+  const result = new Map<string, string>();
+  gridSiteIdToName.forEach((gridSiteName, gridSiteId) => {
+    if (responseSiteNames.has(gridSiteName)) {
+      result.set(gridSiteId, gridSiteName);
+    }
+  });
+
+  return result;
+};
+
 const getCalendarDayDifference = (from: Date, to: Date) => {
   const startUtc = Date.UTC(
     from.getFullYear(),
@@ -789,6 +1016,7 @@ export const useDataExportActions = (
   const posthog = usePostHog();
   const { trigger: fetchDownloadData, isMutating: isDownloading } =
     useDownloadData();
+  const downloadAbortRef = useRef<AbortController | null>(null);
 
   interface HandleDownloadOptions {
     customSelectedGridSiteIds?: Record<string, string[]>;
@@ -892,6 +1120,12 @@ export const useDataExportActions = (
         frequency,
         deviceCategory,
       });
+
+      if (downloadAbortRef.current) {
+        downloadAbortRef.current.abort();
+      }
+      const abortController = new AbortController();
+      downloadAbortRef.current = abortController;
 
       trackFeatureUsage(posthog, 'data_export', 'download_started', {
         active_tab: activeTab,
@@ -1006,6 +1240,9 @@ export const useDataExportActions = (
 
       try {
         const rawResponse = await fetchDownloadData(request);
+
+        if (abortController.signal.aborted) return null;
+
         const normalizedResponse =
           activeTab === 'countries' || activeTab === 'cities'
             ? normalizeCountryCityDownloadResponse(
@@ -1033,6 +1270,47 @@ export const useDataExportActions = (
               ? selectedDeviceIds.length
               : sitesForDownload.length;
 
+        const countriesCitiesGridData =
+          activeTab === 'countries' ? countriesData : citiesData;
+        const gridSiteNames =
+          activeTab === 'countries' || activeTab === 'cities'
+            ? getGridSiteNames(
+                activeTab,
+                selectedGridIds,
+                effectiveSelectedGridSiteIds,
+                selectedGridSites,
+                countriesCitiesGridData
+              )
+            : [];
+
+        const partialDataWarning = buildPartialDataWarning(
+          normalizedResponse,
+          activeTab,
+          activeTab === 'sites'
+            ? selectedSiteIds
+            : activeTab === 'devices'
+              ? selectedDeviceIds
+              : sitesForDownload,
+          activeTab === 'sites'
+            ? selectedSites
+            : activeTab === 'devices'
+              ? selectedDevices
+              : gridSiteNames,
+          countriesCitiesGridData
+        );
+
+        if (partialDataWarning) {
+          const missingList = partialDataWarning.missingNames.slice(0, 3).join(', ');
+          const suffix =
+            partialDataWarning.missingNames.length > 3
+              ? ` and ${partialDataWarning.missingNames.length - 3} more`
+              : '';
+          toast.warning(
+            'Partial data returned',
+            `${partialDataWarning.withData} of ${partialDataWarning.totalSelected} selected locations returned data. No readings found for: ${missingList}${suffix}.`
+          );
+        }
+
         return {
           request,
           response: normalizedResponse,
@@ -1051,8 +1329,11 @@ export const useDataExportActions = (
             downloadColumnKeys,
             false
           ),
+          partialDataWarning,
         };
       } catch (error) {
+        if (abortController.signal.aborted) return null;
+
         if (shouldUseMetadataFallback(error)) {
           toast.warning(
             'No measurement data found',
@@ -1165,6 +1446,15 @@ export const useDataExportActions = (
     dispatch,
     posthog,
   ]);
+
+  // Cleanup abort controller on unmount
+  React.useEffect(() => {
+    return () => {
+      if (downloadAbortRef.current) {
+        downloadAbortRef.current.abort();
+      }
+    };
+  }, []);
 
   return {
     handleDownload,

--- a/src/nexus/src/modules/data-download/hooks/useDataExportActions.ts
+++ b/src/nexus/src/modules/data-download/hooks/useDataExportActions.ts
@@ -701,6 +701,11 @@ const getResponseLocationIds = (
 ): Set<string> => {
   const ids = new Set<string>();
 
+  const addId = (val: string) => {
+    ids.add(val);
+    ids.add(val.toLowerCase());
+  };
+
   if (typeof response === 'string') {
     const rows = parseDownloadCsvRows(response);
     if (rows.length < 2) return ids;
@@ -713,7 +718,7 @@ const getResponseLocationIds = (
       if (deviceIdx === -1) return ids;
       for (let i = 1; i < rows.length; i++) {
         const val = rows[i]?.[deviceIdx]?.trim();
-        if (val) ids.add(val);
+        if (val) addId(val);
       }
     } else {
       // For sites, countries, cities — extract all possible identifiers
@@ -726,11 +731,11 @@ const getResponseLocationIds = (
       for (let i = 1; i < rows.length; i++) {
         if (siteIdIdx !== -1) {
           const val = rows[i]?.[siteIdIdx]?.trim();
-          if (val) ids.add(val);
+          if (val) addId(val);
         }
         if (siteNameIdx !== -1) {
           const val = rows[i]?.[siteNameIdx]?.trim();
-          if (val) ids.add(val);
+          if (val) addId(val);
         }
       }
     }
@@ -741,7 +746,7 @@ const getResponseLocationIds = (
     for (const item of response.data) {
       if (activeTab === 'devices') {
         const id = String(item.device_name ?? '').trim();
-        if (id) ids.add(id);
+        if (id) addId(id);
       } else {
         // For sites, countries, cities — extract all possible identifiers
         const itemRecord = item as unknown as Record<string, unknown>;
@@ -751,8 +756,8 @@ const getResponseLocationIds = (
         const siteName = String(
           item.site_name ?? itemRecord.name ?? itemRecord.search_name ?? ''
         ).trim();
-        if (siteId) ids.add(siteId);
-        if (siteName) ids.add(siteName);
+        if (siteId) addId(siteId);
+        if (siteName) addId(siteName);
       }
     }
   }
@@ -772,41 +777,92 @@ const buildPartialDataWarning = (
   const responseIds = getResponseLocationIds(response, activeTab);
   const missingNames: string[] = [];
 
-  // For countries/cities, build a mapping from GridSite._id to response site_name
-  const siteIdToResponseName =
-    activeTab === 'countries' || activeTab === 'cities'
-      ? buildSiteIdToResponseSiteNameMap(response, gridData || [])
-      : new Map<string, string>();
+  if (activeTab === 'countries' || activeTab === 'cities') {
+    // For countries/cities, we need to match selected site IDs against response site names.
+    // Since grid.sites may be empty, we use two strategies:
+    // 1. If we have names (from grid.sites), try to match directly
+    // 2. Otherwise, count unique sites in response and compare against selected count
 
-  selectedIds.forEach((id, index) => {
-    const name = selectedNames[index] || id;
-    let hasData = false;
+    const siteIdToResponseName = buildSiteIdToResponseSiteNameMap(response, gridData || []);
 
-    if (activeTab === 'countries' || activeTab === 'cities') {
-      // For countries/cities, check if the GridSite._id has a matching site_name in the response
-      const responseSiteName = siteIdToResponseName.get(id);
-      hasData =
-        responseIds.has(id) ||
-        responseIds.has(name) ||
-        (responseSiteName !== undefined && responseIds.has(responseSiteName)) ||
-        // Also check by name directly (in case selectedNames contains site names)
-        responseIds.has(name.toLowerCase()) ||
-        responseIds.has(id.toLowerCase());
-    } else {
-      // For sites/devices, direct comparison
-      hasData =
-        responseIds.has(id) ||
-        responseIds.has(name) ||
-        responseIds.has(name.toLowerCase()) ||
-        responseIds.has(id.toLowerCase());
+    // Count unique sites that have data in the response
+    const responseSiteNames = new Set<string>();
+    if (typeof response === 'string') {
+      const rows = parseDownloadCsvRows(response);
+      if (rows.length >= 2) {
+        const headers = rows[0];
+        const siteNameIdx = headers.findIndex(
+          h => h === 'site_name' || h === 'name' || h === 'search_name'
+        );
+        if (siteNameIdx !== -1) {
+          for (let i = 1; i < rows.length; i++) {
+            const val = rows[i]?.[siteNameIdx]?.trim();
+            if (val) responseSiteNames.add(val.toLowerCase());
+          }
+        }
+      }
+    } else if (Array.isArray(response.data)) {
+      for (const item of response.data) {
+        const siteName = String(item.site_name ?? '').trim().toLowerCase();
+        if (siteName) responseSiteNames.add(siteName);
+      }
     }
 
-    if (!hasData) {
-      missingNames.push(name);
-    }
-  });
+    const sitesWithDataCount = responseSiteNames.size;
 
-  if (missingNames.length === 0 || missingNames.length === selectedIds.length) {
+    // Check each selected site
+    selectedIds.forEach((id, index) => {
+      const name = selectedNames[index];
+      let hasData = false;
+
+      if (name) {
+        // We have a human-readable name — try direct matching
+        const responseSiteName = siteIdToResponseName.get(id);
+        hasData =
+          responseIds.has(id) ||
+          responseIds.has(name) ||
+          (responseSiteName !== undefined && responseIds.has(responseSiteName)) ||
+          responseIds.has(name.toLowerCase()) ||
+          responseIds.has(id.toLowerCase());
+      } else {
+        // No name available — we can't determine if this specific site has data
+        // Mark as unknown (don't add to missingNames)
+        hasData = true; // Assume it might have data to avoid false warnings
+      }
+
+      if (!hasData) {
+        missingNames.push(name || `Site ${index + 1}`);
+      }
+    });
+
+    // If we couldn't resolve names but the response has fewer sites than selected,
+    // adjust the warning to be more accurate
+    if (missingNames.length === 0 && sitesWithDataCount > 0 && sitesWithDataCount < selectedIds.length) {
+      // Some sites are missing but we don't know which ones
+      const missingCount = selectedIds.length - sitesWithDataCount;
+      return {
+        totalSelected: selectedIds.length,
+        withData: sitesWithDataCount,
+        missingNames: [`${missingCount} site${missingCount > 1 ? 's' : ''} with no data`],
+      };
+    }
+  } else {
+    // For sites/devices, direct comparison
+    selectedIds.forEach((id, index) => {
+      const name = selectedNames[index] || id;
+      const hasData =
+        responseIds.has(id) ||
+        responseIds.has(name) ||
+        responseIds.has(name.toLowerCase()) ||
+        responseIds.has(id.toLowerCase());
+
+      if (!hasData) {
+        missingNames.push(name);
+      }
+    });
+  }
+
+  if (missingNames.length === 0) {
     return undefined;
   }
 
@@ -837,13 +893,21 @@ const getGridSiteNames = (
   const siteNames: string[] = [];
   const siteIdToName = new Map<string, string>();
 
-  // Build lookup from grid data
+  // Build lookup from grid data — handles both populated and empty sites arrays
   gridData.forEach(grid => {
-    const sites = grid.sites as Array<{ _id: string; name: string }> | undefined;
-    if (sites) {
+    const sites = grid.sites as Array<{
+      _id: string;
+      name: string;
+      search_name?: string;
+      formatted_name?: string;
+      location_name?: string;
+    }> | undefined;
+    if (sites && sites.length > 0) {
       sites.forEach(site => {
-        if (site._id && site.name) {
-          siteIdToName.set(site._id, site.name);
+        if (site._id) {
+          const name =
+            site.name || site.search_name || site.formatted_name || site.location_name || site._id;
+          siteIdToName.set(site._id, name);
         }
       });
     }
@@ -855,8 +919,11 @@ const getGridSiteNames = (
     const defaultSites = selectedGridSites[gridId];
     const sites = customSites && customSites.length > 0 ? customSites : defaultSites || [];
     sites.forEach(siteId => {
-      const name = siteIdToName.get(siteId) || siteId;
-      siteNames.push(name);
+      const name = siteIdToName.get(siteId);
+      if (name) {
+        siteNames.push(name);
+      }
+      // If no name found, don't add the raw ID — we'll handle this in the warning
     });
   });
 
@@ -868,11 +935,20 @@ const buildGridSiteIdToNameMap = (
 ): Map<string, string> => {
   const map = new Map<string, string>();
   gridData.forEach(grid => {
-    const sites = grid.sites as Array<{ _id: string; name: string }> | undefined;
+    const sites = grid.sites as Array<{
+      _id: string;
+      name: string;
+      search_name?: string;
+      formatted_name?: string;
+      location_name?: string;
+    }> | undefined;
     if (sites) {
       sites.forEach(site => {
-        if (site._id && site.name) {
-          map.set(site._id, site.name);
+        if (site._id) {
+          // Use the most readable name available
+          const name =
+            site.name || site.search_name || site.formatted_name || site.location_name || site._id;
+          map.set(site._id, name);
         }
       });
     }
@@ -884,10 +960,32 @@ const buildSiteIdToResponseSiteNameMap = (
   response: DataDownloadResponse | string,
   gridData: TableItem[]
 ): Map<string, string> => {
-  const gridSiteIdToName = buildGridSiteIdToNameMap(gridData);
-  const responseSiteNames = new Set<string>();
+  // Build a comprehensive lookup from grid site IDs to all possible names
+  const gridSiteIdToNames = new Map<string, Set<string>>();
+  gridData.forEach(grid => {
+    const sites = grid.sites as Array<{
+      _id: string;
+      name: string;
+      search_name?: string;
+      formatted_name?: string;
+      location_name?: string;
+    }> | undefined;
+    if (sites) {
+      sites.forEach(site => {
+        if (site._id) {
+          const names = new Set<string>();
+          if (site.name) names.add(site.name.toLowerCase());
+          if (site.search_name) names.add(site.search_name.toLowerCase());
+          if (site.formatted_name) names.add(site.formatted_name.toLowerCase());
+          if (site.location_name) names.add(site.location_name.toLowerCase());
+          gridSiteIdToNames.set(site._id, names);
+        }
+      });
+    }
+  });
 
   // Extract site names from response
+  const responseSiteNames = new Set<string>();
   if (typeof response === 'string') {
     const rows = parseDownloadCsvRows(response);
     if (rows.length < 2) return new Map();
@@ -895,22 +993,44 @@ const buildSiteIdToResponseSiteNameMap = (
     const siteNameIdx = headers.findIndex(h => h === 'site_name');
     if (siteNameIdx === -1) return new Map();
     for (let i = 1; i < rows.length; i++) {
-      const val = rows[i]?.[siteNameIdx]?.trim();
+      const val = rows[i]?.[siteNameIdx]?.trim().toLowerCase();
       if (val) responseSiteNames.add(val);
     }
   } else if (Array.isArray(response.data)) {
     for (const item of response.data) {
-      const siteName = String(item.site_name ?? '').trim();
+      const siteName = String(item.site_name ?? '').trim().toLowerCase();
       if (siteName) responseSiteNames.add(siteName);
     }
   }
 
   // Build mapping: GridSite._id -> response site_name
-  // by matching grid site names against response site names
+  // by checking if any of the grid site's names appear in the response
   const result = new Map<string, string>();
-  gridSiteIdToName.forEach((gridSiteName, gridSiteId) => {
-    if (responseSiteNames.has(gridSiteName)) {
-      result.set(gridSiteId, gridSiteName);
+  const gridSiteIdToName = buildGridSiteIdToNameMap(gridData);
+
+  gridSiteIdToNames.forEach((gridNames, gridSiteId) => {
+    const responseNameArray = Array.from(responseSiteNames);
+    const gridNameArray = Array.from(gridNames);
+    outer: for (const responseName of responseNameArray) {
+      for (const gridName of gridNameArray) {
+        // Exact match (case-insensitive)
+        if (responseName === gridName) {
+          result.set(gridSiteId, gridSiteIdToName.get(gridSiteId) || gridSiteId);
+          break outer;
+        }
+        // Partial match: shorter string must be at least half the length of longer one
+        // and must be at least 4 characters to avoid false positives
+        const shorter = responseName.length < gridName.length ? responseName : gridName;
+        const longer = responseName.length < gridName.length ? gridName : responseName;
+        if (
+          shorter.length >= 4 &&
+          shorter.length >= longer.length / 2 &&
+          longer.includes(shorter)
+        ) {
+          result.set(gridSiteId, gridSiteIdToName.get(gridSiteId) || gridSiteId);
+          break outer;
+        }
+      }
     }
   });
 

--- a/src/nexus/src/modules/data-download/hooks/useDataExportActions.ts
+++ b/src/nexus/src/modules/data-download/hooks/useDataExportActions.ts
@@ -675,7 +675,10 @@ const shouldUseMetadataFallback = (error: unknown): boolean => {
     return false;
   }
 
-  return status === 404 || (status !== undefined && status >= 500);
+  return (
+    status === 404 ||
+    (status !== undefined && status >= 500 && status < 600)
+  );
 };
 
 const hasDownloadRecords = (response: DataDownloadResponse | string) => {

--- a/src/nexus/src/modules/data-download/hooks/useDataExportActions.ts
+++ b/src/nexus/src/modules/data-download/hooks/useDataExportActions.ts
@@ -695,180 +695,88 @@ const hasDownloadRecords = (response: DataDownloadResponse | string) => {
   return Array.isArray(response.data) && response.data.length > 0;
 };
 
-const getResponseLocationIds = (
-  response: DataDownloadResponse | string,
-  activeTab: TabType
-): Set<string> => {
-  const ids = new Set<string>();
-
-  const addId = (val: string) => {
-    ids.add(val);
-    ids.add(val.toLowerCase());
-  };
-
-  if (typeof response === 'string') {
-    const rows = parseDownloadCsvRows(response);
-    if (rows.length < 2) return ids;
-    const headers = rows[0];
-
-    if (activeTab === 'devices') {
-      const deviceIdx = headers.findIndex(
-        h => h === 'device_id' || h === 'device_name'
-      );
-      if (deviceIdx === -1) return ids;
-      for (let i = 1; i < rows.length; i++) {
-        const val = rows[i]?.[deviceIdx]?.trim();
-        if (val) addId(val);
-      }
-    } else {
-      // For sites, countries, cities — extract all possible identifiers
-      const siteIdIdx = headers.findIndex(
-        h => h === 'site_id' || h === '_id' || h === 'id'
-      );
-      const siteNameIdx = headers.findIndex(
-        h => h === 'site_name' || h === 'name' || h === 'search_name'
-      );
-      for (let i = 1; i < rows.length; i++) {
-        if (siteIdIdx !== -1) {
-          const val = rows[i]?.[siteIdIdx]?.trim();
-          if (val) addId(val);
-        }
-        if (siteNameIdx !== -1) {
-          const val = rows[i]?.[siteNameIdx]?.trim();
-          if (val) addId(val);
-        }
-      }
-    }
-    return ids;
-  }
-
-  if (Array.isArray(response.data)) {
-    for (const item of response.data) {
-      if (activeTab === 'devices') {
-        const id = String(item.device_name ?? '').trim();
-        if (id) addId(id);
-      } else {
-        // For sites, countries, cities — extract all possible identifiers
-        const itemRecord = item as unknown as Record<string, unknown>;
-        const siteId = String(
-          itemRecord.site_id ?? itemRecord._id ?? itemRecord.id ?? ''
-        ).trim();
-        const siteName = String(
-          item.site_name ?? itemRecord.name ?? itemRecord.search_name ?? ''
-        ).trim();
-        if (siteId) addId(siteId);
-        if (siteName) addId(siteName);
-      }
-    }
-  }
-
-  return ids;
-};
-
 const buildPartialDataWarning = (
   response: DataDownloadResponse | string,
   activeTab: TabType,
   selectedIds: string[],
-  selectedNames: string[],
-  gridData?: TableItem[]
+  selectedNames: string[]
 ): { totalSelected: number; withData: number; missingNames: string[] } | undefined => {
   if (selectedIds.length === 0) return undefined;
 
-  const responseIds = getResponseLocationIds(response, activeTab);
-  const missingNames: string[] = [];
-
-  if (activeTab === 'countries' || activeTab === 'cities') {
-    // For countries/cities, we need to match selected site IDs against response site names.
-    // Since grid.sites may be empty, we use two strategies:
-    // 1. If we have names (from grid.sites), try to match directly
-    // 2. Otherwise, count unique sites in response and compare against selected count
-
-    const siteIdToResponseName = buildSiteIdToResponseSiteNameMap(response, gridData || []);
-
-    // Count unique sites that have data in the response
-    const responseSiteNames = new Set<string>();
-    if (typeof response === 'string') {
-      const rows = parseDownloadCsvRows(response);
-      if (rows.length >= 2) {
-        const headers = rows[0];
-        const siteNameIdx = headers.findIndex(
-          h => h === 'site_name' || h === 'name' || h === 'search_name'
-        );
-        if (siteNameIdx !== -1) {
-          for (let i = 1; i < rows.length; i++) {
-            const val = rows[i]?.[siteNameIdx]?.trim();
-            if (val) responseSiteNames.add(val.toLowerCase());
-          }
+  // Extract all site names from the response (normalized to lowercase for comparison)
+  const responseSiteNames = new Set<string>();
+  if (typeof response === 'string') {
+    const rows = parseDownloadCsvRows(response);
+    if (rows.length >= 2) {
+      const headers = rows[0];
+      const siteNameIdx = headers.findIndex(
+        h => h === 'site_name' || h === 'name' || h === 'search_name'
+      );
+      if (siteNameIdx !== -1) {
+        for (let i = 1; i < rows.length; i++) {
+          const val = rows[i]?.[siteNameIdx]?.trim().toLowerCase();
+          if (val) responseSiteNames.add(val);
         }
       }
-    } else if (Array.isArray(response.data)) {
-      for (const item of response.data) {
-        const siteName = String(item.site_name ?? '').trim().toLowerCase();
-        if (siteName) responseSiteNames.add(siteName);
-      }
     }
-
-    const sitesWithDataCount = responseSiteNames.size;
-
-    // Check each selected site
-    selectedIds.forEach((id, index) => {
-      const name = selectedNames[index];
-      let hasData = false;
-
-      if (name) {
-        // We have a human-readable name — try direct matching
-        const responseSiteName = siteIdToResponseName.get(id);
-        hasData =
-          responseIds.has(id) ||
-          responseIds.has(name) ||
-          (responseSiteName !== undefined && responseIds.has(responseSiteName)) ||
-          responseIds.has(name.toLowerCase()) ||
-          responseIds.has(id.toLowerCase());
-      } else {
-        // No name available — we can't determine if this specific site has data
-        // Mark as unknown (don't add to missingNames)
-        hasData = true; // Assume it might have data to avoid false warnings
-      }
-
-      if (!hasData) {
-        missingNames.push(name || `Site ${index + 1}`);
-      }
-    });
-
-    // If we couldn't resolve names but the response has fewer sites than selected,
-    // adjust the warning to be more accurate
-    if (missingNames.length === 0 && sitesWithDataCount > 0 && sitesWithDataCount < selectedIds.length) {
-      // Some sites are missing but we don't know which ones
-      const missingCount = selectedIds.length - sitesWithDataCount;
-      return {
-        totalSelected: selectedIds.length,
-        withData: sitesWithDataCount,
-        missingNames: [`${missingCount} site${missingCount > 1 ? 's' : ''} with no data`],
-      };
+  } else if (Array.isArray(response.data)) {
+    for (const item of response.data) {
+      const siteName = String(item.site_name ?? '').trim().toLowerCase();
+      if (siteName) responseSiteNames.add(siteName);
     }
-  } else {
-    // For sites/devices, direct comparison
-    selectedIds.forEach((id, index) => {
-      const name = selectedNames[index] || id;
-      const hasData =
-        responseIds.has(id) ||
-        responseIds.has(name) ||
-        responseIds.has(name.toLowerCase()) ||
-        responseIds.has(id.toLowerCase());
-
-      if (!hasData) {
-        missingNames.push(name);
-      }
-    });
   }
 
+  // Match selected site names against response site names
+  let sitesWithDataCount = 0;
+  const missingNames: string[] = [];
+  const matchedNames: string[] = [];
+
+  selectedNames.forEach((name) => {
+    if (!name) return;
+
+    const nameLower = name.toLowerCase().trim();
+    const hasData = responseSiteNames.has(nameLower);
+
+    if (hasData) {
+      sitesWithDataCount++;
+      matchedNames.push(name);
+    } else {
+      missingNames.push(name);
+    }
+  });
+
+  // If we matched some sites, return the warning with missing sites
+  if (sitesWithDataCount > 0 && missingNames.length > 0) {
+    return {
+      totalSelected: selectedIds.length,
+      withData: sitesWithDataCount,
+      missingNames,
+    };
+  }
+
+  // If NO names matched but response has data, the API returned different sites
+  // than what was selected. This is a backend filtering issue.
+  if (sitesWithDataCount === 0 && responseSiteNames.size > 0) {
+    const responseNamesList = Array.from(responseSiteNames).slice(0, 3);
+    return {
+      totalSelected: selectedIds.length,
+      withData: 0,
+      missingNames: [
+        `Data returned for different locations than selected`,
+        `Expected: ${selectedNames.filter(Boolean).slice(0, 2).join(', ') || 'selected sites'}`,
+        `Received: ${responseNamesList.join(', ') || 'unknown sites'}`,
+      ],
+    };
+  }
+
+  // All sites have data or no data at all
   if (missingNames.length === 0) {
     return undefined;
   }
 
   return {
     totalSelected: selectedIds.length,
-    withData: selectedIds.length - missingNames.length,
+    withData: sitesWithDataCount,
     missingNames,
   };
 };
@@ -928,113 +836,6 @@ const getGridSiteNames = (
   });
 
   return siteNames;
-};
-
-const buildGridSiteIdToNameMap = (
-  gridData: TableItem[]
-): Map<string, string> => {
-  const map = new Map<string, string>();
-  gridData.forEach(grid => {
-    const sites = grid.sites as Array<{
-      _id: string;
-      name: string;
-      search_name?: string;
-      formatted_name?: string;
-      location_name?: string;
-    }> | undefined;
-    if (sites) {
-      sites.forEach(site => {
-        if (site._id) {
-          // Use the most readable name available
-          const name =
-            site.name || site.search_name || site.formatted_name || site.location_name || site._id;
-          map.set(site._id, name);
-        }
-      });
-    }
-  });
-  return map;
-};
-
-const buildSiteIdToResponseSiteNameMap = (
-  response: DataDownloadResponse | string,
-  gridData: TableItem[]
-): Map<string, string> => {
-  // Build a comprehensive lookup from grid site IDs to all possible names
-  const gridSiteIdToNames = new Map<string, Set<string>>();
-  gridData.forEach(grid => {
-    const sites = grid.sites as Array<{
-      _id: string;
-      name: string;
-      search_name?: string;
-      formatted_name?: string;
-      location_name?: string;
-    }> | undefined;
-    if (sites) {
-      sites.forEach(site => {
-        if (site._id) {
-          const names = new Set<string>();
-          if (site.name) names.add(site.name.toLowerCase());
-          if (site.search_name) names.add(site.search_name.toLowerCase());
-          if (site.formatted_name) names.add(site.formatted_name.toLowerCase());
-          if (site.location_name) names.add(site.location_name.toLowerCase());
-          gridSiteIdToNames.set(site._id, names);
-        }
-      });
-    }
-  });
-
-  // Extract site names from response
-  const responseSiteNames = new Set<string>();
-  if (typeof response === 'string') {
-    const rows = parseDownloadCsvRows(response);
-    if (rows.length < 2) return new Map();
-    const headers = rows[0];
-    const siteNameIdx = headers.findIndex(h => h === 'site_name');
-    if (siteNameIdx === -1) return new Map();
-    for (let i = 1; i < rows.length; i++) {
-      const val = rows[i]?.[siteNameIdx]?.trim().toLowerCase();
-      if (val) responseSiteNames.add(val);
-    }
-  } else if (Array.isArray(response.data)) {
-    for (const item of response.data) {
-      const siteName = String(item.site_name ?? '').trim().toLowerCase();
-      if (siteName) responseSiteNames.add(siteName);
-    }
-  }
-
-  // Build mapping: GridSite._id -> response site_name
-  // by checking if any of the grid site's names appear in the response
-  const result = new Map<string, string>();
-  const gridSiteIdToName = buildGridSiteIdToNameMap(gridData);
-
-  gridSiteIdToNames.forEach((gridNames, gridSiteId) => {
-    const responseNameArray = Array.from(responseSiteNames);
-    const gridNameArray = Array.from(gridNames);
-    outer: for (const responseName of responseNameArray) {
-      for (const gridName of gridNameArray) {
-        // Exact match (case-insensitive)
-        if (responseName === gridName) {
-          result.set(gridSiteId, gridSiteIdToName.get(gridSiteId) || gridSiteId);
-          break outer;
-        }
-        // Partial match: shorter string must be at least half the length of longer one
-        // and must be at least 4 characters to avoid false positives
-        const shorter = responseName.length < gridName.length ? responseName : gridName;
-        const longer = responseName.length < gridName.length ? gridName : responseName;
-        if (
-          shorter.length >= 4 &&
-          shorter.length >= longer.length / 2 &&
-          longer.includes(shorter)
-        ) {
-          result.set(gridSiteId, gridSiteIdToName.get(gridSiteId) || gridSiteId);
-          break outer;
-        }
-      }
-    }
-  });
-
-  return result;
 };
 
 const getCalendarDayDifference = (from: Date, to: Date) => {
@@ -1228,6 +1029,7 @@ export const useDataExportActions = (
         dateRange,
         activeTab,
         selectedSites,
+        selectedSiteIds,
         selectedDeviceIds,
         selectedDeviceNames: selectedDevices,
         selectedGridIds,
@@ -1415,8 +1217,7 @@ export const useDataExportActions = (
             ? selectedSites
             : activeTab === 'devices'
               ? selectedDevices
-              : gridSiteNames,
-          countriesCitiesGridData
+              : gridSiteNames
         );
 
         if (partialDataWarning) {

--- a/src/nexus/src/modules/data-download/hooks/useDataExportActions.ts
+++ b/src/nexus/src/modules/data-download/hooks/useDataExportActions.ts
@@ -22,7 +22,6 @@ import {
 import { parseDownloadResponseRecords } from '../utils/dataExportFile';
 import {
   getMeasurementRecords,
-  getPartialDataWarning,
 } from '../utils/dataAvailability';
 import type {
   DataDownloadRequest,
@@ -46,11 +45,6 @@ export interface PreparedDownloadResult {
   activeTab: TabType;
   locationCount: number;
   summaryItems: Array<{ label: string; value: string }>;
-  partialDataWarning?: {
-    totalSelected: number;
-    withData: number;
-    missingNames: string[];
-  };
 }
 
 type MetadataRow = Record<string, unknown>;
@@ -1086,48 +1080,10 @@ export const useDataExportActions = (
               ? selectedDeviceIds.length
               : sitesForDownload.length;
 
-        const countriesCitiesGridData =
-          activeTab === 'countries' ? countriesData : citiesData;
-        const gridSiteNames =
-          activeTab === 'countries' || activeTab === 'cities'
-            ? getGridSiteNames(
-                activeTab,
-                selectedGridIds,
-                effectiveSelectedGridSiteIds,
-                selectedGridSites,
-                countriesCitiesGridData
-              )
-            : [];
-
-        const partialDataWarning = getPartialDataWarning(
-          normalizedResponse,
-          activeTab,
-          activeTab === 'sites'
-            ? selectedSiteIds
-            : activeTab === 'devices'
-              ? selectedDeviceIds
-              : sitesForDownload,
-          activeTab === 'sites'
-            ? selectedSites
-            : activeTab === 'devices'
-              ? selectedDevices
-              : gridSiteNames,
-          selectedPollutants
+        toast.success(
+          'Download ready',
+          `Your export for ${effectiveLocationCount} location${effectiveLocationCount !== 1 ? 's' : ''} is ready.`
         );
-
-        if (partialDataWarning) {
-          const missingList = partialDataWarning.missingNames
-            .slice(0, 3)
-            .join(', ');
-          const suffix =
-            partialDataWarning.missingNames.length > 3
-              ? ` and ${partialDataWarning.missingNames.length - 3} more`
-              : '';
-          toast.warning(
-            'Partial data returned',
-            `${partialDataWarning.withData} of ${partialDataWarning.totalSelected} selected locations returned data. No readings found for: ${missingList}${suffix}.`
-          );
-        }
 
         return {
           request,
@@ -1147,7 +1103,6 @@ export const useDataExportActions = (
             downloadColumnKeys,
             false
           ),
-          partialDataWarning,
         };
       } catch (error) {
         if (abortController.signal.aborted) return null;

--- a/src/nexus/src/modules/data-download/hooks/useDataExportActions.ts
+++ b/src/nexus/src/modules/data-download/hooks/useDataExportActions.ts
@@ -15,8 +15,15 @@ import {
   createSitesFromDevicesForVisualization,
   createSitesFromGridsForVisualization,
 } from '../utils/dataExportUtils';
-import { buildDataDownloadRequest } from '../utils/dataExportRequest';
-import { parseDownloadCsvRows } from '../utils/dataExportFile';
+import {
+  buildDataDownloadRequest,
+  resolveGridSitesForDownload,
+} from '../utils/dataExportRequest';
+import { parseDownloadResponseRecords } from '../utils/dataExportFile';
+import {
+  getMeasurementRecords,
+  getPartialDataWarning,
+} from '../utils/dataAvailability';
 import type {
   DataDownloadRequest,
   DataDownloadResponse,
@@ -470,9 +477,6 @@ interface GridLocationLookupEntry {
   locationName: string;
 }
 
-const isPlainRecord = (value: unknown): value is DownloadRecord =>
-  !!value && typeof value === 'object' && !Array.isArray(value);
-
 const getNormalizedString = (...values: unknown[]) =>
   getStringValue(...values) || '';
 
@@ -564,23 +568,7 @@ const normalizeCountryCityDownloadResponse = (
     selectedGridSiteIds
   );
 
-  const records: DownloadRecord[] =
-    typeof response === 'string'
-      ? (() => {
-          const rows = parseDownloadCsvRows(response);
-          const [headers = [], ...dataRows] = rows;
-
-          return dataRows.map(row => {
-            const record: DownloadRecord = {};
-
-            headers.forEach((header, index) => {
-              record[header] = row[index] ?? '';
-            });
-
-            return record;
-          });
-        })()
-      : response.data.map(item => (isPlainRecord(item) ? { ...item } : {}));
+  const records: DownloadRecord[] = parseDownloadResponseRecords(response);
 
   const enhancedRecords = records.map(record => {
     const recordSiteId = getNormalizedString(
@@ -681,113 +669,18 @@ const shouldUseMetadataFallback = (error: unknown): boolean => {
   }
 
   return (
-    status === 404 ||
-    (status !== undefined && status >= 500 && status < 600)
+    status === 404 || (status !== undefined && status >= 500 && status < 600)
   );
 };
 
-const hasDownloadRecords = (response: DataDownloadResponse | string) => {
-  if (typeof response === 'string') {
-    const [, ...dataRows] = parseDownloadCsvRows(response);
-    return dataRows.some(row => row.some(value => value.trim() !== ''));
-  }
-
-  return Array.isArray(response.data) && response.data.length > 0;
-};
-
-const buildPartialDataWarning = (
+const hasDownloadRecords = (
   response: DataDownloadResponse | string,
-  activeTab: TabType,
-  selectedIds: string[],
-  selectedNames: string[]
-): { totalSelected: number; withData: number; missingNames: string[] } | undefined => {
-  if (selectedIds.length === 0) return undefined;
-
-  // Extract all site names from the response (normalized to lowercase for comparison)
-  const responseSiteNames = new Set<string>();
-  if (typeof response === 'string') {
-    const rows = parseDownloadCsvRows(response);
-    if (rows.length >= 2) {
-      const headers = rows[0];
-      const siteNameIdx = headers.findIndex(
-        h => h === 'site_name' || h === 'name' || h === 'search_name'
-      );
-      if (siteNameIdx !== -1) {
-        for (let i = 1; i < rows.length; i++) {
-          const val = rows[i]?.[siteNameIdx]?.trim().toLowerCase();
-          if (val) responseSiteNames.add(val);
-        }
-      }
-    }
-  } else if (Array.isArray(response.data)) {
-    for (const item of response.data) {
-      const siteName = String(item.site_name ?? '').trim().toLowerCase();
-      if (siteName) responseSiteNames.add(siteName);
-    }
-  }
-
-  // Match selected site names against response site names
-  let sitesWithDataCount = 0;
-  const missingNames: string[] = [];
-  const matchedNames: string[] = [];
-
-  selectedNames.forEach((name) => {
-    if (!name) return;
-
-    const nameLower = name.toLowerCase().trim();
-    const hasData = responseSiteNames.has(nameLower);
-
-    if (hasData) {
-      sitesWithDataCount++;
-      matchedNames.push(name);
-    } else {
-      missingNames.push(name);
-    }
-  });
-
-  // If we matched some sites, return the warning with missing sites
-  if (sitesWithDataCount > 0 && missingNames.length > 0) {
-    return {
-      totalSelected: selectedIds.length,
-      withData: sitesWithDataCount,
-      missingNames,
-    };
-  }
-
-  // If NO names matched but response has data, the API returned different sites
-  // than what was selected. This is a backend filtering issue.
-  if (sitesWithDataCount === 0 && responseSiteNames.size > 0) {
-    const responseNamesList = Array.from(responseSiteNames).slice(0, 3);
-    return {
-      totalSelected: selectedIds.length,
-      withData: 0,
-      missingNames: [
-        `Data returned for different locations than selected`,
-        `Expected: ${selectedNames.filter(Boolean).slice(0, 2).join(', ') || 'selected sites'}`,
-        `Received: ${responseNamesList.join(', ') || 'unknown sites'}`,
-      ],
-    };
-  }
-
-  // All sites have data or no data at all
-  if (missingNames.length === 0) {
-    return undefined;
-  }
-
-  return {
-    totalSelected: selectedIds.length,
-    withData: sitesWithDataCount,
-    missingNames,
-  };
+  selectedPollutants: string[]
+) => {
+  return getMeasurementRecords(response, selectedPollutants).length > 0;
 };
 
-export type PartialDataWarning = {
-  totalSelected: number;
-  withData: number;
-  missingNames: string[];
-};
-
-export { buildPartialDataWarning, getGridSiteNames };
+export { getGridSiteNames };
 
 const getGridSiteNames = (
   activeTab: TabType,
@@ -803,18 +696,24 @@ const getGridSiteNames = (
 
   // Build lookup from grid data — handles both populated and empty sites arrays
   gridData.forEach(grid => {
-    const sites = grid.sites as Array<{
-      _id: string;
-      name: string;
-      search_name?: string;
-      formatted_name?: string;
-      location_name?: string;
-    }> | undefined;
+    const sites = grid.sites as
+      | Array<{
+          _id: string;
+          name: string;
+          search_name?: string;
+          formatted_name?: string;
+          location_name?: string;
+        }>
+      | undefined;
     if (sites && sites.length > 0) {
       sites.forEach(site => {
         if (site._id) {
           const name =
-            site.name || site.search_name || site.formatted_name || site.location_name || site._id;
+            site.name ||
+            site.search_name ||
+            site.formatted_name ||
+            site.location_name ||
+            site._id;
           siteIdToName.set(site._id, name);
         }
       });
@@ -823,9 +722,13 @@ const getGridSiteNames = (
 
   // Get all selected site IDs and map to names
   selectedGridIds.forEach(gridId => {
-    const customSites = selectedGridSiteIds[gridId];
-    const defaultSites = selectedGridSites[gridId];
-    const sites = customSites && customSites.length > 0 ? customSites : defaultSites || [];
+    const hasCustomSelection = Object.prototype.hasOwnProperty.call(
+      selectedGridSiteIds,
+      gridId
+    );
+    const sites = hasCustomSelection
+      ? selectedGridSiteIds[gridId] || []
+      : selectedGridSites[gridId] || [];
     sites.forEach(siteId => {
       const name = siteIdToName.get(siteId);
       if (name) {
@@ -983,16 +886,24 @@ export const useDataExportActions = (
       }
 
       const effectiveSelectedGridSiteIds =
-        customSelectedGridSiteIds || selectedGridSiteIds;
+        customSelectedGridSiteIds ?? selectedGridSiteIds;
+
+      const sitesForDownload =
+        activeTab === 'countries' || activeTab === 'cities'
+          ? resolveGridSitesForDownload(
+              selectedGridIds,
+              selectedGridSites,
+              effectiveSelectedGridSiteIds
+            )
+          : [];
 
       if (
         (activeTab === 'countries' || activeTab === 'cities') &&
-        Object.keys(effectiveSelectedGridSiteIds).length === 0 &&
-        Object.keys(selectedGridSites).length === 0
+        sitesForDownload.length === 0
       ) {
         toast.error(
           `${activeTab === 'countries' ? 'Country' : 'City'} Selection Required`,
-          `Please select a ${activeTab === 'countries' ? 'country' : 'city'} for data export.`
+          `Please select at least one monitoring site under the selected ${activeTab === 'countries' ? 'country' : 'city'}.`
         );
         return null;
       }
@@ -1079,23 +990,6 @@ export const useDataExportActions = (
         time_period_type: timePeriodType,
       });
 
-      // Extract sites for countries/cities
-      const sitesForDownload: string[] = [];
-      if (activeTab === 'countries' || activeTab === 'cities') {
-        const effectiveSelectedGridSiteIds =
-          customSelectedGridSiteIds || selectedGridSiteIds;
-        // For each selected grid, use custom selection if available, otherwise use default selection
-        selectedGridIds.forEach(gridId => {
-          const customSites = effectiveSelectedGridSiteIds[gridId];
-          const defaultSites = selectedGridSites[gridId];
-          const sites =
-            customSites && customSites.length > 0
-              ? customSites
-              : defaultSites || [];
-          sitesForDownload.push(...sites);
-        });
-      }
-
       const downloadColumnKeys = getDownloadColumnKeysForRequest(
         activeTab,
         exportColumnKeys
@@ -1177,7 +1071,7 @@ export const useDataExportActions = (
               )
             : rawResponse;
 
-        if (!hasDownloadRecords(normalizedResponse)) {
+        if (!hasDownloadRecords(normalizedResponse, selectedPollutants)) {
           toast.warning(
             'No measurement data found',
             'No readings are available for the selected time period and filters. Only location metadata has been included in this export.'
@@ -1205,7 +1099,7 @@ export const useDataExportActions = (
               )
             : [];
 
-        const partialDataWarning = buildPartialDataWarning(
+        const partialDataWarning = getPartialDataWarning(
           normalizedResponse,
           activeTab,
           activeTab === 'sites'
@@ -1217,11 +1111,14 @@ export const useDataExportActions = (
             ? selectedSites
             : activeTab === 'devices'
               ? selectedDevices
-              : gridSiteNames
+              : gridSiteNames,
+          selectedPollutants
         );
 
         if (partialDataWarning) {
-          const missingList = partialDataWarning.missingNames.slice(0, 3).join(', ');
+          const missingList = partialDataWarning.missingNames
+            .slice(0, 3)
+            .join(', ');
           const suffix =
             partialDataWarning.missingNames.length > 3
               ? ` and ${partialDataWarning.missingNames.length - 3} more`
@@ -1368,18 +1265,22 @@ export const useDataExportActions = (
     posthog,
   ]);
 
+  const cancelDownload = useCallback(() => {
+    downloadAbortRef.current?.abort();
+    downloadAbortRef.current = null;
+  }, []);
+
   // Cleanup abort controller on unmount
   React.useEffect(() => {
     return () => {
-      if (downloadAbortRef.current) {
-        downloadAbortRef.current.abort();
-      }
+      cancelDownload();
     };
-  }, []);
+  }, [cancelDownload]);
 
   return {
     handleDownload,
     handleVisualizeData,
     isDownloading,
+    cancelDownload,
   };
 };

--- a/src/nexus/src/modules/data-download/hooks/useDataExportData.ts
+++ b/src/nexus/src/modules/data-download/hooks/useDataExportData.ts
@@ -231,11 +231,6 @@ export const useDataExportData = (
     setSelectedDevices,
   ]);
 
-  // Reset device pagination when category changes
-  useEffect(() => {
-    // This effect is handled in the parent component
-  }, [deviceCategory]);
-
   return {
     sitesHook,
     devicesHook,

--- a/src/nexus/src/modules/data-download/utils/__tests__/dataAvailability.test.ts
+++ b/src/nexus/src/modules/data-download/utils/__tests__/dataAvailability.test.ts
@@ -1,0 +1,330 @@
+import {
+  getDataAvailability,
+  getPartialDataWarning,
+} from '../dataAvailability';
+import type { DataDownloadResponse } from '@/shared/types/api';
+
+const asDownloadResponse = (response: unknown) =>
+  response as DataDownloadResponse;
+
+describe('getPartialDataWarning', () => {
+  (['sites', 'countries', 'cities'] as const).forEach(activeTab => {
+    it(`uses site_name for the ${activeTab} tab when IDs are absent`, () => {
+      const response = ['site_name,pm2_5', 'Selected site,4.46'].join('\n');
+
+      expect(
+        getPartialDataWarning(
+          response,
+          activeTab,
+          ['site-1', 'site-2'],
+          ['Selected site', 'Missing site'],
+          ['pm2_5']
+        )
+      ).toEqual({
+        totalSelected: 2,
+        withData: 1,
+        missingNames: ['Missing site'],
+      });
+    });
+  });
+
+  it('uses device_name for the devices tab when IDs are absent', () => {
+    const response = ['device_name,pm2_5', 'AQ-1,4.46'].join('\n');
+
+    expect(
+      getPartialDataWarning(
+        response,
+        'devices',
+        ['device-1', 'device-2'],
+        ['AQ-1', 'AQ-2'],
+        ['pm2_5']
+      )
+    ).toEqual({
+      totalSelected: 2,
+      withData: 1,
+      missingNames: ['AQ-2'],
+    });
+  });
+
+  it('matches site rows by ID even when API and UI names differ', () => {
+    const response = [
+      'site_id,site_name,datetime',
+      'site-1,Siavonga,2026-07-27T00:00:00Z',
+    ].join('\n');
+
+    expect(
+      getPartialDataWarning(
+        response,
+        'sites',
+        ['site-1'],
+        ['Siavonga Monitoring Site']
+      )
+    ).toBeUndefined();
+  });
+
+  it('reports only selected IDs that are absent from a CSV response', () => {
+    const response = [
+      'site_id,site_name,datetime',
+      'site-1,Siavonga,2026-07-27T00:00:00Z',
+    ].join('\n');
+
+    expect(
+      getPartialDataWarning(
+        response,
+        'sites',
+        ['site-1', 'site-2'],
+        ['Siavonga', 'Kabwe']
+      )
+    ).toEqual({
+      totalSelected: 2,
+      withData: 1,
+      missingNames: ['Kabwe'],
+    });
+  });
+
+  it('handles JSON responses and device identifiers', () => {
+    const response = {
+      status: 'success',
+      message: 'ok',
+      data: [{ device_id: 'device-1', device_name: 'AQ-1' }],
+    };
+
+    expect(
+      getPartialDataWarning(
+        asDownloadResponse(response),
+        'devices',
+        ['device-1'],
+        ['AQ-1']
+      )
+    ).toBeUndefined();
+  });
+
+  it('handles JSON encoded as a string', () => {
+    const response = JSON.stringify({
+      status: 'success',
+      data: [{ site_id: 'site-1', site_name: 'Siavonga' }],
+    });
+
+    expect(
+      getPartialDataWarning(response, 'sites', ['site-1'], ['Other label'])
+    ).toBeUndefined();
+  });
+
+  it('treats an explicit empty success response as no data for every selection', () => {
+    const response = {
+      status: 'success',
+      message: 'No data found for the specified criteria.',
+      data: [],
+      metadata: null,
+    };
+
+    expect(
+      getPartialDataWarning(
+        asDownloadResponse(response),
+        'sites',
+        ['site-1'],
+        ['Kawempe Division'],
+        ['pm2_5']
+      )
+    ).toEqual({
+      totalSelected: 1,
+      withData: 0,
+      missingNames: ['Kawempe Division'],
+    });
+  });
+
+  it('matches duplicate selected names by occurrence instead of collapsing them', () => {
+    const response = [
+      'site_name,pm2_5',
+      'Kawempe Division,4.46',
+      'Kawempe Division,5.12',
+      'Kawempe Division,6.03',
+    ].join('\n');
+
+    expect(
+      getPartialDataWarning(
+        response,
+        'sites',
+        ['site-1', 'site-2'],
+        ['Kawempe Division', 'Kawempe Division'],
+        ['pm2_5']
+      )
+    ).toEqual({
+      totalSelected: 2,
+      withData: 1,
+      missingNames: ['Kawempe Division'],
+    });
+  });
+
+  it('falls back to verified names when returned IDs are not selected IDs', () => {
+    const response = [
+      'site_id,site_name,pm2_5',
+      'device-1,Selected site,4.46',
+    ].join('\n');
+
+    expect(
+      getPartialDataWarning(
+        response,
+        'sites',
+        ['site-1', 'site-2'],
+        ['Selected site', 'Missing site'],
+        ['pm2_5']
+      )
+    ).toEqual({
+      totalSelected: 2,
+      withData: 1,
+      missingNames: ['Missing site'],
+    });
+  });
+
+  it('checks search_name and location_name before rejecting an ID mismatch', () => {
+    const response = [
+      'site_id,site_name,search_name,location_name,pm2_5',
+      'backend-site-id,Backend label,Selected site,Selected site,4.46',
+    ].join('\n');
+
+    expect(
+      getPartialDataWarning(
+        response,
+        'sites',
+        ['selected-site-id', 'missing-site-id'],
+        ['Selected site', 'Missing site'],
+        ['pm2_5']
+      )
+    ).toEqual({
+      totalSelected: 2,
+      withData: 1,
+      missingNames: ['Missing site'],
+    });
+  });
+
+  it('counts unique locations rather than measurement rows', () => {
+    const response = [
+      'site_name,pm2_5',
+      'Lion Pride 1 - Serengeti 782,4.46',
+      'Lion Pride 1 - Serengeti 782,5.12',
+      'Lion Pride 1 - Serengeti 782,6.03',
+    ].join('\n');
+
+    expect(
+      getDataAvailability(
+        response,
+        'sites',
+        ['site-1', 'site-2', 'site-3'],
+        [
+          'Lion Pride 1 - Serengeti 782',
+          'Kawempe Division',
+          'Kanyama residential area',
+        ],
+        ['pm2_5']
+      )
+    ).toEqual({
+      totalSelected: 3,
+      withData: 1,
+      missingNames: ['Kawempe Division', 'Kanyama residential area'],
+    });
+  });
+
+  it('does not invent a missing-location warning without identifiers', () => {
+    const response = {
+      status: 'success',
+      data: [{ datetime: '2026-07-27T00:00:00Z', pm2_5: 4.46 }],
+    };
+
+    expect(
+      getPartialDataWarning(
+        asDownloadResponse(response),
+        'sites',
+        ['site-1', 'site-2'],
+        ['Siavonga', 'Kabwe']
+      )
+    ).toBeUndefined();
+  });
+
+  it('matches country and city site selections by site ID', () => {
+    const response = {
+      status: 'success',
+      data: [{ site_id: 'site-1', site_name: 'API name' }],
+    };
+
+    expect(
+      getPartialDataWarning(
+        asDownloadResponse(response),
+        'countries',
+        ['site-1'],
+        ['UI name']
+      )
+    ).toBeUndefined();
+  });
+
+  it('does not count metadata-only rows as pollutant readings', () => {
+    const response = [
+      'site_name,datetime,pm2_5',
+      'Site with data,2026-07-28 00:00:00Z,4.46',
+      'Metadata only,2026-07-28 00:00:00Z,',
+    ].join('\n');
+
+    expect(
+      getPartialDataWarning(
+        response,
+        'sites',
+        ['site-1', 'site-2'],
+        ['Site with data', 'Metadata only'],
+        ['pm2_5']
+      )
+    ).toEqual({
+      totalSelected: 2,
+      withData: 1,
+      missingNames: ['Metadata only'],
+    });
+  });
+
+  it('ignores response locations outside the current selection', () => {
+    const response = [
+      'site_name,datetime,pm2_5',
+      'Selected site,2026-07-28 00:00:00Z,4.46',
+      'Unverified site,2026-07-28 00:00:00Z,5.12',
+    ].join('\n');
+
+    expect(
+      getPartialDataWarning(
+        response,
+        'sites',
+        ['site-1', 'site-2'],
+        ['Selected site', 'Another selected site'],
+        ['pm2_5']
+      )
+    ).toEqual({
+      totalSelected: 2,
+      withData: 1,
+      missingNames: ['Another selected site'],
+    });
+  });
+
+  it('matches API names with compact spacing and ignores an extra site', () => {
+    const response = [
+      'site_name,pm2_5',
+      'Kanyamaresidentialarea,43.47',
+      'Kanyamaresidentialarea,32.98',
+      'ChungaDumpsite,36.16',
+    ].join('\n');
+
+    expect(
+      getDataAvailability(
+        response,
+        'sites',
+        ['site-1', 'site-2', 'site-3'],
+        [
+          'Fmbs University Of Yaounde 1 Melen Campus',
+          'Lusaka',
+          'Kanyama residential area',
+        ],
+        ['pm2_5']
+      )
+    ).toEqual({
+      totalSelected: 3,
+      withData: 1,
+      missingNames: ['Fmbs University Of Yaounde 1 Melen Campus', 'Lusaka'],
+    });
+  });
+});

--- a/src/nexus/src/modules/data-download/utils/__tests__/dataExportFile.test.ts
+++ b/src/nexus/src/modules/data-download/utils/__tests__/dataExportFile.test.ts
@@ -1,0 +1,24 @@
+import { parseDownloadResponseRecords } from '../dataExportFile';
+
+describe('parseDownloadResponseRecords', () => {
+  it('parses CSV responses into normalized records', () => {
+    const records = parseDownloadResponseRecords(
+      'site_id,site_name,pm2_5\nsite-1,Siavonga,4.46'
+    );
+
+    expect(records).toEqual([
+      { site_id: 'site-1', site_name: 'Siavonga', pm2_5: '4.46' },
+    ]);
+  });
+
+  it('parses JSON responses returned as text', () => {
+    const records = parseDownloadResponseRecords(
+      JSON.stringify({
+        status: 'success',
+        data: [{ site_id: 'site-1', pm2_5: 4.46 }],
+      })
+    );
+
+    expect(records).toEqual([{ site_id: 'site-1', pm2_5: 4.46 }]);
+  });
+});

--- a/src/nexus/src/modules/data-download/utils/__tests__/dataExportRequest.test.ts
+++ b/src/nexus/src/modules/data-download/utils/__tests__/dataExportRequest.test.ts
@@ -1,0 +1,98 @@
+import {
+  buildDataDownloadRequest,
+  resolveGridSitesForDownload,
+} from '../dataExportRequest';
+
+const dateRange = {
+  from: new Date('2026-01-02T12:00:00.000Z'),
+  to: new Date('2026-01-03T12:00:00.000Z'),
+};
+
+const baseArgs = {
+  dateRange,
+  selectedSites: [],
+  selectedSiteIds: [],
+  selectedDeviceIds: [],
+  selectedGridIds: [],
+  selectedGridSites: {},
+  selectedGridSiteIds: {},
+  selectedPollutants: ['pm2_5'],
+  dataType: 'raw',
+  fileType: 'csv',
+  frequency: 'daily',
+  deviceCategory: 'lowcost' as const,
+};
+
+describe('buildDataDownloadRequest', () => {
+  it('uses site IDs and no display-name selector for the sites tab', () => {
+    const request = buildDataDownloadRequest({
+      ...baseArgs,
+      activeTab: 'sites',
+      selectedSites: ['Displayed site name'],
+      selectedSiteIds: ['site-1'],
+    });
+
+    expect(request).toMatchObject({ sites: ['site-1'] });
+    expect(request.device_ids).toBeUndefined();
+    expect(request.device_names).toBeUndefined();
+  });
+
+  it('uses complete device names when they match the selected devices', () => {
+    const request = buildDataDownloadRequest({
+      ...baseArgs,
+      activeTab: 'devices',
+      selectedDeviceIds: ['device-1', 'device-2'],
+      selectedDeviceNames: ['AQ-1', 'AQ-2'],
+    });
+
+    expect(request.device_names).toEqual(['AQ-1', 'AQ-2']);
+    expect(request.device_ids).toBeUndefined();
+    expect(request.sites).toBeUndefined();
+  });
+
+  it('falls back to device IDs when names are incomplete', () => {
+    const request = buildDataDownloadRequest({
+      ...baseArgs,
+      activeTab: 'devices',
+      selectedDeviceIds: ['device-1', 'device-2'],
+      selectedDeviceNames: ['AQ-1'],
+    });
+
+    expect(request.device_ids).toEqual(['device-1', 'device-2']);
+    expect(request.device_names).toBeUndefined();
+  });
+
+  it('uses site IDs resolved from country/city grids', () => {
+    const request = buildDataDownloadRequest({
+      ...baseArgs,
+      activeTab: 'countries',
+      selectedGridIds: ['country-1'],
+      selectedGridSites: { 'country-1': ['site-1', 'site-2'] },
+      selectedGridSiteIds: {},
+    });
+
+    expect(request.sites).toEqual(['site-1', 'site-2']);
+    expect(request.device_ids).toBeUndefined();
+    expect(request.device_names).toBeUndefined();
+  });
+
+  it('honors an explicit empty custom grid selection instead of restoring defaults', () => {
+    expect(
+      resolveGridSitesForDownload(
+        ['country-1'],
+        { 'country-1': ['site-1'] },
+        { 'country-1': [] }
+      )
+    ).toEqual([]);
+
+    expect(() =>
+      buildDataDownloadRequest({
+        ...baseArgs,
+        activeTab: 'cities',
+        selectedGridIds: ['city-1'],
+        selectedGridSites: { 'city-1': ['site-1'] },
+        selectedGridSiteIds: { 'city-1': [] },
+      })
+    ).toThrow('At least one monitoring site');
+  });
+});

--- a/src/nexus/src/modules/data-download/utils/__tests__/dataExportUtils.test.ts
+++ b/src/nexus/src/modules/data-download/utils/__tests__/dataExportUtils.test.ts
@@ -1,0 +1,15 @@
+import { processSitesData } from '../dataExportUtils';
+
+describe('processSitesData', () => {
+  it('uses the canonical site document ID before legacy site_id values', () => {
+    const [site] = processSitesData([
+      {
+        _id: 'mongo-site-1',
+        site_id: 'legacy-site-1',
+        name: 'Kawempe Division',
+      },
+    ]);
+
+    expect(site.id).toBe('mongo-site-1');
+  });
+});

--- a/src/nexus/src/modules/data-download/utils/bannerUtils.tsx
+++ b/src/nexus/src/modules/data-download/utils/bannerUtils.tsx
@@ -156,7 +156,7 @@ export const getBannerNotification = ({
     return (
       <InfoBanner
         title="Ready to Export"
-        message="Your data export configuration is complete. Click 'Download Data' to start the export process."
+        message="Your data export configuration is complete. Click 'Review & Download' to preview and start the export process."
       />
     );
   }

--- a/src/nexus/src/modules/data-download/utils/bannerUtils.tsx
+++ b/src/nexus/src/modules/data-download/utils/bannerUtils.tsx
@@ -12,6 +12,7 @@ interface BannerNotificationProps {
   selectedSiteIds: string[];
   selectedDeviceIds: string[];
   selectedGridIds: string[];
+  selectedGridSiteCount: number;
   selectedPollutants: string[];
   deviceCategory: DeviceCategory;
   isDownloadReady: boolean;
@@ -31,6 +32,7 @@ export const getBannerNotification = ({
   selectedSiteIds,
   selectedDeviceIds,
   selectedGridIds,
+  selectedGridSiteCount,
   selectedPollutants,
   deviceCategory,
   isDownloadReady,
@@ -112,6 +114,18 @@ export const getBannerNotification = ({
       <WarningBanner
         title="Location Selection Required"
         message={`Please select at least one ${locationTypeLabel} to include in your data export.`}
+      />
+    );
+  }
+
+  if (
+    (activeTab === 'countries' || activeTab === 'cities') &&
+    selectedGridSiteCount === 0
+  ) {
+    return (
+      <WarningBanner
+        title="Monitoring Site Selection Required"
+        message={`The selected ${activeTab === 'countries' ? 'country' : 'city'} has no monitoring sites selected. Choose at least one site before exporting.`}
       />
     );
   }

--- a/src/nexus/src/modules/data-download/utils/dataAvailability.ts
+++ b/src/nexus/src/modules/data-download/utils/dataAvailability.ts
@@ -1,0 +1,278 @@
+import type { DataDownloadResponse } from '@/shared/types/api';
+import type { TabType } from '../types/dataExportTypes';
+import { parseDownloadResponseRecords } from './dataExportFile';
+
+export interface PartialDataWarning {
+  totalSelected: number;
+  withData: number;
+  missingNames: string[];
+}
+
+type DownloadRecord = Record<string, unknown>;
+
+const normalizeValue = (value: unknown): string =>
+  typeof value === 'string' || typeof value === 'number'
+    ? String(value).trim().toLowerCase()
+    : '';
+
+const normalizeLabel = (value: unknown): string =>
+  normalizeValue(value)
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[,_-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+const normalizeMatchLabel = (value: unknown): string =>
+  normalizeLabel(value).replace(/\s+/g, '');
+
+const normalizeKey = (value: string): string =>
+  value
+    .trim()
+    .toLowerCase()
+    .replace(/[\s-]+/g, '_');
+
+const getRecordValue = (record: DownloadRecord, aliases: string[]): string => {
+  const normalizedRecord = Object.entries(record).reduce(
+    (values, [key, value]) => {
+      values[normalizeKey(key)] = value;
+      return values;
+    },
+    {} as Record<string, unknown>
+  );
+
+  for (const alias of aliases) {
+    const value = normalizeValue(normalizedRecord[normalizeKey(alias)]);
+    if (value) return value;
+  }
+
+  return '';
+};
+
+const getRecordValues = (
+  record: DownloadRecord,
+  aliases: string[]
+): string[] => {
+  const normalizedRecord = Object.entries(record).reduce(
+    (values, [key, value]) => {
+      values[normalizeKey(key)] = value;
+      return values;
+    },
+    {} as Record<string, unknown>
+  );
+
+  return Array.from(
+    new Set(
+      aliases
+        .map(alias => normalizeValue(normalizedRecord[normalizeKey(alias)]))
+        .filter(Boolean)
+    )
+  );
+};
+
+const getIdentifierAliases = (activeTab: TabType) => {
+  if (activeTab === 'devices') {
+    return {
+      ids: ['device_id', 'deviceId'],
+      names: ['device_name', 'deviceName', 'name'],
+    };
+  }
+
+  return {
+    ids: ['site_id', 'siteId', '_id'],
+    names: [
+      'site_name',
+      'siteName',
+      'name',
+      'search_name',
+      'formatted_name',
+      'location_name',
+    ],
+  };
+};
+
+const getMeasurementAliases = (pollutant: string): string[] => {
+  const normalizedPollutant = pollutant.trim();
+  if (!normalizedPollutant) return [];
+
+  return [
+    normalizedPollutant,
+    `${normalizedPollutant}_value`,
+    `${normalizedPollutant}_calibrated_value`,
+    `s1_${normalizedPollutant}`,
+    `s2_${normalizedPollutant}`,
+  ];
+};
+
+const hasMeasurementValue = (
+  record: DownloadRecord,
+  selectedPollutants: string[]
+): boolean => {
+  const aliases = selectedPollutants.flatMap(getMeasurementAliases);
+
+  return aliases.some(alias => {
+    const value = getRecordValue(record, [alias]);
+    return (
+      value !== '' &&
+      value !== '--' &&
+      value !== 'null' &&
+      Number.isFinite(Number(value))
+    );
+  });
+};
+
+export const getMeasurementRecords = (
+  response: DataDownloadResponse | string,
+  selectedPollutants?: string[]
+): DownloadRecord[] => {
+  const records = parseDownloadResponseRecords(response);
+  if (!selectedPollutants?.length) return records;
+
+  return records.filter(record =>
+    hasMeasurementValue(record, selectedPollutants)
+  );
+};
+
+const getSelectedLabels = (selectedIds: string[], selectedLabels: string[]) =>
+  selectedIds.map((id, index) => {
+    const label = selectedLabels[index]?.trim();
+    return label || id;
+  });
+
+const countValues = (values: string[]) => {
+  const counts = new Map<string, number>();
+  values.forEach(value => counts.set(value, (counts.get(value) || 0) + 1));
+  return counts;
+};
+
+/**
+ * Determines availability from the complete API response.
+ *
+ * An explicitly successful empty response is authoritative: it means none of
+ * the selected locations has a reading for the requested filters. For
+ * non-empty responses, IDs are preferred when every returned record has a
+ * selected ID. Otherwise, names are used only when every returned record can
+ * be matched to the selected names. This prevents a response for a different
+ * location from being counted as data for the current selection.
+ */
+export const getDataAvailability = (
+  response: DataDownloadResponse | string,
+  activeTab: TabType,
+  selectedIds: string[],
+  selectedLabels: string[],
+  selectedPollutants?: string[]
+): PartialDataWarning | undefined => {
+  const normalizedSelectedIds = Array.from(
+    new Set(selectedIds.map(normalizeValue).filter(Boolean))
+  );
+  if (normalizedSelectedIds.length === 0) return undefined;
+
+  const records = getMeasurementRecords(response, selectedPollutants);
+  const labels = getSelectedLabels(normalizedSelectedIds, selectedLabels);
+
+  if (records.length === 0) {
+    return {
+      totalSelected: normalizedSelectedIds.length,
+      withData: 0,
+      missingNames: labels,
+    };
+  }
+
+  const aliases = getIdentifierAliases(activeTab);
+  const responseIds = new Set<string>();
+  const responseNames = new Set<string>();
+
+  records.forEach(record => {
+    const identifier = getRecordValue(record, aliases.ids);
+    if (identifier) responseIds.add(identifier);
+    getRecordValues(record, aliases.names).forEach(name =>
+      responseNames.add(normalizeLabel(name))
+    );
+  });
+
+  const allRecordsHaveIds = records.every(record =>
+    Boolean(getRecordValue(record, aliases.ids))
+  );
+  const canMatchById =
+    allRecordsHaveIds &&
+    responseIds.size > 0 &&
+    Array.from(responseIds).every(responseId =>
+      normalizedSelectedIds.includes(responseId)
+    );
+
+  if (canMatchById) {
+    const missingNames = labels.filter(
+      (_, index) => !responseIds.has(normalizedSelectedIds[index])
+    );
+
+    return {
+      totalSelected: normalizedSelectedIds.length,
+      withData: normalizedSelectedIds.length - missingNames.length,
+      missingNames,
+    };
+  }
+
+  // Names are a safe fallback only when every selected item has a usable
+  // label. Response locations outside the selection are ignored below.
+  if (
+    responseNames.size === 0 ||
+    selectedLabels.length < normalizedSelectedIds.length
+  ) {
+    return undefined;
+  }
+
+  const selectedNameCounts = countValues(labels.map(normalizeMatchLabel));
+  // Multiple readings for one location must count as one available location.
+  // Ignore response locations outside the current selection. The API may
+  // return extra rows, but they must never be credited to selected locations.
+  const responseNameCounts = countValues(
+    Array.from(responseNames)
+      .map(normalizeMatchLabel)
+      .filter(name => selectedNameCounts.has(name))
+  );
+
+  const matchedNameCounts = new Map<string, number>();
+  const missingNames = labels.filter(label => {
+    const normalizedLabel = normalizeMatchLabel(label);
+    const matchedCount = matchedNameCounts.get(normalizedLabel) || 0;
+    const availableCount = responseNameCounts.get(normalizedLabel) || 0;
+
+    if (matchedCount < availableCount) {
+      matchedNameCounts.set(normalizedLabel, matchedCount + 1);
+      return false;
+    }
+
+    return true;
+  });
+
+  return {
+    totalSelected: normalizedSelectedIds.length,
+    withData: normalizedSelectedIds.length - missingNames.length,
+    missingNames,
+  };
+};
+
+/**
+ * Returns a warning only when at least one selected location is missing data.
+ * The full availability summary remains useful to preview totals even when
+ * every selected location has data.
+ */
+export const getPartialDataWarning = (
+  response: DataDownloadResponse | string,
+  activeTab: TabType,
+  selectedIds: string[],
+  selectedLabels: string[],
+  selectedPollutants?: string[]
+): PartialDataWarning | undefined => {
+  const availability = getDataAvailability(
+    response,
+    activeTab,
+    selectedIds,
+    selectedLabels,
+    selectedPollutants
+  );
+
+  return availability && availability.missingNames.length > 0
+    ? availability
+    : undefined;
+};

--- a/src/nexus/src/modules/data-download/utils/dataAvailability.ts
+++ b/src/nexus/src/modules/data-download/utils/dataAvailability.ts
@@ -32,43 +32,42 @@ const normalizeKey = (value: string): string =>
     .toLowerCase()
     .replace(/[\s-]+/g, '_');
 
-const getRecordValue = (record: DownloadRecord, aliases: string[]): string => {
-  const normalizedRecord = Object.entries(record).reduce(
-    (values, [key, value]) => {
-      values[normalizeKey(key)] = value;
-      return values;
-    },
-    {} as Record<string, unknown>
-  );
+const normalizeRecordKeys = (record: DownloadRecord): Record<string, unknown> =>
+  Object.entries(record).reduce((values, [key, value]) => {
+    values[normalizeKey(key)] = value;
+    return values;
+  }, {} as Record<string, unknown>);
 
+const pickNormalizedValue = (
+  normalizedRecord: Record<string, unknown>,
+  aliases: string[]
+): string => {
   for (const alias of aliases) {
     const value = normalizeValue(normalizedRecord[normalizeKey(alias)]);
     if (value) return value;
   }
-
   return '';
 };
 
-const getRecordValues = (
-  record: DownloadRecord,
+const pickNormalizedValues = (
+  normalizedRecord: Record<string, unknown>,
   aliases: string[]
-): string[] => {
-  const normalizedRecord = Object.entries(record).reduce(
-    (values, [key, value]) => {
-      values[normalizeKey(key)] = value;
-      return values;
-    },
-    {} as Record<string, unknown>
-  );
-
-  return Array.from(
+): string[] =>
+  Array.from(
     new Set(
       aliases
         .map(alias => normalizeValue(normalizedRecord[normalizeKey(alias)]))
         .filter(Boolean)
     )
   );
-};
+
+const getRecordValue = (record: DownloadRecord, aliases: string[]): string =>
+  pickNormalizedValue(normalizeRecordKeys(record), aliases);
+
+const getRecordValues = (
+  record: DownloadRecord,
+  aliases: string[]
+): string[] => pickNormalizedValues(normalizeRecordKeys(record), aliases);
 
 const getIdentifierAliases = (activeTab: TabType) => {
   if (activeTab === 'devices') {
@@ -133,12 +132,6 @@ export const getMeasurementRecords = (
   );
 };
 
-const getSelectedLabels = (selectedIds: string[], selectedLabels: string[]) =>
-  selectedIds.map((id, index) => {
-    const label = selectedLabels[index]?.trim();
-    return label || id;
-  });
-
 const countValues = (values: string[]) => {
   const counts = new Map<string, number>();
   values.forEach(value => counts.set(value, (counts.get(value) || 0) + 1));
@@ -162,13 +155,24 @@ export const getDataAvailability = (
   selectedLabels: string[],
   selectedPollutants?: string[]
 ): PartialDataWarning | undefined => {
-  const normalizedSelectedIds = Array.from(
-    new Set(selectedIds.map(normalizeValue).filter(Boolean))
-  );
-  if (normalizedSelectedIds.length === 0) return undefined;
+  // Pair IDs with labels before deduplication to preserve alignment
+  const seenIds = new Set<string>();
+  const selectedPairs = selectedIds
+    .map((id, index) => ({
+      id: normalizeValue(id),
+      label: selectedLabels[index]?.trim() || '',
+    }))
+    .filter(pair => {
+      if (!pair.id || seenIds.has(pair.id)) return false;
+      seenIds.add(pair.id);
+      return true;
+    });
+  if (selectedPairs.length === 0) return undefined;
+
+  const normalizedSelectedIds = selectedPairs.map(pair => pair.id);
 
   const records = getMeasurementRecords(response, selectedPollutants);
-  const labels = getSelectedLabels(normalizedSelectedIds, selectedLabels);
+  const labels = selectedPairs.map(pair => pair.label || pair.id);
 
   if (records.length === 0) {
     return {

--- a/src/nexus/src/modules/data-download/utils/dataExportFile.ts
+++ b/src/nexus/src/modules/data-download/utils/dataExportFile.ts
@@ -221,6 +221,53 @@ const parseCsvRows = (csvText: string): string[][] => {
 export const parseDownloadCsvRows = (csvText: string): string[][] =>
   parseCsvRows(csvText);
 
+/**
+ * Converts either API response format into records for previews and file
+ * transforms. Axios normally gives JSON responses as objects, but accepting a
+ * JSON string here also keeps the export flow safe when content negotiation
+ * returns the body as text.
+ */
+export const parseDownloadResponseRecords = (
+  response: DataDownloadResponse | string
+): DownloadRecord[] => {
+  if (typeof response !== 'string') {
+    return Array.isArray(response?.data)
+      ? response.data.map(item =>
+          normalizeDownloadRecord(isPlainObject(item) ? item : {})
+        )
+      : [];
+  }
+
+  const trimmedResponse = response.trim();
+  if (trimmedResponse.startsWith('{') || trimmedResponse.startsWith('[')) {
+    try {
+      const parsed: unknown = JSON.parse(trimmedResponse);
+      const records = Array.isArray(parsed)
+        ? parsed
+        : parsed && typeof parsed === 'object' && 'data' in parsed
+          ? (parsed as { data?: unknown }).data
+          : [];
+
+      if (Array.isArray(records)) {
+        return records.map(item =>
+          normalizeDownloadRecord(isPlainObject(item) ? item : {})
+        );
+      }
+    } catch {
+      // Fall through to CSV parsing for malformed/non-JSON text responses.
+    }
+  }
+
+  const [headers = [], ...dataRows] = parseCsvRows(response);
+  return dataRows.map(row => {
+    const record: DownloadRecord = {};
+    headers.forEach((header, index) => {
+      record[header] = row[index] ?? '';
+    });
+    return normalizeDownloadRecord(record);
+  });
+};
+
 const escapeCsvValue = (value: unknown) => {
   if (value === null || value === undefined) {
     return '""';
@@ -354,29 +401,35 @@ const resolveSelectedHeaders = (
 
 const extractDownloadRecords = (response: DataDownloadResponse | string) => {
   if (typeof response === 'string') {
-    const rows = parseCsvRows(response);
-    const [headers = [], ...dataRows] = rows;
-
-    const records = dataRows.map(row => {
-      const record: DownloadRecord = {};
-
-      headers.forEach((header, index) => {
-        record[header] = row[index] ?? '';
-      });
-
-      return normalizeDownloadRecord(record);
-    });
+    const records = parseDownloadResponseRecords(response);
+    const trimmedResponse = response.trim();
+    const isJsonResponse =
+      trimmedResponse.startsWith('{') || trimmedResponse.startsWith('[');
+    const parsedJson = isJsonResponse
+      ? (() => {
+          try {
+            return JSON.parse(trimmedResponse);
+          } catch {
+            return null;
+          }
+        })()
+      : null;
+    const responseObject =
+      parsedJson && !Array.isArray(parsedJson) && typeof parsedJson === 'object'
+        ? ({
+            ...(parsedJson as Record<string, unknown>),
+            data: records,
+          } as unknown as DataDownloadResponse)
+        : null;
 
     return {
       records,
-      headers,
-      responseObject: null as DataDownloadResponse | null,
+      headers: getRecordHeaders(records),
+      responseObject,
     };
   }
 
-  const records = response.data.map(item =>
-    normalizeDownloadRecord(isPlainObject(item) ? item : {})
-  );
+  const records = parseDownloadResponseRecords(response);
 
   return {
     records,

--- a/src/nexus/src/modules/data-download/utils/dataExportFile.ts
+++ b/src/nexus/src/modules/data-download/utils/dataExportFile.ts
@@ -398,9 +398,7 @@ export const getDownloadColumnGroups = (
       ? { key: 'site_name', label: 'Site name' }
       : activeTab === 'devices'
         ? { key: 'device_name', label: 'Device name' }
-        : activeTab === 'countries'
-          ? { key: 'country_name', label: 'Country name' }
-          : { key: 'city_name', label: 'City name' };
+        : { key: 'site_name', label: 'Site name' };
 
   const uniquePollutants = Array.from(
     new Set(selectedPollutants.filter(Boolean))

--- a/src/nexus/src/modules/data-download/utils/dataExportFile.ts
+++ b/src/nexus/src/modules/data-download/utils/dataExportFile.ts
@@ -248,11 +248,12 @@ export const parseDownloadResponseRecords = (
           ? (parsed as { data?: unknown }).data
           : [];
 
-      if (Array.isArray(records)) {
-        return records.map(item =>
-          normalizeDownloadRecord(isPlainObject(item) ? item : {})
-        );
-      }
+      // Valid JSON — return even if records is not an array (empty list).
+      return Array.isArray(records)
+        ? records.map(item =>
+            normalizeDownloadRecord(isPlainObject(item) ? item : {})
+          )
+        : [];
     } catch {
       // Fall through to CSV parsing for malformed/non-JSON text responses.
     }

--- a/src/nexus/src/modules/data-download/utils/dataExportRequest.ts
+++ b/src/nexus/src/modules/data-download/utils/dataExportRequest.ts
@@ -5,8 +5,9 @@ import { DeviceCategory, TabType } from '../types/dataExportTypes';
 interface BuildDataDownloadRequestArgs {
   dateRange: DateRange | undefined;
   activeTab: TabType;
-  selectedSites: string[];
-  selectedSiteIds?: string[];
+  /** Human-readable site names are intentionally not used for site exports. */
+  selectedSites?: string[];
+  selectedSiteIds: string[];
   selectedDeviceIds: string[];
   selectedDeviceNames?: string[];
   selectedGridIds: string[];
@@ -38,26 +39,51 @@ const toUtcDayEndIso = (date: Date) =>
     )
   ).toISOString();
 
-const resolveGridSitesForDownload = (
+const normalizeSelection = (values: string[] | undefined): string[] =>
+  Array.from(
+    new Set((values ?? []).map(value => String(value).trim()).filter(Boolean))
+  );
+
+export const resolveGridSitesForDownload = (
   selectedGridIds: string[],
   selectedGridSites: Record<string, string[]>,
   selectedGridSiteIds: Record<string, string[]>
-) => {
-  const sitesForDownload: string[] = [];
+) =>
+  normalizeSelection(
+    selectedGridIds.flatMap(gridId => {
+      const hasCustomSelection = Object.prototype.hasOwnProperty.call(
+        selectedGridSiteIds,
+        gridId
+      );
 
-  selectedGridIds.forEach(gridId => {
-    const hasCustomSelection = Object.prototype.hasOwnProperty.call(
-      selectedGridSiteIds,
-      gridId
-    );
-    const customSites = selectedGridSiteIds[gridId];
-    const defaultSites = selectedGridSites[gridId];
-    const sites = hasCustomSelection ? customSites || [] : defaultSites || [];
+      // An explicit custom selection, including [], is authoritative. Never
+      // silently turn an intentional empty selection back into "all sites".
+      return hasCustomSelection
+        ? (selectedGridSiteIds[gridId] ?? [])
+        : (selectedGridSites[gridId] ?? []);
+    })
+  );
 
-    sitesForDownload.push(...sites);
-  });
+const getDeviceSelector = (
+  selectedDeviceIds: string[],
+  selectedDeviceNames?: string[]
+): { device_ids: string[] } | { device_names: string[] } => {
+  const deviceIds = normalizeSelection(selectedDeviceIds);
+  const deviceNames = normalizeSelection(selectedDeviceNames);
 
-  return sitesForDownload;
+  // Names are only safe when they map one-to-one to the current selection.
+  // Otherwise use IDs, which are the authoritative table selection values.
+  if (deviceNames.length === deviceIds.length && deviceNames.length > 0) {
+    return { device_names: deviceNames };
+  }
+
+  if (deviceIds.length > 0) {
+    return { device_ids: deviceIds };
+  }
+
+  throw new Error(
+    'At least one device ID or device name is required for export'
+  );
 };
 
 export const buildDataDownloadRequest = ({
@@ -85,13 +111,31 @@ export const buildDataDownloadRequest = ({
       ? 'raw'
       : (dataType as DataDownloadRequest['datatype']);
 
-  const effectiveGridSiteIds = customSelectedGridSiteIds || selectedGridSiteIds;
+  const normalizedSiteIds = normalizeSelection(selectedSiteIds);
+  const effectiveGridSiteIds = customSelectedGridSiteIds ?? selectedGridSiteIds;
 
   const sitesForDownload = resolveGridSitesForDownload(
     selectedGridIds,
     selectedGridSites,
     effectiveGridSiteIds
   );
+
+  const selection =
+    activeTab === 'sites'
+      ? normalizedSiteIds.length > 0
+        ? { sites: normalizedSiteIds }
+        : (() => {
+            throw new Error('At least one site ID is required for export');
+          })()
+      : activeTab === 'devices'
+        ? getDeviceSelector(selectedDeviceIds, selectedDeviceNames)
+        : sitesForDownload.length > 0
+          ? { sites: sitesForDownload }
+          : (() => {
+              throw new Error(
+                'At least one monitoring site is required for country or city export'
+              );
+            })();
 
   return {
     datatype: effectiveDataType,
@@ -108,13 +152,6 @@ export const buildDataDownloadRequest = ({
       activeTab === 'countries' || activeTab === 'cities'
         ? 'lowcost'
         : deviceCategory,
-    ...(activeTab === 'sites' && { sites: selectedSiteIds || [] }),
-    ...(activeTab === 'devices' &&
-      (selectedDeviceNames && selectedDeviceNames.length > 0
-        ? { device_names: selectedDeviceNames }
-        : { device_ids: selectedDeviceIds })),
-    ...((activeTab === 'countries' || activeTab === 'cities') && {
-      sites: sitesForDownload,
-    }),
+    ...selection,
   };
 };

--- a/src/nexus/src/modules/data-download/utils/dataExportRequest.ts
+++ b/src/nexus/src/modules/data-download/utils/dataExportRequest.ts
@@ -6,6 +6,7 @@ interface BuildDataDownloadRequestArgs {
   dateRange: DateRange | undefined;
   activeTab: TabType;
   selectedSites: string[];
+  selectedSiteIds?: string[];
   selectedDeviceIds: string[];
   selectedDeviceNames?: string[];
   selectedGridIds: string[];
@@ -62,7 +63,7 @@ const resolveGridSitesForDownload = (
 export const buildDataDownloadRequest = ({
   dateRange,
   activeTab,
-  selectedSites,
+  selectedSiteIds,
   selectedDeviceIds,
   selectedGridIds,
   selectedGridSites,
@@ -107,7 +108,7 @@ export const buildDataDownloadRequest = ({
       activeTab === 'countries' || activeTab === 'cities'
         ? 'lowcost'
         : deviceCategory,
-    ...(activeTab === 'sites' && { sites: selectedSites }),
+    ...(activeTab === 'sites' && { sites: selectedSiteIds || [] }),
     ...(activeTab === 'devices' &&
       (selectedDeviceNames && selectedDeviceNames.length > 0
         ? { device_names: selectedDeviceNames }

--- a/src/nexus/src/modules/data-download/utils/dataExportUtils.ts
+++ b/src/nexus/src/modules/data-download/utils/dataExportUtils.ts
@@ -85,7 +85,7 @@ export const processDevicesData = (
       (device.device_id as string | number) ||
       (device._id as string | number) ||
       index,
-    name: (device.name as string) || '--',
+    name: getFirstNonEmptyString(device.name, device.device_name, (device as Record<string, unknown>).search_name, (device as Record<string, unknown>).formatted_name) || '--',
     network: ((device.network as string) || '--').toUpperCase(),
     category: (device.category as string) || '--',
   }));
@@ -124,18 +124,20 @@ export const getDefaultDateRange = () => {
 };
 
 /**
- * Maps device IDs to device names for API calls
+ * Maps device IDs to device names for API calls.
+ * Preserves order and includes the device ID as fallback when name is missing.
  */
 export const mapDeviceIdsToNames = (
   deviceIds: string[],
   devicesData: TableItem[]
 ): string[] => {
-  return deviceIds
-    .map(id => {
-      const device = devicesData.find(item => String(item.id) === id);
-      return device?.name as string;
-    })
-    .filter(Boolean);
+  return deviceIds.map(id => {
+    const device = devicesData.find(item => String(item.id) === id);
+    if (device?.name && device.name !== '--') {
+      return device.name as string;
+    }
+    return id;
+  });
 };
 
 /**

--- a/src/nexus/src/modules/data-download/utils/dataExportUtils.ts
+++ b/src/nexus/src/modules/data-download/utils/dataExportUtils.ts
@@ -26,7 +26,7 @@ const getFirstNonEmptyString = (...values: unknown[]): string | undefined => {
   return undefined;
 };
 
-const getSiteDisplayName = (site?: SiteNameSource): string => {
+export const getSiteDisplayName = (site?: SiteNameSource): string => {
   const displayName =
     getFirstNonEmptyString(
       site?.search_name,
@@ -59,8 +59,8 @@ export const processSitesData = (
   return sitesData.map((site, index) => ({
     ...site,
     id:
-      (site.site_id as string | number) ||
       (site._id as string | number) ||
+      (site.site_id as string | number) ||
       index,
     name: getSiteDisplayName(site as SiteNameSource),
     city: removeUnderscores((site.city as string) || '--'),
@@ -85,7 +85,13 @@ export const processDevicesData = (
       (device.device_id as string | number) ||
       (device._id as string | number) ||
       index,
-    name: getFirstNonEmptyString(device.name, device.device_name, (device as Record<string, unknown>).search_name, (device as Record<string, unknown>).formatted_name) || '--',
+    name:
+      getFirstNonEmptyString(
+        device.name,
+        device.device_name,
+        (device as Record<string, unknown>).search_name,
+        (device as Record<string, unknown>).formatted_name
+      ) || '--',
     network: ((device.network as string) || '--').toUpperCase(),
     category: (device.category as string) || '--',
   }));

--- a/src/nexus/src/shared/components/ui/checkbox.tsx
+++ b/src/nexus/src/shared/components/ui/checkbox.tsx
@@ -10,6 +10,7 @@ export type CheckboxProps = Omit<
 > & {
   onCheckedChange?: (checked: boolean) => void;
   indeterminate?: boolean;
+  label?: React.ReactNode;
 };
 
 const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
@@ -20,6 +21,7 @@ const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
       checked: controlledChecked,
       defaultChecked,
       indeterminate = false,
+      label,
       ...props
     },
     ref
@@ -90,6 +92,7 @@ const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
             )}
           </span>
         </span>
+        {label && <span className="ml-2">{label}</span>}
       </label>
     );
   }

--- a/src/nexus/src/shared/hooks/useDevice.ts
+++ b/src/nexus/src/shared/hooks/useDevice.ts
@@ -29,8 +29,9 @@ import { normalizeCohortIds } from '../utils/cohortUtils';
 
 const SWR_STABLE_REQUEST_OPTIONS = {
   revalidateOnFocus: false,
-  revalidateOnReconnect: false,
-  shouldRetryOnError: false,
+  revalidateOnReconnect: true,
+  shouldRetryOnError: true,
+  errorRetryCount: 2,
   dedupingInterval: 5000,
 } as const;
 
@@ -54,19 +55,22 @@ const useAbortableFetcher = <T>(
 ) => {
   const abortRef = useRef<AbortController | null>(null);
 
-  useEffect(() => {
-    return () => {
-      abortRef.current?.abort();
-    };
-  }, []);
-
   return useCallback(async () => {
+    // Abort any previous in-flight request
     abortRef.current?.abort();
     const controller = new AbortController();
     abortRef.current = controller;
 
     try {
       return await fetcher(controller.signal);
+    } catch (error) {
+      // Don't throw AbortError — SWR treats errors as permanent failures.
+      // AbortError means the request was cancelled (e.g. new request started),
+      // not that something went wrong. SWR will retry with the new fetcher.
+      if (isAbortError(error)) {
+        return undefined as T;
+      }
+      throw error;
     } finally {
       if (abortRef.current === controller) {
         abortRef.current = null;
@@ -86,6 +90,9 @@ const useCohortSitesQuery = (
   enabled = true,
   cohortsLoading = false
 ) => {
+  const cohortsLoadingRef = useRef(cohortsLoading);
+  cohortsLoadingRef.current = cohortsLoading;
+
   const shouldFetch = enabled && cohortIds.length > 0 && !cohortsLoading;
 
   const key = shouldFetch
@@ -101,7 +108,7 @@ const useCohortSitesQuery = (
 
   const result = useSWR<CohortSitesResponse>(key, fetchCohortSites, {
     ...SWR_STABLE_REQUEST_OPTIONS,
-    isPaused: () => cohortsLoading,
+    isPaused: () => cohortsLoadingRef.current,
   });
   const resolvedError = isAbortError(result.error) ? null : result.error;
   const hasData = typeof result.data !== 'undefined';
@@ -120,6 +127,9 @@ const useCohortDevicesQuery = (
   enabled = true,
   cohortsLoading = false
 ) => {
+  const cohortsLoadingRef = useRef(cohortsLoading);
+  cohortsLoadingRef.current = cohortsLoading;
+
   const shouldFetch = enabled && cohortIds.length > 0 && !cohortsLoading;
 
   const key = shouldFetch
@@ -135,7 +145,7 @@ const useCohortDevicesQuery = (
 
   const result = useSWR<CohortDevicesResponse>(key, fetchCohortDevices, {
     ...SWR_STABLE_REQUEST_OPTIONS,
-    isPaused: () => cohortsLoading,
+    isPaused: () => cohortsLoadingRef.current,
   });
   const resolvedError = isAbortError(result.error) ? null : result.error;
   const hasData = typeof result.data !== 'undefined';

--- a/src/nexus/src/shared/hooks/useDevice.ts
+++ b/src/nexus/src/shared/hooks/useDevice.ts
@@ -30,8 +30,7 @@ import { normalizeCohortIds } from '../utils/cohortUtils';
 const SWR_STABLE_REQUEST_OPTIONS = {
   revalidateOnFocus: false,
   revalidateOnReconnect: true,
-  shouldRetryOnError: true,
-  errorRetryCount: 2,
+  shouldRetryOnError: false,
   dedupingInterval: 5000,
 } as const;
 
@@ -55,6 +54,13 @@ const useAbortableFetcher = <T>(
 ) => {
   const abortRef = useRef<AbortController | null>(null);
 
+  // Cleanup abort controller on unmount to prevent memory leaks
+  useEffect(() => {
+    return () => {
+      abortRef.current?.abort();
+    };
+  }, []);
+
   return useCallback(async () => {
     // Abort any previous in-flight request
     abortRef.current?.abort();
@@ -64,12 +70,9 @@ const useAbortableFetcher = <T>(
     try {
       return await fetcher(controller.signal);
     } catch (error) {
-      // Don't throw AbortError — SWR treats errors as permanent failures.
-      // AbortError means the request was cancelled (e.g. new request started),
-      // not that something went wrong. SWR will retry with the new fetcher.
-      if (isAbortError(error)) {
-        return undefined as T;
-      }
+      // Let AbortError propagate — SWR sets error but useCohortSitesQuery
+      // suppresses it via isAbortError check. This prevents SWR from treating
+      // cancellation as a successful value or triggering unnecessary retries.
       throw error;
     } finally {
       if (abortRef.current === controller) {


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

#### Status of maturity (all need to be checked before merging):

- [x] I've tested this locally
- [x] I consider this code done

#### Screenshots (optional)
<img width="1134" height="861" alt="image" src="https://github.com/user-attachments/assets/84024535-68ca-4103-b8a8-99e588e121d6" />
<img width="1217" height="1178" alt="image" src="https://github.com/user-attachments/assets/3c256c58-2c58-4dc8-b1f5-b51b65374d80" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pre-download previews with loading, error, retry, CSV, and metadata-only support.
  * Added data-availability warnings and clearer summaries for selected locations and monitoring sites.
* **Bug Fixes**
  * Improved device names, site identifiers, grid selections, preview freshness, and download retry handling.
  * Canceled pending downloads when settings or group selections change.
* **UI Improvements**
  * Added confirmation prompts before changing tabs or clearing selections.
  * Updated download states, guidance, optional file titles, responsive layouts, empty states, and PDF descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->