### PR TITLE
fix: correct calendar off-by-one day bug and unify date preset logic

### DIFF
--- a/src/nexus/src/shared/components/calendar/components/Calendar.tsx
+++ b/src/nexus/src/shared/components/calendar/components/Calendar.tsx
@@ -25,7 +25,10 @@ const dateUtils = {
   startOfWeek: (date: Date) => {
     const d = new Date(date);
     const day = d.getDay();
-    d.setDate(d.getDate() - day);
+    // Weeks start on Monday: Mon=0, Tue=1, ..., Sun=6
+    // getDay() returns: Sun=0, Mon=1, ..., Sat=6
+    // Formula: (day + 6) % 7 converts Mon-start offset
+    d.setDate(d.getDate() - ((day + 6) % 7));
     return d;
   },
 
@@ -139,7 +142,9 @@ export function Calendar({
       const month = dateUtils.addMonths(displayMonth, i);
       const start = dateUtils.startOfWeek(dateUtils.startOfMonth(month));
       const end = new Date(dateUtils.endOfMonth(month));
-      end.setDate(end.getDate() + (6 - end.getDay()));
+      // Extend to end of week (Sunday) for Monday-start weeks
+      // (7 - getDay()) % 7 adds 0 for Sunday, 6 for Monday, etc.
+      end.setDate(end.getDate() + ((7 - end.getDay()) % 7));
 
       return {
         month,

--- a/src/nexus/src/shared/components/calendar/components/CalendarFooter.tsx
+++ b/src/nexus/src/shared/components/calendar/components/CalendarFooter.tsx
@@ -26,10 +26,30 @@ const dateUtils = {
       'Nov',
       'Dec',
     ];
+    const fullMonths = [
+      'January',
+      'February',
+      'March',
+      'April',
+      'May',
+      'June',
+      'July',
+      'August',
+      'September',
+      'October',
+      'November',
+      'December',
+    ];
 
     switch (format) {
       case 'full':
         return `${months[date.getMonth()]} ${date.getDate()}, ${date.getFullYear()}`;
+      case 'month-year':
+        return `${fullMonths[date.getMonth()]} ${date.getFullYear()}`;
+      case 'short-month':
+        return months[date.getMonth()];
+      case 'day':
+        return date.getDate().toString();
       default:
         return date.toDateString();
     }

--- a/src/nexus/src/shared/components/calendar/components/RangeCalendar.tsx
+++ b/src/nexus/src/shared/components/calendar/components/RangeCalendar.tsx
@@ -3,49 +3,7 @@
 import React, { useCallback } from 'react';
 import { Calendar } from './Calendar';
 import { DateRange } from '../types';
-
-// Preset configurations
-const getPresets = () => {
-  const today = new Date();
-  return [
-    { label: 'Today', from: today, to: today },
-    {
-      label: 'Yesterday',
-      from: new Date(today.getTime() - 24 * 60 * 60 * 1000),
-      to: new Date(today.getTime() - 24 * 60 * 60 * 1000),
-    },
-    {
-      label: 'Last 7 days',
-      from: new Date(today.getTime() - 6 * 24 * 60 * 60 * 1000),
-      to: today,
-    },
-    {
-      label: 'Last 30 days',
-      from: new Date(today.getTime() - 29 * 24 * 60 * 60 * 1000),
-      to: today,
-    },
-    {
-      label: 'Last 90 days',
-      from: new Date(today.getTime() - 89 * 24 * 60 * 60 * 1000),
-      to: today,
-    },
-    {
-      label: 'This month',
-      from: new Date(today.getFullYear(), today.getMonth(), 1),
-      to: new Date(today.getFullYear(), today.getMonth() + 1, 0),
-    },
-    {
-      label: 'This year',
-      from: new Date(today.getFullYear(), 0, 1),
-      to: new Date(today.getFullYear(), 11, 31),
-    },
-    {
-      label: 'Last year',
-      from: new Date(today.getFullYear() - 1, 0, 1),
-      to: new Date(today.getFullYear() - 1, 11, 31),
-    },
-  ];
-};
+import { DateUtils } from '../utils/date-utils';
 
 interface RangeCalendarProps {
   showPresets?: boolean;
@@ -70,8 +28,8 @@ export function RangeCalendar({
   );
 
   const handlePresetSelect = useCallback(
-    (preset: { from: Date; to: Date }) => {
-      const presetRange = { from: preset.from, to: preset.to };
+    (preset: { label: string; value: DateRange }) => {
+      const presetRange = { from: preset.value.from, to: preset.value.to };
       setSelectedRange(presetRange);
       onApply?.(presetRange);
     },
@@ -82,7 +40,7 @@ export function RangeCalendar({
     setSelectedRange(range);
   }, []);
 
-  const presets = getPresets();
+  const presets = DateUtils.getDefaultPresets();
 
   const presetSidebar = showPresets ? (
     <div

--- a/src/nexus/src/shared/components/calendar/components/RangeCalendar.tsx
+++ b/src/nexus/src/shared/components/calendar/components/RangeCalendar.tsx
@@ -10,7 +10,6 @@ interface RangeCalendarProps {
   onApply?: (value: DateRange) => void;
   onCancel?: () => void;
   initialRange?: DateRange;
-  onPresetSelect?: (value: DateRange) => void;
 }
 
 export function RangeCalendar({

--- a/src/nexus/src/shared/components/calendar/utils/date-utils.ts
+++ b/src/nexus/src/shared/components/calendar/utils/date-utils.ts
@@ -81,7 +81,7 @@ export class DateUtils {
   }
 
   static getDefaultPresets(): CalendarPreset[] {
-    const today = new Date();
+    const today = startOfDay(new Date());
 
     return [
       {

--- a/src/nexus/src/shared/components/calendar/utils/date-utils.ts
+++ b/src/nexus/src/shared/components/calendar/utils/date-utils.ts
@@ -73,8 +73,9 @@ export class DateUtils {
   }
 
   static getCalendarDays(displayMonth: Date): Date[] {
-    const start = startOfWeek(startOfMonth(displayMonth));
-    const end = endOfWeek(endOfMonth(displayMonth));
+    // Weeks start on Monday (weekStartsOn: 1)
+    const start = startOfWeek(startOfMonth(displayMonth), { weekStartsOn: 1 });
+    const end = endOfWeek(endOfMonth(displayMonth), { weekStartsOn: 1 });
 
     return eachDayOfInterval({ start, end });
   }
@@ -100,6 +101,10 @@ export class DateUtils {
         value: { from: subDays(today, 29), to: today },
       },
       {
+        label: 'Last 90 days',
+        value: { from: subDays(today, 89), to: today },
+      },
+      {
         label: 'This month',
         value: { from: startOfMonth(today), to: endOfMonth(today) },
       },
@@ -114,6 +119,13 @@ export class DateUtils {
         label: 'This year',
         value: { from: startOfYear(today), to: endOfYear(today) },
       },
+      {
+        label: 'Last year',
+        value: {
+          from: startOfYear(subMonths(today, 12)),
+          to: endOfYear(subMonths(today, 12)),
+        },
+      },
     ];
   }
 
@@ -122,7 +134,7 @@ export class DateUtils {
   }
 
   static getWeekdays(): string[] {
-    return ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'];
+    return ['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su'];
   }
 
   static getMonthNames(): string[] {


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

#### Status of maturity (all need to be checked before merging):

- [x] I've tested this locally
- [x] I consider this code done

#### Screenshots (optional)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added “Last 90 days” and “Last year” date-range presets.
  * Added support for full month names and clearer date formats in calendar displays.

* **Improvements**
  * Calendar weeks and weekday labels now start on Monday.
  * Month views consistently run from Monday through Sunday.
  * Date-range preset selection is more consistent and uses normalized day boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->