### PR TITLE
feat(mobile): local notifications Phase 1 with background AQ checks

### DIFF
--- a/src/mobile/NOTIFICATION_SCAFFOLD_INVENTORY.md
+++ b/src/mobile/NOTIFICATION_SCAFFOLD_INVENTORY.md
@@ -29,7 +29,9 @@ We audited the existing notification code in the mobile app. **Most of the notif
 
 **FCM** — message sent from our backend via Firebase (Android + iOS). Requires Firebase setup and backend integration.
 
-> None of the scaffold notifications are **scheduled background jobs** yet. Local ones fire when the app runs relevant code; FCM ones fire when the server sends a push.
+> **Background execution (best-effort):** `AirQualityBackgroundTask` schedules periodic (requested every 3 hours) and one-time on-device AQ checks via WorkManager / BGTaskScheduler. On **Android**, WorkManager generally honours the requested interval subject to battery/network constraints. On **iOS**, `frequency` and `initialDelay` are **scheduling hints only** — the system decides when (or if) to run tasks based on usage, battery, and network. Do not treat iOS timing as guaranteed in acceptance tests.
+>
+> Local OS alerts also fire when the app is open (dashboard load / resume). FCM alerts fire when the server sends a push. **Still out of scope:** scheduled reminders (daily digest, learn nudges), quiet hours, per-category preferences, and guaranteed delivery when the app has never been opened or location is unavailable.
 
 ---
 
@@ -220,11 +222,11 @@ flowchart TD
 | **#7–#10 FCM** | Do we need server-sent alerts this quarter? | Keep dormant, or plan a separate push initiative |
 | **Notification settings** | Should users control alert types? | Add settings screen once local alerts are live |
 
-### Phase 3 — True background & advanced (future)
+### Phase 3 — Advanced background & preferences (future)
 
-Not in the current scaffold. Requires separate scoping:
+Partially addressed: on-device AQ checks when the app is backgrounded (`AirQualityBackgroundTask`). Still requires separate scoping:
 
-- Alerts when the app is fully closed (needs push or background tasks)
+- Guaranteed closed-app alerts via server push (FCM) when on-device scheduling is insufficient
 - Scheduled reminders (daily digest, learn nudges)
 - Quiet hours and per-category preferences
 

--- a/src/mobile/NOTIFICATION_SCAFFOLD_INVENTORY.md
+++ b/src/mobile/NOTIFICATION_SCAFFOLD_INVENTORY.md
@@ -1,0 +1,165 @@
+# Mobile Notification Scaffold — Inventory & Plan
+
+## Why this document exists
+
+We audited the existing notification code in the mobile app. **Most of the notification product is already built but not connected.** This doc records what exists, what actually works today, and the recommended path forward — starting with **local, device-driven notifications** before investing in server push (FCM).
+
+---
+
+## Current state (executive summary)
+
+| Status | Count | Detail |
+|--------|-------|--------|
+| **Working today** | 1 | My Places success/error toasts (#6) |
+| **Built but not wired** | 5 | Local notifications (#1–#5) |
+| **Built but deferred** | 4 | Server push via FCM (#7–#10) |
+| **Separate (not OS notifications)** | 1 | Learn tab survey badge (UI only) |
+
+**Bottom line for PM:** We are not starting from zero. We have scaffold code for air quality alerts and survey prompts — the work is **wiring and testing**, not building from scratch. Server push (Firebase) can wait.
+
+---
+
+## How notifications are categorised
+
+**Local OS** — appears in the phone notification shade (`flutter_local_notifications`).
+
+**Local in-app** — overlay, banner, or dialog while the app is open.
+
+**FCM** — message sent from our backend via Firebase (Android + iOS). Requires Firebase setup and backend integration.
+
+> None of the scaffold notifications are **scheduled background jobs** yet. Local ones fire when the app runs relevant code; FCM ones fire when the server sends a push.
+
+---
+
+## Inventory — what exists in the scaffold
+
+### Local (device-driven)
+
+| # | Notification | Where it shows | Wired? | Code |
+|---|--------------|----------------|--------|------|
+| 1 | **Nearby air quality alert** | Local OS (shade) | No | ```372:377:src/mobile/lib/src/app/shared/services/notification_helper.dart``` |
+| 2 | **Survey prompt (modal)** | Local in-app (dialog) | No | Trigger: ```289:289:src/mobile/lib/src/app/surveys/services/survey_trigger_service.dart``` → UI: ```83:94:src/mobile/lib/src/app/shared/services/notification_manager.dart``` |
+| 3 | **Air quality alert banner** (from survey AQ trigger) | Local in-app (top banner) | No | Trigger: ```393:425:src/mobile/lib/src/app/surveys/services/survey_trigger_service.dart``` → UI: ```244:257:src/mobile/lib/src/app/shared/services/notification_manager.dart``` |
+| 4 | **Survey banner** (tap-to-open) | Local in-app (top banner) | No (dead code) | ```492:502:src/mobile/lib/src/app/shared/services/notification_manager.dart``` |
+| 5 | **Permission prompt** (“Enable notifications…”) | Local in-app (bottom toast) | No | ```48:73:src/mobile/lib/src/app/shared/services/notification_manager.dart``` called from ```30:50:src/mobile/lib/src/app/shared/services/notification_helper.dart``` |
+| 6 | **Status toast** (success/error) | Local in-app (bottom toast) | **Yes** (My Places only) | UI: ```16:44:src/mobile/lib/src/app/shared/services/notification_manager.dart``` → caller: ```227:227:src/mobile/lib/src/app/dashboard/widgets/my_places_view.dart``` |
+
+### FCM (server-driven) — deferred for now
+
+| # | Notification | Where it shows | Wired? | Code |
+|---|--------------|----------------|--------|------|
+| 7 | **FCM → local OS mirror** (any push while app is open) | Local OS (shade) | No | ```273:284:src/mobile/lib/src/app/shared/services/push_notification_service.dart``` |
+| 8 | **`air_quality_alert` push** | Local in-app (top banner) | No | Route: ```74:75:src/mobile/lib/src/app/shared/services/notification_helper.dart``` → UI: ```114:123:src/mobile/lib/src/app/shared/services/notification_helper.dart``` |
+| 9 | **`survey` push** | Local in-app (simple toast) | No | ```127:141:src/mobile/lib/src/app/shared/services/notification_helper.dart``` |
+| 10 | **`general` push** | Local in-app (simple toast) | No | ```148:158:src/mobile/lib/src/app/shared/services/notification_helper.dart``` |
+
+FCM routing entry point (all three push types above):
+
+```73:84:src/mobile/lib/src/app/shared/services/notification_helper.dart
+    switch (type) {
+      case 'air_quality_alert':
+        _showAirQualityNotification(context, message);
+        break;
+      case 'survey':
+        _showSurveyNotification(context, message);
+        break;
+      case 'general':
+      default:
+        _showGeneralNotification(context, message);
+        break;
+    }
+```
+
+### Not in this scaffold
+
+- **Learn tab survey badge** — UI badge only, not an OS or push notification (`SurveyNotificationService` + `NavPage`).
+
+---
+
+## Key decision: local-first, defer FCM
+
+The scaffold bundles **local notifications** and **Firebase push (FCM)** in one service. They serve different needs:
+
+| Approach | Who decides to notify | Example | Needed now? |
+|----------|----------------------|---------|-------------|
+| **Local** | The app on the user's device | “Air near you is Unhealthy” when dashboard loads | **Yes** |
+| **FCM (push)** | Our server | City-wide alert broadcast to all users | **No** (later) |
+
+**Recommendation:** Wire up **#1–#5** first. Leave **#7–#10** uninitialised until product requires server-initiated alerts (e.g. admin broadcasts, campaigns). This avoids Firebase setup, backend token storage, and duplicate logic while we validate the core user experience.
+
+---
+
+## Recommended plan
+
+### Phase 1 — Wire existing local scaffold (target: ~1 sprint)
+
+Connect code that is already written. No new notification types — just make the scaffold work.
+
+| Step | What | Maps to | User-facing outcome |
+|------|------|---------|---------------------|
+| 1 | Initialise local notifications + request OS permissions | Foundation for #1, #5 | App can legally show notifications in the shade |
+| 2 | Fix navigation key so in-app dialogs can open | Foundation for #2, #3 | Survey prompts don't silently fail |
+| 3 | Hook nearby AQ check to dashboard / app resume | **#1** | User gets OS alert when air near them is Unhealthy+ |
+| 4 | Start survey trigger service with live data | **#2**, **#3** | User gets in-app survey prompt based on location, time, or AQ |
+| 5 | Show permission prompt at the right moment | **#5** | User is asked once to enable notifications, not spammed |
+| 6 | Add tap routing on OS alerts | **#1** (enhancement) | Tapping an AQ alert opens the app to the relevant screen |
+
+**Phase 1 success criteria:**
+- User receives an **OS notification** when air quality near their location is Unhealthy or worse (with 6-hour cooldown already in code).
+- User sees an **in-app survey dialog** when trigger conditions are met.
+- Permission flow works on Android 13+ and iOS.
+- My Places toasts (#6) continue to work as today.
+
+### Phase 2 — Clean up & decide (after Phase 1 validates UX)
+
+| Item | Question for PM | Options |
+|------|-----------------|---------|
+| **#4 Survey banner** | Do we want a top banner *in addition to* the survey modal? | Wire it, or remove as duplicate |
+| **#7–#10 FCM** | Do we need server-sent alerts this quarter? | Keep dormant, or plan a separate push initiative |
+| **Notification settings** | Should users control alert types? | Add settings screen once local alerts are live |
+
+### Phase 3 — True background & advanced (future)
+
+Not in the current scaffold. Requires separate scoping:
+
+- Alerts when the app is fully closed (needs push or background tasks)
+- Scheduled reminders (daily digest, learn nudges)
+- Quiet hours and per-category preferences
+
+---
+
+## What we are explicitly not doing in Phase 1
+
+- Firebase / FCM setup and token registration
+- Backend push integration
+- Notification preferences screen
+- Deleting FCM code (leave it dormant until team agrees on push scope)
+
+---
+
+## Suggested first sprint breakdown
+
+| Days | Engineering focus |
+|------|-------------------|
+| 1–2 | Local notification init, permissions, navigation fix |
+| 3 | Connect nearby air quality alert (#1) to dashboard |
+| 4 | Connect survey trigger service (#2, #3) |
+| 5 | QA on Android + iOS: permissions granted/denied, cooldown, tap routing |
+
+---
+
+## Train of thought (summary for PM)
+
+1. **Audited the codebase** → found 10 notification touchpoints; only 1 works today.
+2. **Separated local vs push** → most value is in local alerts we can ship without backend work.
+3. **Prioritised wiring over building** → #1–#5 already exist; Phase 1 is connection and QA.
+4. **Deferred FCM** → #7–#10 stay off until we need server-driven broadcasts.
+5. **Defined clear success** → user gets AQ OS alerts and contextual survey prompts; then we iterate on settings and push.
+
+---
+
+## Inventory totals
+
+**6 local** (1 OS + 5 in-app) · **4 FCM** (1 OS mirror + 3 in-app handlers) · **1 working today** (#6)
+
+**Phase 1 focus:** #1–#5 · **Deferred:** #7–#10

--- a/src/mobile/NOTIFICATION_SCAFFOLD_INVENTORY.md
+++ b/src/mobile/NOTIFICATION_SCAFFOLD_INVENTORY.md
@@ -4,6 +4,8 @@
 
 We audited the existing notification code in the mobile app. **Most of the notification product is already built but not connected.** This doc records what exists, what actually works today, and the recommended path forward — starting with **local, device-driven notifications** before investing in server push (FCM).
 
+**This document is the guardrail for Phase 1 implementation.** Sequencing, dependencies, test matrix, and cooldown rules below are requirements, not suggestions.
+
 ---
 
 ## Current state (executive summary)
@@ -89,26 +91,126 @@ The scaffold bundles **local notifications** and **Firebase push (FCM)** in one 
 
 ---
 
+## Implementation guardrails (PM feedback — must follow)
+
+These rules govern Phase 1. Do not pick up steps out of order or in parallel where dependencies exist.
+
+### Guardrail 1 — Permission before OS alerts
+
+**Do not dispatch OS alerts (#1) until notification permission state is known.**
+
+- On **iOS**, an alert fired before permission is granted is **silently dropped**.
+- On **Android 13+**, firing without `POST_NOTIFICATIONS` granted may no-op or error depending on guards.
+
+**Required behaviour:**
+1. Initialise local notifications and resolve permission state **before** wiring dashboard AQ checks.
+2. Show the permission prompt (#5) at an appropriate moment **before** the first OS alert attempt.
+3. **Gate** `checkNearbyAirQuality()` → `showLocalNotification()` behind `hasPermission() == true`. If denied, skip OS alert (optionally show in-app prompt only).
+
+### Guardrail 2 — Navigation fix before survey triggers
+
+**Step “Survey triggers” is blocked until navigation key is fixed.**
+
+Survey triggers (#2, #3) call `NavigationService.showSurveyNotification()`. If `canNavigate` is false (separate `navigatorKey` in `NavigationService` vs `main.dart`), triggers fire but **no dialog appears** — a silent failure that is easy to miss in QA.
+
+**Required behaviour:**
+- Fix shared `navigatorKey` **before** starting `SurveyTriggerService` with live data.
+- Do **not** assign survey trigger wiring to a different engineer in parallel with navigation fix unless Step 2 is already merged.
+
+### Guardrail 3 — Spike before full sprint commitment
+
+Steps 1–2 (local init + permissions + navigation) touch **iOS and Android permission models separately** (Android 13+ runtime permission is a known risk area).
+
+**Required behaviour:**
+- **Timebox a 1–2 day spike** on Steps 1–2 only.
+- Re-estimate Steps 3–6 after the spike surfaces OS-version-specific issues.
+- Do **not** commit to “~1 sprint for all of Phase 1” until spike sign-off.
+
+### Guardrail 4 — Concrete test matrix before Phase 1 sign-off
+
+“Works on Android 13+ and iOS” is not sufficient for sign-off. Phase 1 is **not done** until the matrix below is executed and results recorded.
+
+| Platform | Version | Device / emulator | Must test |
+|----------|---------|-------------------|-----------|
+| Android | 13 (API 33) | Physical or emulator | Runtime permission prompt; OS alert after grant; no alert / no crash when denied |
+| Android | 14+ (API 34+) | Physical or emulator | Same as above |
+| iOS | 16 | Simulator or device | Permission prompt; OS alert after grant; silent skip when denied |
+| iOS | 17+ | Simulator or device | Same as above |
+
+**Additional scenarios (all platforms):**
+- Permission granted → AQ OS alert fires when Unhealthy+ near user
+- Permission denied → no OS alert; app remains stable
+- AQ cooldown: second alert suppressed within 6 hours
+- Survey trigger fires → in-app dialog visible and actionable
+- Survey cooldown: same survey not re-triggered within 6 hours
+- Tap OS AQ alert → app opens to expected screen (Step 6)
+- My Places toasts (#6) still work (regression)
+
+### Guardrail 5 — Cooldowns are independent (do not share state)
+
+Phase 1 activates two trigger surfaces. Their cooldowns **must remain separate**.
+
+| Surface | Storage | Scope | Duration | Code |
+|---------|---------|-------|----------|------|
+| **AQ OS alerts (#1)** | Hive cache key `aq_alert_cooldown` | **Global** — one cooldown for all AQ OS alerts | 6 hours | ```313:384:src/mobile/lib/src/app/shared/services/notification_helper.dart``` |
+| **Survey triggers (#2, #3)** | SharedPreferences `survey_trigger_history` | **Per survey ID** — each survey has its own last-triggered timestamp | 6 hours per survey | ```33:99:src/mobile/lib/src/app/surveys/services/survey_trigger_service.dart``` |
+
+**Required behaviour:**
+- Do **not** merge AQ and survey cooldown into a single shared key.
+- AQ alert cooldown suppresses **OS shade alerts only**; it does not block survey in-app dialogs.
+- Survey cooldown suppresses **that survey’s** re-trigger; it does not block AQ OS alerts.
+- If product later wants a global “max N notifications per day” cap, that is a **new** rule — out of Phase 1 scope.
+
+---
+
 ## Recommended plan
 
-### Phase 1 — Wire existing local scaffold (target: ~1 sprint)
+### Phase 0 — Spike (timebox: 1–2 days)
+
+**Goal:** De-risk permissions and navigation before committing to full Phase 1 estimate.
+
+| Step | What | Exit criteria |
+|------|------|---------------|
+| 0a | Initialise local notifications (local-only path; no FCM) | Plugin initialises without error on Android + iOS |
+| 0b | Request/check notification permission on both platforms | Permission granted/denied/permanently-denied paths documented |
+| 0c | Unify `navigatorKey` (`main.dart` ↔ `NavigationService`) | `NavigationService.canNavigate == true` when app is on dashboard |
+| 0d | Re-estimate Steps 1–6 | Updated day breakdown agreed before full implementation |
+
+**Spike sign-off required before starting Phase 1 proper.**
+
+---
+
+### Phase 1 — Wire existing local scaffold
 
 Connect code that is already written. No new notification types — just make the scaffold work.
 
-| Step | What | Maps to | User-facing outcome |
-|------|------|---------|---------------------|
-| 1 | Initialise local notifications + request OS permissions | Foundation for #1, #5 | App can legally show notifications in the shade |
-| 2 | Fix navigation key so in-app dialogs can open | Foundation for #2, #3 | Survey prompts don't silently fail |
-| 3 | Hook nearby AQ check to dashboard / app resume | **#1** | User gets OS alert when air near them is Unhealthy+ |
-| 4 | Start survey trigger service with live data | **#2**, **#3** | User gets in-app survey prompt based on location, time, or AQ |
-| 5 | Show permission prompt at the right moment | **#5** | User is asked once to enable notifications, not spammed |
-| 6 | Add tap routing on OS alerts | **#1** (enhancement) | Tapping an AQ alert opens the app to the relevant screen |
+**Steps must be executed in this order.** Dependencies are explicit.
 
-**Phase 1 success criteria:**
-- User receives an **OS notification** when air quality near their location is Unhealthy or worse (with 6-hour cooldown already in code).
-- User sees an **in-app survey dialog** when trigger conditions are met.
-- Permission flow works on Android 13+ and iOS.
+| Step | What | Maps to | Depends on | User-facing outcome |
+|------|------|---------|------------|---------------------|
+| **1** | Initialise local notifications + resolve OS permission state | Foundation for #1, #5 | Phase 0 spike | App knows whether it may show OS notifications |
+| **2** | Fix navigation key so in-app dialogs can open | Foundation for #2, #3 | Step 1 | Survey prompts can render (not silent failure) |
+| **3** | Show permission prompt (#5) at the right moment | **#5** | Step 1 | User is asked once to enable notifications before first OS alert |
+| **4** | Hook nearby AQ check to dashboard / app resume — **gated on permission** | **#1** | Steps 1, 3 | User gets OS alert when air near them is Unhealthy+ **and** permission granted |
+| **5** | Start survey trigger service with live data | **#2**, **#3** | **Step 2** (hard dependency) | User gets in-app survey prompt based on location, time, or AQ |
+| **6** | Add tap routing on OS alerts | **#1** (enhancement) | Step 4 | Tapping an AQ alert opens the app to the relevant screen |
+
+```mermaid
+flowchart TD
+    S0[Phase 0 spike] --> S1[Step 1: Local init + permission state]
+    S1 --> S2[Step 2: Navigation key fix]
+    S1 --> S3[Step 3: Permission prompt UX]
+    S3 --> S4[Step 4: AQ OS alerts gated on permission]
+    S2 --> S5[Step 5: Survey triggers]
+    S4 --> S6[Step 6: Tap routing]
+```
+
+**Phase 1 success criteria (all required for sign-off):**
+- User receives an **OS notification** when air quality near their location is Unhealthy or worse — **only when permission is granted** (6-hour AQ cooldown applies).
+- User sees an **in-app survey dialog** when trigger conditions are met (6-hour per-survey cooldown applies).
+- Permission flow works on Android 13+ and iOS per **test matrix above**.
 - My Places toasts (#6) continue to work as today.
+- Test matrix completed and results recorded.
 
 ### Phase 2 — Clean up & decide (after Phase 1 validates UX)
 
@@ -134,17 +236,22 @@ Not in the current scaffold. Requires separate scoping:
 - Backend push integration
 - Notification preferences screen
 - Deleting FCM code (leave it dormant until team agrees on push scope)
+- Merging AQ and survey cooldown state
+- Dispatching OS alerts before permission state is resolved
 
 ---
 
-## Suggested first sprint breakdown
+## Suggested schedule (post-spike)
 
-| Days | Engineering focus |
-|------|-------------------|
-| 1–2 | Local notification init, permissions, navigation fix |
-| 3 | Connect nearby air quality alert (#1) to dashboard |
-| 4 | Connect survey trigger service (#2, #3) |
-| 5 | QA on Android + iOS: permissions granted/denied, cooldown, tap routing |
+Estimate is **TBD until Phase 0 spike completes.** Indicative breakdown after spike sign-off:
+
+| Block | Engineering focus | Guardrail |
+|-------|-------------------|-----------|
+| Phase 0 (1–2 days) | Local init, permissions, navigation key | Spike sign-off before continuing |
+| Block A | Steps 1–3: permission foundation + prompt UX | No OS alerts until Step 3 done |
+| Block B | Step 4: AQ OS alerts (permission-gated) | Gate on `hasPermission()` |
+| Block C | Step 5: Survey triggers | **Blocked until Step 2 merged** |
+| Block D | Step 6 + full test matrix | Sign-off requires matrix pass |
 
 ---
 
@@ -154,7 +261,8 @@ Not in the current scaffold. Requires separate scoping:
 2. **Separated local vs push** → most value is in local alerts we can ship without backend work.
 3. **Prioritised wiring over building** → #1–#5 already exist; Phase 1 is connection and QA.
 4. **Deferred FCM** → #7–#10 stay off until we need server-driven broadcasts.
-5. **Defined clear success** → user gets AQ OS alerts and contextual survey prompts; then we iterate on settings and push.
+5. **Incorporated PM feedback** → permission before OS alerts, explicit Step 2 → Step 5 dependency, spike before full estimate, concrete test matrix, independent cooldowns documented.
+6. **Defined clear success** → user gets AQ OS alerts (when permitted) and contextual survey prompts; test matrix passed; then iterate on settings and push.
 
 ---
 

--- a/src/mobile/android/app/src/main/AndroidManifest.xml
+++ b/src/mobile/android/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-feature android:name="android.hardware.camera" android:required="false" />
     <uses-feature android:name="android.hardware.camera.front" android:required="false" />
     <application

--- a/src/mobile/ios/Runner/AppDelegate.swift
+++ b/src/mobile/ios/Runner/AppDelegate.swift
@@ -1,6 +1,7 @@
 import UIKit
 import Flutter
 import GoogleMaps
+import workmanager_apple
 
 @main
 @objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
@@ -9,6 +10,12 @@ import GoogleMaps
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
     GMSServices.provideAPIKey(Bundle.main.object(forInfoDictionaryKey: "GMSApiKey") as? String ?? "")
+
+    WorkmanagerPlugin.registerLaunchHandlers()
+    WorkmanagerPlugin.setPluginRegistrantCallback { registry in
+      GeneratedPluginRegistrant.register(with: registry)
+    }
+
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }
 

--- a/src/mobile/ios/Runner/Info.plist
+++ b/src/mobile/ios/Runner/Info.plist
@@ -74,6 +74,14 @@
 			</array>
 		</dict>
 	</dict>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>fetch</string>
+	</array>
+	<key>BGTaskSchedulerPermittedIdentifiers</key>
+	<array>
+		<string>com.airqo.net.aqBackgroundCheck</string>
+	</array>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/src/mobile/ios/Runner/Info.plist
+++ b/src/mobile/ios/Runner/Info.plist
@@ -80,7 +80,8 @@
 	</array>
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>
-		<string>airqo-aq-background-check</string>
+		<string>com.airqo.net.aqBackgroundCheck</string>
+		<string>com.airqo.net.aqInitialCheck</string>
 	</array>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>

--- a/src/mobile/ios/Runner/Info.plist
+++ b/src/mobile/ios/Runner/Info.plist
@@ -80,7 +80,7 @@
 	</array>
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>
-		<string>com.airqo.net.aqBackgroundCheck</string>
+		<string>airqo-aq-background-check</string>
 	</array>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>

--- a/src/mobile/lib/main.dart
+++ b/src/mobile/lib/main.dart
@@ -42,10 +42,11 @@ import 'package:airqo/src/app/other/language/services/app_localizations.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:posthog_flutter/posthog_flutter.dart';
 import 'package:airqo/src/app/shared/services/feature_flag_service.dart';
+import 'package:airqo/src/app/shared/navigation/app_navigator.dart';
+import 'package:airqo/src/app/shared/services/notification_helper.dart';
 import 'package:airqo/src/app/surveys/bloc/survey_bloc.dart';
 import 'package:airqo/src/app/surveys/repository/survey_repository.dart';
 
-final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
 void main() async {
   runZonedGuarded(
     () async {
@@ -197,7 +198,7 @@ class AirqoMobile extends StatelessWidget {
               bool isLightTheme = themeState is ThemeLight;
 
               return MaterialApp(
-                navigatorKey: navigatorKey,
+                navigatorKey: appNavigatorKey,
                 // Captures $screen events for named PageRoutes; routes are
                 // named via RouteSettings at each push site.
                 navigatorObservers: [PosthogObserver()],
@@ -253,7 +254,7 @@ class _DeciderState extends State<Decider> with WidgetsBindingObserver {
     WidgetsBinding.instance.addObserver(this);
 
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      AutoUpdateService().initialize(navigatorKey);
+      AutoUpdateService().initialize(appNavigatorKey);
       _fetchCountries();
       _initLearnGuestSession();
     });
@@ -288,6 +289,18 @@ class _DeciderState extends State<Decider> with WidgetsBindingObserver {
     if (state == AppLifecycleState.resumed) {
       AutoUpdateService().checkForUpdates(showDialog: true);
       _checkTokenExpiryOnResume();
+      _refreshLocalNotificationsOnResume();
+    }
+  }
+
+  Future<void> _refreshLocalNotificationsOnResume() async {
+    if (!mounted) return;
+    final dashboardState = context.read<DashboardBloc>().state;
+    if (dashboardState is DashboardLoaded &&
+        dashboardState.response.measurements != null) {
+      await NotificationHelper().onDashboardMeasurementsLoaded(
+        dashboardState.response.measurements,
+      );
     }
   }
 

--- a/src/mobile/lib/main.dart
+++ b/src/mobile/lib/main.dart
@@ -43,15 +43,18 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:posthog_flutter/posthog_flutter.dart';
 import 'package:airqo/src/app/shared/services/feature_flag_service.dart';
 import 'package:airqo/src/app/shared/navigation/app_navigator.dart';
+import 'package:airqo/src/app/shared/services/air_quality_background_task.dart';
 import 'package:airqo/src/app/shared/services/notification_helper.dart';
 import 'package:airqo/src/app/surveys/bloc/survey_bloc.dart';
 import 'package:airqo/src/app/surveys/repository/survey_repository.dart';
+import 'package:workmanager/workmanager.dart';
 
 void main() async {
   runZonedGuarded(
     () async {
       try {
         WidgetsFlutterBinding.ensureInitialized();
+        Workmanager().initialize(airQualityBackgroundCallbackDispatcher);
 
         await HiveBoxSetup.initializeBoxes();
         await CacheManager().initialize();

--- a/src/mobile/lib/src/app/dashboard/pages/dashboard_page.dart
+++ b/src/mobile/lib/src/app/dashboard/pages/dashboard_page.dart
@@ -19,6 +19,7 @@ import '../widgets/my_places_view.dart';
 import '../widgets/explore_countries_view.dart';
 import '../widgets/nearby_view.dart';
 import '../widgets/view_selector.dart';
+import 'package:airqo/src/app/shared/services/notification_helper.dart';
 import 'package:loggy/loggy.dart';
 
 class DashboardPage extends StatefulWidget {
@@ -143,7 +144,14 @@ class _DashboardPageState extends State<DashboardPage> with UiLoggy {
       appBar: DashboardAppBar(),
       body: BlocListener<DashboardBloc, DashboardState>(
         listenWhen: (previous, current) => current is DashboardLoaded,
-        listener: (context, state) => _scheduleCardGesturesTourCheck(),
+        listener: (context, state) {
+          _scheduleCardGesturesTourCheck();
+          if (state is DashboardLoaded) {
+            NotificationHelper().onDashboardMeasurementsLoaded(
+              state.response.measurements,
+            );
+          }
+        },
         child: Stack(
           children: [
             RefreshIndicator(

--- a/src/mobile/lib/src/app/dashboard/pages/dashboard_page.dart
+++ b/src/mobile/lib/src/app/dashboard/pages/dashboard_page.dart
@@ -147,9 +147,9 @@ class _DashboardPageState extends State<DashboardPage> with UiLoggy {
         listener: (context, state) {
           _scheduleCardGesturesTourCheck();
           if (state is DashboardLoaded) {
-            NotificationHelper().onDashboardMeasurementsLoaded(
+            unawaited(NotificationHelper().onDashboardMeasurementsLoaded(
               state.response.measurements,
-            );
+            ));
           }
         },
         child: Stack(

--- a/src/mobile/lib/src/app/dashboard/widgets/nearby_view.dart
+++ b/src/mobile/lib/src/app/dashboard/widgets/nearby_view.dart
@@ -12,6 +12,7 @@ import 'package:airqo/src/app/dashboard/widgets/nearby_view_empty_state.dart';
 import 'package:airqo/src/app/dashboard/models/airquality_response.dart';
 import 'package:airqo/src/meta/utils/colors.dart';
 import 'package:airqo/src/app/shared/services/cache_manager.dart';
+import 'package:airqo/src/app/surveys/services/survey_trigger_service.dart';
 
 class NearbyView extends StatefulWidget {
   final VoidCallback? onNavigateToFavorites;
@@ -99,6 +100,8 @@ class _NearbyViewState extends State<NearbyView> with UiLoggy {
           _userPosition = position;
         });
 
+        SurveyTriggerService().updateLocation(position);
+
         // Update nearby locations with this position
         await _updateNearbyLocations();
       }
@@ -117,6 +120,8 @@ class _NearbyViewState extends State<NearbyView> with UiLoggy {
             _userPosition = position;
           });
         }
+
+        SurveyTriggerService().updateLocation(position);
         
         // Update nearby locations with the more accurate position
         await _updateNearbyLocations();

--- a/src/mobile/lib/src/app/shared/navigation/app_navigator.dart
+++ b/src/mobile/lib/src/app/shared/navigation/app_navigator.dart
@@ -1,0 +1,4 @@
+import 'package:flutter/material.dart';
+
+/// Root navigator key shared by [MaterialApp] and [NavigationService].
+final GlobalKey<NavigatorState> appNavigatorKey = GlobalKey<NavigatorState>();

--- a/src/mobile/lib/src/app/shared/pages/nav_page.dart
+++ b/src/mobile/lib/src/app/shared/pages/nav_page.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:airqo/src/app/dashboard/pages/dashboard_page.dart';
 import 'package:airqo/src/app/exposure/pages/exposure_dashboard_view.dart';
 import 'package:airqo/src/app/learn/pages/kya_page.dart';
@@ -48,7 +50,7 @@ class _NavPageState extends State<NavPage> with AutomaticKeepAliveClientMixin {
   void initState() {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      _initializeLocalNotifications();
+      unawaited(_initializeLocalNotifications());
     });
   }
 

--- a/src/mobile/lib/src/app/shared/pages/nav_page.dart
+++ b/src/mobile/lib/src/app/shared/pages/nav_page.dart
@@ -4,13 +4,18 @@ import 'package:airqo/src/app/learn/pages/kya_page.dart';
 import 'package:airqo/src/app/map/pages/map_page.dart';
 import 'package:airqo/src/app/shared/services/analytics_service.dart';
 import 'package:airqo/src/app/shared/services/feature_flag_service.dart';
+import 'package:airqo/src/app/shared/services/local_notification_bootstrap.dart';
+import 'package:airqo/src/app/shared/services/notification_helper.dart';
+import 'package:airqo/src/app/shared/services/push_notification_service.dart';
 import 'package:airqo/src/app/shared/widgets/translated_text.dart';
 import 'package:airqo/src/app/surveys/bloc/survey_bloc.dart';
 import 'package:airqo/src/app/surveys/services/survey_notification_service.dart';
+import 'package:airqo/src/app/surveys/services/survey_trigger_service.dart';
 import 'package:airqo/src/meta/utils/colors.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_svg/svg.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class NavPage extends StatefulWidget {
   const NavPage({super.key});
@@ -37,14 +42,40 @@ class _NavPageState extends State<NavPage> with AutomaticKeepAliveClientMixin {
       ? ['dashboard', 'map', 'exposure', 'learn']
       : ['dashboard', 'map', 'learn'];
 
+  static const _permissionPromptShownKey = 'notification_permission_prompt_shown';
+
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _initializeLocalNotifications();
+    });
+  }
+
+  Future<void> _initializeLocalNotifications() async {
+    await LocalNotificationBootstrap.instance.ensureInitialized();
+    await _maybePromptNotificationPermission();
+
     if (_surveysEnabled) {
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        context.read<SurveyBloc>().add(const LoadSurveys());
-      });
+      if (!mounted) return;
+      context.read<SurveyBloc>().add(const LoadSurveys());
+      await SurveyTriggerService().initialize();
     }
+  }
+
+  Future<void> _maybePromptNotificationPermission() async {
+    if (!mounted) return;
+
+    final hasPermission = await PushNotificationService().hasPermission();
+    if (hasPermission) return;
+
+    final prefs = await SharedPreferences.getInstance();
+    if (prefs.getBool(_permissionPromptShownKey) == true) return;
+
+    await prefs.setBool(_permissionPromptShownKey, true);
+    if (!mounted) return;
+
+    await NotificationHelper().checkAndShowPermissionPrompt(context);
   }
 
   Future<void> _updateBadgeCount() async {
@@ -131,7 +162,12 @@ class _NavPageState extends State<NavPage> with AutomaticKeepAliveClientMixin {
     // When surveys are enabled, listen for badge updates
     return BlocListener<SurveyBloc, SurveyState>(
       listener: (context, state) {
-        if (state is SurveysLoaded) _updateBadgeCount();
+        if (state is SurveysLoaded) {
+          _updateBadgeCount();
+          if (_surveysEnabled) {
+            SurveyTriggerService().setActiveSurveys(state.surveys);
+          }
+        }
       },
       child: body,
     );

--- a/src/mobile/lib/src/app/shared/services/air_quality_background_task.dart
+++ b/src/mobile/lib/src/app/shared/services/air_quality_background_task.dart
@@ -10,6 +10,13 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:workmanager/workmanager.dart';
 
 /// Periodic on-device AQ checks when the app is not in the foreground.
+///
+/// Timing is platform-dependent:
+/// - **Android:** WorkManager generally runs near the requested [checkInterval]
+///   when network and battery constraints are met.
+/// - **iOS:** [checkInterval] and [initialCheckDelay] are best-effort hints to
+///   BGTaskScheduler. The system may defer or skip runs — do not treat these
+///   as guaranteed delivery times in acceptance tests.
 class AirQualityBackgroundTask with UiLoggy {
   AirQualityBackgroundTask._();
 
@@ -31,8 +38,9 @@ class AirQualityBackgroundTask with UiLoggy {
       ),
       existingWorkPolicy: ExistingPeriodicWorkPolicy.keep,
     );
-    Loggy('AirQualityBackgroundTask')
-        .info('Scheduled periodic AQ background check (${checkInterval.inHours}h)');
+    Loggy('AirQualityBackgroundTask').info(
+      'Scheduled periodic AQ background check (requested every ${checkInterval.inHours}h; iOS timing is best-effort)',
+    );
   }
 
   /// One-time check shortly after first NavPage load — validates the background
@@ -54,7 +62,7 @@ class AirQualityBackgroundTask with UiLoggy {
 
     await prefs.setBool(initialCheckScheduledKey, true);
     Loggy('AirQualityBackgroundTask').info(
-      'Scheduled initial AQ background check in ${initialCheckDelay.inSeconds}s',
+      'Scheduled initial AQ background check (requested in ${initialCheckDelay.inSeconds}s; iOS timing is best-effort)',
     );
   }
 

--- a/src/mobile/lib/src/app/shared/services/air_quality_background_task.dart
+++ b/src/mobile/lib/src/app/shared/services/air_quality_background_task.dart
@@ -22,6 +22,7 @@ class AirQualityBackgroundTask with UiLoggy {
 
   static const uniqueName = 'airqo-aq-background-check';
   static const initialCheckUniqueName = 'airqo-aq-initial-check';
+  /// Android one-off handler name. iOS periodic tasks receive [uniqueName] instead.
   static const taskName = 'com.airqo.net.aqBackgroundCheck';
   static const initialCheckScheduledKey = 'aq_background_initial_check_scheduled';
   static const checkInterval = Duration(hours: 3);
@@ -94,6 +95,7 @@ class AirQualityBackgroundTask with UiLoggy {
 void airQualityBackgroundCallbackDispatcher() {
   Workmanager().executeTask((task, inputData) async {
     switch (task) {
+      case AirQualityBackgroundTask.uniqueName:
       case AirQualityBackgroundTask.taskName:
       case Workmanager.iOSBackgroundTask:
         return AirQualityBackgroundTask.run();

--- a/src/mobile/lib/src/app/shared/services/air_quality_background_task.dart
+++ b/src/mobile/lib/src/app/shared/services/air_quality_background_task.dart
@@ -1,0 +1,96 @@
+import 'package:airqo/core/utils/hive_box_setup.dart';
+import 'package:airqo/src/app/dashboard/repository/dashboard_repository.dart';
+import 'package:airqo/src/app/shared/services/cache_manager.dart';
+import 'package:airqo/src/app/shared/services/notification_helper.dart';
+import 'package:airqo/src/app/shared/services/push_notification_service.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:loggy/loggy.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:workmanager/workmanager.dart';
+
+/// Periodic on-device AQ checks when the app is not in the foreground.
+class AirQualityBackgroundTask with UiLoggy {
+  AirQualityBackgroundTask._();
+
+  static const uniqueName = 'airqo-aq-background-check';
+  static const initialCheckUniqueName = 'airqo-aq-initial-check';
+  static const taskName = 'com.airqo.net.aqBackgroundCheck';
+  static const initialCheckScheduledKey = 'aq_background_initial_check_scheduled';
+  static const checkInterval = Duration(hours: 3);
+  static const initialCheckDelay = Duration(seconds: 15);
+
+  static Future<void> schedule() async {
+    await Workmanager().registerPeriodicTask(
+      uniqueName,
+      taskName,
+      frequency: checkInterval,
+      constraints: Constraints(
+        networkType: NetworkType.connected,
+        requiresBatteryNotLow: true,
+      ),
+      existingWorkPolicy: ExistingPeriodicWorkPolicy.keep,
+    );
+    Loggy('AirQualityBackgroundTask')
+        .info('Scheduled periodic AQ background check (${checkInterval.inHours}h)');
+  }
+
+  /// One-time check shortly after first NavPage load — validates the background
+  /// path on device without waiting for the 3-hour periodic schedule.
+  static Future<void> scheduleInitialCheck() async {
+    final prefs = await SharedPreferences.getInstance();
+    if (prefs.getBool(initialCheckScheduledKey) ?? false) {
+      return;
+    }
+
+    await Workmanager().registerOneOffTask(
+      initialCheckUniqueName,
+      taskName,
+      initialDelay: initialCheckDelay,
+      constraints: Constraints(
+        networkType: NetworkType.connected,
+      ),
+    );
+
+    await prefs.setBool(initialCheckScheduledKey, true);
+    Loggy('AirQualityBackgroundTask').info(
+      'Scheduled initial AQ background check in ${initialCheckDelay.inSeconds}s',
+    );
+  }
+
+  /// Runs in a background isolate — AQ OS alerts only (no survey UI).
+  static Future<bool> run() async {
+    try {
+      WidgetsFlutterBinding.ensureInitialized();
+
+      await HiveBoxSetup.initializeBoxes();
+      await CacheManager().initialize();
+      await dotenv.load(fileName: '.env.prod');
+      await PushNotificationService().initializeLocalOnly();
+
+      final response = await DashboardImpl().fetchAirQualityReadings(
+        forceRefresh: true,
+      );
+
+      await NotificationHelper().checkNearbyAirQuality(response.measurements);
+      return true;
+    } catch (e, stackTrace) {
+      Loggy('AirQualityBackgroundTask')
+          .error('Background AQ check failed', e, stackTrace);
+      return false;
+    }
+  }
+}
+
+@pragma('vm:entry-point')
+void airQualityBackgroundCallbackDispatcher() {
+  Workmanager().executeTask((task, inputData) async {
+    switch (task) {
+      case AirQualityBackgroundTask.taskName:
+      case Workmanager.iOSBackgroundTask:
+        return AirQualityBackgroundTask.run();
+      default:
+        return false;
+    }
+  });
+}

--- a/src/mobile/lib/src/app/shared/services/air_quality_background_task.dart
+++ b/src/mobile/lib/src/app/shared/services/air_quality_background_task.dart
@@ -20,10 +20,13 @@ import 'package:workmanager/workmanager.dart';
 class AirQualityBackgroundTask with UiLoggy {
   AirQualityBackgroundTask._();
 
-  static const uniqueName = 'airqo-aq-background-check';
-  static const initialCheckUniqueName = 'airqo-aq-initial-check';
-  /// Android one-off handler name. iOS periodic tasks receive [uniqueName] instead.
-  static const taskName = 'com.airqo.net.aqBackgroundCheck';
+  /// BGTaskScheduler identifier (iOS) / WorkManager unique name (Android).
+  /// Must match `BGTaskSchedulerPermittedIdentifiers` in Info.plist.
+  static const uniqueName = 'com.airqo.net.aqBackgroundCheck';
+  static const initialCheckUniqueName = 'com.airqo.net.aqInitialCheck';
+  /// Handler name returned to the Dart callback on Android; also used for iOS one-off tasks.
+  static const taskName = uniqueName;
+  static const initialTaskName = initialCheckUniqueName;
   static const initialCheckScheduledKey = 'aq_background_initial_check_scheduled';
   static const checkInterval = Duration(hours: 3);
   static const initialCheckDelay = Duration(seconds: 15);
@@ -54,7 +57,7 @@ class AirQualityBackgroundTask with UiLoggy {
 
     await Workmanager().registerOneOffTask(
       initialCheckUniqueName,
-      taskName,
+      initialTaskName,
       initialDelay: initialCheckDelay,
       constraints: Constraints(
         networkType: NetworkType.connected,
@@ -96,7 +99,7 @@ void airQualityBackgroundCallbackDispatcher() {
   Workmanager().executeTask((task, inputData) async {
     switch (task) {
       case AirQualityBackgroundTask.uniqueName:
-      case AirQualityBackgroundTask.taskName:
+      case AirQualityBackgroundTask.initialCheckUniqueName:
       case Workmanager.iOSBackgroundTask:
         return AirQualityBackgroundTask.run();
       default:

--- a/src/mobile/lib/src/app/shared/services/local_notification_bootstrap.dart
+++ b/src/mobile/lib/src/app/shared/services/local_notification_bootstrap.dart
@@ -16,8 +16,9 @@ class LocalNotificationBootstrap with UiLoggy {
     if (_initialized) return;
 
     NavigationService.setNavigatorKey(appNavigatorKey);
-    await PushNotificationService().initializeLocalOnly();
     NotificationHelper().configureTapHandling();
+    await PushNotificationService().initializeLocalOnly();
+    await PushNotificationService().processLaunchNotification();
     await AirQualityBackgroundTask.schedule();
     await AirQualityBackgroundTask.scheduleInitialCheck();
 

--- a/src/mobile/lib/src/app/shared/services/local_notification_bootstrap.dart
+++ b/src/mobile/lib/src/app/shared/services/local_notification_bootstrap.dart
@@ -1,0 +1,24 @@
+import 'package:airqo/src/app/shared/navigation/app_navigator.dart';
+import 'package:airqo/src/app/shared/services/notification_helper.dart';
+import 'package:airqo/src/app/shared/services/navigation_service.dart';
+import 'package:airqo/src/app/shared/services/push_notification_service.dart';
+import 'package:loggy/loggy.dart';
+
+/// Phase 0/1 entry point: local notifications only (no FCM).
+class LocalNotificationBootstrap with UiLoggy {
+  LocalNotificationBootstrap._();
+  static final LocalNotificationBootstrap instance = LocalNotificationBootstrap._();
+
+  static bool _initialized = false;
+
+  Future<void> ensureInitialized() async {
+    if (_initialized) return;
+
+    NavigationService.setNavigatorKey(appNavigatorKey);
+    await PushNotificationService().initializeLocalOnly();
+    NotificationHelper().configureTapHandling();
+
+    _initialized = true;
+    loggy.info('Local notification bootstrap complete');
+  }
+}

--- a/src/mobile/lib/src/app/shared/services/local_notification_bootstrap.dart
+++ b/src/mobile/lib/src/app/shared/services/local_notification_bootstrap.dart
@@ -1,4 +1,5 @@
 import 'package:airqo/src/app/shared/navigation/app_navigator.dart';
+import 'package:airqo/src/app/shared/services/air_quality_background_task.dart';
 import 'package:airqo/src/app/shared/services/notification_helper.dart';
 import 'package:airqo/src/app/shared/services/navigation_service.dart';
 import 'package:airqo/src/app/shared/services/push_notification_service.dart';
@@ -17,6 +18,8 @@ class LocalNotificationBootstrap with UiLoggy {
     NavigationService.setNavigatorKey(appNavigatorKey);
     await PushNotificationService().initializeLocalOnly();
     NotificationHelper().configureTapHandling();
+    await AirQualityBackgroundTask.schedule();
+    await AirQualityBackgroundTask.scheduleInitialCheck();
 
     _initialized = true;
     loggy.info('Local notification bootstrap complete');

--- a/src/mobile/lib/src/app/shared/services/navigation_service.dart
+++ b/src/mobile/lib/src/app/shared/services/navigation_service.dart
@@ -11,11 +11,15 @@ class NavigationService with UiLoggy {
   factory NavigationService() => _instance;
   NavigationService._internal();
 
-  static final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
+  static GlobalKey<NavigatorState>? _navigatorKey;
   final NotificationManager _notificationManager = NotificationManager();
 
-  NavigatorState? get _navigator => navigatorKey.currentState;
-  BuildContext? get currentContext => navigatorKey.currentContext;
+  static void setNavigatorKey(GlobalKey<NavigatorState> key) {
+    _navigatorKey = key;
+  }
+
+  NavigatorState? get _navigator => _navigatorKey?.currentState;
+  BuildContext? get currentContext => _navigatorKey?.currentContext;
   bool get canNavigate => _navigator != null && currentContext != null;
 
   Future<void> navigateToSurvey(Survey survey) async {

--- a/src/mobile/lib/src/app/shared/services/notification_helper.dart
+++ b/src/mobile/lib/src/app/shared/services/notification_helper.dart
@@ -10,6 +10,7 @@ import 'package:airqo/src/app/shared/services/push_notification_service.dart';
 import 'package:airqo/src/app/shared/services/notification_manager.dart';
 import 'package:airqo/src/app/shared/services/navigation_service.dart';
 import 'package:airqo/src/app/surveys/repository/survey_repository.dart';
+import 'package:airqo/src/app/surveys/services/survey_trigger_service.dart';
 import 'package:loggy/loggy.dart';
 
 /// Helper class to integrate push notifications with in-app notifications
@@ -50,16 +51,17 @@ class NotificationHelper with UiLoggy {
     );
   }
 
-  /// Initialize notification handling
+  /// Register OS notification tap routing (no [BuildContext] required).
+  void configureTapHandling() {
+    PushNotificationService().onNotificationTap = _handleNotificationTap;
+  }
+
+  /// Wire FCM foreground handlers when server push is enabled later.
   void initialize(BuildContext context) {
-    // Handle foreground messages by showing in-app notifications
+    configureTapHandling();
+
     PushNotificationService().onForegroundMessage = (RemoteMessage message) {
       _handleForegroundMessage(context, message);
-    };
-
-    // Handle notification taps for navigation
-    PushNotificationService().onNotificationTap = (Map<String, dynamic> data) {
-      _handleNotificationTap(context, data);
     };
   }
 
@@ -85,17 +87,17 @@ class NotificationHelper with UiLoggy {
   }
 
   /// Handle notification taps (when user taps notification)
-  void _handleNotificationTap(BuildContext context, Map<String, dynamic> data) {
+  void _handleNotificationTap(Map<String, dynamic> data) {
     loggy.info('Handling notification tap');
 
     final type = data['type'] as String?;
 
     switch (type) {
       case 'survey':
-        _navigateToSurvey(context, data);
+        _navigateToSurvey(data);
         break;
       case 'air_quality_alert':
-        _navigateToAirQuality(context, data);
+        _navigateToAirQuality(data);
         break;
       default:
         loggy.info('No specific action for notification type: $type');
@@ -159,7 +161,7 @@ class NotificationHelper with UiLoggy {
   }
 
   /// Navigate to survey page
-  Future<void> _navigateToSurvey(BuildContext context, Map<String, dynamic> data) async {
+  Future<void> _navigateToSurvey(Map<String, dynamic> data) async {
     final surveyId = data['survey_id'] as String?;
 
     if (surveyId == null) {
@@ -182,12 +184,76 @@ class NotificationHelper with UiLoggy {
   }
 
   /// Navigate to air quality page (returns to dashboard root)
-  void _navigateToAirQuality(BuildContext context, Map<String, dynamic> data) {
+  void _navigateToAirQuality(Map<String, dynamic> data) {
     final location = data['location'] as String?;
 
     loggy.info('Navigating to air quality: $location');
 
     NavigationService().popUntil((route) => route.isFirst);
+  }
+
+  /// Dashboard hook: nearby AQ OS alert + survey trigger inputs.
+  Future<void> onDashboardMeasurementsLoaded(
+    List<Measurement>? measurements,
+  ) async {
+    if (measurements == null || measurements.isEmpty) return;
+
+    await checkNearbyAirQuality(measurements);
+    await _feedSurveyTriggers(measurements);
+  }
+
+  Future<void> _feedSurveyTriggers(List<Measurement> measurements) async {
+    try {
+      Position? position = await Geolocator.getLastKnownPosition();
+      position ??= await Geolocator.getCurrentPosition(
+        locationSettings: const LocationSettings(
+          accuracy: LocationAccuracy.low,
+          timeLimit: Duration(seconds: 5),
+        ),
+      );
+
+      SurveyTriggerService().updateLocation(position);
+
+      final closest = _findClosestMeasurement(measurements, position);
+      if (closest == null) return;
+
+      SurveyTriggerService().updateAirQuality({
+        'pm2_5': closest.pm25?.value,
+        'category': closest.aqiCategory,
+        'location': closest.siteDetails?.name ??
+            closest.siteDetails?.formattedName ??
+            'your area',
+      });
+    } catch (e) {
+      loggy.warning('Could not feed survey triggers from dashboard: $e');
+    }
+  }
+
+  Measurement? _findClosestMeasurement(
+    List<Measurement> measurements,
+    Position position,
+  ) {
+    Measurement? closest;
+    var minDistance = double.infinity;
+
+    for (final measurement in measurements) {
+      final lat = measurement.siteDetails?.approximateLatitude;
+      final lon = measurement.siteDetails?.approximateLongitude;
+      if (lat == null || lon == null) continue;
+
+      final distance = _haversineDistance(
+        position.latitude,
+        position.longitude,
+        lat,
+        lon,
+      );
+      if (distance < minDistance) {
+        minDistance = distance;
+        closest = measurement;
+      }
+    }
+
+    return closest;
   }
 
   /// Request notification permission with user-friendly prompt
@@ -315,11 +381,22 @@ class NotificationHelper with UiLoggy {
 
   /// Check nearby air quality and fire a local notification if unhealthy+.
   /// Respects a 6-hour cooldown stored in Hive cache.
+  /// OS alerts are only dispatched when notification permission is granted.
   Future<void> checkNearbyAirQuality(List<Measurement>? measurements) async {
     if (measurements == null || measurements.isEmpty) return;
 
+    final pushService = PushNotificationService();
+    if (!pushService.isInitialized) {
+      loggy.info('Local notifications not initialized — skipping AQ check');
+      return;
+    }
+
+    if (!await pushService.hasPermission()) {
+      loggy.info('Notification permission not granted — skipping AQ OS alert');
+      return;
+    }
+
     try {
-      // 1. Get user position (prefer last-known for speed)
       Position? position = await Geolocator.getLastKnownPosition();
       position ??= await Geolocator.getCurrentPosition(
         locationSettings: const LocationSettings(
@@ -328,24 +405,7 @@ class NotificationHelper with UiLoggy {
         ),
       );
 
-      // 2. Find closest measurement using Haversine distance
-      Measurement? closest;
-      double minDistance = double.infinity;
-
-      for (final m in measurements) {
-        final lat = m.siteDetails?.approximateLatitude;
-        final lon = m.siteDetails?.approximateLongitude;
-        if (lat == null || lon == null) continue;
-
-        final d = _haversineDistance(
-          position.latitude, position.longitude, lat, lon,
-        );
-        if (d < minDistance) {
-          minDistance = d;
-          closest = m;
-        }
-      }
-
+      final closest = _findClosestMeasurement(measurements, position);
       if (closest == null) {
         loggy.info('No measurement with coordinates found');
         return;
@@ -357,26 +417,28 @@ class NotificationHelper with UiLoggy {
         return;
       }
 
-      // 3. Check 6-hour cooldown
       final cooldown = await HiveRepository.getCache(_aqAlertCooldownKey);
       if (cooldown != null) {
         loggy.info('Air quality alert cooldown active — skipping');
         return;
       }
 
-      // 4. Show local notification
       final locationName = closest.siteDetails?.name ??
           closest.siteDetails?.formattedName ??
           'your area';
 
-      await PushNotificationService().showLocalNotification(
+      await pushService.showLocalNotification(
         id: _aqAlertCooldownKey.hashCode,
         title: 'Air Quality Alert',
         body: 'Air quality near $locationName is $category. '
             'Consider reducing outdoor activities.',
+        payload: {
+          'type': 'air_quality_alert',
+          'location': locationName,
+          'category': category,
+        },
       );
 
-      // 5. Save cooldown (6 hours)
       await HiveRepository.saveCache(
         _aqAlertCooldownKey,
         true,

--- a/src/mobile/lib/src/app/shared/services/notification_helper.dart
+++ b/src/mobile/lib/src/app/shared/services/notification_helper.dart
@@ -237,8 +237,13 @@ class NotificationHelper with UiLoggy {
     var minDistance = double.infinity;
 
     for (final measurement in measurements) {
-      final lat = measurement.siteDetails?.approximateLatitude;
-      final lon = measurement.siteDetails?.approximateLongitude;
+      final siteDetails = measurement.siteDetails;
+      if (siteDetails == null) continue;
+
+      final lat = siteDetails.approximateLatitude ??
+          siteDetails.siteCategory?.latitude;
+      final lon = siteDetails.approximateLongitude ??
+          siteDetails.siteCategory?.longitude;
       if (lat == null || lon == null) continue;
 
       final distance = _haversineDistance(

--- a/src/mobile/lib/src/app/shared/services/push_notification_service.dart
+++ b/src/mobile/lib/src/app/shared/services/push_notification_service.dart
@@ -53,6 +53,25 @@ class PushNotificationService with UiLoggy {
     }
   }
 
+  /// Handle a local notification that launched the app from a terminated state.
+  /// Call after [onNotificationTap] is wired — [onDidReceiveNotificationResponse]
+  /// does not fire for cold-start launches.
+  Future<void> processLaunchNotification() async {
+    try {
+      final details =
+          await _localNotifications.getNotificationAppLaunchDetails();
+      if (details == null || !details.didNotificationLaunchApp) return;
+
+      final payload = details.notificationResponse?.payload;
+      if (payload == null || payload.isEmpty) return;
+
+      loggy.info('App launched from terminated state via local notification');
+      onNotificationTap?.call(_decodePayload(payload));
+    } catch (e, stackTrace) {
+      loggy.error('Failed to process launch notification', e, stackTrace);
+    }
+  }
+
   /// Initialize push notifications (local + FCM). Deferred until server push is needed.
   Future<void> initialize() async {
     if (_isInitialized && !_localOnly) {

--- a/src/mobile/lib/src/app/shared/services/push_notification_service.dart
+++ b/src/mobile/lib/src/app/shared/services/push_notification_service.dart
@@ -24,6 +24,10 @@ class PushNotificationService with UiLoggy {
 
   String? _currentToken;
   bool _isInitialized = false;
+  bool _localOnly = false;
+
+  bool get isInitialized => _isInitialized;
+  bool get isLocalOnly => _localOnly;
 
   /// Callback for handling notification taps when app is in foreground/background
   Function(Map<String, dynamic>)? onNotificationTap;
@@ -31,9 +35,27 @@ class PushNotificationService with UiLoggy {
   /// Callback for handling notification received in foreground
   Function(RemoteMessage)? onForegroundMessage;
 
-  /// Initialize push notifications
-  Future<void> initialize() async {
+  /// Local notifications only — no Firebase / FCM (Phase 0/1).
+  Future<void> initializeLocalOnly() async {
     if (_isInitialized) {
+      loggy.info('Local notifications already initialized');
+      return;
+    }
+
+    try {
+      loggy.info('Initializing local notification service...');
+      await _initializeLocalNotifications();
+      _localOnly = true;
+      _isInitialized = true;
+      loggy.info('Local notification service initialized');
+    } catch (e, stackTrace) {
+      loggy.error('Failed to initialize local notifications', e, stackTrace);
+    }
+  }
+
+  /// Initialize push notifications (local + FCM). Deferred until server push is needed.
+  Future<void> initialize() async {
+    if (_isInitialized && !_localOnly) {
       loggy.info('Push notifications already initialized');
       return;
     }
@@ -43,6 +65,7 @@ class PushNotificationService with UiLoggy {
 
       // Initialize local notifications
       await _initializeLocalNotifications();
+      _localOnly = false;
 
       // Request notification permissions
       await requestPermission();
@@ -141,21 +164,19 @@ class PushNotificationService with UiLoggy {
 
       // Handle iOS permissions
       if (Platform.isIOS) {
-        final settings = await _firebaseMessaging.requestPermission(
-          alert: true,
-          badge: true,
-          sound: true,
-          provisional: false,
-          announcement: false,
-          carPlay: false,
-          criticalAlert: false,
-        );
+        final status = await Permission.notification.status;
+        if (status.isGranted) return true;
 
-        final enabled = settings.authorizationStatus == AuthorizationStatus.authorized ||
-            settings.authorizationStatus == AuthorizationStatus.provisional;
+        if (status.isDenied || status.isLimited) {
+          final result = await Permission.notification.request();
+          loggy.info('iOS notification permission request result: $result');
+          return result.isGranted;
+        }
 
-        loggy.info('iOS notification permission status: ${settings.authorizationStatus}');
-        return enabled;
+        if (status.isPermanentlyDenied) {
+          loggy.warning('iOS notification permission permanently denied');
+          return false;
+        }
       }
 
       return false;
@@ -174,9 +195,8 @@ class PushNotificationService with UiLoggy {
       }
 
       if (Platform.isIOS) {
-        final settings = await _firebaseMessaging.getNotificationSettings();
-        return settings.authorizationStatus == AuthorizationStatus.authorized ||
-            settings.authorizationStatus == AuthorizationStatus.provisional;
+        final status = await Permission.notification.status;
+        return status.isGranted;
       }
 
       return false;
@@ -289,6 +309,7 @@ class PushNotificationService with UiLoggy {
     required int id,
     required String title,
     required String body,
+    Map<String, dynamic>? payload,
   }) async {
     try {
       await _localNotifications.show(
@@ -310,6 +331,7 @@ class PushNotificationService with UiLoggy {
             presentSound: true,
           ),
         ),
+        payload: payload != null ? _encodePayload(payload) : null,
       );
     } catch (e, stackTrace) {
       loggy.error('Failed to show local notification', e, stackTrace);

--- a/src/mobile/pubspec.lock
+++ b/src/mobile/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: da0d9209ca76bde579f2da330aeb9df62b6319c834fa7baae052021b0462401f
+      sha256: "3b19a47f6ea7c2632760777c78174f47f6aec1e05f0cd611380d4593b8af1dbc"
       url: "https://pub.dev"
     source: hosted
-    version: "85.0.0"
+    version: "96.0.0"
   _flutterfire_internals:
     dependency: transitive
     description:
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "974859dc0ff5f37bc4313244b3218c791810d03ab3470a579580279ba971a48d"
+      sha256: "0c516bc4ad36a1a75759e54d5047cb9d15cded4459df01aa35a0b5ec7db2c2a0"
       url: "https://pub.dev"
     source: hosted
-    version: "7.7.1"
+    version: "10.2.0"
   args:
     dependency: transitive
     description:
@@ -85,18 +85,18 @@ packages:
     dependency: transitive
     description:
       name: build
-      sha256: "51dc711996cbf609b90cbe5b335bbce83143875a9d58e4b5c6d3c4f684d3dda7"
+      sha256: "45d14a0fb23e018d8287c32fc98d726ce466b231928ed9b9200f29bd3ccd39ae"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.4"
+    version: "4.0.7"
   build_config:
     dependency: transitive
     description:
       name: build_config
-      sha256: "4ae2de3e1e67ea270081eaee972e1bd8f027d459f249e0f1186730784c2e7e33"
+      sha256: "94eaf6708fe64408c632ef2689ca3777b112f9421306ccf4f8c84d7c5c9f83f8"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "1.3.2"
   build_daemon:
     dependency: transitive
     description:
@@ -105,30 +105,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.1"
-  build_resolvers:
-    dependency: transitive
-    description:
-      name: build_resolvers
-      sha256: ee4257b3f20c0c90e72ed2b57ad637f694ccba48839a821e87db762548c22a62
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.5.4"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "382a4d649addbfb7ba71a3631df0ec6a45d5ab9b098638144faf27f02778eb53"
+      sha256: "5367e521935b102bdf1e735d2aab461e36b2edca6517662d088dd04cc39f8d16"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.4"
-  build_runner_core:
-    dependency: transitive
-    description:
-      name: build_runner_core
-      sha256: "85fbbb1036d576d966332a3f5ce83f2ce66a40bea1a94ad2d5fc29a19a0d3792"
-      url: "https://pub.dev"
-    source: hosted
-    version: "9.1.2"
+    version: "2.15.1"
   built_collection:
     dependency: transitive
     description:
@@ -189,10 +173,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -301,10 +285,10 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "8a0e5fba27e8ee025d2ffb4ee820b4e6e2cf5e4246a6b1a477eb66866947e0bb"
+      sha256: "29f7ecc274a86d32920b1d9cfc7502fa87220da41ec60b55f329559d5732e2b2"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.1"
+    version: "3.1.7"
   dbus:
     dependency: transitive
     description:
@@ -365,10 +349,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.3.3"
   ffi:
     dependency: transitive
     description:
@@ -961,10 +945,10 @@ packages:
     dependency: "direct main"
     description:
       name: intl
-      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
+      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
       url: "https://pub.dev"
     source: hosted
-    version: "0.19.0"
+    version: "0.20.2"
   io:
     dependency: transitive
     description:
@@ -993,10 +977,10 @@ packages:
     dependency: "direct dev"
     description:
       name: json_serializable
-      sha256: c50ef5fc083d5b5e12eef489503ba3bf5ccc899e487d691584699b4bdefeea8c
+      sha256: "5b89c1e32ae3840bb20a1b3434e3a590173ad3cb605896fb0f60487ce2f8104e"
       url: "https://pub.dev"
     source: hosted
-    version: "6.9.5"
+    version: "6.11.4"
   jwt_decoder:
     dependency: "direct main"
     description:
@@ -1009,26 +993,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.8"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -1065,26 +1049,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -1097,10 +1081,10 @@ packages:
     dependency: "direct main"
     description:
       name: mockito
-      sha256: "4546eac99e8967ea91bae633d2ca7698181d008e95fa4627330cf903d573277a"
+      sha256: eff30d002f0c8bf073b6f929df4483b543133fcafce056870163587b03f1d422
       url: "https://pub.dev"
     source: hosted
-    version: "5.4.6"
+    version: "5.6.4"
   mocktail:
     dependency: transitive
     description:
@@ -1510,18 +1494,18 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      sha256: "35c8150ece9e8c8d263337a265153c3329667640850b9304861faea59fc98f6b"
+      sha256: a603f1fb984a7391ae5978d1b92bfaaa08b350dca5c825256f925818f7943bf5
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "4.2.4"
   source_helper:
     dependency: transitive
     description:
       name: source_helper
-      sha256: a447acb083d3a5ef17f983dd36201aeea33fedadb3228fa831f2f0c92f0f3aca
+      sha256: "5e6f216fdf6376c9f3852381ae037499797a3385377d388b011dac98d303c67c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.7"
+    version: "1.3.13"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -1598,26 +1582,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "301b213cd241ca982e9ba50266bd3f5bd1ea33f1455554c5abb85d1be0e2d87e"
+      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
       url: "https://pub.dev"
     source: hosted
-    version: "1.25.15"
+    version: "1.31.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.11"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "84d17c3486c8dfdbe5e12a50c8ae176d15e2a771b96909a9442b40173649ccaa"
+      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.8"
+    version: "0.6.17"
   timezone:
     dependency: transitive
     description:
@@ -1626,14 +1610,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.10.1"
-  timing:
-    dependency: transitive
-    description:
-      name: timing
-      sha256: "62ee18aca144e4a9f29d212f5a4c6a053be252b895ab14b5821996cff4ed90fe"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.2"
   typed_data:
     dependency: transitive
     description:
@@ -1758,10 +1734,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   video_player:
     dependency: "direct main"
     description:
@@ -1906,6 +1882,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.0.4"
+  workmanager:
+    dependency: "direct main"
+    description:
+      name: workmanager
+      sha256: "6a919b83138e457dc8f68d725755e11f47e19a8943b4554f3abbb18fdafa8e2d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.10.8"
+  workmanager_android:
+    dependency: transitive
+    description:
+      name: workmanager_android
+      sha256: "08bbc7805b762bd93de6b137ef5c2651d305e43adf00b8e0e6da9bc525e40281"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.10.7"
+  workmanager_apple:
+    dependency: transitive
+    description:
+      name: workmanager_apple
+      sha256: "15558fb54415a010910c3529eaf8f61f94d23903dac620331895c472602d6f6e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.10"
+  workmanager_linux:
+    dependency: transitive
+    description:
+      name: workmanager_linux
+      sha256: "7d8520e1103b910a43d8bafe37ec2415f4c7c148afcb1eee0ec73ae67b4cdd22"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.1+1"
+  workmanager_platform_interface:
+    dependency: transitive
+    description:
+      name: workmanager_platform_interface
+      sha256: "378b392db15ee88cd878ab983d3a0b4b1e460cfbb0f096ff74fda2614b1ba172"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.10.4"
+  workmanager_web:
+    dependency: transitive
+    description:
+      name: workmanager_web
+      sha256: "2ac481ade599bdd957ee2891be09a0c34be87923a2c3ca4dfe36add6fc735ffd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
   xdg_directories:
     dependency: transitive
     description:
@@ -1947,5 +1971,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.7.0 <4.0.0"
-  flutter: ">=3.29.0"
+  dart: ">=3.10.0 <4.0.0"
+  flutter: ">=3.38.0"

--- a/src/mobile/pubspec.yaml
+++ b/src/mobile/pubspec.yaml
@@ -95,6 +95,7 @@ dependencies:
   path_provider: ^2.1.5
   pasteboard: ^0.5.0
   gal: ^2.3.0
+  workmanager: ^0.10.8
 
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- Wires the existing local notification scaffold for Phase 1: permission-gated AQ OS alerts, survey trigger inputs, shared navigation key, and permission prompt UX.
- Adds periodic on-device background AQ checks via WorkManager/BGTaskScheduler (3-hour interval) so alerts can fire when the app is not in the foreground — no FCM required.
- Schedules a one-time initial background check 15 seconds after first NavPage load to validate the background path on device.

## Test plan
- [ ] Android 13+: grant notification permission, open app to dashboard, verify AQ OS alert when nearby air is Unhealthy+ (foreground/resume path)
- [ ] Android 13+: kill app within 15s of first NavPage load, verify initial background check runs and respects permission + 6h cooldown
- [ ] iOS 16+: same foreground/resume AQ alert test
- [ ] iOS 16+: background/kill app test for initial 15s one-off check (Xcode → Simulate Background Fetch as fallback)
- [ ] Verify survey in-app dialog still renders when trigger conditions met (requires Step 2 nav key)
- [ ] Verify permission denied → no OS alerts dispatched
- [ ] Verify 6h AQ cooldown is independent of per-survey cooldowns


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added local air-quality alerts based on nearby measurements.
  * Added background air-quality checks to support timely updates when the app is inactive.
  * Added notification tap navigation to relevant air-quality and survey screens.
  * Added survey triggers based on location and air-quality conditions.

* **Improvements**
  * Added notification permission handling for Android and iOS.
  * Improved notification setup, launch handling, and resume behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->