### PR TITLE
fix(vertex): derive cohort assign banner from the API response

### DIFF
--- a/src/vertex/app/changelog.md
+++ b/src/vertex/app/changelog.md
@@ -2,6 +2,24 @@
 
 > **Note**: This changelog consolidates all recent improvements, features, and fixes to the AirQo Vertex frontend.
 
+## Version 2.0.35
+**Released:** August 15, 2026
+
+### Fix: "assigned successfully" was reported even when the assignment changed nothing
+
+`POST /devices/cohorts/:id/assign-devices` splits the submitted ids into `updated_cohort.assigned` and `updated_cohort.already_assigned`, but the frontend threw the response away. `useAssignDevicesToCohort`'s `onSuccess` forwarded only the request variables, so both `assign-cohort-devices.tsx` and the post-import assignment in `import-device-modal.tsx` derived their banner from `deviceIds.length` — the count *submitted*, not the count *assigned*. Re-adding a device that was already in the cohort produced "1 device(s) assigned to cohort successfully" for a request that did nothing.
+
+<details>
+<summary><strong>Fix: the banner is now built from the API response</strong></summary>
+
+- **`useAssignDevicesToCohort` now passes `(data, variables)`** to its `onSuccess` option instead of `variables` alone. Consumers using per-call `mutate(..., { onSuccess })` — `orphaned-devices-alert.tsx` and `import-device-modal.tsx` — already received the response from react-query and are unaffected by the signature change.
+- **New `core/utils/cohortAssignment.ts`** maps the response to a severity + message so both call sites stay in step: all new → `success`, none new → `info` ("Device is already assigned to this cohort" / "N device(s) were already assigned and skipped"), mixed → `success` naming both counts.
+- **Older backends that omit `updated_cohort` fall back** to the submitted count and the previous wording, so nothing regresses where the breakdown isn't reported. `AssignDevicesToCohortResponse` marks the field optional to force callers through that path rather than assuming it exists.
+- **The import modal was fixed too** — it carried a copy of the same `deviceIds.length` message. Freshly-imported devices are rarely already assigned, but the message was wrong for the same reason.
+- Covered by unit tests on the mapping and three banner assertions in `assign-cohort-devices.test.tsx` (all-new, all-skipped, partial).
+
+</details>
+
 ## Version 2.0.34
 **Released:** August 10, 2026
 

--- a/src/vertex/components/features/cohorts/assign-cohort-devices.test.tsx
+++ b/src/vertex/components/features/cohorts/assign-cohort-devices.test.tsx
@@ -71,6 +71,21 @@ function mockAssignDevices(
   );
 }
 
+/**
+ * Drives the assign mutation to success with a given API breakdown, so the
+ * banner assertions exercise the response → message mapping rather than the
+ * submitted device count.
+ */
+function respondWith(updated_cohort: {
+  assigned: string[];
+  already_assigned: string[];
+}) {
+  return vi.fn((variables, hookOptions, callOptions) => {
+    hookOptions?.onSuccess?.({ success: true, updated_cohort }, variables);
+    callOptions?.onSuccess?.();
+  });
+}
+
 const DEVICE_A = { _id: "device-1", name: "airqo_g1", long_name: "AirQo G1" };
 const DEVICE_B = { _id: "device-2", name: "airqo_g2", long_name: "AirQo G2" };
 
@@ -150,11 +165,9 @@ describe("AssignCohortDevicesDialog", () => {
   });
 
   it("shows a success banner and closes on success", async () => {
-    const assignSpy = vi.fn((variables, hookOptions, callOptions) => {
-      hookOptions?.onSuccess?.(variables);
-      callOptions?.onSuccess?.();
-    });
-    mockAssignDevices(assignSpy);
+    mockAssignDevices(
+      respondWith({ assigned: ["device-1"], already_assigned: [] })
+    );
     const onOpenChange = vi.fn();
     const onSuccess = vi.fn();
     const user = userEvent.setup();
@@ -179,6 +192,59 @@ describe("AssignCohortDevicesDialog", () => {
     });
     expect(onOpenChange).toHaveBeenCalledWith(false);
     expect(onSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it("says the device was already assigned instead of claiming success", async () => {
+    // Regression: the banner used to be built from the submitted id count, so a
+    // no-op assignment still reported "1 device(s) assigned ... successfully".
+    mockAssignDevices(
+      respondWith({ assigned: [], already_assigned: ["device-1"] })
+    );
+    const user = userEvent.setup();
+    render(
+      <AssignCohortDevicesDialog
+        open
+        onOpenChange={vi.fn()}
+        cohortId="cohort-1"
+        selectedDevices={[DEVICE_A] as never}
+      />
+    );
+
+    await user.click(dialog().getByRole("button", { name: "Add" }));
+
+    await waitFor(() => {
+      expect(showBannerWithDelayMock).toHaveBeenCalledWith({
+        severity: "info",
+        message: "Device is already assigned to this cohort",
+        scoped: false,
+      });
+    });
+  });
+
+  it("reports the assigned and skipped counts separately for a partial assignment", async () => {
+    mockAssignDevices(
+      respondWith({ assigned: ["device-1"], already_assigned: ["device-2"] })
+    );
+    const user = userEvent.setup();
+    render(
+      <AssignCohortDevicesDialog
+        open
+        onOpenChange={vi.fn()}
+        cohortId="cohort-1"
+        selectedDevices={[DEVICE_A, DEVICE_B] as never}
+      />
+    );
+
+    await user.click(dialog().getByRole("button", { name: "Add" }));
+
+    await waitFor(() => {
+      expect(showBannerWithDelayMock).toHaveBeenCalledWith({
+        severity: "success",
+        message:
+          "1 device(s) assigned to cohort successfully, 1 already assigned and skipped",
+        scoped: false,
+      });
+    });
   });
 
   it("opens Create New Cohort with the currently-selected devices preselected, closing this dialog", async () => {

--- a/src/vertex/components/features/cohorts/assign-cohort-devices.tsx
+++ b/src/vertex/components/features/cohorts/assign-cohort-devices.tsx
@@ -24,6 +24,7 @@ import { Device } from "@/app/types/devices";
 import { useUserContext } from "@/core/hooks/useUserContext";
 import { useBanner } from "@/context/banner-context";
 import { getApiErrorMessage } from "@/core/utils/getApiErrorMessage";
+import { getCohortAssignmentOutcome } from "@/core/utils/cohortAssignment";
 import { useBannerWithDelay } from "@/core/hooks/useBannerWithDelay";
 
 interface AssignCohortDevicesDialogProps {
@@ -109,10 +110,9 @@ export function AssignCohortDevicesDialog({
     search: debouncedDeviceSearch,
   });
   const { mutate: assignDevices, isPending: isAssigning } = useAssignDevicesToCohort({
-    onSuccess: (variables) => {
+    onSuccess: (data, variables) => {
       showBannerWithDelay({
-        severity: 'success',
-        message: `${variables.deviceIds.length} device(s) assigned to cohort successfully`,
+        ...getCohortAssignmentOutcome(data, variables.deviceIds.length),
         scoped: false,
       });
     },

--- a/src/vertex/components/features/devices/import-device-modal.tsx
+++ b/src/vertex/components/features/devices/import-device-modal.tsx
@@ -15,6 +15,7 @@ import { useBannerWithDelay } from "@/core/hooks/useBannerWithDelay";
 import { NetworkRequestDialog } from "../networks/network-request-dialog";
 import Papa from "papaparse";
 import { getApiErrorMessage } from "@/core/utils/getApiErrorMessage";
+import { getCohortAssignmentOutcome } from "@/core/utils/cohortAssignment";
 import { Collapsible, CollapsibleTrigger, CollapsibleContent } from "@/components/ui/collapsible";
 import { AqChevronDown, AqChevronUp } from "@airqo/icons-react";
 import { Card, CardContent, CardHeader, CardTitle, CardFooter } from "@/components/ui/card";
@@ -411,10 +412,9 @@ const ImportDeviceModal: React.FC<ImportDeviceModalProps> = ({
       cohortId,
       deviceIds,
     }, {
-      onSuccess: () => {
+      onSuccess: (data) => {
         showBannerWithDelay({
-          severity: 'success',
-          message: `${deviceIds.length} device(s) assigned to cohort successfully`,
+          ...getCohortAssignmentOutcome(data, deviceIds.length),
           scoped: false,
         }, 600);
         onAssigned?.();

--- a/src/vertex/core/apis/cohorts.ts
+++ b/src/vertex/core/apis/cohorts.ts
@@ -12,6 +12,24 @@ export interface GetCohortsSummaryParams {
   tags?: string;
 }
 
+/**
+ * Response of POST /devices/cohorts/:id/assign-devices.
+ *
+ * The backend splits the submitted device ids into those it actually attached
+ * (`assigned`) and those that were already members of the cohort and were
+ * therefore skipped (`already_assigned`). Both are optional here on purpose:
+ * older backend versions omit `updated_cohort` entirely, so consumers must
+ * cope with the breakdown being absent rather than assume it.
+ */
+export interface AssignDevicesToCohortResponse {
+  success: boolean;
+  message?: string;
+  updated_cohort?: {
+    assigned?: string[];
+    already_assigned?: string[];
+  };
+}
+
 export const cohorts = {
   getCohortsSummary: async (params: GetCohortsSummaryParams, signal?: AbortSignal): Promise<CohortsSummaryResponse> => {
     try {
@@ -177,13 +195,7 @@ export const cohorts = {
         { device_ids: deviceIds },
         { headers: { 'X-Auth-Type': 'JWT' } }
       );
-      return response.data as {
-        success: boolean;
-        updated_cohort: {
-          assigned: string[];
-          already_assigned: string[];
-        };
-      };
+      return response.data as AssignDevicesToCohortResponse;
     } catch (error) {
       throw error;
     }

--- a/src/vertex/core/hooks/useCohorts.ts
+++ b/src/vertex/core/hooks/useCohorts.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQuery, useQueryClient, type QueryFunctionContext } from '@tanstack/react-query';
 import {
+  AssignDevicesToCohortResponse,
   GetCohortsSummaryParams,
   cohorts as cohortsApi,
 } from '../apis/cohorts';
@@ -371,7 +372,13 @@ export const useCreateCohortFromCohorts = (options?: UseCreateCohortFromCohortsO
 };
 
 interface UseAssignDevicesToCohortOptions {
-  onSuccess?: (variables: { cohortId: string; deviceIds: string[] }) => void;
+  // `data` carries the assigned/already_assigned breakdown — callers building a
+  // success message must use it rather than the submitted id count, which says
+  // nothing about whether the assignment was a no-op.
+  onSuccess?: (
+    data: AssignDevicesToCohortResponse,
+    variables: { cohortId: string; deviceIds: string[] }
+  ) => void;
   onError?: (error: AxiosError) => void;
 }
 
@@ -391,14 +398,14 @@ export const useAssignDevicesToCohort = (options?: UseAssignDevicesToCohortOptio
       }
       return cohortsApi.assignDevicesToCohort(cohortId, deviceIds);
     },
-    onSuccess: (_data, variables) => {
+    onSuccess: (data, variables) => {
       queryClient.invalidateQueries({ queryKey: ['cohorts'] });
       queryClient.invalidateQueries({ queryKey: ['user-cohorts'] });
       queryClient.invalidateQueries({ queryKey: ['devices'], exact: false });
       queryClient.invalidateQueries({
         queryKey: ['cohort-details', variables.cohortId],
       });
-      options?.onSuccess?.(variables);
+      options?.onSuccess?.(data, variables);
     },
     onError: (error: AxiosError) => {
       options?.onError?.(error);

--- a/src/vertex/core/utils/cohortAssignment.test.ts
+++ b/src/vertex/core/utils/cohortAssignment.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import { getCohortAssignmentOutcome } from "./cohortAssignment";
+
+describe("getCohortAssignmentOutcome", () => {
+  it("reports the newly-assigned count when every device was assigned", () => {
+    expect(
+      getCohortAssignmentOutcome(
+        {
+          success: true,
+          updated_cohort: { assigned: ["d1", "d2"], already_assigned: [] },
+        },
+        2
+      )
+    ).toEqual({
+      severity: "success",
+      message: "2 device(s) assigned to cohort successfully",
+    });
+  });
+
+  it("reports a single already-assigned device as a no-op, not a success", () => {
+    expect(
+      getCohortAssignmentOutcome(
+        {
+          success: true,
+          updated_cohort: { assigned: [], already_assigned: ["d1"] },
+        },
+        1
+      )
+    ).toEqual({
+      severity: "info",
+      message: "Device is already assigned to this cohort",
+    });
+  });
+
+  it("pluralises the message when several devices were already assigned", () => {
+    expect(
+      getCohortAssignmentOutcome(
+        {
+          success: true,
+          updated_cohort: { assigned: [], already_assigned: ["d1", "d2"] },
+        },
+        2
+      )
+    ).toEqual({
+      severity: "info",
+      message: "2 device(s) were already assigned and skipped",
+    });
+  });
+
+  it("combines both counts for a partial assignment", () => {
+    expect(
+      getCohortAssignmentOutcome(
+        {
+          success: true,
+          updated_cohort: { assigned: ["d1"], already_assigned: ["d2", "d3"] },
+        },
+        3
+      )
+    ).toEqual({
+      severity: "success",
+      message:
+        "1 device(s) assigned to cohort successfully, 2 already assigned and skipped",
+    });
+  });
+
+  it("counts only what the API reports, ignoring the submitted count", () => {
+    // The submitted count (5) must not leak into the message when the backend
+    // says only one device was actually attached.
+    expect(
+      getCohortAssignmentOutcome(
+        { success: true, updated_cohort: { assigned: ["d1"] } },
+        5
+      ).message
+    ).toBe("1 device(s) assigned to cohort successfully");
+  });
+
+  it("falls back to the submitted count when the API omits the breakdown", () => {
+    expect(getCohortAssignmentOutcome({ success: true }, 3)).toEqual({
+      severity: "success",
+      message: "3 device(s) assigned to cohort successfully",
+    });
+    expect(getCohortAssignmentOutcome(undefined, 1)).toEqual({
+      severity: "success",
+      message: "1 device(s) assigned to cohort successfully",
+    });
+  });
+
+  it("does not claim success when the API reports both lists empty", () => {
+    expect(
+      getCohortAssignmentOutcome(
+        {
+          success: true,
+          updated_cohort: { assigned: [], already_assigned: [] },
+        },
+        2
+      )
+    ).toEqual({
+      severity: "info",
+      message: "No devices were assigned to the cohort",
+    });
+  });
+});

--- a/src/vertex/core/utils/cohortAssignment.ts
+++ b/src/vertex/core/utils/cohortAssignment.ts
@@ -1,0 +1,65 @@
+import type { AssignDevicesToCohortResponse } from "@/core/apis/cohorts";
+import type { BannerSeverity } from "@/components/ui/banner";
+
+export interface CohortAssignmentOutcome {
+  severity: BannerSeverity;
+  message: string;
+}
+
+/**
+ * Turns the assign-devices API response into the banner the user should see.
+ *
+ * The response reports which devices were newly attached and which were already
+ * in the cohort, so a request can succeed while changing nothing. Reporting the
+ * submitted count instead would tell a user that devices were assigned when the
+ * call was a no-op.
+ *
+ * `requestedCount` is only used when the backend returns no breakdown at all
+ * (older deployments), where the submitted count remains the best estimate.
+ */
+export const getCohortAssignmentOutcome = (
+  data: AssignDevicesToCohortResponse | undefined,
+  requestedCount: number
+): CohortAssignmentOutcome => {
+  const assigned = data?.updated_cohort?.assigned;
+  const alreadyAssigned = data?.updated_cohort?.already_assigned;
+
+  if (!Array.isArray(assigned) && !Array.isArray(alreadyAssigned)) {
+    return {
+      severity: "success",
+      message: `${requestedCount} device(s) assigned to cohort successfully`,
+    };
+  }
+
+  const assignedCount = assigned?.length ?? 0;
+  const skippedCount = alreadyAssigned?.length ?? 0;
+
+  if (assignedCount === 0 && skippedCount === 0) {
+    return {
+      severity: "info",
+      message: "No devices were assigned to the cohort",
+    };
+  }
+
+  if (assignedCount === 0) {
+    return {
+      severity: "info",
+      message:
+        skippedCount === 1
+          ? "Device is already assigned to this cohort"
+          : `${skippedCount} device(s) were already assigned and skipped`,
+    };
+  }
+
+  if (skippedCount === 0) {
+    return {
+      severity: "success",
+      message: `${assignedCount} device(s) assigned to cohort successfully`,
+    };
+  }
+
+  return {
+    severity: "success",
+    message: `${assignedCount} device(s) assigned to cohort successfully, ${skippedCount} already assigned and skipped`,
+  };
+};


### PR DESCRIPTION
#### Summary of Changes (What does this PR do?)

Assigning devices to a cohort always showed `N device(s) assigned to cohort
successfully`, even when every selected device was already in the cohort and
nothing changed. The user had no way to tell a real assignment from a no-op.

**Root cause:** `POST /devices/cohorts/:id/assign-devices` splits the submitted
ids into `updated_cohort.assigned` and `updated_cohort.already_assigned`, but
`useAssignDevicesToCohort`'s `onSuccess` discarded the response and forwarded
only the request variables. Both call sites therefore built their message from
`deviceIds.length` — the count *submitted*, not the count *assigned*. The
response shape was already typed correctly in `core/apis/cohorts.ts`; it was
thrown away one layer up in the hook.

**Changes:**

- `useAssignDevicesToCohort` now passes `(data, variables)` to its `onSuccess`
  option instead of `variables` alone.
- New `core/utils/cohortAssignment.ts` maps the response to a banner severity
  and message, so every call site stays in step:

  | Response | Banner |
  |---|---|
  | all newly assigned | success — `N device(s) assigned to cohort successfully` |
  | 1 already assigned | info — `Device is already assigned to this cohort` |
  | N already assigned | info — `N device(s) were already assigned and skipped` |
  | mixed | success — `1 device(s) assigned to cohort successfully, 2 already assigned and skipped` |
  | no breakdown returned | success — falls back to the submitted count (previous wording) |

- `AssignDevicesToCohortResponse` marks `updated_cohort` optional, so older
  backends that omit the breakdown fall back to today's behaviour instead of
  reporting zero.
- `import-device-modal.tsx` carried a duplicate of the same
  `deviceIds.length` message for post-import assignment and now uses the
  shared helper. Slightly beyond the reported scope — same bug, same fix;
  happy to split it out if preferred.
- `orphaned-devices-alert.tsx` needed no change — it uses per-call
  `mutate(..., { onSuccess })`, which already receives the response.

No dependency or migration required; frontend-only.

#### Status of maturity (all need to be checked before merging):

- [x] I've tested this locally
- [x] I consider this code done
- [x] This change ready to hit production in its current state
- [x] The title of the PR states what changed and the related issues number (used for the release note).
- [x] I've included issue number in the "Closes #3913" part of the "[What are the relevant tickets?](#what-are-the-relevant-tickets)" section to [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] I've updated corresponding documentation for the changes in this PR.
- [x] I have written unit and/or e2e tests for my change(s).

#### How should this be manually tested?

Setup: `cd src/vertex && npm install && npm run dev`, signed in as a user with
`DEVICE_VIEW` and access to at least one cohort with devices in it.

1. **No-op case (the reported bug):** open a cohort's detail page → **Add
   Devices** → select a device already in that cohort → **Add**.
   - Before: `1 device(s) assigned to cohort successfully`
   - Now: `Device is already assigned to this cohort` (info banner)
2. **Real assignment:** repeat with a device not in the cohort → success
   banner with the count.
3. **Partial:** select one already-assigned and one new device →
   `1 device(s) assigned to cohort successfully, 1 already assigned and skipped`.
4. **Bulk path:** same three cases via **Assign to Cohort** from a device table.
5. **Import path:** import an external device and assign it to a cohort in the
   final step → success banner still shows the assigned count.

<img width="1064" height="432" alt="image" src="https://github.com/user-attachments/assets/7f1f63a7-7db0-49bd-abdd-bd249b23f3fe" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Assignment notifications now accurately distinguish successfully assigned devices, devices already assigned, and mixed results.
  * Added fallback messaging for older backend responses without assignment breakdown details.
  * Improved singular and plural wording in assignment banners.

* **Tests**
  * Added coverage for full, partial, skipped, empty, and unavailable assignment results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->