### PR TITLE
Fix/import external device btn

### DIFF
--- a/src/vertex/app/(authenticated)/admin/networks/[id]/page.tsx
+++ b/src/vertex/app/(authenticated)/admin/networks/[id]/page.tsx
@@ -70,7 +70,7 @@ export default function NetworkDetailsPage() {
                                 Icon={Upload}
                                 permission={PERMISSIONS.DEVICE.UPDATE}
                             >
-                                Import External Device
+                                Register Non-AirQo Device
                             </ReusableButton>
                         )}
                     </div>

--- a/src/vertex/app/(authenticated)/devices/my-devices/page.tsx
+++ b/src/vertex/app/(authenticated)/devices/my-devices/page.tsx
@@ -121,7 +121,7 @@ const MyDevicesPage = () => {
                 Icon={Upload}
                 permission={PERMISSIONS.DEVICE.UPDATE}
               >
-                Import External Device
+                Register Non-AirQo Device
               </ReusableButton>
             </div>
           </div>
@@ -185,7 +185,7 @@ const MyDevicesPage = () => {
               Icon={Upload}
               permission={PERMISSIONS.DEVICE.UPDATE}
             >
-              Import External Device
+              Register Non-AirQo Device
             </ReusableButton>
             {/* <DropdownMenu>
               <DropdownMenuTrigger asChild>

--- a/src/vertex/app/(authenticated)/devices/overview/page.tsx
+++ b/src/vertex/app/(authenticated)/devices/overview/page.tsx
@@ -51,7 +51,7 @@ export default function DevicesPage() {
               Icon={Upload}
               permission={PERMISSIONS.DEVICE.UPDATE}
             >
-              Import External Device
+              Register Non-AirQo Device
             </ReusableButton>
           </div>
         </div>

--- a/src/vertex/app/(authenticated)/home/page.tsx
+++ b/src/vertex/app/(authenticated)/home/page.tsx
@@ -348,11 +348,11 @@ const WelcomePage = () => {
             </div>
             <div>
               <span className="text-lg font-medium text-gray-900 dark:text-white">
-                Import Different Sensor Manufacturer
+                Register Non-AirQo Device
               </span>
               <span className="block text-sm text-gray-500 dark:text-gray-400">
-                Import a device from a different manufacturer using a CSV
-                template.
+                Register a sensor from a different manufacturer, singly or from
+                a CSV template.
               </span>
             </div>
           </button>
@@ -448,7 +448,7 @@ const WelcomePage = () => {
                 onClick={() => setIsImportModalOpen(true)}
                 Icon={Upload}
               >
-                Import External Device
+                Register Non-AirQo Device
               </ReusableButton>
             </div>
           </div>

--- a/src/vertex/app/changelog.md
+++ b/src/vertex/app/changelog.md
@@ -15,6 +15,7 @@ The button that adds a third-party sensor was labelled **"Import External Device
 - Seven triggers open `ImportDeviceModal`, enumerated by what calls `setImportDeviceOpen`/`openImportModal` rather than by label — which is how the odd one out surfaced. Renamed on `devices/my-devices` (both the loaded and error-state headers), `devices/overview`, `home` (header button **and** the card inside the "Add a device" chooser dialog), `HomeEmptyState`, and `admin/networks/[id]` (which shows this button only in its `!isAirQoNetwork` branch).
 - **The dialog title moved with them.** `import-device-modal.tsx` set `title="Import External Device"`, so renaming only the buttons would have sent users from "Register Non-AirQo Device" to a dialog headed "Import External Device" — the same button/modal split corrected on the claim side.
 - **The chooser card was the outlier.** It read "Import Different Sensor Manufacturer" and its description mentioned only the CSV template, understating a button that opens both the single and bulk paths. Now "Register Non-AirQo Device", described as registering a sensor "singly or from a CSV template".
+- **Surrounding copy followed the buttons.** Renaming a CTA without its neighbouring prose leaves the same block contradicting itself, so three descriptions moved too: the home empty state ("import external devices from any Sensor Manufacturer" → "register devices from any other sensor manufacturer"), the register dialog's subtitle ("Add a device…" → "Register a device…"), and the onboarding checklist's add-device step, whose verbs were the wrong way round under the new vocabulary — it said "**Register** your new AirQo sensor or **add** a device from a different manufacturer", now "**Claim** your new AirQo sensor or **register** a device from a different manufacturer".
 
 </details>
 
@@ -32,7 +33,8 @@ The button that adds a third-party sensor was labelled **"Import External Device
 - `app/(authenticated)/home/page.tsx` — header button + chooser-dialog card and its description
 - `app/(authenticated)/admin/networks/[id]/page.tsx` — non-AirQo network branch
 - `components/features/home/HomeEmptyState.tsx` — empty-state button
-- `components/features/devices/import-device-modal.tsx` — dialog title
+- `components/features/devices/import-device-modal.tsx` — dialog title and subtitle
+- `components/onboarding-checklist/ChecklistUI.tsx` — add-device step description
 - `components/features/claim/steps/ManualInputStep.tsx` — the claim form's escape-hatch prose names this button
 - `e2e/tests/rbac/action-visibility.spec.ts`, `e2e/tests/rbac/resource-scoped.spec.ts`, `e2e/tests/devices/import-external-device.spec.ts`, `e2e/tests/devices/import-external-device-bulk.spec.ts` — 13 selectors; three target the dialog by accessible name and so depend on the title change
 

--- a/src/vertex/app/changelog.md
+++ b/src/vertex/app/changelog.md
@@ -2,6 +2,40 @@
 
 > **Note**: This changelog consolidates all recent improvements, features, and fixes to the AirQo Vertex frontend.
 
+## Version 2.0.35
+**Released:** August 15, 2026
+
+### Fix: "Import External Device" renamed to "Register Non-AirQo Device"
+
+The button that adds a third-party sensor was labelled **"Import External Device"** in five places and **"Import Different Sensor Manufacturer"** in a sixth — two names for one flow, neither of which described what it does. The action hits `POST /devices/soft`, which *creates* a device record for a sensor AirQo did not ship; "import" implied bringing across data that already existed somewhere. All entry points now read **"Register Non-AirQo Device"**.
+
+<details>
+<summary><strong>Every trigger renamed, including the dialog it opens</strong></summary>
+
+- Seven triggers open `ImportDeviceModal`, enumerated by what calls `setImportDeviceOpen`/`openImportModal` rather than by label — which is how the odd one out surfaced. Renamed on `devices/my-devices` (both the loaded and error-state headers), `devices/overview`, `home` (header button **and** the card inside the "Add a device" chooser dialog), `HomeEmptyState`, and `admin/networks/[id]` (which shows this button only in its `!isAirQoNetwork` branch).
+- **The dialog title moved with them.** `import-device-modal.tsx` set `title="Import External Device"`, so renaming only the buttons would have sent users from "Register Non-AirQo Device" to a dialog headed "Import External Device" — the same button/modal split corrected on the claim side.
+- **The chooser card was the outlier.** It read "Import Different Sensor Manufacturer" and its description mentioned only the CSV template, understating a button that opens both the single and bulk paths. Now "Register Non-AirQo Device", described as registering a sensor "singly or from a CSV template".
+
+</details>
+
+<details>
+<summary><strong>Note: internal names deliberately unchanged</strong></summary>
+
+- `import-device-modal.tsx`, `import-steps/`, `useImportDevice`, `useBulkImportDevices`, and the `import-external-device*.spec.ts` filenames all keep "import". They carry no user-visible copy, and renaming them would produce a large diff with no behavioural or UX benefit.
+- Gating is untouched: the button remains `DEVICE_UPDATE` everywhere it is gated. As on the claim side, the `home` header button, the `home` chooser card, and `HomeEmptyState` gate on nothing at all — pre-existing, and left for a dedicated permissions pass.
+
+</details>
+
+**Files changed:**
+- `app/(authenticated)/devices/my-devices/page.tsx` — both header buttons
+- `app/(authenticated)/devices/overview/page.tsx` — header button
+- `app/(authenticated)/home/page.tsx` — header button + chooser-dialog card and its description
+- `app/(authenticated)/admin/networks/[id]/page.tsx` — non-AirQo network branch
+- `components/features/home/HomeEmptyState.tsx` — empty-state button
+- `components/features/devices/import-device-modal.tsx` — dialog title
+- `components/features/claim/steps/ManualInputStep.tsx` — the claim form's escape-hatch prose names this button
+- `e2e/tests/rbac/action-visibility.spec.ts`, `e2e/tests/rbac/resource-scoped.spec.ts`, `e2e/tests/devices/import-external-device.spec.ts`, `e2e/tests/devices/import-external-device-bulk.spec.ts` — 13 selectors; three target the dialog by accessible name and so depend on the title change
+
 ## Version 2.0.33
 **Released:** July 30, 2026
 

--- a/src/vertex/components/features/claim/steps/ManualInputStep.tsx
+++ b/src/vertex/components/features/claim/steps/ManualInputStep.tsx
@@ -56,7 +56,7 @@ const ManualInputStep = ({
         >
           Contact AirQo support
         </a>
-        , or close this dialog and use <span className="font-medium">Import External Device</span> to add a sensor you already own.
+        , or close this dialog and use <span className="font-medium">Register Non-AirQo Device</span> to add a sensor you already own.
       </p>
     </div>
   </Form>

--- a/src/vertex/components/features/devices/import-device-modal.tsx
+++ b/src/vertex/components/features/devices/import-device-modal.tsx
@@ -734,7 +734,7 @@ const ImportDeviceModal: React.FC<ImportDeviceModalProps> = ({
       <ReusableDialog
         isOpen={open}
         onClose={() => onOpenChange(false)}
-        title="Import External Device"
+        title="Register Non-AirQo Device"
         subtitle={isSuccess ? undefined : "Add a device from a different sensor manufacturer"}
         size="3xl"
         maxHeight="max-h-[55vh]"

--- a/src/vertex/components/features/devices/import-device-modal.tsx
+++ b/src/vertex/components/features/devices/import-device-modal.tsx
@@ -735,7 +735,7 @@ const ImportDeviceModal: React.FC<ImportDeviceModalProps> = ({
         isOpen={open}
         onClose={() => onOpenChange(false)}
         title="Register Non-AirQo Device"
-        subtitle={isSuccess ? undefined : "Add a device from a different sensor manufacturer"}
+        subtitle={isSuccess ? undefined : "Register a device from a different sensor manufacturer"}
         size="3xl"
         maxHeight="max-h-[55vh]"
         preventBackdropClose={true}

--- a/src/vertex/components/features/home/HomeEmptyState.tsx
+++ b/src/vertex/components/features/home/HomeEmptyState.tsx
@@ -49,7 +49,7 @@ const HomeEmptyState = () => {
                         onClick={() => setIsImportModalOpen(true)}
                         Icon={Upload}
                     >
-                        Import External Device
+                        Register Non-AirQo Device
                     </ReusableButton>
                 </div>
 

--- a/src/vertex/components/features/home/HomeEmptyState.tsx
+++ b/src/vertex/components/features/home/HomeEmptyState.tsx
@@ -36,7 +36,7 @@ const HomeEmptyState = () => {
                 </h2>
 
                 <p className="text-gray-600 dark:text-gray-400 max-w-md mb-8">
-                    Claim the AirQo devices shipped to you, or import external devices from any Sensor Manufacturer, to begin tracking your device fleet.
+                    Claim the AirQo devices shipped to you, or register devices from any other sensor manufacturer, to begin tracking your device fleet.
                 </p>
 
                 <div className="flex flex-col sm:flex-row gap-4 w-full sm:w-auto">

--- a/src/vertex/components/onboarding-checklist/ChecklistUI.tsx
+++ b/src/vertex/components/onboarding-checklist/ChecklistUI.tsx
@@ -39,7 +39,7 @@ const STEPS: ChecklistStep[] = [
     id: "add-device",
     title: "Add your first device",
     description:
-      "Register your new AirQo sensor or add a device from a different sensor manufacturer (Clarity, PurpleAir, and others).",
+      "Claim your new AirQo sensor or register a device from a different sensor manufacturer (Clarity, PurpleAir, and others).",
     cta: "Add a device",
     heuristic: "Start here",
   },

--- a/src/vertex/e2e/tests/devices/import-external-device-bulk.spec.ts
+++ b/src/vertex/e2e/tests/devices/import-external-device-bulk.spec.ts
@@ -8,7 +8,7 @@ import {
 } from "../../support/device-mocks";
 
 /**
- * Import External Device — bulk/CSV flow, personal context.
+ * Register Non-AirQo Device — bulk/CSV flow, personal context.
  *
  * Same hybrid-interception approach as the single-device spec: real auth,
  * navigation, and data GETs; POST /devices/soft/bulk and the cohort
@@ -57,11 +57,11 @@ test.beforeAll(() => {
 async function openBulkImportWizard(page: Page): Promise<Locator> {
   await page.goto("/devices/my-devices");
 
-  const importButton = page.getByRole("button", { name: "Import External Device" });
+  const importButton = page.getByRole("button", { name: "Register Non-AirQo Device" });
   await expect(importButton).toBeVisible({ timeout: 60_000 });
   await importButton.click();
 
-  const wizard = page.getByRole("dialog", { name: "Import External Device" });
+  const wizard = page.getByRole("dialog", { name: "Register Non-AirQo Device" });
   await expect(wizard).toBeVisible();
   await wizard.getByRole("button", { name: /Import Multiple Devices/ }).click();
   return wizard;

--- a/src/vertex/e2e/tests/devices/import-external-device.spec.ts
+++ b/src/vertex/e2e/tests/devices/import-external-device.spec.ts
@@ -8,7 +8,7 @@ import {
 } from "../../support/device-mocks";
 
 /**
- * Import External Device — single-device flow, personal context.
+ * Register Non-AirQo Device — single-device flow, personal context.
  *
  * Hybrid interception: navigation, auth, and data GETs (networks, cohorts)
  * run against the real backend; the two mutations (device import, cohort
@@ -34,11 +34,11 @@ test.beforeAll(() => {
 async function openSingleImportWizard(page: Page): Promise<Locator> {
   await page.goto("/devices/my-devices");
 
-  const importButton = page.getByRole("button", { name: "Import External Device" });
+  const importButton = page.getByRole("button", { name: "Register Non-AirQo Device" });
   await expect(importButton).toBeVisible({ timeout: 60_000 });
   await importButton.click();
 
-  const wizard = page.getByRole("dialog", { name: "Import External Device" });
+  const wizard = page.getByRole("dialog", { name: "Register Non-AirQo Device" });
   await expect(wizard).toBeVisible();
   await wizard.getByRole("button", { name: /Import Single Device/ }).click();
   return wizard;

--- a/src/vertex/e2e/tests/rbac/action-visibility.spec.ts
+++ b/src/vertex/e2e/tests/rbac/action-visibility.spec.ts
@@ -50,7 +50,7 @@ test.describe("claim — Add AirQo Device", () => {
     // settled — only then is the claim button's disabled state attributable
     // to the missing permission rather than the loading state.
     await expect(
-      page.getByRole("button", { name: "Import External Device" })
+      page.getByRole("button", { name: "Register Non-AirQo Device" })
     ).toBeEnabled({ timeout: 60_000 });
 
     await expect(
@@ -88,7 +88,7 @@ test.describe("import & claim — Devices overview", () => {
       page.getByRole("button", { name: "Add AirQo Device" })
     ).toBeEnabled({ timeout: 60_000 });
     await expect(
-      page.getByRole("button", { name: "Import External Device" })
+      page.getByRole("button", { name: "Register Non-AirQo Device" })
     ).toBeDisabled();
   });
 
@@ -103,7 +103,7 @@ test.describe("import & claim — Devices overview", () => {
 
     // Control first: import gates on DEVICE_UPDATE, which this user holds.
     await expect(
-      page.getByRole("button", { name: "Import External Device" })
+      page.getByRole("button", { name: "Register Non-AirQo Device" })
     ).toBeEnabled({ timeout: 60_000 });
     await expect(
       page.getByRole("button", { name: "Add AirQo Device" })
@@ -118,11 +118,11 @@ test.describe("import & claim — Devices overview", () => {
 
     await page.goto("/devices/overview");
 
-    const importButton = page.getByRole("button", { name: "Import External Device" });
+    const importButton = page.getByRole("button", { name: "Register Non-AirQo Device" });
     await expect(importButton).toBeEnabled({ timeout: 60_000 });
     await importButton.click();
     await expect(
-      page.getByRole("dialog", { name: "Import External Device" })
+      page.getByRole("dialog", { name: "Register Non-AirQo Device" })
     ).toBeVisible({ timeout: 30_000 });
   });
 });

--- a/src/vertex/e2e/tests/rbac/resource-scoped.spec.ts
+++ b/src/vertex/e2e/tests/rbac/resource-scoped.spec.ts
@@ -64,7 +64,7 @@ test("denies device actions in an org where the role lacks DEVICE_UPDATE, despit
   // …but the mutating actions are denied: DEVICE_UPDATE and DEVICE_CLAIM
   // exist on the user's AirQo membership, not on this organization's role.
   await expect(
-    page.getByRole("button", { name: "Import External Device" })
+    page.getByRole("button", { name: "Register Non-AirQo Device" })
   ).toBeDisabled();
   await expect(
     page.getByRole("button", { name: "Add AirQo Device" })
@@ -81,7 +81,7 @@ test("allows the same device actions in the personal scope that holds DEVICE_UPD
   await page.goto("/devices/overview");
 
   await expect(
-    page.getByRole("button", { name: "Import External Device" })
+    page.getByRole("button", { name: "Register Non-AirQo Device" })
   ).toBeEnabled({ timeout: 60_000 });
   await expect(
     page.getByRole("button", { name: "Add AirQo Device" })


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

The action that adds a third-party sensor was labelled **"Import External Device"** in five places and **"Import Different Sensor Manufacturer"** in a sixth — two names for one flow, neither describing what it does. It hits `POST /devices/soft`, which *creates* a device record for a sensor AirQo did not ship. "Import" implied bringing across data that already existed somewhere. All entry points now read **"Register Non-AirQo Device"**.

#### Status of maturity (all need to be checked before merging):

- [x] I've tested this locally
- [x] I consider this code done
- [x] This change ready to hit production in its current state
- [x] The title of the PR states what changed and the related issues number (used for the release note).
- [ ] I've included issue number in the "Closes #ISSUE-NUMBER" part of the "[What are the relevant tickets?](#what-are-the-relevant-tickets)" section to [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] I've updated corresponding documentation for the changes in this PR.
- [x] I have written unit and/or e2e tests for my change(s).

**Verified locally:** `npx tsc --noEmit` clean; no `Import External Device` or `Import Different Sensor Manufacturer` string remains in `app/`, `components/` or `e2e/`; unit suites for `components/features/{devices,claim,cohorts}` pass.

**Note on a flaky suite:** `deploy-device-component.test.tsx` intermittently times out when the full set runs in parallel (~5s limit under contention). It passes in isolation both with and without these changes, so it is unrelated — flagging it so a red CI run isn't misattributed here.

**Not verified:** the four e2e specs are updated but unrun — they need a live non-production API target. Please confirm they pass in CI before merging.

#### How should this be manually tested?

1. `cd src/vertex && npm run dev`, sign in as a user holding `DEVICE_UPDATE`.
2. **My Devices** (`/devices/my-devices`) — the outlined button reads **"Register Non-AirQo Device"**; clicking it opens a dialog with the same title.
3. **Devices → Overview** (`/devices/overview`) — same label.
4. **Home** — the header button reads the same. Then open the **"Add a device"** chooser: the second card is now "Register Non-AirQo Device", described as registering a sensor "singly or from a CSV template".
5. **Home empty state** — with no devices and no cohorts, the second button matches.
6. **Admin → Networks → pick a non-AirQo network** — the button reads "Register Non-AirQo Device". On an *AirQo* network the button is "Add AirQo Device" (device creation) and must be unaffected.
7. **Claim-side cross-reference** — open Claim AirQo Device → Claim Single Device → manual entry. The helper text under the fields now points at "Register Non-AirQo Device".
8. **Regression:** both registration paths still work end to end — single device, and bulk via CSV template.


#### Screenshots (optional)
<img width="1074" height="158" alt="image" src="https://github.com/user-attachments/assets/d947b332-c1fd-485b-b327-d5b96d398218" />


<!-- Before/after of the My Devices header and the "Add a device" chooser dialog would be useful here. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **User Interface**
  - Renamed “Import External Device” actions and dialog text to “Register Non-AirQo Device” across device management, home, onboarding, and claim workflows.
  - Clarified that non-AirQo sensors can be registered individually or using a CSV template.
  - Updated empty-state and guidance messaging for consistent terminology.

- **Documentation**
  - Added release notes for version 2.0.36.

- **Tests**
  - Updated automated test labels and selectors to reflect the new terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->