### PR TITLE
Fix Android state restoration after reinstall

### DIFF
--- a/src/mobile/android/app/src/main/AndroidManifest.xml
+++ b/src/mobile/android/app/src/main/AndroidManifest.xml
@@ -9,7 +9,8 @@
     <application
         android:label="AirQo"
         android:name="${applicationName}"
-        android:icon="@mipmap/launcher_icon">
+        android:icon="@mipmap/launcher_icon"
+        android:allowBackup="false">
 
         <!-- TODO: Add your Google Maps API key here -->
         <meta-data android:name="com.google.android.geo.API_KEY"


### PR DESCRIPTION
## What changed

Disabled Android app-data backup by setting `android:allowBackup="false"` in the mobile app manifest.

## Why

After uninstalling and reinstalling the Android app from the Play Store, Android Auto Backup could restore PostHog's persisted identity and feature-flag cache while authentication credentials were absent. This allowed a guest session to temporarily inherit feature access from the previously signed-in user.

## Impact

Reinstalls now begin with fresh local state, preventing stale analytics identity, feature flags, and user-specific caches from appearing in guest mode. Normal guest route storage and login-time synchronization are unaffected while the app remains installed.

## Validation

- `xmllint --noout src/mobile/android/app/src/main/AndroidManifest.xml`
- `git diff --check`
- APK build was not run because the local Android SDK is not configured (`ANDROID_HOME` is unavailable).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled Android app backup to help prevent application data from being copied or restored through system backup services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->