### PR TITLE
fix(mobile): reconcile live reading with forecast view for today

### DIFF
--- a/src/mobile/lib/src/app/dashboard/models/forecast_guidance.dart
+++ b/src/mobile/lib/src/app/dashboard/models/forecast_guidance.dart
@@ -1,3 +1,4 @@
+import 'package:airqo/src/app/dashboard/models/airquality_response.dart';
 import 'package:airqo/src/app/dashboard/models/forecast_response.dart';
 
 /// API-sourced guidance for the forecast modal guidance panel.
@@ -29,6 +30,36 @@ ForecastGuidance guidanceFromHourlyEntry(HourlyForecastEntry entry) {
     trendMessage: _trimOrNull(entry.trendMessage),
   );
 }
+
+ForecastGuidance guidanceFromMeasurement(Measurement measurement) {
+  final tips = measurement.healthTips;
+  if (tips == null || tips.isEmpty) {
+    return const ForecastGuidance();
+  }
+  final tip = tips.first;
+  return ForecastGuidance(
+    message: _trimOrNull(tip.description) ??
+        _trimOrNull(tip.tagLine) ??
+        _trimOrNull(tip.title),
+  );
+}
+
+bool isForecastToday(DateTime forecastTime, [DateTime? now]) {
+  final reference = (now ?? DateTime.now()).toLocal();
+  return _fmtDate(forecastTime.toLocal()) == _fmtDate(reference);
+}
+
+bool isCurrentHourEntry(HourlyForecastEntry entry, [DateTime? now]) {
+  final reference = (now ?? DateTime.now()).toLocal();
+  final entryTime = entry.time.toLocal();
+  return entryTime.year == reference.year &&
+      entryTime.month == reference.month &&
+      entryTime.day == reference.day &&
+      entryTime.hour == reference.hour;
+}
+
+bool hasLiveReading(Measurement? measurement) =>
+    measurement?.pm25?.value != null;
 
 String? _trimOrNull(String? value) {
   if (value == null) return null;
@@ -70,6 +101,38 @@ class ForecastReadingSnapshot {
       forecastConfidence: entry.forecastConfidence,
       met: entry.met,
     );
+  }
+
+  factory ForecastReadingSnapshot.fromMeasurement(Measurement measurement) {
+    return ForecastReadingSnapshot(
+      pm25: measurement.pm25!.value!,
+      aqiCategory: measurement.aqiCategory ?? 'Unavailable',
+      aqiColor: measurement.aqiColor ?? '',
+    );
+  }
+
+  factory ForecastReadingSnapshot.fromDailyOrLive({
+    required Forecast forecast,
+    Measurement? measurement,
+    DateTime? now,
+  }) {
+    if (isForecastToday(forecast.time, now) && hasLiveReading(measurement)) {
+      return ForecastReadingSnapshot.fromMeasurement(measurement!);
+    }
+    return ForecastReadingSnapshot.fromDaily(forecast);
+  }
+
+  factory ForecastReadingSnapshot.fromHourlyOrLive({
+    required HourlyForecastEntry entry,
+    Measurement? measurement,
+    DateTime? now,
+  }) {
+    if (isCurrentHourEntry(entry, now) &&
+        isForecastToday(entry.time, now) &&
+        hasLiveReading(measurement)) {
+      return ForecastReadingSnapshot.fromMeasurement(measurement!);
+    }
+    return ForecastReadingSnapshot.fromHourly(entry);
   }
 }
 

--- a/src/mobile/lib/src/app/dashboard/pages/forecast_overview_page.dart
+++ b/src/mobile/lib/src/app/dashboard/pages/forecast_overview_page.dart
@@ -134,12 +134,25 @@ class _ForecastOverviewPageState extends State<ForecastOverviewPage> {
     }
   }
 
-  List<Forecast> _futureDailyForecasts(List<Forecast> forecasts) {
-    final today = _dateOnly(DateTime.now());
-    return forecasts
-        .where((f) => _dateOnly(f.time.toLocal()).isAfter(today))
-        .toList();
+  void _syncTodayIndex(List<Forecast> forecasts) {
+    if (_selectedDayIndex != 0) return;
+    final todayIdx =
+        forecasts.indexWhere((f) => isForecastToday(f.time.toLocal()));
+    if (todayIdx <= 0) return;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      setState(() => _selectedDayIndex = todayIdx);
+    });
   }
+
+  bool _isLiveDailyReading(Forecast day, DateTime now) =>
+      isForecastToday(day.time, now) && hasLiveReading(widget.measurement);
+
+  bool _isLiveHourlyReading(HourlyForecastEntry? entry, DateTime now) =>
+      entry != null &&
+      isCurrentHourEntry(entry, now) &&
+      isForecastToday(entry.time, now) &&
+      hasLiveReading(widget.measurement);
 
   void _syncHourIndex(List<HourlyForecastEntry> entries, DateTime day) {
     if (_timeScope != ForecastTimeScope.hourly || entries.isEmpty) return;
@@ -350,19 +363,22 @@ class _ForecastOverviewPageState extends State<ForecastOverviewPage> {
     bool hourlyLoading = false,
     String? hourlyError,
   }) {
-    final forecasts = _futureDailyForecasts(state.response.forecasts);
+    final forecasts = state.response.forecasts;
     if (forecasts.isEmpty) {
       return const Center(child: Text('No forecast data available.'));
     }
+
+    _syncTodayIndex(forecasts);
 
     final idx = _selectedDayIndex.clamp(0, forecasts.length - 1).toInt();
     final day = forecasts[idx];
     final selectedDateLabel = DateFormat('EEEE, MMMM d').format(day.time);
     final now = DateTime.now();
+    final viewingToday = isForecastToday(day.time, now);
     final hourEntries = hourlyEntriesForDate(
       state.hourlyResponse,
       day.time,
-      skipCurrentHour: true,
+      skipCurrentHour: !viewingToday,
       now: now,
     );
     _syncHourIndex(hourEntries, day.time);
@@ -371,6 +387,20 @@ class _ForecastOverviewPageState extends State<ForecastOverviewPage> {
         ? 0
         : _selectedHourIndex.clamp(0, hourEntries.length - 1).toInt();
     final selectedHour = hourEntries.isNotEmpty ? hourEntries[hourIdx] : null;
+    final dailyReading = ForecastReadingSnapshot.fromDailyOrLive(
+      forecast: day,
+      measurement: widget.measurement,
+      now: now,
+    );
+    final hourlyReading = selectedHour == null
+        ? null
+        : ForecastReadingSnapshot.fromHourlyOrLive(
+            entry: selectedHour,
+            measurement: widget.measurement,
+            now: now,
+          );
+    final isLiveDaily = _isLiveDailyReading(day, now);
+    final isLiveHourly = _isLiveHourlyReading(selectedHour, now);
 
     return SingleChildScrollView(
       controller: scrollController,
@@ -402,16 +432,21 @@ class _ForecastOverviewPageState extends State<ForecastOverviewPage> {
               onSelected: _selectDay,
               isDark: isDark,
               onInsetPanel: true,
+              liveReading: widget.measurement,
             ),
           ),
           const SizedBox(height: 20),
           if (_timeScope == ForecastTimeScope.daily) ...[
             ForecastDayDetailCard(
-              reading: ForecastReadingSnapshot.fromDaily(day),
+              reading: dailyReading,
               isDark: isDark,
+              liveMeasurement: isLiveDaily ? widget.measurement : null,
             ),
             const SizedBox(height: 20),
-            ForecastGuidanceSection.fromForecast(day),
+            if (isLiveDaily && widget.measurement != null)
+              ForecastGuidanceSection.fromMeasurement(widget.measurement!)
+            else
+              ForecastGuidanceSection.fromForecast(day),
           ] else ...[
             Container(
               padding: const EdgeInsets.all(12),
@@ -426,17 +461,22 @@ class _ForecastOverviewPageState extends State<ForecastOverviewPage> {
                 onInsetPanel: true,
                 selectedHourIndex: hourIdx,
                 onHourSelected: _selectHour,
-                skipCurrentHour: true,
+                skipCurrentHour: !viewingToday,
+                liveReading: widget.measurement,
               ),
             ),
-            if (selectedHour != null) ...[
+            if (selectedHour != null && hourlyReading != null) ...[
               const SizedBox(height: 20),
               ForecastDayDetailCard(
-                reading: ForecastReadingSnapshot.fromHourly(selectedHour),
+                reading: hourlyReading,
                 isDark: isDark,
+                liveMeasurement: isLiveHourly ? widget.measurement : null,
               ),
               const SizedBox(height: 20),
-              ForecastGuidanceSection.fromHourly(selectedHour),
+              if (isLiveHourly && widget.measurement != null)
+                ForecastGuidanceSection.fromMeasurement(widget.measurement!)
+              else
+                ForecastGuidanceSection.fromHourly(selectedHour),
             ],
           ],
           const SizedBox(height: 32),
@@ -521,6 +561,4 @@ class _ForecastOverviewPageState extends State<ForecastOverviewPage> {
       ),
     );
   }
-
-  DateTime _dateOnly(DateTime dt) => DateTime(dt.year, dt.month, dt.day);
 }

--- a/src/mobile/lib/src/app/dashboard/widgets/analytics_forecast_widget.dart
+++ b/src/mobile/lib/src/app/dashboard/widgets/analytics_forecast_widget.dart
@@ -1,8 +1,11 @@
 import 'package:airqo/src/app/dashboard/bloc/forecast/forecast_bloc.dart';
+import 'package:airqo/src/app/dashboard/models/airquality_response.dart';
+import 'package:airqo/src/app/dashboard/models/forecast_guidance.dart';
 import 'package:airqo/src/app/shared/widgets/translated_text.dart';
 import 'package:airqo/src/app/shared/widgets/loading_widget.dart';
 import 'package:airqo/src/meta/utils/colors.dart';
 import 'package:airqo/src/meta/utils/forecast_utils.dart';
+import 'package:airqo/src/meta/utils/utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -11,7 +14,13 @@ import 'package:loggy/loggy.dart';
 
 class AnalyticsForecastWidget extends StatefulWidget {
   final String siteId;
-  const AnalyticsForecastWidget({super.key, required this.siteId});
+  final Measurement? measurement;
+
+  const AnalyticsForecastWidget({
+    super.key,
+    required this.siteId,
+    this.measurement,
+  });
 
   @override
   State<AnalyticsForecastWidget> createState() => _AnalyticsForecastWidgetState();
@@ -149,12 +158,19 @@ class _AnalyticsForecastWidgetState extends State<AnalyticsForecastWidget> with 
                           // Check if this forecast is for the current date
                           final forecastDate = DateFormat('yyyy-MM-dd').format(e.time);
                           final isCurrentDay = forecastDate == currentDateFormatted;
+                          final useLiveReading =
+                              isCurrentDay && hasLiveReading(widget.measurement);
+                          final iconPath = useLiveReading
+                              ? getAirQualityIcon(
+                                  widget.measurement!,
+                                  widget.measurement!.pm25!.value!,
+                                )
+                              : getForecastAirQualityIcon(e.aqiCategory);
                           
                           return ForeCastChip(
                             active: isCurrentDay,
                             day: DateFormat.E().format(e.time).substring(0, 2),
-                            imagePath:
-                                getForecastAirQualityIcon(e.aqiCategory),
+                            imagePath: iconPath,
                             height: _getResponsiveHeight(context),
                             iconSize: _getResponsiveIconSize(context),
                             margin: _getResponsiveMargin(context),

--- a/src/mobile/lib/src/app/dashboard/widgets/analytics_forecast_widget.dart
+++ b/src/mobile/lib/src/app/dashboard/widgets/analytics_forecast_widget.dart
@@ -94,9 +94,6 @@ class _AnalyticsForecastWidgetState extends State<AnalyticsForecastWidget> with 
         return BlocBuilder<ForecastBloc, ForecastState>(
           builder: (context, state) {
             if (state is ForecastLoaded) {
-              final today = DateTime.now();
-              final currentDateFormatted = DateFormat('yyyy-MM-dd').format(today);
-              
               // Check if data is stale and show a subtle indicator
               final isStale = state.isStale;
               
@@ -155,9 +152,7 @@ class _AnalyticsForecastWidgetState extends State<AnalyticsForecastWidget> with 
                   Row(
                     children: state.response.forecasts
                         .map((e) {
-                          // Check if this forecast is for the current date
-                          final forecastDate = DateFormat('yyyy-MM-dd').format(e.time);
-                          final isCurrentDay = forecastDate == currentDateFormatted;
+                          final isCurrentDay = isForecastToday(e.time);
                           final useLiveReading =
                               isCurrentDay && hasLiveReading(widget.measurement);
                           final iconPath = useLiveReading
@@ -169,7 +164,7 @@ class _AnalyticsForecastWidgetState extends State<AnalyticsForecastWidget> with 
                           
                           return ForeCastChip(
                             active: isCurrentDay,
-                            day: DateFormat.E().format(e.time).substring(0, 2),
+                            day: DateFormat.E().format(e.time.toLocal()).substring(0, 2),
                             imagePath: iconPath,
                             height: _getResponsiveHeight(context),
                             iconSize: _getResponsiveIconSize(context),

--- a/src/mobile/lib/src/app/dashboard/widgets/analytics_specifics.dart
+++ b/src/mobile/lib/src/app/dashboard/widgets/analytics_specifics.dart
@@ -217,6 +217,7 @@ class _AnalyticsSpecificsState extends State<AnalyticsSpecifics> {
                 if (widget.measurement.siteDetails?.id != null)
                   AnalyticsForecastWidget(
                     siteId: widget.measurement.siteDetails!.id!,
+                    measurement: widget.measurement,
                   )
                 else
                   const Center(

--- a/src/mobile/lib/src/app/dashboard/widgets/forecast_day_detail_card.dart
+++ b/src/mobile/lib/src/app/dashboard/widgets/forecast_day_detail_card.dart
@@ -1,20 +1,27 @@
+import 'package:airqo/src/app/dashboard/models/airquality_response.dart';
 import 'package:airqo/src/app/dashboard/models/forecast_guidance.dart';
 import 'package:airqo/src/app/dashboard/widgets/forecast_met_row.dart';
 import 'package:airqo/src/app/shared/widgets/aqi_category_chip.dart';
 import 'package:airqo/src/meta/utils/colors.dart';
 import 'package:airqo/src/meta/utils/forecast_utils.dart';
+import 'package:airqo/src/meta/utils/utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 
 class ForecastDayDetailCard extends StatelessWidget {
   final ForecastReadingSnapshot reading;
   final bool isDark;
+  final Measurement? liveMeasurement;
 
   const ForecastDayDetailCard({
     super.key,
     required this.reading,
     required this.isDark,
+    this.liveMeasurement,
   });
+
+  bool get _isLiveReading =>
+      liveMeasurement != null && reading.forecastConfidence == null;
 
   @override
   Widget build(BuildContext context) {
@@ -91,7 +98,10 @@ class ForecastDayDetailCard extends StatelessWidget {
               ),
               const SizedBox(width: 16),
               SvgPicture.asset(
-                getForecastAirQualityIcon(reading.aqiCategory),
+                _isLiveReading
+                    ? getAirQualityIcon(
+                        liveMeasurement!, liveMeasurement!.pm25!.value!)
+                    : getForecastAirQualityIcon(reading.aqiCategory),
                 width: 72,
                 height: 72,
               ),

--- a/src/mobile/lib/src/app/dashboard/widgets/forecast_day_selector.dart
+++ b/src/mobile/lib/src/app/dashboard/widgets/forecast_day_selector.dart
@@ -37,7 +37,7 @@ class ForecastDaySelector extends StatelessWidget {
         final isToday = DateFormat('yyyy-MM-dd').format(f.time) == todayStr;
         final useLiveReading = isToday && hasLiveReading(liveReading);
         final pm25Label = useLiveReading
-            ? liveReading!.pm25!.value!.round().toString()
+            ? liveReading!.pm25!.value!.toStringAsFixed(1)
             : '${f.pm25.round()}';
         final iconPath = useLiveReading
             ? getAirQualityIcon(liveReading!, liveReading!.pm25!.value!)

--- a/src/mobile/lib/src/app/dashboard/widgets/forecast_day_selector.dart
+++ b/src/mobile/lib/src/app/dashboard/widgets/forecast_day_selector.dart
@@ -1,6 +1,9 @@
+import 'package:airqo/src/app/dashboard/models/airquality_response.dart';
+import 'package:airqo/src/app/dashboard/models/forecast_guidance.dart';
 import 'package:airqo/src/app/dashboard/models/forecast_response.dart';
 import 'package:airqo/src/meta/utils/colors.dart';
 import 'package:airqo/src/meta/utils/forecast_utils.dart';
+import 'package:airqo/src/meta/utils/utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:intl/intl.dart';
@@ -12,6 +15,7 @@ class ForecastDaySelector extends StatelessWidget {
   final ValueChanged<int> onSelected;
   final bool isDark;
   final bool onInsetPanel;
+  final Measurement? liveReading;
 
   const ForecastDaySelector({
     super.key,
@@ -21,6 +25,7 @@ class ForecastDaySelector extends StatelessWidget {
     required this.onSelected,
     required this.isDark,
     this.onInsetPanel = false,
+    this.liveReading,
   });
 
   @override
@@ -30,6 +35,13 @@ class ForecastDaySelector extends StatelessWidget {
         final f = forecasts[i];
         final isActive = i == selectedIndex;
         final isToday = DateFormat('yyyy-MM-dd').format(f.time) == todayStr;
+        final useLiveReading = isToday && hasLiveReading(liveReading);
+        final pm25Label = useLiveReading
+            ? liveReading!.pm25!.value!.round().toString()
+            : '${f.pm25.round()}';
+        final iconPath = useLiveReading
+            ? getAirQualityIcon(liveReading!, liveReading!.pm25!.value!)
+            : getForecastAirQualityIcon(f.aqiCategory);
 
         Color bgColor;
         Border? chipBorder;
@@ -87,12 +99,11 @@ class ForecastDaySelector extends StatelessWidget {
                   SizedBox(
                     width: 26,
                     height: 26,
-                    child: SvgPicture.asset(
-                        getForecastAirQualityIcon(f.aqiCategory)),
+                    child: SvgPicture.asset(iconPath),
                   ),
                   const SizedBox(height: 4),
                   Text(
-                    '${f.pm25.round()}',
+                    pm25Label,
                     style: TextStyle(
                       fontSize: 11,
                       fontWeight: FontWeight.w500,

--- a/src/mobile/lib/src/app/dashboard/widgets/forecast_day_selector.dart
+++ b/src/mobile/lib/src/app/dashboard/widgets/forecast_day_selector.dart
@@ -34,7 +34,7 @@ class ForecastDaySelector extends StatelessWidget {
       children: List.generate(forecasts.length, (i) {
         final f = forecasts[i];
         final isActive = i == selectedIndex;
-        final isToday = DateFormat('yyyy-MM-dd').format(f.time) == todayStr;
+        final isToday = isForecastToday(f.time);
         final useLiveReading = isToday && hasLiveReading(liveReading);
         final pm25Label = useLiveReading
             ? liveReading!.pm25!.value!.toStringAsFixed(1)
@@ -81,7 +81,7 @@ class ForecastDaySelector extends StatelessWidget {
                 mainAxisSize: MainAxisSize.min,
                 children: [
                   Text(
-                    DateFormat.E().format(f.time).substring(0, 2),
+                    DateFormat.E().format(f.time.toLocal()).substring(0, 2),
                     style: TextStyle(
                       fontSize: 12,
                       fontWeight: FontWeight.w700,

--- a/src/mobile/lib/src/app/dashboard/widgets/forecast_guidance_section.dart
+++ b/src/mobile/lib/src/app/dashboard/widgets/forecast_guidance_section.dart
@@ -1,3 +1,4 @@
+import 'package:airqo/src/app/dashboard/models/airquality_response.dart';
 import 'package:airqo/src/app/dashboard/models/forecast_guidance.dart';
 import 'package:airqo/src/app/dashboard/models/forecast_response.dart';
 import 'package:airqo/src/app/shared/widgets/translated_text.dart';
@@ -15,6 +16,12 @@ class ForecastGuidanceSection extends StatelessWidget {
 
   factory ForecastGuidanceSection.fromHourly(HourlyForecastEntry entry) {
     return ForecastGuidanceSection(guidance: guidanceFromHourlyEntry(entry));
+  }
+
+  factory ForecastGuidanceSection.fromMeasurement(Measurement measurement) {
+    return ForecastGuidanceSection(
+      guidance: guidanceFromMeasurement(measurement),
+    );
   }
 
   @override

--- a/src/mobile/lib/src/app/dashboard/widgets/forecast_hourly_section.dart
+++ b/src/mobile/lib/src/app/dashboard/widgets/forecast_hourly_section.dart
@@ -232,7 +232,7 @@ class _HourlyChip extends StatelessWidget {
 
     final useLiveReading = hasLiveReading(liveReading);
     final pm25Label = useLiveReading
-        ? liveReading!.pm25!.value!.round().toString()
+        ? liveReading!.pm25!.value!.toStringAsFixed(1)
         : '${entry.pm25Mean.round()}';
     final iconPath = useLiveReading
         ? getAirQualityIcon(liveReading!, liveReading!.pm25!.value!)

--- a/src/mobile/lib/src/app/dashboard/widgets/forecast_hourly_section.dart
+++ b/src/mobile/lib/src/app/dashboard/widgets/forecast_hourly_section.dart
@@ -1,9 +1,11 @@
 import 'package:airqo/src/app/dashboard/bloc/forecast/forecast_bloc.dart';
+import 'package:airqo/src/app/dashboard/models/airquality_response.dart';
 import 'package:airqo/src/app/dashboard/models/forecast_guidance.dart';
 import 'package:airqo/src/app/dashboard/models/forecast_response.dart';
 import 'package:airqo/src/app/shared/widgets/loading_widget.dart';
 import 'package:airqo/src/meta/utils/colors.dart';
 import 'package:airqo/src/meta/utils/forecast_utils.dart';
+import 'package:airqo/src/meta/utils/utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -20,6 +22,7 @@ class ForecastHourlySection extends StatelessWidget {
   final int selectedHourIndex;
   final ValueChanged<int>? onHourSelected;
   final bool skipCurrentHour;
+  final Measurement? liveReading;
 
   const ForecastHourlySection({
     super.key,
@@ -33,6 +36,7 @@ class ForecastHourlySection extends StatelessWidget {
     this.selectedHourIndex = 0,
     this.onHourSelected,
     this.skipCurrentHour = false,
+    this.liveReading,
   });
 
   @override
@@ -68,6 +72,7 @@ class ForecastHourlySection extends StatelessWidget {
             selectedHourIndex: selectedHourIndex,
             onHourSelected: onHourSelected,
             skipCurrentHour: skipCurrentHour,
+            liveReading: liveReading,
           ),
       ],
     );
@@ -120,6 +125,7 @@ class _HourlyList extends StatelessWidget {
   final int selectedHourIndex;
   final ValueChanged<int>? onHourSelected;
   final bool skipCurrentHour;
+  final Measurement? liveReading;
 
   const _HourlyList({
     required this.hourlyResponse,
@@ -129,6 +135,7 @@ class _HourlyList extends StatelessWidget {
     required this.selectedHourIndex,
     this.onHourSelected,
     this.skipCurrentHour = false,
+    this.liveReading,
   });
 
   Color _surfaceColor(BuildContext context) => onInsetPanel
@@ -183,11 +190,15 @@ class _HourlyList extends StatelessWidget {
           final isSelected = onHourSelected != null
               ? i == selectedHourIndex.clamp(0, dayEntries.length - 1).toInt()
               : isNow;
+          final useLiveReading = isNow &&
+              isForecastToday(entry.time, now) &&
+              hasLiveReading(liveReading);
           return _HourlyChip(
             entry: entry,
             isSelected: isSelected,
             onInsetPanel: onInsetPanel,
             onTap: onHourSelected != null ? () => onHourSelected!(i) : null,
+            liveReading: useLiveReading ? liveReading : null,
           );
         },
       ),
@@ -200,12 +211,14 @@ class _HourlyChip extends StatelessWidget {
   final bool isSelected;
   final bool onInsetPanel;
   final VoidCallback? onTap;
+  final Measurement? liveReading;
 
   const _HourlyChip({
     required this.entry,
     required this.isSelected,
     this.onInsetPanel = false,
     this.onTap,
+    this.liveReading,
   });
 
   @override
@@ -216,6 +229,14 @@ class _HourlyChip extends StatelessWidget {
     final inactiveMetaColor = isDarkTheme
         ? Colors.white.withValues(alpha: 0.85)
         : AppTextColors.muted(context);
+
+    final useLiveReading = hasLiveReading(liveReading);
+    final pm25Label = useLiveReading
+        ? liveReading!.pm25!.value!.round().toString()
+        : '${entry.pm25Mean.round()}';
+    final iconPath = useLiveReading
+        ? getAirQualityIcon(liveReading!, liveReading!.pm25!.value!)
+        : getForecastAirQualityIcon(entry.aqiCategory);
 
     final chip = Container(
       width: 64,
@@ -247,13 +268,13 @@ class _HourlyChip extends StatelessWidget {
           ),
           const SizedBox(height: 5),
           SvgPicture.asset(
-            getForecastAirQualityIcon(entry.aqiCategory),
+            iconPath,
             width: 24,
             height: 24,
           ),
           const SizedBox(height: 4),
           Text(
-            '${entry.pm25Mean.round()}',
+            pm25Label,
             style: TextStyle(
               fontSize: 12,
               fontWeight: FontWeight.w600,

--- a/src/mobile/test/app/dashboard/models/forecast_guidance_test.dart
+++ b/src/mobile/test/app/dashboard/models/forecast_guidance_test.dart
@@ -24,7 +24,7 @@ Forecast _forecast({
     aqiColorName: 'orange',
     pm25: pm25,
     time: time,
-    forecastConfidence: 80,
+    forecastConfidence: 80.0,
   );
 }
 
@@ -37,7 +37,7 @@ HourlyForecastEntry _hourlyEntry({
     aqiColor: '#FF9900',
     pm25Mean: pm25,
     time: time,
-    forecastConfidence: 75,
+    forecastConfidence: 75.0,
   );
 }
 

--- a/src/mobile/test/app/dashboard/models/forecast_guidance_test.dart
+++ b/src/mobile/test/app/dashboard/models/forecast_guidance_test.dart
@@ -48,6 +48,11 @@ void main() {
       expect(isForecastToday(DateTime(2026, 8, 17, 8), now), isTrue);
     });
 
+    test('returns true for UTC timestamp representing the same local day', () {
+      final now = DateTime(2026, 8, 17, 12);
+      expect(isForecastToday(now.toUtc(), now), isTrue);
+    });
+
     test('returns false for a different day', () {
       final now = DateTime(2026, 8, 17, 15, 30);
       expect(isForecastToday(DateTime(2026, 8, 18, 8), now), isFalse);

--- a/src/mobile/test/app/dashboard/models/forecast_guidance_test.dart
+++ b/src/mobile/test/app/dashboard/models/forecast_guidance_test.dart
@@ -1,0 +1,143 @@
+import 'package:airqo/src/app/dashboard/models/airquality_response.dart';
+import 'package:airqo/src/app/dashboard/models/forecast_guidance.dart';
+import 'package:airqo/src/app/dashboard/models/forecast_response.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Measurement _measurement({double pm25 = 42.3}) {
+  return Measurement(
+    aqiCategory: 'Moderate',
+    aqiColor: '#FF9900',
+    pm25: Pm25(value: pm25),
+    healthTips: [
+      HealthTip(description: 'Limit outdoor activity.'),
+    ],
+  );
+}
+
+Forecast _forecast({
+  required DateTime time,
+  double pm25 = 55.0,
+}) {
+  return Forecast(
+    aqiCategory: 'Unhealthy for Sensitive Groups',
+    aqiColor: '#FF6600',
+    aqiColorName: 'orange',
+    pm25: pm25,
+    time: time,
+    forecastConfidence: 80,
+  );
+}
+
+HourlyForecastEntry _hourlyEntry({
+  required DateTime time,
+  double pm25 = 48.0,
+}) {
+  return HourlyForecastEntry(
+    aqiCategory: 'Moderate',
+    aqiColor: '#FF9900',
+    pm25Mean: pm25,
+    time: time,
+    forecastConfidence: 75,
+  );
+}
+
+void main() {
+  group('isForecastToday', () {
+    test('returns true for same calendar day', () {
+      final now = DateTime(2026, 8, 17, 15, 30);
+      expect(isForecastToday(DateTime(2026, 8, 17, 8), now), isTrue);
+    });
+
+    test('returns false for a different day', () {
+      final now = DateTime(2026, 8, 17, 15, 30);
+      expect(isForecastToday(DateTime(2026, 8, 18, 8), now), isFalse);
+    });
+  });
+
+  group('isCurrentHourEntry', () {
+    test('returns true when entry matches current hour on today', () {
+      final now = DateTime(2026, 8, 17, 15, 45);
+      final entry = _hourlyEntry(time: DateTime(2026, 8, 17, 15));
+      expect(isCurrentHourEntry(entry, now), isTrue);
+    });
+
+    test('returns false for a different hour', () {
+      final now = DateTime(2026, 8, 17, 15, 45);
+      final entry = _hourlyEntry(time: DateTime(2026, 8, 17, 16));
+      expect(isCurrentHourEntry(entry, now), isFalse);
+    });
+  });
+
+  group('ForecastReadingSnapshot.fromDailyOrLive', () {
+    test('uses live reading for today when measurement is available', () {
+      final now = DateTime(2026, 8, 17, 12);
+      final snapshot = ForecastReadingSnapshot.fromDailyOrLive(
+        forecast: _forecast(time: DateTime(2026, 8, 17)),
+        measurement: _measurement(pm25: 42.3),
+        now: now,
+      );
+
+      expect(snapshot.pm25, 42.3);
+      expect(snapshot.aqiCategory, 'Moderate');
+      expect(snapshot.forecastConfidence, isNull);
+    });
+
+    test('uses forecast for future days', () {
+      final now = DateTime(2026, 8, 17, 12);
+      final snapshot = ForecastReadingSnapshot.fromDailyOrLive(
+        forecast: _forecast(time: DateTime(2026, 8, 18), pm25: 55),
+        measurement: _measurement(pm25: 42.3),
+        now: now,
+      );
+
+      expect(snapshot.pm25, 55);
+      expect(snapshot.forecastConfidence, 80);
+    });
+
+    test('falls back to forecast for today without live reading', () {
+      final now = DateTime(2026, 8, 17, 12);
+      final snapshot = ForecastReadingSnapshot.fromDailyOrLive(
+        forecast: _forecast(time: DateTime(2026, 8, 17), pm25: 55),
+        measurement: Measurement(aqiCategory: 'Moderate'),
+        now: now,
+      );
+
+      expect(snapshot.pm25, 55);
+      expect(snapshot.forecastConfidence, 80);
+    });
+  });
+
+  group('ForecastReadingSnapshot.fromHourlyOrLive', () {
+    test('uses live reading for current hour on today', () {
+      final now = DateTime(2026, 8, 17, 15, 20);
+      final snapshot = ForecastReadingSnapshot.fromHourlyOrLive(
+        entry: _hourlyEntry(time: DateTime(2026, 8, 17, 15), pm25: 48),
+        measurement: _measurement(pm25: 42.3),
+        now: now,
+      );
+
+      expect(snapshot.pm25, 42.3);
+      expect(snapshot.forecastConfidence, isNull);
+    });
+
+    test('uses forecast for a future hour on today', () {
+      final now = DateTime(2026, 8, 17, 15, 20);
+      final snapshot = ForecastReadingSnapshot.fromHourlyOrLive(
+        entry: _hourlyEntry(time: DateTime(2026, 8, 17, 16), pm25: 48),
+        measurement: _measurement(pm25: 42.3),
+        now: now,
+      );
+
+      expect(snapshot.pm25, 48);
+      expect(snapshot.forecastConfidence, 75);
+    });
+  });
+
+  group('guidanceFromMeasurement', () {
+    test('maps first health tip description to guidance message', () {
+      final guidance = guidanceFromMeasurement(_measurement());
+      expect(guidance.message, 'Limit outdoor activity.');
+      expect(guidance.trendMessage, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Show the dashboard card's live PM2.5/AQI on today's forecast chip and the current hour in hourly view, instead of today's forecast API value
- Omit forecast-only UI (confidence bar, met row) for live readings while keeping the same detail card layout
- Format live reading chips with one decimal place to match the dashboard card and detail card
- Add unit tests for live-vs-forecast snapshot selection helpers

## Test plan
- [x] Unit tests pass: `flutter test test/app/dashboard/models/forecast_guidance_test.dart`
- [x] Manual device test: dashboard card PM2.5 matches today's forecast chip and detail card
- [x] Manual device test: current hour chip matches live reading; future hours show forecast values
- [x] Manual device test: tomorrow+ chips still show forecast values
- [ ] CI checks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Forecasts now include today’s live air-quality readings when available.
  - Current-day and current-hour views show the latest PM2.5 value and matching air-quality icon.
  - Added live-reading guidance and detail cards, with forecast information used as a fallback.
  - Forecast selection now synchronizes to the current day when data loads.

- **Bug Fixes**
  - Improved handling of current-hour readings and future-day forecast displays.
  - Improved date and weekday display consistency across forecast views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->