### PR TITLE
Document network coverage metadata resource

### DIFF
--- a/src/docs-website/docs/data-access/researchers-guide/data-access-channels.md
+++ b/src/docs-website/docs/data-access/researchers-guide/data-access-channels.md
@@ -12,6 +12,17 @@ sidebar_label: 7. Data Access Channels
 | Mobile App (iOS/Android) | Field work, real-time monitoring | https://airqo.africa/products/mobile-app |
 | Analytics Platform | Researchers, visualisation, historical analysis, CSV export | https://airqo.africa/products/analytics |
 | API (RESTful) | Programmatic, large-scale, automated pipelines | https://airqo.africa/products/api |
+| Network Coverage Explorer | Metadata on Africa's air quality monitoring landscape (stations, instrumentation, institutional ownership) | https://airqo.net/solutions/network-coverage |
+
+### Network Coverage Metadata (Africa-wide)
+
+Separate from AirQo's own sensor data, AirQo also publishes a continent-wide **Air Quality Monitoring Landscape in Africa** platform at [airqo.net/solutions/network-coverage](https://airqo.net/solutions/network-coverage). Rather than pollutant readings, it provides *metadata* describing the monitoring infrastructure itself:
+
+> This platform provides a unified view of Africa's air quality monitoring landscape. It integrates metadata on monitoring initiatives across the continent, combining both low-cost sensors and high-precision reference monitors. Users can explore the geographic distribution of monitoring stations by country, identify active coverage, understand the types of instrumentation in use, and review institutional stewardship for each monitoring location.
+>
+> By offering a structured and comprehensive overview of Africa's air quality monitoring capacity, the platform seeks to incentivise collaboration towards scaling the development of open data infrastructure.
+
+This is useful for researchers who need to understand *where* monitoring exists and *who* operates it — for example, when scoping a new study, checking for co-located reference-grade instruments to validate low-cost sensor data against, or identifying potential institutional partners in a given country. A downloadable report of this metadata is available directly from the site.
 
 ### Downloading Large Historical Datasets
 

--- a/src/docs-website/docs/data-access/researchers-guide/monitoring-network-information.md
+++ b/src/docs-website/docs/data-access/researchers-guide/monitoring-network-information.md
@@ -19,3 +19,5 @@ sidebar_label: 6. Monitoring Network Information
 ### Data Partnerships and Accessibility
 
 The AirQo monitoring network includes devices owned and operated by multiple stakeholders: AirQo (Makerere University) as primary operator, municipal governments, research institutions, and international development partners. Most partner-owned monitors are publicly accessible through the AirQo platform.
+
+For a continent-wide view beyond AirQo's own network — including monitoring initiatives run by other institutions across Africa — see the [Network Coverage Metadata](./data-access-channels.md#network-coverage-metadata-africa-wide) resource, which lets you explore station coverage by country, instrumentation type, and institutional ownership.


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
<!-- Brief summary of the changes -->
Documents the AirQo Network Coverage Explorer (airqo.net/solutions/network-coverage) as a data access channel in the Researcher's Guide. Adds a new "Network Coverage Metadata (Africa-wide)" section to the data access channels page and cross-links it from the monitoring network information page.

### Why is this change needed?
<!-- Explain the motivation/problem this solves -->
Researchers currently have no documented pointer to AirQo's continent-wide monitoring metadata platform, which lets them explore station coverage, instrumentation types, and institutional ownership across Africa. This is distinct from AirQo's own sensor data and was previously undiscoverable from the docs.

---

## :link: Related Issues
- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change
- [ ] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [x] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services
**Microservices changed:**
- `docs-website` — researcher's guide (data-access-channels.md, monitoring-network-information.md)

---

## :test_tube: Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:** Reviewed rendered markdown for correct table formatting, blockquote rendering, and internal anchor link (`data-access-channels.md#network-coverage-metadata-africa-wide`).

---

## :boom: Breaking Changes
- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

<!-- If breaking changes, explain what breaks and migration steps -->

---

## :memo: Additional Notes
<!-- Any additional context, dependencies, or concerns -->
Intro copy quoted in the new section is sourced directly from the airqo.net/solutions/network-coverage landing page.

---

## :white_check_mark: Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the Network Coverage Explorer to the available data access channels.
  * Documented Africa-wide monitoring network metadata, including station locations, instrumentation, coverage, ownership, research use cases, and report availability.
  * Added a link to the network coverage metadata resource in the monitoring network information guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->