### PR TITLE
De-brand mobile selfie filter and add save-to-photos flow.

### DIFF
--- a/src/mobile/assets/icons/download-01.svg
+++ b/src/mobile/assets/icons/download-01.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M21 15V16.2C21 17.8802 21 18.7202 20.673 19.362C20.3854 19.9265 19.9265 20.3854 19.362 20.673C18.7202 21 17.8802 21 16.2 21H7.8C6.11984 21 5.27976 21 4.63803 20.673C4.07354 20.3854 3.6146 19.9265 3.32698 19.362C3 18.7202 3 17.8802 3 16.2V15M17 10L12 15M12 15L7 10M12 15V3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/mobile/ios/Runner/Info.plist
+++ b/src/mobile/ios/Runner/Info.plist
@@ -36,6 +36,8 @@
 	<string>AirQo needs access to your location to show relevant air quality data for your area and help you find nearby air quality monitoring stations.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>AirQo needs photo library access to let you select profile pictures and attach images for feedback.</string>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>AirQo needs permission to save your air quality selfie filter to your photo library.</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>GMSApiKey</key>

--- a/src/mobile/lib/src/app/dashboard/utils/clean_air_forum_branding.dart
+++ b/src/mobile/lib/src/app/dashboard/utils/clean_air_forum_branding.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:intl/intl.dart';
 
-/// Branding for the Africa Clean Air Forum selfie filter, based on the
-/// "AQ/CAF" Figma templates (file `Z0OLd2awVqgZhytJULgO8L`, node 169:534 /
-/// 169:491).
+/// Visual theme for the AirQo selfie filter, based on the "AQ/CAF" Figma
+/// templates (file `Z0OLd2awVqgZhytJULgO8L`, node 169:534 / 169:491).
 ///
 /// All templates were designed on a 1080x1080 canvas — [kCafReferenceWidth]
 /// — so every size/gap in [CleanAirForumFilterCard] and
@@ -14,28 +14,28 @@ import 'package:flutter_svg/flutter_svg.dart';
 class CleanAirForumBrand {
   const CleanAirForumBrand._();
 
-  /// "Vibrant sky blue" — matches the Africa Clean Air Network palette.
-  static const Color skyBlue = Color(0xFF1E9BE0);
-
-  /// "Nature green" — matches the Africa Clean Air Network palette.
-  static const Color natureGreen = Color(0xFF2FA84F);
-
-  /// Deep teal used for the filter card's bottom scrim, matching the Figma
-  /// "AQ/CAF" template.
+  /// Deep teal used for the filter card's bottom scrim (default option).
   static const Color scrimTeal = Color(0xFF005257);
 
-  /// Text color for the "Shared from the AirQo app" pill/caption, matching
-  /// the Figma template exactly (distinct from [scrimTeal]).
+  /// Text color for the "Shared from the AirQo app" pill/caption.
   static const Color sharedCaptionText = Color(0xFF1F3D3D);
+}
 
-  /// Wordmark shown top-left on the selfie filter card.
-  static const String title = 'Africa Clean Air Forum';
+/// Selectable bottom-scrim colors for the selfie filter overlay.
+enum FilterScrimColor {
+  teal('Teal', Color(0xFF005257)),
+  airqoBlue('AirQo blue', Color(0xFF145FFF)),
+  pink('Pink', Color(0xFFE8538F));
 
-  /// Host city + year shown under the [title] wordmark.
-  static const String edition = 'Pretoria 2026';
+  final String label;
+  final Color color;
 
-  /// Event date range shown in the corner of the filter card.
-  static const String dateRange = '13TH-16TH JULY';
+  const FilterScrimColor(this.label, this.color);
+}
+
+/// Formats the timestamp shown on the filter card, e.g. "5 Aug 2026 · 7:33 PM".
+String formatFilterTimestamp(DateTime dateTime) {
+  return DateFormat('d MMM yyyy · h:mm a').format(dateTime);
 }
 
 /// Reference canvas width the Figma "AQ/CAF" templates were designed at.
@@ -68,66 +68,98 @@ class AirQoIconMark extends StatelessWidget {
   }
 }
 
-/// AirQo icon + [CleanAirForumBrand.title] wordmark lockup shown top-left on the
-/// selfie filter card: logo mark, a vertical divider, then the title/edition
-/// text — matches the Figma "AQ/CAF" header exactly (node 169:538).
+/// AirQo icon shown top-left on the selfie filter card.
 ///
 /// [scale] is the card's rendered width divided by [kCafReferenceWidth];
 /// every size below is a Figma design pixel value multiplied by it.
-class CleanAirForumBrandHeader extends StatelessWidget {
+class AirQoFilterHeader extends StatelessWidget {
   final double scale;
 
-  const CleanAirForumBrandHeader({super.key, required this.scale});
+  const AirQoFilterHeader({super.key, required this.scale});
 
   @override
   Widget build(BuildContext context) {
-    final iconSize = 143.38 * scale;
-    final gap = 17 * scale;
-    final dividerWidth = (4 * scale).clamp(1.0, double.infinity);
-    final dividerHeight = 98 * scale;
-    final titleFontSize = 35.974 * scale;
+    return Align(
+      alignment: Alignment.centerLeft,
+      child: AirQoIconMark(size: 143.38 * scale),
+    );
+  }
+}
 
+/// Horizontal row of scrim color swatches for filter personalization.
+class FilterScrimColorPicker extends StatelessWidget {
+  final FilterScrimColor selected;
+  final ValueChanged<FilterScrimColor> onSelected;
+
+  const FilterScrimColorPicker({
+    super.key,
+    required this.selected,
+    required this.onSelected,
+  });
+
+  @override
+  Widget build(BuildContext context) {
     return Row(
-      mainAxisSize: MainAxisSize.min,
-      crossAxisAlignment: CrossAxisAlignment.center,
+      mainAxisAlignment: MainAxisAlignment.center,
       children: [
-        AirQoIconMark(size: iconSize),
-        SizedBox(width: gap),
-        Container(width: dividerWidth, height: dividerHeight, color: Colors.white),
-        SizedBox(width: gap),
-        Flexible(
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                CleanAirForumBrand.title,
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-                style: TextStyle(
-                  color: Colors.white,
-                  fontSize: titleFontSize,
-                  height: 1.1,
-                  fontWeight: FontWeight.w700,
-                ),
-              ),
-              if (CleanAirForumBrand.edition.isNotEmpty)
-                Text(
-                  CleanAirForumBrand.edition,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: TextStyle(
-                    color: Colors.white,
-                    fontSize: titleFontSize,
-                    height: 1.1,
-                    fontStyle: FontStyle.italic,
-                    fontWeight: FontWeight.w400,
-                  ),
-                ),
-            ],
+        for (final option in FilterScrimColor.values) ...[
+          if (option != FilterScrimColor.values.first) const SizedBox(width: 12),
+          _ScrimSwatch(
+            color: option.color,
+            selected: selected == option,
+            onTap: () => onSelected(option),
           ),
-        ),
+        ],
       ],
+    );
+  }
+}
+
+class _ScrimSwatch extends StatelessWidget {
+  final Color color;
+  final bool selected;
+  final VoidCallback onTap;
+
+  const _ScrimSwatch({
+    required this.color,
+    required this.selected,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      button: true,
+      selected: selected,
+      label: 'Filter color',
+      child: GestureDetector(
+        onTap: onTap,
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 150),
+          width: 36,
+          height: 36,
+          decoration: BoxDecoration(
+            shape: BoxShape.circle,
+            color: color,
+            border: Border.all(
+              color: selected ? Colors.white : Colors.transparent,
+              width: 2,
+            ),
+            boxShadow: selected
+                ? [
+                    BoxShadow(
+                      color: color.withValues(alpha: 0.5),
+                      blurRadius: 6,
+                      spreadRadius: 1,
+                    ),
+                  ]
+                : null,
+          ),
+          child: selected
+              ? const Icon(Icons.check, color: Colors.white, size: 18)
+              : null,
+        ),
+      ),
     );
   }
 }

--- a/src/mobile/lib/src/app/dashboard/utils/clean_air_forum_branding.dart
+++ b/src/mobile/lib/src/app/dashboard/utils/clean_air_forum_branding.dart
@@ -105,6 +105,7 @@ class FilterScrimColorPicker extends StatelessWidget {
         for (final option in FilterScrimColor.values) ...[
           if (option != FilterScrimColor.values.first) const SizedBox(width: 12),
           _ScrimSwatch(
+            label: option.label,
             color: option.color,
             selected: selected == option,
             onTap: () => onSelected(option),
@@ -116,11 +117,13 @@ class FilterScrimColorPicker extends StatelessWidget {
 }
 
 class _ScrimSwatch extends StatelessWidget {
+  final String label;
   final Color color;
   final bool selected;
   final VoidCallback onTap;
 
   const _ScrimSwatch({
+    required this.label,
     required this.color,
     required this.selected,
     required this.onTap,
@@ -131,7 +134,7 @@ class _ScrimSwatch extends StatelessWidget {
     return Semantics(
       button: true,
       selected: selected,
-      label: 'Filter color',
+      label: 'Filter color, $label',
       child: GestureDetector(
         onTap: onTap,
         child: AnimatedContainer(

--- a/src/mobile/lib/src/app/dashboard/widgets/air_quality_share_sheet.dart
+++ b/src/mobile/lib/src/app/dashboard/widgets/air_quality_share_sheet.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:airqo/src/app/dashboard/models/airquality_response.dart';
+import 'package:airqo/src/app/dashboard/utils/clean_air_forum_branding.dart';
 import 'package:airqo/src/app/dashboard/widgets/air_quality_share_card.dart';
 import 'package:airqo/src/app/dashboard/widgets/clean_air_forum_filter_tab.dart';
 import 'package:airqo/src/app/dashboard/widgets/clean_air_forum_sticker_frame.dart';
@@ -44,7 +45,7 @@ Future<void> showAirQualityShareSheet(
 /// is the stable `tab` property on share_tab_selected and the `format` on
 /// share_completed; don't rename shipped values.
 enum _ShareTab {
-  filter(label: 'Forum filter', analyticsName: 'forum_filter'),
+  filter(label: 'Selfie filter', analyticsName: 'forum_filter'),
   card(label: 'Card', analyticsName: 'card'),
   sticker(label: 'IG sticker', analyticsName: 'ig_sticker');
 
@@ -81,16 +82,17 @@ class AirQualityShareSheet extends StatefulWidget {
 }
 
 class _AirQualityShareSheetState extends State<AirQualityShareSheet> {
-  // The Clean Air Forum is imminent, so lead with the branded filter tab.
   _ShareTab _tab = _ShareTab.filter;
 
   final GlobalKey _cardKey = GlobalKey();
   final GlobalKey _stickerKey = GlobalKey();
 
   // Lifted from the filter tab: its subtree is unmounted on tab switch, so
-  // the picked selfie and consent choice live here to survive switching.
+  // the picked selfie, consent choice, and scrim color live here to survive
+  // switching.
   File? _selfieFile;
   bool _consentToDisplay = false;
+  FilterScrimColor _scrimColor = FilterScrimColor.teal;
 
   bool _isSharingCard = false;
   bool _isCopyingSticker = false;
@@ -354,7 +356,7 @@ class _AirQualityShareSheetState extends State<AirQualityShareSheet> {
   String _subtitleForTab(_ShareTab tab) {
     switch (tab) {
       case _ShareTab.filter:
-        return 'Add a selfie for a Clean Air Forum branded filter.';
+        return 'Add a selfie with your air quality reading.';
       case _ShareTab.card:
         return 'Preview the card before sending it.';
       case _ShareTab.sticker:
@@ -392,6 +394,8 @@ class _AirQualityShareSheetState extends State<AirQualityShareSheet> {
           consentToDisplay: _consentToDisplay,
           onConsentChanged: (value) =>
               setState(() => _consentToDisplay = value),
+          scrimColor: _scrimColor,
+          onScrimColorChanged: (color) => setState(() => _scrimColor = color),
           onMessage: _showMessage,
           submissionService: widget.submissionService,
         );

--- a/src/mobile/lib/src/app/dashboard/widgets/clean_air_forum_camera_screen.dart
+++ b/src/mobile/lib/src/app/dashboard/widgets/clean_air_forum_camera_screen.dart
@@ -20,11 +20,13 @@ import 'package:permission_handler/permission_handler.dart';
 class CleanAirForumCameraScreen extends StatefulWidget {
   final Measurement measurement;
   final String? fallbackLocationName;
+  final FilterScrimColor scrimColor;
 
   const CleanAirForumCameraScreen({
     super.key,
     required this.measurement,
     this.fallbackLocationName,
+    this.scrimColor = FilterScrimColor.teal,
   });
 
   @override
@@ -256,6 +258,7 @@ class _CleanAirForumCameraScreenState extends State<CleanAirForumCameraScreen>
                     child: _FilterGuideOverlay(
                       measurement: widget.measurement,
                       fallbackLocationName: widget.fallbackLocationName,
+                      scrimColor: widget.scrimColor,
                     ),
                   ),
                 ),
@@ -324,10 +327,12 @@ class _CleanAirForumCameraScreenState extends State<CleanAirForumCameraScreen>
 class _FilterGuideOverlay extends StatelessWidget {
   final Measurement measurement;
   final String? fallbackLocationName;
+  final FilterScrimColor scrimColor;
 
   const _FilterGuideOverlay({
     required this.measurement,
     this.fallbackLocationName,
+    required this.scrimColor,
   });
 
   @override
@@ -347,6 +352,7 @@ class _FilterGuideOverlay extends StatelessWidget {
     return LayoutBuilder(
       builder: (context, constraints) {
         final scale = constraints.maxWidth / kCafReferenceWidth;
+        final scrim = scrimColor.color;
 
         return IgnorePointer(
           child: Stack(
@@ -363,8 +369,8 @@ class _FilterGuideOverlay extends StatelessWidget {
                       begin: Alignment.topCenter,
                       end: Alignment.bottomCenter,
                       colors: [
-                        CleanAirForumBrand.scrimTeal.withValues(alpha: 0),
-                        CleanAirForumBrand.scrimTeal.withValues(alpha: 0.75),
+                        scrim.withValues(alpha: 0),
+                        scrim.withValues(alpha: 0.75),
                       ],
                     ),
                   ),
@@ -390,7 +396,7 @@ class _FilterGuideOverlay extends StatelessWidget {
                 top: 53 * scale,
                 left: 44 * scale,
                 right: 44 * scale,
-                child: CleanAirForumBrandHeader(scale: scale),
+                child: AirQoFilterHeader(scale: scale),
               ),
               Positioned(
                 left: 44 * scale,

--- a/src/mobile/lib/src/app/dashboard/widgets/clean_air_forum_filter_card.dart
+++ b/src/mobile/lib/src/app/dashboard/widgets/clean_air_forum_filter_card.dart
@@ -7,11 +7,9 @@ import 'package:airqo/src/app/dashboard/utils/measurement_location_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 
-/// A full-bleed selfie photo with an AirQo + Clean Air Forum branded overlay
-/// (location, live AQI value/category, event dates) anchored near the
-/// bottom — matches the "AQ/CAF" Figma template exactly (file
-/// `Z0OLd2awVqgZhytJULgO8L`, node 169:534), including its 1080x1080
-/// reference proportions (see [kCafReferenceWidth]).
+/// A full-bleed selfie photo with an AirQo-branded overlay (location, live
+/// AQI value/category, timestamp) anchored near the bottom — matches the
+/// "AQ/CAF" Figma template proportions (see [kCafReferenceWidth]).
 ///
 /// If [selfieFile] is null a neutral placeholder avatar is shown instead so
 /// the template stays visible/previewable before the user picks a photo.
@@ -22,12 +20,16 @@ class CleanAirForumFilterCard extends StatelessWidget {
   final File? selfieFile;
   final Measurement measurement;
   final String? fallbackLocationName;
+  final FilterScrimColor scrimColor;
+  final DateTime? capturedAt;
 
   const CleanAirForumFilterCard({
     super.key,
     required this.selfieFile,
     required this.measurement,
     this.fallbackLocationName,
+    this.scrimColor = FilterScrimColor.teal,
+    this.capturedAt,
   });
 
   @override
@@ -46,6 +48,7 @@ class CleanAirForumFilterCard extends StatelessWidget {
     );
     final pm25Value = measurement.pm25?.value;
     final categoryColor = getMeasurementAqiColor(measurement);
+    final timestamp = capturedAt ?? DateTime.now();
 
     return AspectRatio(
       aspectRatio: 1,
@@ -53,6 +56,7 @@ class CleanAirForumFilterCard extends StatelessWidget {
         builder: (context, constraints) {
           final width = constraints.maxWidth;
           final scale = width / kCafReferenceWidth;
+          final scrim = scrimColor.color;
 
           return ClipRRect(
             borderRadius: BorderRadius.circular(32 * scale),
@@ -62,8 +66,6 @@ class CleanAirForumFilterCard extends StatelessWidget {
                 selfieFile != null
                     ? Image.file(selfieFile!, fit: BoxFit.cover)
                     : _SelfiePlaceholder(scale: scale),
-                // Soft top scrim so the brand header stays legible over
-                // bright photos.
                 const DecoratedBox(
                   decoration: BoxDecoration(
                     gradient: LinearGradient(
@@ -74,8 +76,6 @@ class CleanAirForumFilterCard extends StatelessWidget {
                     ),
                   ),
                 ),
-                // Teal scrim rising from the bottom, approximating the
-                // Figma radial-gradient wash behind the AQI panel.
                 Positioned(
                   left: 0,
                   right: 0,
@@ -87,9 +87,9 @@ class CleanAirForumFilterCard extends StatelessWidget {
                         begin: Alignment.topCenter,
                         end: Alignment.bottomCenter,
                         colors: [
-                          CleanAirForumBrand.scrimTeal.withValues(alpha: 0),
-                          CleanAirForumBrand.scrimTeal.withValues(alpha: 0.5),
-                          CleanAirForumBrand.scrimTeal.withValues(alpha: 0.94),
+                          scrim.withValues(alpha: 0),
+                          scrim.withValues(alpha: 0.5),
+                          scrim.withValues(alpha: 0.94),
                         ],
                         stops: const [0.0, 0.5, 1.0],
                       ),
@@ -100,7 +100,7 @@ class CleanAirForumFilterCard extends StatelessWidget {
                   top: 53 * scale,
                   left: 44 * scale,
                   right: 44 * scale,
-                  child: CleanAirForumBrandHeader(scale: scale),
+                  child: AirQoFilterHeader(scale: scale),
                 ),
                 Positioned(
                   left: 44 * scale,
@@ -113,6 +113,7 @@ class CleanAirForumFilterCard extends StatelessWidget {
                     locationDescription: locationDescription,
                     pm25Value: pm25Value,
                     category: category,
+                    timestamp: formatFilterTimestamp(timestamp),
                   ),
                 ),
               ],
@@ -172,6 +173,7 @@ class _BottomPanel extends StatelessWidget {
   final String locationDescription;
   final double? pm25Value;
   final String category;
+  final String timestamp;
 
   const _BottomPanel({
     required this.scale,
@@ -180,6 +182,7 @@ class _BottomPanel extends StatelessWidget {
     required this.locationDescription,
     required this.pm25Value,
     required this.category,
+    required this.timestamp,
   });
 
   @override
@@ -292,19 +295,18 @@ class _BottomPanel extends StatelessWidget {
                 ),
               ),
             ),
-            if (CleanAirForumBrand.dateRange.isNotEmpty) ...[
-              const Spacer(),
-              Text(
-                CleanAirForumBrand.dateRange,
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-                style: TextStyle(
-                  color: Colors.white,
-                  fontSize: 35.974 * scale,
-                  fontWeight: FontWeight.w800,
-                ),
+            const Spacer(),
+            Text(
+              timestamp,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              textAlign: TextAlign.right,
+              style: TextStyle(
+                color: Colors.white,
+                fontSize: 28 * scale,
+                fontWeight: FontWeight.w700,
               ),
-            ],
+            ),
           ],
         ),
       ],

--- a/src/mobile/lib/src/app/dashboard/widgets/clean_air_forum_filter_tab.dart
+++ b/src/mobile/lib/src/app/dashboard/widgets/clean_air_forum_filter_tab.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:airqo/src/app/dashboard/models/airquality_response.dart';
+import 'package:airqo/src/app/dashboard/utils/clean_air_forum_branding.dart';
 import 'package:airqo/src/app/dashboard/widgets/clean_air_forum_camera_screen.dart';
 import 'package:airqo/src/app/dashboard/widgets/clean_air_forum_filter_card.dart';
 import 'package:airqo/src/app/dashboard/widgets/share_sheet_widgets.dart';
@@ -10,6 +11,7 @@ import 'package:airqo/src/app/learn/widgets/learn_sheet_button_styles.dart';
 import 'package:airqo/src/app/shared/services/air_quality_share_service.dart';
 import 'package:airqo/src/app/shared/services/analytics_service.dart';
 import 'package:airqo/src/app/shared/services/clean_air_forum_submission_service.dart';
+import 'package:airqo/src/app/shared/services/feature_flag_service.dart';
 import 'package:airqo/src/app/shared/widgets/custom_switch.dart';
 import 'package:airqo/src/meta/utils/colors.dart';
 import 'package:flutter/material.dart';
@@ -21,13 +23,13 @@ import 'package:share_plus/share_plus.dart';
 
 enum _SelfieSource { liveCamera, gallery }
 
-/// The "Forum filter" tab of the share sheet: selfie acquisition (live
-/// camera or gallery), branded filter preview, the share action, and the
-/// opt-in submission to the conference wall display.
+/// The "Selfie filter" tab of the share sheet: selfie acquisition (live
+/// camera or gallery), filter preview, save/share actions, and the opt-in
+/// submission to the conference wall display (when enabled).
 ///
-/// The selfie and consent values are lifted to the parent sheet — this
-/// widget is unmounted when the user switches share tabs, so holding them
-/// here would lose them on every switch.
+/// The selfie, consent, and scrim color values are lifted to the parent
+/// sheet — this widget is unmounted when the user switches share tabs, so
+/// holding them here would lose them on every switch.
 class CleanAirForumFilterTab extends StatefulWidget {
   final Measurement measurement;
   final String? fallbackLocationName;
@@ -41,6 +43,8 @@ class CleanAirForumFilterTab extends StatefulWidget {
   final ValueChanged<File> onSelfieChanged;
   final bool consentToDisplay;
   final ValueChanged<bool> onConsentChanged;
+  final FilterScrimColor scrimColor;
+  final ValueChanged<FilterScrimColor> onScrimColorChanged;
 
   /// Surfaces status/error text in the sheet's inline banner.
   final ShareSheetMessenger onMessage;
@@ -57,6 +61,8 @@ class CleanAirForumFilterTab extends StatefulWidget {
     required this.onSelfieChanged,
     required this.consentToDisplay,
     required this.onConsentChanged,
+    required this.scrimColor,
+    required this.onScrimColorChanged,
     required this.onMessage,
     this.fallbackLocationName,
     this.sharePositionOrigin,
@@ -72,8 +78,13 @@ class _CleanAirForumFilterTabState extends State<CleanAirForumFilterTab> {
   final ImagePicker _picker = ImagePicker();
 
   bool _isPickingSelfie = false;
+  bool _isSavingFilter = false;
   bool _isSharingFilter = false;
   bool _isSendingToWall = false;
+  DateTime? _capturedAt;
+
+  bool get _conferenceWallEnabled =>
+      FeatureFlagService.instance.isEnabled(AppFeatureFlag.conferenceWall);
 
   CleanAirForumSubmissionService get _submissionService =>
       widget.submissionService ?? CleanAirForumSubmissionService.instance;
@@ -93,10 +104,10 @@ class _CleanAirForumFilterTabState extends State<CleanAirForumFilterTab> {
       if (!mounted) return;
 
       widget.onSelfieChanged(File(picked.path));
-      if (widget.consentToDisplay) unawaited(_submitCurrentSelfieToWall());
+      if (_conferenceWallEnabled && widget.consentToDisplay) {
+        unawaited(_submitCurrentSelfieToWall());
+      }
     } on PlatformException catch (e) {
-      // "Try again" is wrong advice when access is denied — the fix lives
-      // in system settings, so link straight there.
       if (e.code.contains('denied')) {
         widget.onMessage(
           source == ImageSource.camera
@@ -131,9 +142,6 @@ class _CleanAirForumFilterTabState extends State<CleanAirForumFilterTab> {
       context: context,
       backgroundColor: Colors.transparent,
       builder: (sheetContext) {
-        // Same flush-to-bottom treatment as the main sheet — fold the
-        // safe-area inset into the content's own padding rather than
-        // leaving a transparent gap below the sheet.
         final bottomSafeArea = MediaQuery.paddingOf(sheetContext).bottom;
 
         return DecoratedBox(
@@ -155,7 +163,7 @@ class _CleanAirForumFilterTabState extends State<CleanAirForumFilterTab> {
                     _SelfieSourceTile(
                       iconAsset: 'assets/icons/camera.svg',
                       title: 'Take photo',
-                      subtitle: 'See the branding while you frame your shot',
+                      subtitle: 'See the overlay while you frame your shot',
                       onTap: () => Navigator.of(sheetContext)
                           .pop(_SelfieSource.liveCamera),
                     ),
@@ -200,13 +208,16 @@ class _CleanAirForumFilterTabState extends State<CleanAirForumFilterTab> {
           builder: (_) => CleanAirForumCameraScreen(
             measurement: widget.measurement,
             fallbackLocationName: widget.fallbackLocationName,
+            scrimColor: widget.scrimColor,
           ),
         ),
       );
       if (file != null && mounted) {
         widget.onSelfieChanged(file);
         AnalyticsService().trackCafSelfieCaptured();
-        if (widget.consentToDisplay) unawaited(_submitCurrentSelfieToWall());
+        if (_conferenceWallEnabled && widget.consentToDisplay) {
+          unawaited(_submitCurrentSelfieToWall());
+        }
       }
     } catch (_) {
       widget.onMessage("Couldn't open the camera.", isError: true);
@@ -215,12 +226,51 @@ class _CleanAirForumFilterTabState extends State<CleanAirForumFilterTab> {
     }
   }
 
+  Future<Uint8List?> _captureFilterImage() async {
+    final capturedAt = DateTime.now();
+    setState(() => _capturedAt = capturedAt);
+    await WidgetsBinding.instance.endOfFrame;
+    if (!mounted) return null;
+    return captureShareBoundary(context, _filterKey);
+  }
+
+  Future<void> _saveFilter() async {
+    if (_isSavingFilter || widget.selfieFile == null) return;
+    setState(() => _isSavingFilter = true);
+
+    try {
+      final imageBytes = await _captureFilterImage();
+      if (imageBytes == null) {
+        widget.onMessage("Couldn't save the filter. Try again.", isError: true);
+        return;
+      }
+
+      await AirQualityShareService.saveFilterToGallery(imageBytes);
+      widget.onMessage('Saved to your photos!');
+    } on GallerySaveException catch (e) {
+      if (e.kind == GallerySaveFailure.permissionDenied) {
+        widget.onMessage(
+          'Photo library access is off.',
+          isError: true,
+          actionLabel: 'Settings',
+          onAction: openAppSettings,
+        );
+      } else {
+        widget.onMessage("Couldn't save the filter. Try again.", isError: true);
+      }
+    } catch (_) {
+      widget.onMessage("Couldn't save the filter. Try again.", isError: true);
+    } finally {
+      if (mounted) setState(() => _isSavingFilter = false);
+    }
+  }
+
   Future<void> _shareFilter() async {
     if (_isSharingFilter || widget.selfieFile == null) return;
     setState(() => _isSharingFilter = true);
 
     try {
-      final imageBytes = await captureShareBoundary(context, _filterKey);
+      final imageBytes = await _captureFilterImage();
       if (imageBytes == null) {
         widget.onMessage("Couldn't share the filter. Try again.",
             isError: true);
@@ -247,16 +297,11 @@ class _CleanAirForumFilterTabState extends State<CleanAirForumFilterTab> {
     }
   }
 
-  /// Captures the current filter card and sends it to the wall — triggered
-  /// the moment consent is given (or a new/changed photo is picked while
-  /// already consented), rather than being bundled into the personal
-  /// "Share" action. Piggybacking on share made consent look like it should
-  /// be enough on its own, but nothing was actually sent to the wall until
-  /// the user *also* shared the filter externally.
   Future<void> _submitCurrentSelfieToWall() async {
+    if (!_conferenceWallEnabled) return;
     if (widget.selfieFile == null) return;
     if (_isSendingToWall) return;
-    final imageBytes = await captureShareBoundary(context, _filterKey);
+    final imageBytes = await _captureFilterImage();
     if (imageBytes == null) {
       widget.onMessage("Couldn't prepare the filter. Try again.",
           isError: true);
@@ -266,26 +311,18 @@ class _CleanAirForumFilterTabState extends State<CleanAirForumFilterTab> {
   }
 
   Future<void> _submitToConferenceWall(Uint8List imageBytes) async {
-    // Retry (which can fire from the root SnackBar even after dismissal)
-    // and repeated shares must not enqueue duplicate wall submissions.
-    // Not rendered directly — the sheet's inline banner (via onMessage's
-    // `loading: true`) is the only visible sign of progress now.
     if (_isSendingToWall) return;
     _isSendingToWall = true;
     widget.onMessage('Sending to the wall…', loading: true);
     try {
-      // The API's displayName can be the user's email when they're logged
-      // in — never surface it here, since the wall itself hides identity.
       await _submissionService.submitSelfie(
         imageBytes: imageBytes,
         measurement: widget.measurement,
         fallbackLocationName: widget.fallbackLocationName,
       );
       AnalyticsService().trackCafWallSubmissionSent();
-      widget.onMessage("You're on the forum wall!");
+      widget.onMessage("You're on the conference wall!");
     } catch (e) {
-      // Report only the failure category — raw messages can carry API
-      // response details that don't belong in analytics.
       AnalyticsService().trackCafWallSubmissionFailed(
         error: e is SelfieSubmissionException
             ? e.kind.name
@@ -319,21 +356,25 @@ class _CleanAirForumFilterTabState extends State<CleanAirForumFilterTab> {
   @override
   Widget build(BuildContext context) {
     final hasSelfie = widget.selfieFile != null;
+    final isBusy = _isSavingFilter || _isSharingFilter;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        // The template is always visible — even before a selfie is picked —
-        // so it stays previewable while switching between share tabs. Full
-        // width (no artificial max-width cap) so it matches the Card tab's
-        // size for a consistent look across all three share formats.
         RepaintBoundary(
           key: _filterKey,
           child: CleanAirForumFilterCard(
             selfieFile: widget.selfieFile,
             measurement: widget.measurement,
             fallbackLocationName: widget.fallbackLocationName,
+            scrimColor: widget.scrimColor,
+            capturedAt: _capturedAt,
           ),
+        ),
+        const SizedBox(height: 12),
+        FilterScrimColorPicker(
+          selected: widget.scrimColor,
+          onSelected: widget.onScrimColorChanged,
         ),
         const SizedBox(height: 16),
         if (hasSelfie)
@@ -378,13 +419,56 @@ class _CleanAirForumFilterTabState extends State<CleanAirForumFilterTab> {
             label: const Text('Take selfie'),
           ),
         if (hasSelfie) ...[
-          const SizedBox(height: 12),
-          _buildConsentSection(),
+          if (_conferenceWallEnabled) ...[
+            const SizedBox(height: 12),
+            _buildConsentSection(),
+          ],
           const SizedBox(height: 16),
-          ShareActionButton(
-            label: _isSharingFilter ? 'Preparing filter...' : 'Share filter',
-            loading: _isSharingFilter,
-            onPressed: _isSharingFilter ? null : _shareFilter,
+          Row(
+            children: [
+              Expanded(
+                child: ShareActionButton(
+                  label: _isSavingFilter ? 'Saving...' : 'Save to photos',
+                  loading: _isSavingFilter,
+                  onPressed: isBusy ? null : _saveFilter,
+                  icon: SvgPicture.asset(
+                    'assets/icons/download-01.svg',
+                    width: 18,
+                    height: 18,
+                    colorFilter:
+                        const ColorFilter.mode(Colors.white, BlendMode.srcIn),
+                  ),
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: OutlinedButton.icon(
+                  onPressed: isBusy ? null : _shareFilter,
+                  style: learnExposureSecondaryButtonStyle(context),
+                  icon: _isSharingFilter
+                      ? SizedBox(
+                          width: 16,
+                          height: 16,
+                          child: CircularProgressIndicator(
+                            strokeWidth: 2,
+                            color: LearnDesignTokens.headline(context),
+                          ),
+                        )
+                      : SvgPicture.asset(
+                          'assets/icons/share-icon.svg',
+                          width: 18,
+                          height: 18,
+                          colorFilter: ColorFilter.mode(
+                            LearnDesignTokens.headline(context),
+                            BlendMode.srcIn,
+                          ),
+                        ),
+                  label: Text(
+                    _isSharingFilter ? 'Preparing...' : 'Share',
+                  ),
+                ),
+              ),
+            ],
           ),
         ],
       ],
@@ -409,7 +493,7 @@ class _CleanAirForumFilterTabState extends State<CleanAirForumFilterTab> {
               ),
               const SizedBox(height: 2),
               Text(
-                'Shown live on the Clean Air Forum wall display.',
+                'Shown live on the conference wall display.',
                 style: LearnDesignTokens.completionCaption(context),
               ),
             ],

--- a/src/mobile/lib/src/app/dashboard/widgets/share_sheet_widgets.dart
+++ b/src/mobile/lib/src/app/dashboard/widgets/share_sheet_widgets.dart
@@ -212,12 +212,14 @@ class ShareActionButton extends StatelessWidget {
   final String label;
   final bool loading;
   final VoidCallback? onPressed;
+  final Widget? icon;
 
   const ShareActionButton({
     super.key,
     required this.label,
     required this.loading,
     required this.onPressed,
+    this.icon,
   });
 
   @override
@@ -234,13 +236,14 @@ class ShareActionButton extends StatelessWidget {
                 color: Colors.white,
               ),
             )
-          : SvgPicture.asset(
-              'assets/icons/share-icon.svg',
-              width: 18,
-              height: 18,
-              colorFilter:
-                  const ColorFilter.mode(Colors.white, BlendMode.srcIn),
-            ),
+          : icon ??
+              SvgPicture.asset(
+                'assets/icons/share-icon.svg',
+                width: 18,
+                height: 18,
+                colorFilter:
+                    const ColorFilter.mode(Colors.white, BlendMode.srcIn),
+              ),
       label: Text(label),
     );
   }

--- a/src/mobile/lib/src/app/exposure/widgets/my_trips_view.dart
+++ b/src/mobile/lib/src/app/exposure/widgets/my_trips_view.dart
@@ -331,7 +331,7 @@ class _TripDropdownField extends StatelessWidget {
 
     return DropdownButtonFormField<String>(
       key: ValueKey(value),
-      initialValue: value,
+      value: value,
       decoration: InputDecoration(
         labelText: label,
         filled: true,

--- a/src/mobile/lib/src/app/shared/services/air_quality_share_service.dart
+++ b/src/mobile/lib/src/app/shared/services/air_quality_share_service.dart
@@ -2,6 +2,7 @@ import 'dart:typed_data';
 
 import 'package:airqo/src/app/dashboard/models/airquality_response.dart';
 import 'package:flutter/material.dart';
+import 'package:gal/gal.dart';
 import 'package:share_plus/share_plus.dart';
 
 class AirQualityShareService {
@@ -45,7 +46,7 @@ class AirQualityShareService {
     );
   }
 
-  /// Shares the composited selfie + Clean Air Forum branded card.
+  /// Shares the composited selfie + AirQo filter card.
   static Future<ShareResult> shareCleanAirForumFilter(
     Uint8List imageBytes,
     Measurement measurement, {
@@ -58,13 +59,39 @@ class AirQualityShareService {
 
     return _shareImage(
       imageBytes,
-      fileName: 'clean-air-forum-filter.png',
-      text: "I'm checking the air quality in $locationName with AirQo at "
-          'the Clean Air Forum! 🌍💨\n\n'
+      fileName: 'airqo-selfie-filter.png',
+      text: "I'm checking the air quality in $locationName with AirQo! 🌍💨\n\n"
           'Join me on the app here: $appLink',
-      subject: 'Clean Air Forum x AirQo',
+      subject: 'Air quality selfie from AirQo',
       sharePositionOrigin: sharePositionOrigin,
     );
+  }
+
+  /// Saves the composited selfie filter directly to the device photo library.
+  ///
+  /// Throws [GallerySaveException] when permission is denied or the save fails.
+  static Future<void> saveFilterToGallery(Uint8List imageBytes) async {
+    final hasAccess = await Gal.hasAccess(toAlbum: true);
+    if (!hasAccess) {
+      final granted = await Gal.requestAccess(toAlbum: true);
+      if (!granted) {
+        throw GallerySaveException.permissionDenied();
+      }
+    }
+
+    try {
+      await Gal.putImageBytes(
+        imageBytes,
+        name: 'airqo-selfie-filter-${DateTime.now().millisecondsSinceEpoch}',
+      );
+    } on GalException catch (e) {
+      if (e.type == GalExceptionType.accessDenied) {
+        throw GallerySaveException.permissionDenied();
+      }
+      throw GallerySaveException.failed();
+    } catch (_) {
+      throw GallerySaveException.failed();
+    }
   }
 
   /// Shares the transparent branding sticker meant to be pasted onto an
@@ -75,9 +102,9 @@ class AirQualityShareService {
   }) {
     return _shareImage(
       imageBytes,
-      fileName: 'clean-air-forum-sticker.png',
-      text: 'Add this to your Instagram Story! 🌍💨 #CleanAirForum #AirQo',
-      subject: 'Clean Air Forum x AirQo',
+      fileName: 'airqo-sticker.png',
+      text: 'Add this to your Instagram Story! 🌍💨 #AirQo',
+      subject: 'Air quality sticker from AirQo',
       sharePositionOrigin: sharePositionOrigin,
     );
   }
@@ -153,4 +180,18 @@ class AirQualityShareService {
 
     return parts.join(', ');
   }
+}
+
+enum GallerySaveFailure { permissionDenied, failed }
+
+class GallerySaveException implements Exception {
+  final GallerySaveFailure kind;
+
+  const GallerySaveException._(this.kind);
+
+  factory GallerySaveException.permissionDenied() =>
+      const GallerySaveException._(GallerySaveFailure.permissionDenied);
+
+  factory GallerySaveException.failed() =>
+      const GallerySaveException._(GallerySaveFailure.failed);
 }

--- a/src/mobile/lib/src/app/shared/services/air_quality_share_service.dart
+++ b/src/mobile/lib/src/app/shared/services/air_quality_share_service.dart
@@ -71,9 +71,9 @@ class AirQualityShareService {
   ///
   /// Throws [GallerySaveException] when permission is denied or the save fails.
   static Future<void> saveFilterToGallery(Uint8List imageBytes) async {
-    final hasAccess = await Gal.hasAccess(toAlbum: true);
+    final hasAccess = await Gal.hasAccess();
     if (!hasAccess) {
-      final granted = await Gal.requestAccess(toAlbum: true);
+      final granted = await Gal.requestAccess();
       if (!granted) {
         throw GallerySaveException.permissionDenied();
       }

--- a/src/mobile/lib/src/app/shared/services/feature_flag_service.dart
+++ b/src/mobile/lib/src/app/shared/services/feature_flag_service.dart
@@ -6,7 +6,8 @@ enum AppFeatureFlag {
   surveys('surveys'),
   dataSharing('data_sharing'),
   feedback('feedback'),
-  socialLogin('social_login');
+  socialLogin('social_login'),
+  conferenceWall('conference_wall');
 
   final String key;
   const AppFeatureFlag(this.key);

--- a/src/mobile/pubspec.lock
+++ b/src/mobile/pubspec.lock
@@ -677,6 +677,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
+  gal:
+    dependency: "direct main"
+    description:
+      name: gal
+      sha256: f71e79840fe023a21f2f949771375444b6efcd34b9e625d5f4f5504971380a77
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.3"
   geocoding:
     dependency: "direct main"
     description:

--- a/src/mobile/pubspec.yaml
+++ b/src/mobile/pubspec.yaml
@@ -94,6 +94,7 @@ dependencies:
   screenshot: ^3.0.0
   path_provider: ^2.1.5
   pasteboard: ^0.5.0
+  gal: ^2.3.0
 
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- Remove Clean Air Forum branding from the mobile selfie filter (AirQo-only header, live date/time stamp, generic share copy)
- Add scrim color personalization (teal, AirQo blue, pink) and a **Save to photos** action with the AqDownload01 icon
- Gate conference wall submission behind the `conference_wall` PostHog feature flag (off by default)
- Fix `DropdownButtonFormField` compile error on Flutter 3.29 (`initialValue` → `value` in `my_trips_view.dart`)

## Test plan
- [ ] Open share sheet → **Selfie filter** tab shows no Clean Air Forum text
- [ ] Take a selfie → timestamp appears bottom-right; scrim swatches update preview and camera overlay
- [ ] **Save to photos** saves the composited filter to the device gallery
- [ ] **Share** opens OS share sheet with generic AirQo message
- [ ] With `conference_wall` flag **off** → no conference wall consent toggle
- [ ] With flag **on** → consent toggle appears and wall submission works
- [ ] IG sticker tab share copy has no Clean Air Forum references
- [ ] App builds on Flutter 3.29 (`flutter run --flavor airqodev --debug`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AirQo-branded selfie filters with selectable overlay colors and capture timestamps.
  * Added options to save filters to the photo gallery or share them.
  * Added configurable conference-wall sharing with consent controls.
* **Improvements**
  * Added photo library permission handling and clearer save-error feedback.
  * Updated sharing labels, descriptions, and branding throughout the experience.
  * Improved accessibility with clearer color selection controls.
* **Bug Fixes**
  * Corrected trip endpoint selection so the current value displays properly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->