### PR TITLE
Revamp dashboard card share UX (mobile)

### DIFF
--- a/src/mobile/lib/src/app/dashboard/pages/dashboard_page.dart
+++ b/src/mobile/lib/src/app/dashboard/pages/dashboard_page.dart
@@ -1,4 +1,5 @@
 import 'package:airqo/src/app/dashboard/pages/location_selection/location_selection_screen.dart';
+import 'package:airqo/src/app/dashboard/widgets/measurement_card_tour.dart';
 import 'package:airqo/src/app/shared/widgets/translated_text.dart';
 import 'package:airqo/src/app/dashboard/repository/country_repository.dart';
 import 'package:airqo/src/app/dashboard/services/location_service_mananger.dart';
@@ -6,6 +7,7 @@ import 'package:airqo/src/meta/utils/colors.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'dart:async';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../auth/bloc/auth_bloc.dart';
 import '../bloc/dashboard/dashboard_bloc.dart';
@@ -31,6 +33,8 @@ class _DashboardPageState extends State<DashboardPage> with UiLoggy {
   String? selectedCountry;
   String? userCountry;
   Timer? _backgroundRefreshTimer;
+  final MeasurementCardTourKeys _cardTourKeys = MeasurementCardTourKeys();
+  bool _showCardGesturesTour = false;
 
   @override
   void initState() {
@@ -84,6 +88,32 @@ class _DashboardPageState extends State<DashboardPage> with UiLoggy {
     });
   }
 
+  Future<void> _dismissCardGesturesTour() async {
+    setState(() => _showCardGesturesTour = false);
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(measurementCardGesturesTourSeenKey, true);
+  }
+
+  void _maybeShowCardGesturesTour() {
+    if (!kMeasurementCardGesturesTourEnabled || _showCardGesturesTour) return;
+    SharedPreferences.getInstance().then((prefs) {
+      final seen = prefs.getBool(measurementCardGesturesTourSeenKey) ?? false;
+      if (!seen && mounted) setState(() => _showCardGesturesTour = true);
+    });
+  }
+
+  void _scheduleCardGesturesTourCheck() {
+    if (!kMeasurementCardGesturesTourEnabled) return;
+    scheduleMeasurementCardTourReady(
+      keys: _cardTourKeys,
+      onReady: _maybeShowCardGesturesTour,
+      isActive: () => mounted && !_showCardGesturesTour,
+    );
+  }
+
+  MeasurementCardTourKeys? get _activeCardTourKeys =>
+      kMeasurementCardGesturesTourEnabled ? _cardTourKeys : null;
+
   Future<void> _refreshDashboard() async {
     final completer = Completer<void>();
 
@@ -111,9 +141,12 @@ class _DashboardPageState extends State<DashboardPage> with UiLoggy {
 
     return Scaffold(
       appBar: DashboardAppBar(),
-      body: Stack(
-        children: [
-          RefreshIndicator(
+      body: BlocListener<DashboardBloc, DashboardState>(
+        listenWhen: (previous, current) => current is DashboardLoaded,
+        listener: (context, state) => _scheduleCardGesturesTourCheck(),
+        child: Stack(
+          children: [
+            RefreshIndicator(
             onRefresh: _refreshDashboard,
             color: AppColors.primaryColor,
             backgroundColor: Theme.of(context).scaffoldBackgroundColor,
@@ -170,7 +203,14 @@ class _DashboardPageState extends State<DashboardPage> with UiLoggy {
                 child: const Icon(Icons.add, color: Colors.white),
               ),
             ),
+          if (kMeasurementCardGesturesTourEnabled && _showCardGesturesTour)
+            MeasurementCardGesturesTour(
+              tourKeys: _cardTourKeys,
+              steps: buildMeasurementCardGesturesTourSteps(),
+              onDismiss: _dismissCardGesturesTour,
+            ),
         ],
+        ),
       ),
     );
   }
@@ -248,6 +288,11 @@ class _DashboardPageState extends State<DashboardPage> with UiLoggy {
               return SliverToBoxAdapter(
                 child: MyPlacesView(
                   userPreferences: state.userPreferences,
+                  tourKeys: _activeCardTourKeys,
+                  onTourTargetReady:
+                      kMeasurementCardGesturesTourEnabled
+                          ? _maybeShowCardGesturesTour
+                          : null,
                 ),
               );
 
@@ -259,6 +304,11 @@ class _DashboardPageState extends State<DashboardPage> with UiLoggy {
                   onExploreCities: isGuest
                       ? () => setView(DashboardView.explore)
                       : null,
+                  tourKeys: _activeCardTourKeys,
+                  onTourTargetReady:
+                      kMeasurementCardGesturesTourEnabled
+                          ? _maybeShowCardGesturesTour
+                          : null,
                 ),
               );
 
@@ -268,7 +318,14 @@ class _DashboardPageState extends State<DashboardPage> with UiLoggy {
                       .where((m) => m.siteDetails?.country == selectedCountry)
                       .toList();
 
-              return MeasurementsList(measurements: countryMeasurements);
+              return MeasurementsList(
+                measurements: countryMeasurements,
+                tourKeys: _activeCardTourKeys,
+                onTourTargetReady:
+                    kMeasurementCardGesturesTourEnabled
+                        ? _maybeShowCardGesturesTour
+                        : null,
+              );
 
             case DashboardView.explore:
               return SliverToBoxAdapter(
@@ -281,6 +338,11 @@ class _DashboardPageState extends State<DashboardPage> with UiLoggy {
               return MeasurementsList(
                 measurements:
                     (state.response.measurements ?? []).take(5).toList(),
+                tourKeys: _activeCardTourKeys,
+                onTourTargetReady:
+                    kMeasurementCardGesturesTourEnabled
+                        ? _maybeShowCardGesturesTour
+                        : null,
               );
           }
         }

--- a/src/mobile/lib/src/app/dashboard/pages/location_selection/components/swipeable_analytics_card.dart
+++ b/src/mobile/lib/src/app/dashboard/pages/location_selection/components/swipeable_analytics_card.dart
@@ -3,6 +3,9 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:loggy/loggy.dart';
 import 'package:airqo/src/app/dashboard/models/airquality_response.dart';
 import 'package:airqo/src/app/dashboard/pages/forecast_overview_page.dart';
+import 'package:airqo/src/app/dashboard/widgets/measurement_card_tour.dart';
+import 'package:airqo/src/app/dashboard/widgets/measurement_card_action_strip.dart';
+import 'package:airqo/src/app/dashboard/widgets/measurement_card_gestures.dart';
 import 'package:airqo/src/app/shared/widgets/translated_text.dart';
 import 'package:airqo/src/meta/utils/colors.dart';
 import 'package:airqo/src/meta/utils/forecast_utils.dart';
@@ -13,11 +16,15 @@ class SwipeableAnalyticsCard extends StatefulWidget {
   final Measurement measurement;
   final Function(String) onRemove;
   final String? fallbackLocationName;
+  final MeasurementCardTourKeys? tourKeys;
+  final VoidCallback? onTourTargetReady;
 
   const SwipeableAnalyticsCard({
     required this.measurement,
     required this.onRemove,
     this.fallbackLocationName,
+    this.tourKeys,
+    this.onTourTargetReady,
     super.key,
   });
 
@@ -30,6 +37,10 @@ class _SwipeableAnalyticsCardState extends State<SwipeableAnalyticsCard>
   double _dragOffset = 0;
   bool _isDeleteVisible = false;
   final double _deleteWidth = 80.0;
+  final GlobalKey _defaultShareButtonKey = GlobalKey();
+  bool _tourReadyNotified = false;
+
+  GlobalKey get _shareButtonKey => _defaultShareButtonKey;
 
   Timer? _autoHideTimer;
 
@@ -71,7 +82,22 @@ class _SwipeableAnalyticsCardState extends State<SwipeableAnalyticsCard>
 
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _showHelpTooltip();
+      if (widget.tourKeys != null) {
+        scheduleMeasurementCardTourReady(
+          keys: widget.tourKeys!,
+          onReady: _notifyTourTargetReady,
+          isActive: () => mounted && !_tourReadyNotified,
+        );
+      }
     });
+  }
+
+  void _notifyTourTargetReady() {
+    if (_tourReadyNotified || !mounted || widget.onTourTargetReady == null) {
+      return;
+    }
+    _tourReadyNotified = true;
+    widget.onTourTargetReady!();
   }
 
   @override
@@ -176,6 +202,19 @@ class _SwipeableAnalyticsCardState extends State<SwipeableAnalyticsCard>
     );
   }
 
+  Future<void> _openShare(String source) {
+    if (_isDeleteVisible || _dragOffset < 0) return Future.value();
+    return openMeasurementShareSheet(
+      context,
+      measurement: widget.measurement,
+      source: source,
+      fallbackLocationName: widget.fallbackLocationName,
+      shareButtonKey: _shareButtonKey,
+    );
+  }
+
+  bool get _cardActionsEnabled => !_isDeleteVisible && _dragOffset >= 0;
+
   String _getLocationDescription(Measurement measurement) {
     final siteDetails = measurement.siteDetails;
     if (siteDetails == null) return "Unknown location";
@@ -207,18 +246,6 @@ class _SwipeableAnalyticsCardState extends State<SwipeableAnalyticsCard>
 
   Color _getAqiColor(Measurement measurement) {
     return getAppAqiCategoryColor(measurement.aqiCategory ?? '');
-  }
-
-  Widget _chevron(BuildContext context) {
-    return SvgPicture.asset(
-      'assets/icons/chevron-right.svg',
-      width: 20,
-      height: 20,
-      colorFilter: ColorFilter.mode(
-        AppTextColors.modalCloseIcon(context),
-        BlendMode.srcIn,
-      ),
-    );
   }
 
   void _handleRemove() {
@@ -294,7 +321,6 @@ class _SwipeableAnalyticsCardState extends State<SwipeableAnalyticsCard>
             final shakeOffset = (_shakeAnimation?.value ?? 0.0) * 15.0;
 
             return GestureDetector(
-              onTap: _openForecast,
               onLongPress: _showHelpTooltip,
               onHorizontalDragStart: (details) {
                 if (_showTooltip) {
@@ -329,189 +355,236 @@ class _SwipeableAnalyticsCardState extends State<SwipeableAnalyticsCard>
               child: Transform.translate(
                 offset: Offset(_dragOffset + shakeOffset, 0),
                 child: Container(
+                  key: widget.tourKeys?.cardKey,
                   margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
                   decoration: AppSurfaceColors.elevatedCardDecoration(context),
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       Padding(
-                        padding: const EdgeInsets.only(
-                            left: 16, right: 16, bottom: 16, top: 16),
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Row(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                Expanded(
-                                  child: Column(
-                                    crossAxisAlignment: CrossAxisAlignment.start,
-                                    children: [
-                                      Text(
-                                        widget.measurement.siteDetails?.searchName ??
-                                            widget.measurement.siteDetails?.name ??
-                                            widget.fallbackLocationName ??
-                                            "---",
-                                        style: TextStyle(
-                                          fontSize: 22,
-                                          fontWeight: FontWeight.w700,
-                                          color: Theme.of(context)
-                                              .textTheme
-                                              .headlineSmall
-                                              ?.color,
+                              padding: const EdgeInsets.fromLTRB(
+                                kMeasurementCardHorizontalPadding,
+                                kMeasurementCardTopPadding,
+                                kMeasurementCardHorizontalPadding,
+                                16,
+                              ),
+                              child: Row(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  Expanded(
+                                    child: Column(
+                                      crossAxisAlignment:
+                                          CrossAxisAlignment.start,
+                                      children: [
+                                        Text(
+                                          widget.measurement.siteDetails
+                                                  ?.searchName ??
+                                              widget.measurement.siteDetails
+                                                  ?.name ??
+                                              widget.fallbackLocationName ??
+                                              "---",
+                                          style: TextStyle(
+                                            fontSize: 22,
+                                            fontWeight: FontWeight.w700,
+                                            color: Theme.of(context)
+                                                .textTheme
+                                                .headlineSmall
+                                                ?.color,
+                                          ),
+                                          maxLines: 1,
+                                          overflow: TextOverflow.ellipsis,
                                         ),
-                                        maxLines: 1,
-                                        overflow: TextOverflow.ellipsis,
-                                      ),
-                                      const SizedBox(height: 4),
-                                      Row(
-                                        children: [
-                                          SvgPicture.asset(
-                                            'assets/images/shared/location_pin.svg',
-                                            width: 14,
-                                            height: 14,
-                                            colorFilter: ColorFilter.mode(
-                                              locationColor,
-                                              BlendMode.srcIn,
-                                            ),
-                                          ),
-                                          const SizedBox(width: 4),
-                                          Expanded(
-                                            child: Text(
-                                              _getLocationDescription(widget.measurement),
-                                              style: TextStyle(
-                                                fontSize: 14,
-                                                color: locationColor,
+                                        const SizedBox(height: 4),
+                                        Row(
+                                          children: [
+                                            SvgPicture.asset(
+                                              'assets/images/shared/location_pin.svg',
+                                              width: 14,
+                                              height: 14,
+                                              colorFilter: ColorFilter.mode(
+                                                locationColor,
+                                                BlendMode.srcIn,
                                               ),
-                                              maxLines: 1,
-                                              overflow: TextOverflow.ellipsis,
                                             ),
-                                          ),
-                                        ],
-                                      ),
-                                    ],
+                                            const SizedBox(width: 4),
+                                            Expanded(
+                                              child: Text(
+                                                _getLocationDescription(
+                                                    widget.measurement),
+                                                style: TextStyle(
+                                                  fontSize: 14,
+                                                  color: locationColor,
+                                                ),
+                                                maxLines: 1,
+                                                overflow: TextOverflow.ellipsis,
+                                              ),
+                                            ),
+                                          ],
+                                        ),
+                                      ],
+                                    ),
                                   ),
-                                ),
-                                Padding(
-                                  padding: const EdgeInsets.only(left: 8, top: 2),
-                                  child: _chevron(context),
-                                ),
-                              ],
+                                  MeasurementCardHeaderShare(
+                                    shareButtonKey: _shareButtonKey,
+                                    onShare: () => _openShare('dashboard_card'),
+                                  ),
+                                ],
+                              ),
                             ),
-                          ],
-                        ),
-                      ),
-                      Divider(
-                        thickness: .5,
-                        color: Theme.of(context).dividerColor,
-                      ),
-                      Padding(
-                        padding: const EdgeInsets.only(
-                            left: 16, right: 16, bottom: 16, top: 4),
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Row(
-                              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                              crossAxisAlignment: CrossAxisAlignment.center,
-                              children: [
-                                Expanded(
-                                  child: Column(
-                                    crossAxisAlignment: CrossAxisAlignment.start,
-                                    children: [
-                                      Row(
-                                        children: [
-                                          SvgPicture.asset(
-                                            Theme.of(context).brightness == Brightness.light
-                                                ? "assets/images/shared/pm_rating_white.svg"
-                                                : 'assets/images/shared/pm_rating.svg',
-                                          ),
-                                          const SizedBox(width: 2),
-                                          TranslatedText(
-                                            "PM2.5",
-                                            style: TextStyle(
-                                              color: Theme.of(context)
-                                                  .textTheme
-                                                  .headlineSmall
-                                                  ?.color,
+                      MeasurementCardTapLayer(
+                              enabled: _cardActionsEnabled,
+                              onForecast: _openForecast,
+                              onShareDoubleTap: () =>
+                                  _openShare('dashboard_card_double_tap'),
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  Divider(
+                                    thickness: .5,
+                                    color: Theme.of(context).dividerColor,
+                                  ),
+                                  Padding(
+                                    padding: const EdgeInsets.fromLTRB(
+                                      kMeasurementCardHorizontalPadding,
+                                      4,
+                                      kMeasurementCardHorizontalPadding,
+                                      8,
+                                    ),
+                                    child: Column(
+                                      crossAxisAlignment:
+                                          CrossAxisAlignment.start,
+                                      children: [
+                                        Row(
+                                          mainAxisAlignment:
+                                              MainAxisAlignment.spaceBetween,
+                                          crossAxisAlignment:
+                                              CrossAxisAlignment.center,
+                                          children: [
+                                            Expanded(
+                                              child: Column(
+                                                crossAxisAlignment:
+                                                    CrossAxisAlignment.start,
+                                                children: [
+                                                  Row(
+                                                    children: [
+                                                      SvgPicture.asset(
+                                                        Theme.of(context)
+                                                                    .brightness ==
+                                                                Brightness.light
+                                                            ? "assets/images/shared/pm_rating_white.svg"
+                                                            : 'assets/images/shared/pm_rating.svg',
+                                                      ),
+                                                      const SizedBox(width: 2),
+                                                      TranslatedText(
+                                                        "PM2.5",
+                                                        style: TextStyle(
+                                                          color: Theme.of(
+                                                                  context)
+                                                              .textTheme
+                                                              .headlineSmall
+                                                              ?.color,
+                                                        ),
+                                                      ),
+                                                    ],
+                                                  ),
+                                                  Row(
+                                                    children: [
+                                                      Text(
+                                                        widget.measurement.pm25
+                                                                    ?.value !=
+                                                                null
+                                                            ? widget
+                                                                .measurement
+                                                                .pm25!
+                                                                .value!
+                                                                .toStringAsFixed(
+                                                                    1)
+                                                            : "-",
+                                                        style: TextStyle(
+                                                          fontWeight:
+                                                              FontWeight.w700,
+                                                          fontSize: 36,
+                                                          color: Theme.of(
+                                                                  context)
+                                                              .textTheme
+                                                              .headlineLarge
+                                                              ?.color,
+                                                        ),
+                                                      ),
+                                                      Text(
+                                                        " μg/m³",
+                                                        style: TextStyle(
+                                                          fontWeight:
+                                                              FontWeight.w600,
+                                                          fontSize: 18,
+                                                          color: Theme.of(
+                                                                  context)
+                                                              .textTheme
+                                                              .headlineLarge
+                                                              ?.color,
+                                                        ),
+                                                      ),
+                                                    ],
+                                                  ),
+                                                ],
+                                              ),
                                             ),
-                                          ),
-                                        ],
-                                      ),
-                                      Row(
-                                        children: [
-                                          Text(
-                                            widget.measurement.pm25?.value != null
-                                                ? widget.measurement.pm25!.value!
-                                                    .toStringAsFixed(1)
-                                                : "-",
-                                            style: TextStyle(
-                                              fontWeight: FontWeight.w700,
-                                              fontSize: 36,
-                                              color: Theme.of(context)
-                                                  .textTheme
-                                                  .headlineLarge
-                                                  ?.color,
+                                            SizedBox(
+                                              child: Center(
+                                                child: widget.measurement.pm25
+                                                            ?.value !=
+                                                        null
+                                                    ? SvgPicture.asset(
+                                                        getAirQualityIcon(
+                                                          widget.measurement,
+                                                          widget.measurement
+                                                              .pm25!.value!,
+                                                        ),
+                                                        height: 86,
+                                                        width: 86,
+                                                      )
+                                                    : const Icon(
+                                                        Icons.help_outline,
+                                                        size: 60,
+                                                        color: Colors.grey,
+                                                      ),
+                                              ),
                                             ),
+                                          ],
+                                        ),
+                                        const SizedBox(height: 16),
+                                        Container(
+                                          margin: EdgeInsets.zero,
+                                          padding: const EdgeInsets.symmetric(
+                                              horizontal: 16, vertical: 8),
+                                          decoration: BoxDecoration(
+                                            color: _getAqiColor(
+                                                    widget.measurement)
+                                                .withValues(alpha: 0.15),
+                                            borderRadius:
+                                                BorderRadius.circular(20),
                                           ),
-                                          Text(
-                                            " μg/m³",
+                                          child: TranslatedText(
+                                            widget.measurement.aqiCategory ??
+                                                'Unknown',
                                             style: TextStyle(
+                                              fontSize: 14,
                                               fontWeight: FontWeight.w600,
-                                              fontSize: 18,
-                                              color: Theme.of(context)
-                                                  .textTheme
-                                                  .headlineLarge
-                                                  ?.color,
+                                              color: _getAqiColor(
+                                                  widget.measurement),
                                             ),
+                                            maxLines: 1,
                                           ),
-                                        ],
-                                      ),
-                                    ],
+                                        ),
+                                      ],
+                                    ),
                                   ),
-                                ),
-                                SizedBox(
-                                  child: Center(
-                                    child: widget.measurement.pm25?.value != null
-                                        ? SvgPicture.asset(
-                                            getAirQualityIcon(
-                                              widget.measurement,
-                                              widget.measurement.pm25!.value!,
-                                            ),
-                                            height: 86,
-                                            width: 86,
-                                          )
-                                        : const Icon(
-                                            Icons.help_outline,
-                                            size: 60,
-                                            color: Colors.grey,
-                                          ),
-                                  ),
-                                ),
-                              ],
-                            ),
-                            const SizedBox(height: 16),
-                            Container(
-                              margin: const EdgeInsets.only(bottom: 12),
-                              padding: const EdgeInsets.symmetric(
-                                  horizontal: 16, vertical: 8),
-                              decoration: BoxDecoration(
-                                color: _getAqiColor(widget.measurement)
-                                    .withValues(alpha: 0.15),
-                                borderRadius: BorderRadius.circular(20),
-                              ),
-                              child: TranslatedText(
-                                widget.measurement.aqiCategory ?? 'Unknown',
-                                style: TextStyle(
-                                  fontSize: 14,
-                                  fontWeight: FontWeight.w600,
-                                  color: _getAqiColor(widget.measurement),
-                                ),
-                                maxLines: 1,
+                                ],
                               ),
                             ),
-                          ],
-                        ),
+                      MeasurementCardFooterForecast(
+                        enabled: _cardActionsEnabled,
+                        onForecast: _openForecast,
                       ),
                     ],
                   ),

--- a/src/mobile/lib/src/app/dashboard/widgets/analytics_card.dart
+++ b/src/mobile/lib/src/app/dashboard/widgets/analytics_card.dart
@@ -3,21 +3,72 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:loggy/loggy.dart';
 import 'package:airqo/src/app/dashboard/models/airquality_response.dart';
 import 'package:airqo/src/app/dashboard/pages/forecast_overview_page.dart';
+import 'package:airqo/src/app/dashboard/widgets/measurement_card_tour.dart';
+import 'package:airqo/src/app/dashboard/widgets/measurement_card_action_strip.dart';
+import 'package:airqo/src/app/dashboard/widgets/measurement_card_gestures.dart';
 import 'package:airqo/src/meta/utils/colors.dart';
 import 'package:airqo/src/meta/utils/forecast_utils.dart';
 import 'package:airqo/src/meta/utils/utils.dart';
 
-class AnalyticsCard extends StatelessWidget with UiLoggy {
+class AnalyticsCard extends StatefulWidget {
   final Measurement measurement;
   final String? fallbackLocationName;
+  final MeasurementCardTourKeys? tourKeys;
+  final VoidCallback? onTourTargetReady;
 
-  const AnalyticsCard(this.measurement, {super.key, this.fallbackLocationName});
+  const AnalyticsCard(
+    this.measurement, {
+    super.key,
+    this.fallbackLocationName,
+    this.tourKeys,
+    this.onTourTargetReady,
+  });
 
-  void _openForecast(BuildContext context) {
+  @override
+  State<AnalyticsCard> createState() => _AnalyticsCardState();
+}
+
+class _AnalyticsCardState extends State<AnalyticsCard> with UiLoggy {
+  final GlobalKey _defaultShareButtonKey = GlobalKey();
+  bool _tourReadyNotified = false;
+
+  GlobalKey get _shareButtonKey => _defaultShareButtonKey;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.tourKeys != null) {
+      scheduleMeasurementCardTourReady(
+        keys: widget.tourKeys!,
+        onReady: _notifyTourTargetReady,
+        isActive: () => mounted && !_tourReadyNotified,
+      );
+    }
+  }
+
+  void _notifyTourTargetReady() {
+    if (_tourReadyNotified || !mounted || widget.onTourTargetReady == null) {
+      return;
+    }
+    _tourReadyNotified = true;
+    widget.onTourTargetReady!();
+  }
+
+  void _openForecast() {
     ForecastOverviewPage.showForMeasurement(
       context,
-      measurement: measurement,
-      fallbackLocationName: fallbackLocationName,
+      measurement: widget.measurement,
+      fallbackLocationName: widget.fallbackLocationName,
+    );
+  }
+
+  Future<void> _openShare(String source) {
+    return openMeasurementShareSheet(
+      context,
+      measurement: widget.measurement,
+      source: source,
+      fallbackLocationName: widget.fallbackLocationName,
+      shareButtonKey: _shareButtonKey,
     );
   }
 
@@ -55,199 +106,212 @@ class AnalyticsCard extends StatelessWidget with UiLoggy {
     return getAppAqiCategoryColor(measurement.aqiCategory ?? '');
   }
 
-  Widget _chevron(BuildContext context) {
-    return SvgPicture.asset(
-      'assets/icons/chevron-right.svg',
-      width: 20,
-      height: 20,
-      colorFilter: ColorFilter.mode(
-        AppTextColors.modalCloseIcon(context),
-        BlendMode.srcIn,
-      ),
-    );
-  }
-
   @override
   Widget build(BuildContext context) {
+    final measurement = widget.measurement;
     final locationColor = AppTextColors.muted(context);
-    return InkWell(
-      onTap: () => _openForecast(context),
-      child: Container(
-        margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-        decoration: AppSurfaceColors.elevatedCardDecoration(context),
-        child: SingleChildScrollView(
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            mainAxisSize: MainAxisSize.min,
-            children: [
-            Padding(
-              padding: const EdgeInsets.only(
-                  left: 16, right: 16, bottom: 16, top: 16),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Row(
+    return Container(
+      key: widget.tourKeys?.cardKey,
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      decoration: AppSurfaceColors.elevatedCardDecoration(context),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(
+              kMeasurementCardHorizontalPadding,
+              kMeasurementCardTopPadding,
+              kMeasurementCardHorizontalPadding,
+              16,
+            ),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Expanded(
+                  child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      Expanded(
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Text(
-                              measurement.siteDetails?.searchName ??
-                                  measurement.siteDetails?.name ??
-                                  fallbackLocationName ??
-                                  "---",
+                      Text(
+                        measurement.siteDetails?.searchName ??
+                            measurement.siteDetails?.name ??
+                            widget.fallbackLocationName ??
+                            "---",
+                        style: TextStyle(
+                          fontSize: 22,
+                          fontWeight: FontWeight.w700,
+                          color: Theme.of(context)
+                              .textTheme
+                              .headlineSmall
+                              ?.color,
+                        ),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                      const SizedBox(height: 4),
+                      Row(
+                        children: [
+                          SvgPicture.asset(
+                            'assets/images/shared/location_pin.svg',
+                            width: 14,
+                            height: 14,
+                            colorFilter: ColorFilter.mode(
+                              locationColor,
+                              BlendMode.srcIn,
+                            ),
+                          ),
+                          const SizedBox(width: 4),
+                          Expanded(
+                            child: Text(
+                              _getLocationDescription(measurement),
                               style: TextStyle(
-                                fontSize: 22,
-                                fontWeight: FontWeight.w700,
-                                color: Theme.of(context)
-                                    .textTheme
-                                    .headlineSmall
-                                    ?.color,
+                                fontSize: 14,
+                                color: locationColor,
                               ),
                               maxLines: 1,
                               overflow: TextOverflow.ellipsis,
                             ),
-                            SizedBox(height: 4),
-                            Row(
-                              children: [
-                                SvgPicture.asset(
-                                  'assets/images/shared/location_pin.svg',
-                                  width: 14,
-                                  height: 14,
-                                  colorFilter: ColorFilter.mode(
-                                    locationColor,
-                                    BlendMode.srcIn,
-                                  ),
-                                ),
-                                SizedBox(width: 4),
-                                Expanded(
-                                  child: Text(
-                                    _getLocationDescription(measurement),
-                                    style: TextStyle(
-                                      fontSize: 14,
-                                      color: locationColor,
-                                    ),
-                                    maxLines: 1,
-                                    overflow: TextOverflow.ellipsis,
-                                  ),
-                                ),
-                              ],
-                            ),
-                          ],
-                        ),
-                      ),
-                      Padding(
-                        padding: const EdgeInsets.only(left: 8, top: 2),
-                        child: _chevron(context),
+                          ),
+                        ],
                       ),
                     ],
                   ),
-                ],
-              ),
+                ),
+                MeasurementCardHeaderShare(
+                  shareButtonKey: _shareButtonKey,
+                  onShare: () => _openShare('dashboard_card'),
+                ),
+              ],
             ),
-            Divider(thickness: .5, color: Theme.of(context).dividerColor),
-            Padding(
-              padding: const EdgeInsets.only(
-                  left: 16, right: 16, bottom: 16, top: 4),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    crossAxisAlignment: CrossAxisAlignment.center,
+          ),
+          MeasurementCardTapLayer(
+            onForecast: _openForecast,
+            onShareDoubleTap: () => _openShare('dashboard_card_double_tap'),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Divider(thickness: .5, color: Theme.of(context).dividerColor),
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(
+                    kMeasurementCardHorizontalPadding,
+                    4,
+                    kMeasurementCardHorizontalPadding,
+                    8,
+                  ),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        crossAxisAlignment: CrossAxisAlignment.center,
                         children: [
-                          Row(
+                          Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
                             children: [
-                              SvgPicture.asset(Theme.of(context).brightness ==
-                                      Brightness.light
-                                  ? "assets/images/shared/pm_rating_white.svg"
-                                  : 'assets/images/shared/pm_rating.svg'),
-                              const SizedBox(width: 2),
-                              Text(
-                                " PM2.5",
-                                style: TextStyle(
-                                  color: Theme.of(context)
-                                      .textTheme
-                                      .headlineSmall
-                                      ?.color,
-                                ),
+                              Row(
+                                children: [
+                                  SvgPicture.asset(
+                                    Theme.of(context).brightness ==
+                                            Brightness.light
+                                        ? "assets/images/shared/pm_rating_white.svg"
+                                        : 'assets/images/shared/pm_rating.svg',
+                                  ),
+                                  const SizedBox(width: 2),
+                                  Text(
+                                    " PM2.5",
+                                    style: TextStyle(
+                                      color: Theme.of(context)
+                                          .textTheme
+                                          .headlineSmall
+                                          ?.color,
+                                    ),
+                                  ),
+                                ],
+                              ),
+                              Row(
+                                children: [
+                                  Text(
+                                    measurement.pm25?.value != null
+                                        ? measurement.pm25!.value!
+                                            .toStringAsFixed(1)
+                                        : "-",
+                                    style: TextStyle(
+                                      fontWeight: FontWeight.w700,
+                                      fontSize: 36,
+                                      color: Theme.of(context)
+                                          .textTheme
+                                          .headlineLarge
+                                          ?.color,
+                                    ),
+                                  ),
+                                  Text(
+                                    " μg/m³",
+                                    style: TextStyle(
+                                      fontWeight: FontWeight.w600,
+                                      fontSize: 18,
+                                      color: Theme.of(context)
+                                          .textTheme
+                                          .headlineLarge
+                                          ?.color,
+                                    ),
+                                  ),
+                                ],
                               ),
                             ],
                           ),
-                          Row(children: [
-                            Text(
-                              measurement.pm25?.value != null
-                                  ? measurement.pm25!.value!.toStringAsFixed(1)
-                                  : "-",
-                              style: TextStyle(
-                                  fontWeight: FontWeight.w700,
-                                  fontSize: 36,
-                                  color: Theme.of(context)
-                                      .textTheme
-                                      .headlineLarge
-                                      ?.color),
+                          SizedBox(
+                            child: Center(
+                              child: measurement.pm25?.value != null
+                                  ? SvgPicture.asset(
+                                      getAirQualityIcon(measurement,
+                                          measurement.pm25!.value!),
+                                      height: 86,
+                                      width: 86,
+                                    )
+                                  : const Icon(
+                                      Icons.help_outline,
+                                      size: 60,
+                                      color: Colors.grey,
+                                    ),
                             ),
-                            Text(" μg/m³",
-                                style: TextStyle(
-                                    fontWeight: FontWeight.w600,
-                                    fontSize: 18,
-                                    color: Theme.of(context)
-                                        .textTheme
-                                        .headlineLarge
-                                        ?.color))
-                          ]),
+                          ),
                         ],
                       ),
-                      SizedBox(
-                        child: Center(
-                          child: measurement.pm25?.value != null
-                              ? SvgPicture.asset(
-                                  getAirQualityIcon(
-                                      measurement, measurement.pm25!.value!),
-                                  height: 86,
-                                  width: 86,
-                                )
-                              : Icon(
-                                  Icons.help_outline,
-                                  size: 60,
-                                  color: Colors.grey,
-                                ),
-                        ),
+                      const SizedBox(height: 16),
+                      Wrap(
+                        children: [
+                          Container(
+                            margin: EdgeInsets.zero,
+                            padding: const EdgeInsets.symmetric(
+                                horizontal: 16, vertical: 8),
+                            decoration: BoxDecoration(
+                              color: _getAqiColor(measurement)
+                                  .withValues(alpha: 0.15),
+                              borderRadius: BorderRadius.circular(20),
+                            ),
+                            child: Text(
+                              measurement.aqiCategory ?? "Unknown",
+                              style: TextStyle(
+                                fontSize: 14,
+                                fontWeight: FontWeight.w600,
+                                color: _getAqiColor(measurement),
+                              ),
+                              maxLines: 1,
+                            ),
+                          ),
+                        ],
                       ),
                     ],
                   ),
-                  SizedBox(height: 16),
-                  Wrap(children: [
-                    Container(
-                      margin: EdgeInsets.only(bottom: 12),
-                      padding:
-                          EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-                      decoration: BoxDecoration(
-                        color: _getAqiColor(measurement).withValues(alpha: 0.15),
-                        borderRadius: BorderRadius.circular(20),
-                      ),
-                      child: Text(
-                        measurement.aqiCategory ?? "Unknown",
-                        style: TextStyle(
-                          fontSize: 14,
-                          fontWeight: FontWeight.w600,
-                          color: _getAqiColor(measurement),
-                        ),
-                        maxLines: 1,
-                      ),
-                    ),
-                  ]),
-                ],
-              ),
+                ),
+              ],
             ),
-          ],
-        ),
-      ),
+          ),
+          MeasurementCardFooterForecast(
+            onForecast: _openForecast,
+          ),
+        ],
       ),
     );
   }

--- a/src/mobile/lib/src/app/dashboard/widgets/measurement_card_action_strip.dart
+++ b/src/mobile/lib/src/app/dashboard/widgets/measurement_card_action_strip.dart
@@ -1,0 +1,172 @@
+import 'package:airqo/src/app/dashboard/models/airquality_response.dart';
+import 'package:airqo/src/app/dashboard/widgets/air_quality_share_sheet.dart';
+import 'package:airqo/src/app/shared/services/analytics_service.dart';
+import 'package:airqo/src/meta/utils/colors.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+
+const double kMeasurementCardActionIconSize = 18;
+const double kMeasurementCardActionTapTarget = 40;
+const double kMeasurementCardHorizontalPadding = 16;
+const double kMeasurementCardTopPadding = 16;
+const double kMeasurementCardBottomPadding = 12;
+
+/// Right-aligned icon slot shared by header share and footer chevron.
+class MeasurementCardTrailingIconSlot extends StatelessWidget {
+  final Widget icon;
+
+  const MeasurementCardTrailingIconSlot({super.key, required this.icon});
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: kMeasurementCardActionTapTarget,
+      height: kMeasurementCardActionTapTarget,
+      child: Center(child: icon),
+    );
+  }
+}
+
+/// Opens the air quality share sheet for a dashboard card measurement.
+Future<void> openMeasurementShareSheet(
+  BuildContext context, {
+  required Measurement measurement,
+  required String source,
+  String? fallbackLocationName,
+  GlobalKey? shareButtonKey,
+}) async {
+  final renderObject =
+      shareButtonKey?.currentContext?.findRenderObject() as RenderBox?;
+  final shareOrigin = renderObject == null
+      ? null
+      : renderObject.localToGlobal(Offset.zero) & renderObject.size;
+
+  await showAirQualityShareSheet(
+    context,
+    measurement: measurement,
+    source: source,
+    fallbackLocationName: fallbackLocationName,
+    sharePositionOrigin: shareOrigin,
+  );
+}
+
+/// Share action for the top-right of measurement dashboard cards.
+class MeasurementCardHeaderShare extends StatelessWidget {
+  final VoidCallback onShare;
+  final GlobalKey? shareButtonKey;
+
+  const MeasurementCardHeaderShare({
+    super.key,
+    required this.onShare,
+    this.shareButtonKey,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final iconColor = AppTextColors.modalCloseIcon(context);
+
+    return MeasurementCardTrailingIconSlot(
+      key: shareButtonKey,
+      icon: _CompactIconAction(
+        tooltip: 'Share',
+        semanticsLabel: 'Share air quality',
+        onPressed: () {
+          AnalyticsService().trackCardActionTapped(action: 'share');
+          onShare();
+        },
+        icon: SvgPicture.asset(
+          'assets/icons/share-icon.svg',
+          width: kMeasurementCardActionIconSize,
+          height: kMeasurementCardActionIconSize,
+          colorFilter: ColorFilter.mode(iconColor, BlendMode.srcIn),
+        ),
+      ),
+    );
+  }
+}
+
+/// Forecast chevron for the bottom-right of measurement dashboard cards.
+class MeasurementCardFooterForecast extends StatelessWidget {
+  final VoidCallback onForecast;
+  final bool enabled;
+
+  const MeasurementCardFooterForecast({
+    super.key,
+    required this.onForecast,
+    this.enabled = true,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final iconColor = AppTextColors.modalCloseIcon(context);
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(
+        kMeasurementCardHorizontalPadding,
+        0,
+        kMeasurementCardHorizontalPadding,
+        kMeasurementCardBottomPadding,
+      ),
+      child: Align(
+        alignment: Alignment.centerRight,
+        child: MeasurementCardTrailingIconSlot(
+          icon: _CompactIconAction(
+            tooltip: 'Forecast',
+            semanticsLabel: 'View forecast',
+            onPressed: enabled
+                ? () {
+                    AnalyticsService().trackCardActionTapped(action: 'forecast');
+                    onForecast();
+                  }
+                : null,
+            icon: SvgPicture.asset(
+              'assets/icons/chevron-right.svg',
+              width: kMeasurementCardActionIconSize,
+              height: kMeasurementCardActionIconSize,
+              colorFilter: ColorFilter.mode(iconColor, BlendMode.srcIn),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _CompactIconAction extends StatelessWidget {
+  final String tooltip;
+  final String semanticsLabel;
+  final VoidCallback? onPressed;
+  final Widget icon;
+
+  const _CompactIconAction({
+    required this.tooltip,
+    required this.semanticsLabel,
+    required this.onPressed,
+    required this.icon,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      button: true,
+      label: semanticsLabel,
+      child: Tooltip(
+        message: tooltip,
+        child: SizedBox(
+          width: kMeasurementCardActionTapTarget,
+          height: kMeasurementCardActionTapTarget,
+          child: IconButton(
+            onPressed: onPressed,
+            padding: EdgeInsets.zero,
+            visualDensity: VisualDensity.compact,
+            constraints: const BoxConstraints(
+              minWidth: kMeasurementCardActionTapTarget,
+              minHeight: kMeasurementCardActionTapTarget,
+            ),
+            icon: icon,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/src/mobile/lib/src/app/dashboard/widgets/measurement_card_gestures.dart
+++ b/src/mobile/lib/src/app/dashboard/widgets/measurement_card_gestures.dart
@@ -1,0 +1,64 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+/// Debounced single-tap + double-tap layer for measurement cards.
+///
+/// Single tap opens forecast after [tapDelay]; double tap cancels the pending
+/// tap and invokes [onShareDoubleTap] with light haptic feedback.
+class MeasurementCardTapLayer extends StatefulWidget {
+  final Widget child;
+  final VoidCallback onForecast;
+  final VoidCallback onShareDoubleTap;
+  final bool enabled;
+
+  const MeasurementCardTapLayer({
+    super.key,
+    required this.child,
+    required this.onForecast,
+    required this.onShareDoubleTap,
+    this.enabled = true,
+  });
+
+  @override
+  State<MeasurementCardTapLayer> createState() =>
+      _MeasurementCardTapLayerState();
+}
+
+class _MeasurementCardTapLayerState extends State<MeasurementCardTapLayer> {
+  static const _tapDelay = Duration(milliseconds: 250);
+  Timer? _singleTapTimer;
+
+  @override
+  void dispose() {
+    _singleTapTimer?.cancel();
+    super.dispose();
+  }
+
+  void _handleTap() {
+    if (!widget.enabled) return;
+    _singleTapTimer?.cancel();
+    _singleTapTimer = Timer(_tapDelay, () {
+      if (!mounted) return;
+      widget.onForecast();
+    });
+  }
+
+  void _handleDoubleTap() {
+    if (!widget.enabled) return;
+    _singleTapTimer?.cancel();
+    HapticFeedback.lightImpact();
+    widget.onShareDoubleTap();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: widget.enabled ? _handleTap : null,
+      onDoubleTap: widget.enabled ? _handleDoubleTap : null,
+      child: widget.child,
+    );
+  }
+}

--- a/src/mobile/lib/src/app/dashboard/widgets/measurement_card_tour.dart
+++ b/src/mobile/lib/src/app/dashboard/widgets/measurement_card_tour.dart
@@ -1,0 +1,588 @@
+import 'package:airqo/src/app/dashboard/widgets/measurement_card_action_strip.dart';
+import 'package:airqo/src/meta/utils/colors.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+
+/// GlobalKey for the first dashboard measurement card used by the gestures tour.
+class MeasurementCardTourKeys {
+  final GlobalKey cardKey = GlobalKey(debugLabel: 'measurement_card');
+}
+
+const String measurementCardGesturesTourSeenKey =
+    'measurement_card_gestures_tour_seen';
+
+/// Set to true when ready to show the first-run card gestures tour again.
+const bool kMeasurementCardGesturesTourEnabled = false;
+
+enum MeasurementCardTourTargetKind { tapZone, shareIcon, forecastIcon }
+
+/// Whether the first card is attached and laid out.
+bool measurementCardTourTargetsReady(MeasurementCardTourKeys keys) {
+  return keys.cardKey.currentContext != null;
+}
+
+/// Waits until the tour card is measurable, then invokes [onReady] once.
+void scheduleMeasurementCardTourReady({
+  required MeasurementCardTourKeys keys,
+  required VoidCallback onReady,
+  required bool Function() isActive,
+  int attempt = 0,
+  int maxAttempts = 40,
+}) {
+  WidgetsBinding.instance.addPostFrameCallback((_) {
+    if (!isActive()) return;
+    if (measurementCardTourTargetsReady(keys)) {
+      onReady();
+      return;
+    }
+    if (attempt < maxAttempts) {
+      scheduleMeasurementCardTourReady(
+        keys: keys,
+        onReady: onReady,
+        isActive: isActive,
+        attempt: attempt + 1,
+        maxAttempts: maxAttempts,
+      );
+    }
+  });
+}
+
+/// Spotlight rect derived from the card bounds and known icon layout constants.
+Rect measurementCardTourTargetRect(
+  MeasurementCardTourKeys keys,
+  MeasurementCardTourTargetKind kind,
+) {
+  final ctx = keys.cardKey.currentContext;
+  if (ctx == null) return Rect.zero;
+  final box = ctx.findRenderObject() as RenderBox?;
+  if (box == null || !box.hasSize) return Rect.zero;
+
+  final card = box.localToGlobal(Offset.zero) & box.size;
+  const footerHeight =
+      kMeasurementCardBottomPadding + kMeasurementCardActionTapTarget;
+
+  switch (kind) {
+    case MeasurementCardTourTargetKind.tapZone:
+      return Rect.fromLTRB(
+        card.left,
+        card.top,
+        card.right,
+        card.bottom - footerHeight,
+      );
+    case MeasurementCardTourTargetKind.shareIcon:
+      return Rect.fromLTWH(
+        card.right -
+            kMeasurementCardHorizontalPadding -
+            kMeasurementCardActionTapTarget,
+        card.top + kMeasurementCardTopPadding,
+        kMeasurementCardActionTapTarget,
+        kMeasurementCardActionTapTarget,
+      );
+    case MeasurementCardTourTargetKind.forecastIcon:
+      return Rect.fromLTWH(
+        card.right -
+            kMeasurementCardHorizontalPadding -
+            kMeasurementCardActionTapTarget,
+        card.bottom - footerHeight,
+        kMeasurementCardActionTapTarget,
+        kMeasurementCardActionTapTarget,
+      );
+  }
+}
+
+class MeasurementCardTourStep {
+  const MeasurementCardTourStep({
+    required this.targetKind,
+    required this.title,
+    required this.subtitle,
+    this.icon,
+    this.svgAssetPath,
+  }) : assert(icon != null || svgAssetPath != null);
+
+  final MeasurementCardTourTargetKind targetKind;
+  final IconData? icon;
+  final String? svgAssetPath;
+  final String title;
+  final String subtitle;
+}
+
+List<MeasurementCardTourStep> buildMeasurementCardGesturesTourSteps() {
+  return const [
+    MeasurementCardTourStep(
+      targetKind: MeasurementCardTourTargetKind.tapZone,
+      icon: Icons.touch_app_rounded,
+      title: 'Tap for forecast',
+      subtitle:
+          'Tap the card once to open the air quality forecast for this location.',
+    ),
+    MeasurementCardTourStep(
+      targetKind: MeasurementCardTourTargetKind.tapZone,
+      icon: Icons.touch_app_rounded,
+      title: 'Double tap to share',
+      subtitle:
+          'Double tap the card to share air quality instantly with friends.',
+    ),
+    MeasurementCardTourStep(
+      targetKind: MeasurementCardTourTargetKind.shareIcon,
+      svgAssetPath: 'assets/icons/share-icon.svg',
+      title: 'Share button',
+      subtitle:
+          'You can also tap the share icon here to open sharing options.',
+    ),
+    MeasurementCardTourStep(
+      targetKind: MeasurementCardTourTargetKind.forecastIcon,
+      svgAssetPath: 'assets/icons/chevron-right.svg',
+      title: 'Forecast shortcut',
+      subtitle: 'Tap the arrow to jump straight to the forecast.',
+    ),
+  ];
+}
+
+/// Guided tour for dashboard measurement card gestures.
+class MeasurementCardGesturesTour extends StatefulWidget {
+  const MeasurementCardGesturesTour({
+    super.key,
+    required this.tourKeys,
+    required this.steps,
+    required this.onDismiss,
+  });
+
+  final MeasurementCardTourKeys tourKeys;
+  final List<MeasurementCardTourStep> steps;
+  final VoidCallback onDismiss;
+
+  @override
+  State<MeasurementCardGesturesTour> createState() =>
+      _MeasurementCardGesturesTourState();
+}
+
+class _MeasurementCardGesturesTourState extends State<MeasurementCardGesturesTour>
+    with SingleTickerProviderStateMixin {
+  int _stepIndex = 0;
+  Rect? _targetRect;
+  late AnimationController _fade;
+  late Animation<double> _opacity;
+
+  MeasurementCardTourStep get _step => widget.steps[_stepIndex];
+  bool get _isLastStep => _stepIndex >= widget.steps.length - 1;
+
+  @override
+  void initState() {
+    super.initState();
+    _fade = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 280),
+    );
+    _opacity = CurvedAnimation(parent: _fade, curve: Curves.easeOut);
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _remeasureTargetAfterLayout();
+      _fade.forward();
+    });
+  }
+
+  @override
+  void dispose() {
+    _fade.dispose();
+    super.dispose();
+  }
+
+  void _applyTargetRect() {
+    final rect = measurementCardTourTargetRect(
+      widget.tourKeys,
+      _step.targetKind,
+    );
+    if (rect == Rect.zero || !mounted) return;
+    setState(() => _targetRect = rect);
+  }
+
+  void _remeasureTargetAfterLayout() {
+    final ctx = widget.tourKeys.cardKey.currentContext;
+    if (ctx != null) {
+      Scrollable.ensureVisible(
+        ctx,
+        alignment: 0.05,
+        duration: const Duration(milliseconds: 280),
+        curve: Curves.easeInOut,
+      );
+    }
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      _applyTargetRect();
+      if (_targetRect == null) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (mounted) _applyTargetRect();
+        });
+      }
+    });
+  }
+
+  void _advance() {
+    if (_isLastStep) {
+      _fade.reverse().then((_) {
+        if (mounted) widget.onDismiss();
+      });
+      return;
+    }
+
+    _fade.reverse().then((_) {
+      if (!mounted) return;
+      setState(() {
+        _stepIndex++;
+        _targetRect = null;
+      });
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        _remeasureTargetAfterLayout();
+        _fade.forward();
+      });
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final targetRect = _targetRect;
+    final compact = targetRect != null && _isCompactTarget(targetRect);
+
+    return FadeTransition(
+      opacity: _opacity,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: _advance,
+        child: Stack(
+          children: [
+            if (targetRect != null)
+              CustomPaint(
+                size: MediaQuery.of(context).size,
+                painter: _CardSpotlightPainter(
+                  spotlight: targetRect,
+                  compact: compact,
+                ),
+              )
+            else
+              Container(color: Colors.black54),
+            if (targetRect != null)
+              _CardTourTooltipBubble(
+                targetRect: targetRect,
+                isDark: isDark,
+                step: _step,
+                stepIndex: _stepIndex,
+                stepCount: widget.steps.length,
+                isLastStep: _isLastStep,
+                compact: compact,
+                preferAbove: _step.targetKind ==
+                    MeasurementCardTourTargetKind.forecastIcon,
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  static bool _isCompactTarget(Rect rect) =>
+      rect.width <= 80 && rect.height <= 80;
+}
+
+class _CardSpotlightPainter extends CustomPainter {
+  final Rect spotlight;
+  final bool compact;
+
+  static const double _pad = 8;
+  static const double _radius = 12;
+
+  const _CardSpotlightPainter({
+    required this.spotlight,
+    required this.compact,
+  });
+
+  Rect get _expanded {
+    if (compact) {
+      return Rect.fromLTRB(
+        spotlight.left - _pad,
+        spotlight.top - _pad,
+        spotlight.right + _pad,
+        spotlight.bottom + _pad,
+      );
+    }
+    return Rect.fromLTRB(
+      spotlight.left - _pad,
+      spotlight.top - _pad,
+      spotlight.right + _pad,
+      spotlight.bottom - _pad,
+    );
+  }
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final expanded = _expanded;
+    canvas.saveLayer(Offset.zero & size, Paint());
+
+    canvas.drawRect(
+      Offset.zero & size,
+      Paint()..color = Colors.black.withValues(alpha: 0.68),
+    );
+
+    canvas.drawRRect(
+      RRect.fromRectAndRadius(expanded, const Radius.circular(_radius)),
+      Paint()..blendMode = BlendMode.clear,
+    );
+
+    canvas.restore();
+
+    canvas.drawRRect(
+      RRect.fromRectAndRadius(expanded, const Radius.circular(_radius)),
+      Paint()
+        ..color = Colors.white.withValues(alpha: 0.25)
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = 1.5,
+    );
+  }
+
+  @override
+  bool shouldRepaint(_CardSpotlightPainter old) =>
+      old.spotlight != spotlight || old.compact != compact;
+}
+
+class _CardTourTooltipBubble extends StatelessWidget {
+  final Rect targetRect;
+  final bool isDark;
+  final MeasurementCardTourStep step;
+  final int stepIndex;
+  final int stepCount;
+  final bool isLastStep;
+  final bool compact;
+  final bool preferAbove;
+
+  static const double _arrowH = 10.0;
+  static const double _hPad = 16.0;
+  static const double _gap = 8.0;
+  static const double _estimatedBubbleHeight = 150.0;
+
+  const _CardTourTooltipBubble({
+    required this.targetRect,
+    required this.isDark,
+    required this.step,
+    required this.stepIndex,
+    required this.stepCount,
+    required this.isLastStep,
+    required this.compact,
+    required this.preferAbove,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final padding = MediaQuery.paddingOf(context);
+    final screen = MediaQuery.sizeOf(context);
+    final bubbleBg = isDark ? AppColors.darkHighlight : Colors.white;
+    final textColor = isDark ? Colors.white : const Color(0xFF1A1D23);
+    final subColor =
+        isDark ? AppColors.boldHeadlineColor2 : AppColors.boldHeadlineColor3;
+
+    final spotlightBottom = compact
+        ? targetRect.bottom + _gap
+        : targetRect.bottom - 8 + _gap;
+    final spotlightTop = compact ? targetRect.top - _gap : targetRect.top - 8;
+
+    final placeBelow = !preferAbove &&
+        spotlightBottom + _arrowH + _estimatedBubbleHeight <=
+            screen.height - padding.bottom - _hPad;
+    final arrowCx =
+        targetRect.center.dx.clamp(_hPad + 20, screen.width - _hPad - 20);
+
+    if (placeBelow) {
+      return Positioned(
+        top: spotlightBottom + _arrowH,
+        left: _hPad + padding.left,
+        right: _hPad + padding.right,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Padding(
+              padding: EdgeInsets.only(
+                left: (arrowCx - _hPad - padding.left - 10)
+                    .clamp(0.0, screen.width - (_hPad + padding.horizontal) - 20),
+              ),
+              child: CustomPaint(
+                size: const Size(20, _arrowH),
+                painter: _UpArrowPainter(color: bubbleBg),
+              ),
+            ),
+            _bubbleBody(bubbleBg, textColor, subColor),
+          ],
+        ),
+      );
+    }
+
+    final bubbleBottom = spotlightTop - _arrowH;
+    return Positioned(
+      bottom: screen.height - bubbleBottom,
+      left: _hPad + padding.left,
+      right: _hPad + padding.right,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _bubbleBody(bubbleBg, textColor, subColor),
+          Padding(
+            padding: EdgeInsets.only(
+              left: (arrowCx - _hPad - padding.left - 10)
+                  .clamp(0.0, screen.width - (_hPad + padding.horizontal) - 20),
+            ),
+            child: CustomPaint(
+              size: const Size(20, _arrowH),
+              painter: _DownArrowPainter(color: bubbleBg),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _bubbleBody(Color bubbleBg, Color textColor, Color subColor) {
+    return Container(
+      padding: const EdgeInsets.fromLTRB(16, 14, 16, 14),
+      decoration: BoxDecoration(
+        color: bubbleBg,
+        borderRadius: BorderRadius.circular(14),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.18),
+            blurRadius: 24,
+            offset: const Offset(0, 8),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Container(
+                width: 36,
+                height: 36,
+                decoration: BoxDecoration(
+                  color: AppColors.primaryColor.withValues(alpha: 0.12),
+                  borderRadius: BorderRadius.circular(10),
+                ),
+                child: Center(child: _stepIcon()),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      step.title,
+                      style: TextStyle(
+                        fontSize: 15,
+                        fontWeight: FontWeight.w700,
+                        color: textColor,
+                        height: 1.2,
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      step.subtitle,
+                      style: TextStyle(
+                        fontSize: 13,
+                        fontWeight: FontWeight.w400,
+                        color: subColor,
+                        height: 1.45,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 14),
+          Row(
+            children: [
+              Text(
+                '${stepIndex + 1} of $stepCount',
+                style: TextStyle(
+                  fontSize: 11,
+                  color: subColor,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              const Spacer(),
+              Text(
+                isLastStep
+                    ? 'Tap anywhere to dismiss'
+                    : 'Tap anywhere to continue',
+                style: TextStyle(
+                  fontSize: 11,
+                  color: subColor,
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+              const SizedBox(width: 4),
+              Icon(
+                isLastStep
+                    ? Icons.keyboard_arrow_down_rounded
+                    : Icons.keyboard_arrow_right_rounded,
+                size: 14,
+                color: subColor,
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _stepIcon() {
+    if (step.svgAssetPath != null) {
+      return SvgPicture.asset(
+        step.svgAssetPath!,
+        width: 20,
+        height: 20,
+        colorFilter:
+            ColorFilter.mode(AppColors.primaryColor, BlendMode.srcIn),
+      );
+    }
+    return Icon(
+      step.icon,
+      size: 20,
+      color: AppColors.primaryColor,
+    );
+  }
+}
+
+class _UpArrowPainter extends CustomPainter {
+  final Color color;
+  const _UpArrowPainter({required this.color});
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final path = Path()
+      ..moveTo(0, size.height)
+      ..lineTo(size.width / 2, 0)
+      ..lineTo(size.width, size.height)
+      ..close();
+    canvas.drawPath(path, Paint()..color = color);
+  }
+
+  @override
+  bool shouldRepaint(_UpArrowPainter old) => old.color != color;
+}
+
+class _DownArrowPainter extends CustomPainter {
+  final Color color;
+  const _DownArrowPainter({required this.color});
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final path = Path()
+      ..moveTo(0, 0)
+      ..lineTo(size.width / 2, size.height)
+      ..lineTo(size.width, 0)
+      ..close();
+    canvas.drawPath(path, Paint()..color = color);
+  }
+
+  @override
+  bool shouldRepaint(_DownArrowPainter old) => old.color != color;
+}

--- a/src/mobile/lib/src/app/dashboard/widgets/measurements_list.dart
+++ b/src/mobile/lib/src/app/dashboard/widgets/measurements_list.dart
@@ -1,20 +1,29 @@
 import 'package:flutter/material.dart';
 import 'package:airqo/src/app/dashboard/models/airquality_response.dart';
+import 'package:airqo/src/app/dashboard/widgets/measurement_card_tour.dart';
 import 'analytics_card.dart';
 
 class MeasurementsList extends StatelessWidget {
   final List<Measurement> measurements;
+  final MeasurementCardTourKeys? tourKeys;
+  final VoidCallback? onTourTargetReady;
 
   const MeasurementsList({
     super.key,
     required this.measurements,
+    this.tourKeys,
+    this.onTourTargetReady,
   });
 
   @override
   Widget build(BuildContext context) {
     return SliverList(
       delegate: SliverChildBuilderDelegate(
-        (context, index) => AnalyticsCard(measurements[index]),
+        (context, index) => AnalyticsCard(
+          measurements[index],
+          tourKeys: index == 0 ? tourKeys : null,
+          onTourTargetReady: index == 0 ? onTourTargetReady : null,
+        ),
         childCount: measurements.length,
       ),
     );

--- a/src/mobile/lib/src/app/dashboard/widgets/my_places_view.dart
+++ b/src/mobile/lib/src/app/dashboard/widgets/my_places_view.dart
@@ -1,3 +1,4 @@
+import 'package:airqo/src/app/dashboard/widgets/measurement_card_tour.dart';
 import 'package:airqo/src/app/dashboard/pages/location_selection/components/swipeable_analytics_card.dart';
 import 'package:airqo/src/app/dashboard/widgets/unmatched_site_card.dart';
 import 'package:flutter/material.dart';
@@ -18,10 +19,14 @@ import 'package:airqo/src/app/shared/widgets/translated_text.dart';
 
 class MyPlacesView extends StatefulWidget {
   final UserPreferencesModel? userPreferences;
+  final MeasurementCardTourKeys? tourKeys;
+  final VoidCallback? onTourTargetReady;
 
   const MyPlacesView({
     super.key,
     this.userPreferences,
+    this.tourKeys,
+    this.onTourTargetReady,
   });
 
   @override
@@ -396,7 +401,9 @@ class _MyPlacesViewState extends State<MyPlacesView> with UiLoggy {
                       unmatchedSites.isEmpty)
                     (_prefsAuthError ? _buildSessionExpiredState() : _buildEmptyState())
                   else ...[
-                    ...selectedMeasurements.map((measurement) {
+                    ...selectedMeasurements.asMap().entries.map((entry) {
+                      final index = entry.key;
+                      final measurement = entry.value;
                       String? preferenceLocationName;
                       if (widget.userPreferences != null) {
                         for (var site in widget.userPreferences!.selectedSites) {
@@ -413,6 +420,9 @@ class _MyPlacesViewState extends State<MyPlacesView> with UiLoggy {
                           measurement: measurement,
                           onRemove: _removeLocation,
                           fallbackLocationName: preferenceLocationName,
+                          tourKeys: index == 0 ? widget.tourKeys : null,
+                          onTourTargetReady:
+                              index == 0 ? widget.onTourTargetReady : null,
                         ),
                       );
                     }),

--- a/src/mobile/lib/src/app/dashboard/widgets/nearby_measurement_card.dart
+++ b/src/mobile/lib/src/app/dashboard/widgets/nearby_measurement_card.dart
@@ -3,6 +3,9 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:loggy/loggy.dart';
 import 'package:airqo/src/app/dashboard/models/airquality_response.dart';
 import 'package:airqo/src/app/dashboard/pages/forecast_overview_page.dart';
+import 'package:airqo/src/app/dashboard/widgets/measurement_card_tour.dart';
+import 'package:airqo/src/app/dashboard/widgets/measurement_card_action_strip.dart';
+import 'package:airqo/src/app/dashboard/widgets/measurement_card_gestures.dart';
 import 'package:airqo/src/app/shared/widgets/loading_widget.dart';
 import 'package:airqo/src/meta/utils/colors.dart';
 import 'package:airqo/src/meta/utils/forecast_utils.dart';
@@ -67,21 +70,66 @@ class NearbyMeasurementCardLoader extends StatelessWidget {
   }
 }
 
-class NearbyMeasurementCard extends StatelessWidget with UiLoggy {
+class NearbyMeasurementCard extends StatefulWidget {
   final Measurement measurement;
   final String? fallbackLocationName;
+  final MeasurementCardTourKeys? tourKeys;
+  final VoidCallback? onTourTargetReady;
 
   const NearbyMeasurementCard({
     super.key,
     required this.measurement,
     this.fallbackLocationName,
+    this.tourKeys,
+    this.onTourTargetReady,
   });
 
-  void _openForecast(BuildContext context) {
+  @override
+  State<NearbyMeasurementCard> createState() => _NearbyMeasurementCardState();
+}
+
+class _NearbyMeasurementCardState extends State<NearbyMeasurementCard>
+    with UiLoggy {
+  final GlobalKey _defaultShareButtonKey = GlobalKey();
+  bool _tourReadyNotified = false;
+
+  GlobalKey get _shareButtonKey => _defaultShareButtonKey;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.tourKeys != null) {
+      scheduleMeasurementCardTourReady(
+        keys: widget.tourKeys!,
+        onReady: _notifyTourTargetReady,
+        isActive: () => mounted && !_tourReadyNotified,
+      );
+    }
+  }
+
+  void _notifyTourTargetReady() {
+    if (_tourReadyNotified || !mounted || widget.onTourTargetReady == null) {
+      return;
+    }
+    _tourReadyNotified = true;
+    widget.onTourTargetReady!();
+  }
+
+  void _openForecast() {
     ForecastOverviewPage.showForMeasurement(
       context,
-      measurement: measurement,
-      fallbackLocationName: fallbackLocationName,
+      measurement: widget.measurement,
+      fallbackLocationName: widget.fallbackLocationName,
+    );
+  }
+
+  Future<void> _openShare(String source) {
+    return openMeasurementShareSheet(
+      context,
+      measurement: widget.measurement,
+      source: source,
+      fallbackLocationName: widget.fallbackLocationName,
+      shareButtonKey: _shareButtonKey,
     );
   }
 
@@ -118,37 +166,27 @@ class NearbyMeasurementCard extends StatelessWidget with UiLoggy {
     return getAppAqiCategoryColor(measurement.aqiCategory ?? '');
   }
 
-  Widget _chevron(BuildContext context) {
-    return SvgPicture.asset(
-      'assets/icons/chevron-right.svg',
-      width: 20,
-      height: 20,
-      colorFilter: ColorFilter.mode(
-        AppTextColors.modalCloseIcon(context),
-        BlendMode.srcIn,
-      ),
-    );
-  }
-
   @override
   Widget build(BuildContext context) {
+    final measurement = widget.measurement;
     final locationColor = AppTextColors.muted(context);
 
-    return InkWell(
-      onTap: () => _openForecast(context),
-      child: Container(
-        margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-        decoration: AppSurfaceColors.elevatedCardDecoration(context),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Padding(
-              padding: const EdgeInsets.only(
-                  left: 16, right: 16, bottom: 16, top: 16),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Row(
+    return Container(
+      key: widget.tourKeys?.cardKey,
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      decoration: AppSurfaceColors.elevatedCardDecoration(context),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Padding(
+                  padding: const EdgeInsets.fromLTRB(
+                    kMeasurementCardHorizontalPadding,
+                    kMeasurementCardTopPadding,
+                    kMeasurementCardHorizontalPadding,
+                    16,
+                  ),
+                  child: Row(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       Expanded(
@@ -158,7 +196,7 @@ class NearbyMeasurementCard extends StatelessWidget with UiLoggy {
                             Text(
                               measurement.siteDetails?.searchName ??
                                   measurement.siteDetails?.name ??
-                                  fallbackLocationName ??
+                                  widget.fallbackLocationName ??
                                   "---",
                               style: TextStyle(
                                 fontSize: 22,
@@ -171,7 +209,7 @@ class NearbyMeasurementCard extends StatelessWidget with UiLoggy {
                               maxLines: 1,
                               overflow: TextOverflow.ellipsis,
                             ),
-                            SizedBox(height: 4),
+                            const SizedBox(height: 4),
                             Row(
                               children: [
                                 SvgPicture.asset(
@@ -183,7 +221,7 @@ class NearbyMeasurementCard extends StatelessWidget with UiLoggy {
                                     BlendMode.srcIn,
                                   ),
                                 ),
-                                SizedBox(width: 4),
+                                const SizedBox(width: 4),
                                 Expanded(
                                   child: Text(
                                     _getLocationDescription(measurement),
@@ -200,117 +238,143 @@ class NearbyMeasurementCard extends StatelessWidget with UiLoggy {
                           ],
                         ),
                       ),
+                      MeasurementCardHeaderShare(
+                        shareButtonKey: _shareButtonKey,
+                        onShare: () => _openShare('dashboard_card'),
+                      ),
+                    ],
+                  ),
+                ),
+                MeasurementCardTapLayer(
+                  onForecast: _openForecast,
+                  onShareDoubleTap: () =>
+                      _openShare('dashboard_card_double_tap'),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Divider(
+                          thickness: .5, color: Theme.of(context).dividerColor),
                       Padding(
-                        padding: const EdgeInsets.only(left: 8, top: 2),
-                        child: _chevron(context),
-                      ),
-                    ],
-                  ),
-                ],
-              ),
-            ),
-            Divider(thickness: .5, color: Theme.of(context).dividerColor),
-            Padding(
-              padding: const EdgeInsets.only(
-                  left: 16, right: 16, bottom: 16, top: 4),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    crossAxisAlignment: CrossAxisAlignment.center,
-                    children: [
-                      Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Row(
-                            children: [
-                              SvgPicture.asset(Theme.of(context).brightness ==
-                                      Brightness.light
-                                  ? "assets/images/shared/pm_rating_white.svg"
-                                  : 'assets/images/shared/pm_rating.svg'),
-                              const SizedBox(width: 2),
-                              Text(
-                                " PM2.5",
-                                style: TextStyle(
-                                  color: Theme.of(context)
-                                      .textTheme
-                                      .headlineSmall
-                                      ?.color,
+                        padding: const EdgeInsets.fromLTRB(
+                          kMeasurementCardHorizontalPadding,
+                          4,
+                          kMeasurementCardHorizontalPadding,
+                          8,
+                        ),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Row(
+                              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                              crossAxisAlignment: CrossAxisAlignment.center,
+                              children: [
+                                Column(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: [
+                                    Row(
+                                      children: [
+                                        SvgPicture.asset(
+                                          Theme.of(context).brightness ==
+                                                  Brightness.light
+                                              ? "assets/images/shared/pm_rating_white.svg"
+                                              : 'assets/images/shared/pm_rating.svg',
+                                        ),
+                                        const SizedBox(width: 2),
+                                        Text(
+                                          " PM2.5",
+                                          style: TextStyle(
+                                            color: Theme.of(context)
+                                                .textTheme
+                                                .headlineSmall
+                                                ?.color,
+                                          ),
+                                        ),
+                                      ],
+                                    ),
+                                    Row(
+                                      children: [
+                                        Text(
+                                          measurement.pm25?.value != null
+                                              ? measurement.pm25!.value!
+                                                  .toStringAsFixed(1)
+                                              : "-",
+                                          style: TextStyle(
+                                            fontWeight: FontWeight.w700,
+                                            fontSize: 36,
+                                            color: Theme.of(context)
+                                                .textTheme
+                                                .headlineLarge
+                                                ?.color,
+                                          ),
+                                        ),
+                                        Text(
+                                          " μg/m³",
+                                          style: TextStyle(
+                                            fontWeight: FontWeight.w600,
+                                            fontSize: 18,
+                                            color: Theme.of(context)
+                                                .textTheme
+                                                .headlineLarge
+                                                ?.color,
+                                          ),
+                                        ),
+                                      ],
+                                    ),
+                                  ],
                                 ),
-                              ),
-                            ],
-                          ),
-                          Row(children: [
-                            Text(
-                              measurement.pm25?.value != null
-                                  ? measurement.pm25!.value!.toStringAsFixed(1)
-                                  : "-",
-                              style: TextStyle(
-                                  fontWeight: FontWeight.w700,
-                                  fontSize: 36,
-                                  color: Theme.of(context)
-                                      .textTheme
-                                      .headlineLarge
-                                      ?.color),
+                                SizedBox(
+                                  child: Center(
+                                    child: measurement.pm25?.value != null
+                                        ? SvgPicture.asset(
+                                            getAirQualityIcon(measurement,
+                                                measurement.pm25!.value!),
+                                            height: 86,
+                                            width: 86,
+                                          )
+                                        : const Icon(
+                                            Icons.help_outline,
+                                            size: 60,
+                                            color: Colors.grey,
+                                          ),
+                                  ),
+                                ),
+                              ],
                             ),
-                            Text(" μg/m³",
-                                style: TextStyle(
-                                    fontWeight: FontWeight.w600,
-                                    fontSize: 18,
-                                    color: Theme.of(context)
-                                        .textTheme
-                                        .headlineLarge
-                                        ?.color))
-                          ]),
-                        ],
-                      ),
-                      SizedBox(
-                        child: Center(
-                          child: measurement.pm25?.value != null
-                              ? SvgPicture.asset(
-                                  getAirQualityIcon(
-                                      measurement, measurement.pm25!.value!),
-                                  height: 86,
-                                  width: 86,
-                                )
-                              : Icon(
-                                  Icons.help_outline,
-                                  size: 60,
-                                  color: Colors.grey,
+                            const SizedBox(height: 16),
+                            Wrap(
+                              children: [
+                                Container(
+                                  margin: EdgeInsets.zero,
+                                  padding: const EdgeInsets.symmetric(
+                                      horizontal: 16, vertical: 8),
+                                  decoration: BoxDecoration(
+                                    color: _getAqiColor(measurement)
+                                        .withValues(alpha: 0.15),
+                                    borderRadius: BorderRadius.circular(20),
+                                  ),
+                                  child: Text(
+                                    measurement.aqiCategory ?? "Unknown",
+                                    style: TextStyle(
+                                      fontSize: 14,
+                                      fontWeight: FontWeight.w600,
+                                      color: _getAqiColor(measurement),
+                                    ),
+                                    maxLines: 1,
+                                  ),
                                 ),
+                              ],
+                            ),
+                          ],
                         ),
                       ),
                     ],
                   ),
-                  SizedBox(height: 16),
-                  Wrap(
-                    children: [
-                      Container(
-                        margin: EdgeInsets.only(bottom: 12),
-                        padding:
-                            EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-                        decoration: BoxDecoration(
-                          color: _getAqiColor(measurement).withValues(alpha: 0.15),
-                          borderRadius: BorderRadius.circular(20),
-                        ),
-                        child: Text(
-                          measurement.aqiCategory ?? "Unknown",
-                          style: TextStyle(
-                            fontSize: 14,
-                            fontWeight: FontWeight.w600,
-                            color: _getAqiColor(measurement),
-                          ),
-                          maxLines: 1,
-                        ),
-                      ),
-                    ],
-                  ),
-                ],
-              ),
-            ),
-          ],
-        ),
+                ),
+          MeasurementCardFooterForecast(
+            onForecast: _openForecast,
+          ),
+        ],
       ),
     );
   }

--- a/src/mobile/lib/src/app/dashboard/widgets/nearby_view.dart
+++ b/src/mobile/lib/src/app/dashboard/widgets/nearby_view.dart
@@ -1,4 +1,5 @@
 import 'package:airqo/src/app/dashboard/widgets/nearby_measurement_card.dart';
+import 'package:airqo/src/app/dashboard/widgets/measurement_card_tour.dart';
 import 'package:airqo/src/app/shared/widgets/translated_text.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart';
@@ -15,8 +16,16 @@ import 'package:airqo/src/app/shared/services/cache_manager.dart';
 class NearbyView extends StatefulWidget {
   final VoidCallback? onNavigateToFavorites;
   final VoidCallback? onExploreCities;
+  final MeasurementCardTourKeys? tourKeys;
+  final VoidCallback? onTourTargetReady;
 
-  const NearbyView({super.key, this.onNavigateToFavorites, this.onExploreCities});
+  const NearbyView({
+    super.key,
+    this.onNavigateToFavorites,
+    this.onExploreCities,
+    this.tourKeys,
+    this.onTourTargetReady,
+  });
 
   @override
   State<NearbyView> createState() => _NearbyViewState();
@@ -594,6 +603,9 @@ class _NearbyViewState extends State<NearbyView> with UiLoggy {
                   final entry = _nearbyMeasurementsWithDistance[index];
                   return NearbyMeasurementCard(
                     measurement: entry.key,
+                    tourKeys: index == 0 ? widget.tourKeys : null,
+                    onTourTargetReady:
+                        index == 0 ? widget.onTourTargetReady : null,
                   );
                 },
               ),

--- a/src/mobile/lib/src/app/dashboard/widgets/share_sheet_widgets.dart
+++ b/src/mobile/lib/src/app/dashboard/widgets/share_sheet_widgets.dart
@@ -187,7 +187,7 @@ class ShareTabChip extends StatelessWidget {
           color: selected
               ? AppColors.primaryColor
               : (isDark
-                  ? AppColors.darkHighlight
+                  ? AppSurfaceColors.nested(context)
                   : AppColors.dividerColorlight),
           borderRadius: BorderRadius.circular(30),
         ),
@@ -200,7 +200,7 @@ class ShareTabChip extends StatelessWidget {
             fontWeight: FontWeight.w500,
             color: selected
                 ? Colors.white
-                : (isDark ? Colors.white : Colors.black87),
+                : (isDark ? Colors.white : AppColors.boldHeadlineColor4),
           ),
         ),
       ),

--- a/src/mobile/lib/src/app/shared/services/analytics/analytics_share_events.dart
+++ b/src/mobile/lib/src/app/shared/services/analytics/analytics_share_events.dart
@@ -18,6 +18,9 @@ extension ShareAnalyticsEvents on AnalyticsService {
         'method': method,
       });
 
+  Future<void> trackCardActionTapped({required String action}) =>
+      trackEvent('card_action_tapped', properties: {'action': action});
+
   Future<void> trackCafFilterTabOpened() => trackEvent('caf_filter_tab_opened');
 
   Future<void> trackCafSelfieSourceSelected({required String source}) =>


### PR DESCRIPTION
## Summary
- Add a shared measurement card action strip with compact share (header) and forecast chevron (footer) icons on all dashboard card variants
- Introduce hybrid gestures: single tap opens forecast, double tap opens share, with analytics for icon taps and gesture sources
- Align unselected share sheet tab chips with forecast modal surface styling
- Include a first-run card gestures tour implementation that is currently disabled behind `kMeasurementCardGesturesTourEnabled`

## Test plan
- [ ] Near You / My Places / country lists: verify share icon (top-right) opens share sheet
- [ ] Verify chevron (bottom-right) and single tap on card body open forecast modal once
- [ ] Double tap card body opens share sheet with haptic feedback
- [ ] Confirm share sheet chip styling in light and dark mode
- [ ] Confirm no tour overlay appears on fresh install (tour flag is off)
- [ ] `dart analyze` on touched mobile dashboard files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an interactive dashboard tour explaining measurement-card gestures, sharing, and forecast actions.
  * Added single-tap forecast access and double-tap sharing with haptic feedback.
  * Added share buttons and improved action controls across measurement cards.
  * Tour dismissal is remembered and the tour appears when cards are ready.
* **Style**
  * Refined measurement-card layouts, spacing, colors, and share-sheet styling.
* **Analytics**
  * Added tracking for measurement-card actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->