### PR TITLE
Add device claiming, SLA, and location docs

### DIFF
--- a/src/docs-website/docs/api/reference/metadata.md
+++ b/src/docs-website/docs/api/reference/metadata.md
@@ -89,7 +89,7 @@ curl "https://api.airqo.net/api/v2/devices/grids/summary?admin_level=city"
 ```json
 {
   "success": true,
-  "message": "Successfull Operation",
+  "message": "Successfully retrieved grids",
   "grids": [
     {
       "_id": "67c96c4771c7b0001383dde1",
@@ -141,7 +141,7 @@ const stationCoordinates = data.grids
 
 ```python
 import requests
-import geopy.distance
+import geopy.distance  # pip install geopy
 
 response = requests.get('https://api.airqo.net/api/v2/devices/grids/summary')
 data = response.json()

--- a/src/docs-website/docs/api/reference/metadata.md
+++ b/src/docs-website/docs/api/reference/metadata.md
@@ -118,7 +118,7 @@ curl "https://api.airqo.net/api/v2/devices/grids/summary?admin_level=city"
 ```
 
 :::info Coordinates are approximated
-`approximate_latitude` and `approximate_longitude` are intentionally offset by up to ~0.5km from each site's true physical location, to protect the privacy of hosting institutions. The offset is consistent per site, so it's safe for temporal and area-based analysis, but proximity queries should use a widened radius. See [Location Approximation](../../data-access/researchers-guide/spatial-disaggregation-and-geographic-filtering.md#31-location-approximation-for-monitor-coordinates) for the full policy and research best practices.
+`approximate_latitude` and `approximate_longitude` are intentionally offset by up to ~0.5km from each site's true physical location, to protect the privacy of hosting institutions. The offset is consistent per site, so it's safe for temporal and area-based analysis, but proximity queries should use a widened radius. See [Location Approximation](../../data-access/researchers-guide/location-approximation.md) for the full policy and research best practices.
 :::
 
 **Example — extract coordinates for mapping (JavaScript)**

--- a/src/docs-website/docs/api/reference/metadata.md
+++ b/src/docs-website/docs/api/reference/metadata.md
@@ -7,7 +7,7 @@ sidebar_label: Metadata API
 
 The Metadata API lets you browse the AirQo monitoring infrastructure — grids, cohorts, sites, devices, and geographic boundaries — so you can discover the right identifiers before querying measurement or forecast data.
 
-All endpoints require your `token` query parameter. See [Authentication →](../getting-started/authentication.md).
+All endpoints require your `token` query parameter, with one exception noted below. See [Authentication →](../getting-started/authentication.md).
 
 ---
 
@@ -62,23 +62,26 @@ Returns all publicly visible grids.
 ### Grid summary with site details
 
 ```http
-GET /api/v2/devices/grids/summary?token={SECRET_TOKEN}
+GET /api/v2/devices/grids/summary
 ```
 
 Returns grids with their constituent site details nested inside. This is the most useful endpoint for **discovering Grid IDs and the sites within them**.
+
+:::note No authentication required
+Unlike most endpoints on this page, grid summary is publicly accessible without a `token` — it's the recommended way to pull AirQo's monitoring station locations into a public research or mapping project.
+:::
 
 **Query parameters**
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `token` | string | Required |
 | `admin_level` | string | Filter by level: `country`, `province`, `city`, `district`, `subcounty`, `county`, `division`, `parish` |
 | `id` | string | Filter by a specific Grid ID |
 
 **Example — filter to city-level grids**
 
 ```bash
-curl "https://api.airqo.net/api/v2/devices/grids/summary?admin_level=city&token=YOUR_SECRET_TOKEN"
+curl "https://api.airqo.net/api/v2/devices/grids/summary?admin_level=city"
 ```
 
 **Example response**
@@ -86,29 +89,74 @@ curl "https://api.airqo.net/api/v2/devices/grids/summary?admin_level=city&token=
 ```json
 {
   "success": true,
+  "message": "Successfull Operation",
   "grids": [
     {
-      "_id": "64b7ac8fd7249f0029feca80",
-      "name": "nairobi_city",
-      "long_name": "Nairobi City",
+      "_id": "67c96c4771c7b0001383dde1",
+      "name": "kampala_city",
+      "long_name": "Kampala City",
       "admin_level": "city",
       "visibility": true,
       "network": "airqo",
-      "numberOfSites": 12,
-      "createdAt": "2023-07-19T10:25:00.000Z",
+      "createdAt": "2025-03-06T09:35:03.672Z",
       "sites": [
         {
-          "_id": "64f7b3e8c9d25a0013f2d456",
-          "name": "nairobi_road",
-          "long_name": "Nairobi Road, Nairobi",
-          "latitude": -1.2921,
-          "longitude": 36.8219,
-          "data_provider": "airqo"
+          "_id": "60d058c8048305120d2d6145",
+          "name": "Civic Centre, Kampala Central",
+          "country": "Uganda",
+          "district": "Kampala",
+          "city": "Kampala",
+          "formatted_name": "5 Jinja Road, Kampala, Uganda",
+          "approximate_latitude": 0.317725206350973,
+          "approximate_longitude": 32.5925094863702,
+          "data_provider": "AirQo"
         }
       ]
     }
   ]
 }
+```
+
+:::info Coordinates are approximated
+`approximate_latitude` and `approximate_longitude` are intentionally offset by up to ~0.5km from each site's true physical location, to protect the privacy of hosting institutions. The offset is consistent per site, so it's safe for temporal and area-based analysis, but proximity queries should use a widened radius. See [Location Approximation](../../data-access/researchers-guide/spatial-disaggregation-and-geographic-filtering.md#31-location-approximation-for-monitor-coordinates) for the full policy and research best practices.
+:::
+
+**Example — extract coordinates for mapping (JavaScript)**
+
+```js
+const response = await fetch('https://api.airqo.net/api/v2/devices/grids/summary');
+const data = await response.json();
+
+const stationCoordinates = data.grids
+  .flatMap((grid) => grid.sites || [])
+  .map((site) => ({
+    id: site._id,
+    name: site.name,
+    lat: site.approximate_latitude,
+    lng: site.approximate_longitude,
+  }));
+```
+
+**Example — find stations near a point of interest, with an adjusted radius (Python)**
+
+```python
+import requests
+import geopy.distance
+
+response = requests.get('https://api.airqo.net/api/v2/devices/grids/summary')
+data = response.json()
+
+all_sites = [site for grid in data['grids'] for site in grid.get('sites', [])]
+
+poi = (0.33500, 32.57140)  # latitude, longitude
+
+# Use 500m rather than 100m to account for the ~0.5km coordinate offset
+nearby_sites = [
+    site for site in all_sites
+    if geopy.distance.distance(
+        poi, (site['approximate_latitude'], site['approximate_longitude'])
+    ).meters <= 500
+]
 ```
 
 ---

--- a/src/docs-website/docs/data-access/device-claiming-guide/_category_.json
+++ b/src/docs-website/docs/data-access/device-claiming-guide/_category_.json
@@ -1,0 +1,10 @@
+{
+  "label": "Device Claiming Guide",
+  "position": 3,
+  "collapsible": true,
+  "collapsed": true,
+  "link": {
+    "type": "doc",
+    "id": "data-access/device-claiming-guide/index"
+  }
+}

--- a/src/docs-website/docs/data-access/device-claiming-guide/alternative-claiming-scenarios.md
+++ b/src/docs-website/docs/data-access/device-claiming-guide/alternative-claiming-scenarios.md
@@ -1,0 +1,20 @@
+---
+sidebar_position: 3
+sidebar_label: 2. Alternative Claiming Scenarios
+---
+
+# 2. Alternative Claiming Scenarios
+
+Not every device follows the [standard flow](./main-claiming-flow.md). The table below covers common variations.
+
+| Scenario | What happens |
+|----------|--------------|
+| **Your device has no claim token at all** (it was never formally "shipped" through AirQo's process — e.g. a device set up directly by AirQo staff) | You can still claim it with just the exact **Device Name** and your account — leave the claim token field blank. |
+| **Claiming several devices at once** | Use the bulk-claim option: add each device name (and token, if it has one) as a row, or upload a spreadsheet/CSV. You'll get a per-device result — some may succeed while others fail, so check the results list. |
+| **The device was previously deployed elsewhere** (e.g. a returned or reassigned unit) | Claiming it automatically "recalls" it from its old deployment first — its previous location history is preserved, but it comes to you as freshly claimed, not still attached to somewhere else. |
+| **You already claimed a device, but it doesn't show up under any group** | This is called an "orphaned" device — check your My Devices page for a "Complete Device Setup" prompt, which lets you finish attaching it to a group with one click. |
+| **You want to put the device in a specific existing group** | During claiming (or via "import cohort"), enter that group's ID — you can use either the internal ID or, for newer groups, a human-readable slug (e.g. `wri-nairobi-2026`). |
+
+:::info Recalling deployed devices
+See [Recall a Device](../../vertex/device-deployment/recall-device.md) for more on how deployment history is preserved when a device changes hands.
+:::

--- a/src/docs-website/docs/data-access/device-claiming-guide/completion-and-troubleshooting.md
+++ b/src/docs-website/docs/data-access/device-claiming-guide/completion-and-troubleshooting.md
@@ -1,0 +1,27 @@
+---
+sidebar_position: 4
+sidebar_label: 3. Completion & Troubleshooting
+---
+
+# 3. Completion Criteria & Troubleshooting
+
+## Completion Criteria
+
+Claiming has succeeded once:
+
+- ✅ Device shows up under "My Devices" with status "claimed."
+- ✅ Device is attached to a cohort/group (either the one you chose, your personal default, or completed later via "Complete Device Setup").
+- ✅ You can see incoming readings once the device starts transmitting.
+
+## Troubleshooting
+
+| Message you might see | What it means | What to do |
+|------------------------|----------------|-------------|
+| "We couldn't find this device" | The device name doesn't match anything in the system — check for typos. | Re-check the label, retry manual entry carefully. |
+| "Device already claimed" | Someone (possibly you, on a previous attempt) already claimed this device. | Check your My Devices list first; if it's genuinely not yours, contact your AirQo representative. |
+| Claim token rejected / doesn't match | The token entered doesn't match what's on record for that device. | Re-scan the QR code rather than typing manually, or double-check for a mixed-up character (letters vs. digits, e.g. `0` vs `O`). |
+| A device you're trying to claim into a specific group can't find that group | The group ID/slug was mistyped, or the group doesn't exist. | Confirm the exact ID/slug with whoever manages that group. |
+
+:::caution Still stuck?
+If something looks wrong and none of the above explains it, contact your AirQo representative with the device name and a screenshot of the error, or reach out to [support@airqo.net](mailto:support@airqo.net).
+:::

--- a/src/docs-website/docs/data-access/device-claiming-guide/index.md
+++ b/src/docs-website/docs/data-access/device-claiming-guide/index.md
@@ -1,0 +1,40 @@
+---
+sidebar_position: 1
+sidebar_label: Overview
+---
+
+# Device Claiming Guide for Partners
+
+Guidance for external partners on claiming ownership of an AirQo air quality monitor so its data appears on your account.
+
+:::info Document version
+Version 1.0 — August 2026
+:::
+
+---
+
+## Introduction
+
+If you've received an AirQo air quality monitor — whether through a formal shipment or a direct handover from AirQo staff — you need to **claim** it before its readings show up under your account. Claiming links a physical device to your AirQo Platform ([Vertex](https://platform.airqo.net)) account, which is what makes its data yours to access, export, and monitor through the [data access channels](../researchers-guide/data-access-channels.md) described elsewhere in this guide.
+
+This document walks through the claiming process end to end: prerequisites, the standard flow, alternative scenarios (no claim token, bulk claiming, previously deployed devices), how to confirm claiming succeeded, and how to troubleshoot common errors.
+
+---
+
+## Before You Start
+
+You need an AirQo account on the [AirQo Platform](https://platform.airqo.net) (Vertex). Claiming happens inside the app once you're logged in — there is no separate public "claim" website. If you don't have an account yet, create one first; your account is what claiming attaches the device to.
+
+:::tip Already have a Cohort ID instead?
+If your AirQo network support contact gave you a **Cohort ID** rather than a device claim token, you're looking for the related [Add an AirQo Device](../../vertex/device-deployment/add-airqo-device.md) flow, which imports an entire cohort of devices at once. Claiming (this guide) is for attaching individual devices using their own name and token, typically from a printed label.
+:::
+
+---
+
+## See Also
+
+- [Main Claiming Flow](./main-claiming-flow.md) — the standard, happy-path steps.
+- [Alternative Claiming Scenarios](./alternative-claiming-scenarios.md) — no claim token, bulk claiming, previously deployed devices, and more.
+- [Completion Criteria & Troubleshooting](./completion-and-troubleshooting.md) — how to confirm success and resolve common errors.
+
+*This document is prepared by AirQo, Makerere University. For the latest information: https://airqo.africa | Contact: [support@airqo.net](mailto:support@airqo.net)*

--- a/src/docs-website/docs/data-access/device-claiming-guide/main-claiming-flow.md
+++ b/src/docs-website/docs/data-access/device-claiming-guide/main-claiming-flow.md
@@ -1,0 +1,23 @@
+---
+sidebar_position: 2
+sidebar_label: 1. Main Claiming Flow
+---
+
+# 1. Main Claiming Flow
+
+This is the happy path: your device shipped with a printed claim label attached.
+
+1. **Unbox your device.** If AirQo prepared it for shipping, it comes with a printed label showing the **Device Name**, a **Claim Token**, and a **QR code**.
+2. **Log in to the AirQo Platform** and open the "Claim Device" option (available from your Home page, Devices page, or My Devices page).
+3. **Choose how to enter the device**:
+   - **Scan the QR code** on the label with your camera, or
+   - **Enter manually**: type the Device Name and Claim Token exactly as printed.
+4. **Confirm the details** shown on screen.
+5. **(Optional) Choose a group/cohort** for the device — if you skip this, it's automatically placed in a personal collection tied to your account, so you can always find it under "My Devices."
+6. **Submit.** On success, the device is now yours — it'll show up under your devices with live data as soon as it starts transmitting.
+
+:::tip Prefer scanning over typing
+QR codes remove the risk of mistyping a claim token (letters vs. digits, e.g. `0` vs `O`). Scan the label whenever your device has a camera-readable code available.
+:::
+
+Once your device is claimed, its readings become available through the same channels covered in the [Data Access Guide for Researchers](../researchers-guide/data-access-channels.md) — mobile app, Analytics Platform, and API.

--- a/src/docs-website/docs/data-access/device-performance-guide/_category_.json
+++ b/src/docs-website/docs/data-access/device-performance-guide/_category_.json
@@ -1,0 +1,10 @@
+{
+  "label": "Device Performance & SLA Guide",
+  "position": 4,
+  "collapsible": true,
+  "collapsed": true,
+  "link": {
+    "type": "doc",
+    "id": "data-access/device-performance-guide/index"
+  }
+}

--- a/src/docs-website/docs/data-access/device-performance-guide/data-availability-targets.md
+++ b/src/docs-website/docs/data-access/device-performance-guide/data-availability-targets.md
@@ -1,0 +1,15 @@
+---
+sidebar_position: 4
+sidebar_label: 3. Data Availability Targets
+---
+
+# 3. Data Availability Targets
+
+**Data availability** is the percentage of expected data points that are successfully received and processed by our system.
+
+| Power Source | Firmware Version | Availability Target | Key Influences |
+|--------------|-------------------|-----------------------|------------------|
+| Solar | New Firmware V42.74+ | 85% | Timely maintenance · Good IoT network connectivity · At least one day of sunshine per week for optimal charging |
+| Solar | Old Firmware V42.0 and below | 75% | Timely maintenance · Good IoT network connectivity · At least one day of sunshine every 3–4 days for adequate charging |
+| Mains | New Firmware V42.74+ | 95% | Timely maintenance · Consistent power · Good IoT network connectivity |
+| Mains | Old Firmware V42.0 and below | 90% | Timely maintenance · Consistent power · Good IoT network connectivity |

--- a/src/docs-website/docs/data-access/device-performance-guide/data-reporting-frequency.md
+++ b/src/docs-website/docs/data-access/device-performance-guide/data-reporting-frequency.md
@@ -1,0 +1,21 @@
+---
+sidebar_position: 2
+sidebar_label: 1. Data Reporting Frequency
+---
+
+# 1. Data Reporting Frequency
+
+The performance of your air quality monitor, including how often it sends data and its overall reliability, depends on its power source. Other behaviours can depend on the firmware version a device is running.
+
+Our devices are configured to send data at specific intervals, ensuring a balance between real-time insights and power efficiency.
+
+| Device Type | Power Source | Avg. Data Points / Hour | Firmware Version |
+|-------------|--------------|--------------------------|-------------------|
+| Binos | Solar | 6 | New Firmware V42.74+ |
+| Binos | Solar | 20 | Old Firmware V42.0 and below |
+| Binos | Mains | 6 | New Firmware V42.74+ |
+| Binos | Mains | 20 | Old Firmware V42.0 and below |
+
+:::info Adjustable on request
+While these are the standard rates, we can often adjust the data reporting frequency upon request. Keep in mind that for battery-powered (solar) devices, increasing the frequency leads to higher power consumption and reduces the time the device can operate on a single charge — see [Device Uptime Targets](./device-uptime-targets.md) for how this trades off against uptime.
+:::

--- a/src/docs-website/docs/data-access/device-performance-guide/device-uptime-targets.md
+++ b/src/docs-website/docs/data-access/device-performance-guide/device-uptime-targets.md
@@ -1,0 +1,12 @@
+---
+sidebar_position: 3
+sidebar_label: 2. Device Uptime Targets
+---
+
+# 2. Device Uptime Targets
+
+**Uptime** is the percentage of time your monitor is operational and actively collecting/transmitting data. Our targets are based on regular maintenance and a stable internet connection for the device.
+
+| Power Source | Firmware Version | Uptime Target | Key Influences |
+|--------------|-------------------|----------------|------------------|
+| Solar | New Firmware V42.74+ | 90% | 6 data points per hour · Timely maintenance · Good IoT network connectivity · 2–3 hours of sunshine per day · 12–18 hours of discharge time |

--- a/src/docs-website/docs/data-access/device-performance-guide/factors-affecting-performance.md
+++ b/src/docs-website/docs/data-access/device-performance-guide/factors-affecting-performance.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 6
+sidebar_label: 5. Factors Affecting Performance
+---
+
+# 5. Factors Affecting Performance
+
+While we strive for high reliability, certain environmental conditions and external factors can influence device performance, especially uptime and data availability:
+
+- **Extended bad weather periods**: For solar-powered devices, prolonged periods without sufficient sunlight (e.g., weeks of continuous heavy cloud cover, intense rainy seasons in certain regions) can significantly reduce battery charge and affect operation.
+- **Elongated sandy/dusty seasons**: During very dusty or sandy periods, sensors can become clogged, potentially interfering with accurate readings and requiring more frequent cleaning.
+- **IoT network connectivity**: The reliability of the cellular or other IoT network at the device's location is critical for data transmission. Poor signal strength or network outages can directly impact data availability.
+
+We are committed to providing you with a reliable and insightful air quality monitoring experience. By understanding these operational details and engaging in timely maintenance, we can ensure your devices continuously deliver the valuable data you need.

--- a/src/docs-website/docs/data-access/device-performance-guide/index.md
+++ b/src/docs-website/docs/data-access/device-performance-guide/index.md
@@ -1,0 +1,48 @@
+---
+sidebar_position: 1
+sidebar_label: Overview
+---
+
+# Understanding Your Air Quality Monitors
+
+A comprehensive guide to what our devices do, how they operate, the data you can expect, and our commitment to maintaining their performance.
+
+:::info Document version
+Version 1.0 — August 2026
+:::
+
+---
+
+## Introduction
+
+Welcome to the guide to AirQo's Air Quality Monitoring Service. This document provides a clear overview of what our devices do, how they operate, the data you can expect, and our commitment to maintaining their performance. Our goal is to empower you with reliable environmental insights through our advanced end-to-end monitoring solutions.
+
+Once a device is [claimed onto your account](../device-claiming-guide/index.md), this guide explains what to expect from it operationally — how often it reports, the uptime and data-availability targets we work to, and how we keep it running.
+
+---
+
+## What Your Monitors Do
+
+Our monitors are designed to provide essential environmental data by accurately measuring:
+
+- **Air quality**: Particulate Matter (PM2.5 and PM10) — tiny particles in the air that can impact health and air quality.
+- **Environmental conditions**: Temperature and Humidity, giving you a complete picture of the local environment.
+
+These monitors are engineered for flexibility, capable of operating using two distinct power sources:
+
+- **Solar-powered with battery backup**: Ideal for remote or off-grid locations, these units use integrated solar panels to charge their internal batteries.
+- **Mains power connection**: For stable, continuous operation in areas with readily available electricity.
+
+All collected data is wirelessly transmitted to our secure cloud platform, making it easily accessible to you through the [data access channels](../researchers-guide/data-access-channels.md) described elsewhere in this guide.
+
+---
+
+## See Also
+
+- [Data Reporting Frequency](./data-reporting-frequency.md) — how often devices send data, by power source and firmware.
+- [Device Uptime Targets](./device-uptime-targets.md) — our operational availability commitment.
+- [Data Availability Targets](./data-availability-targets.md) — the share of expected data points you can expect to receive.
+- [Maintenance & Support](./maintenance-and-support.md) — maintenance responsibilities and cost options.
+- [Factors Affecting Performance](./factors-affecting-performance.md) — environmental conditions that influence uptime and data availability.
+
+*This document is prepared by AirQo, Makerere University. For the latest information: https://airqo.africa | Contact: [support@airqo.net](mailto:support@airqo.net)*

--- a/src/docs-website/docs/data-access/device-performance-guide/maintenance-and-support.md
+++ b/src/docs-website/docs/data-access/device-performance-guide/maintenance-and-support.md
@@ -1,0 +1,45 @@
+---
+sidebar_position: 5
+sidebar_label: 4. Maintenance & Support
+---
+
+# 4. Maintenance & Support
+
+To ensure your air quality monitors deliver consistent and accurate data, regular maintenance is crucial.
+
+## Maintenance Responsibility
+
+While AirQo's responsibility covers the physical device and its software, the purchasing organization is responsible for ensuring the reliability and uptime of their AirQloud. Regular maintenance of the AirQloud is fundamental for the continuous transmission of data from the monitors to the platform.
+
+## Scheduled Device Maintenance
+
+We recommend and conduct routine maintenance on each device at least every six (6) months, depending on location and season. These visits are essential for optimal performance and include:
+
+- **Battery inspection/replacement**: For solar-powered units, we check battery health and replace it if needed to ensure maximum uptime.
+- **Sensor cleaning/replacement**: Crucial for accurate PM readings, we clean or replace particulate matter sensors.
+- **Solar panel cleaning**: For solar-powered units, we clean the panels to ensure they efficiently convert sunlight into power.
+- **Firmware updates**: We apply the latest firmware updates to improve performance, enhance features, and boost security.
+- **General device health check**: A thorough inspection of the device's physical condition and connectivity.
+
+## Maintenance Cost Options
+
+We offer flexible options to ensure your devices receive the necessary maintenance.
+
+### Knowledge Transfer & Self-Maintenance
+
+For organizations that prefer to handle device maintenance internally, we offer comprehensive knowledge transfer. Our team can train your technical staff on the specific procedures for maintaining our air quality monitors, including hands-on sessions and access to our detailed maintenance guide.
+
+- **Cost**: A one-time fee for the training program, plus continued access to our support resources for your trained personnel. Contact us for a detailed quotation based on the scope of training required. We can also commit to providing device consumables (solar panels, batteries, sensors) at a cost you will meet.
+- **Benefit**: Empowers your team with direct control over maintenance schedules, and can reduce long-term operational costs by leveraging internal resources.
+
+### On-Site Maintenance by Our Team
+
+We can provide our expert engineers to travel to your locations and perform scheduled maintenance as outlined above, ensuring maintenance is carried out by specialists who are intimately familiar with the devices.
+
+- **Cost**: Agreed upon based on your specific travel requirements and the number/distribution of devices. Key factors include:
+  - **Distance/location**: Travel expenses (flights, accommodation, local transport) vary significantly based on the proximity of your sites to our operational bases and the complexity of reaching them.
+  - **Number of devices**: The time required per site depends on the number of units to be serviced.
+  - **Frequency**: While we recommend bi-annual maintenance, a different agreed-upon schedule would affect costs.
+- **Benefit**: Guarantees that maintenance is performed by highly skilled personnel, minimizing potential issues and ensuring optimal device performance with minimal burden on your internal team.
+
+For either option, contact [support@airqo.net](mailto:support@airqo.net) to discuss a plan and get a quotation.

--- a/src/docs-website/docs/data-access/researchers-guide/additional-resources.md
+++ b/src/docs-website/docs/data-access/researchers-guide/additional-resources.md
@@ -1,9 +1,9 @@
 ---
-sidebar_position: 17
-sidebar_label: 16. Additional Resources
+sidebar_position: 18
+sidebar_label: 17. Additional Resources
 ---
 
-# 16. Additional Resources
+# 17. Additional Resources
 
 - **Research Repository** — AirQo maintains a repository of peer-reviewed publications using our data. Visit https://airqo.africa or request a bibliography from [support@airqo.net](mailto:support@airqo.net).
 - **Educational Materials** — Resources on air quality fundamentals, health effects, data visualisation techniques, and policy frameworks.

--- a/src/docs-website/docs/data-access/researchers-guide/appendix-quick-reference-checklist.md
+++ b/src/docs-website/docs/data-access/researchers-guide/appendix-quick-reference-checklist.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 19
+sidebar_position: 20
 sidebar_label: "Appendix: Quick Reference Checklist"
 ---
 

--- a/src/docs-website/docs/data-access/researchers-guide/best-practices-for-researchers.md
+++ b/src/docs-website/docs/data-access/researchers-guide/best-practices-for-researchers.md
@@ -1,9 +1,9 @@
 ---
-sidebar_position: 12
-sidebar_label: 11. Best Practices for Researchers
+sidebar_position: 13
+sidebar_label: 12. Best Practices for Researchers
 ---
 
-# 11. Best Practices for Researchers
+# 12. Best Practices for Researchers
 
 ### Data Download and Processing Workflow
 

--- a/src/docs-website/docs/data-access/researchers-guide/city-wide-aggregation-methodology.md
+++ b/src/docs-website/docs/data-access/researchers-guide/city-wide-aggregation-methodology.md
@@ -1,9 +1,9 @@
 ---
-sidebar_position: 5
-sidebar_label: 4. City-Wide Aggregation Methodology
+sidebar_position: 6
+sidebar_label: 5. City-Wide Aggregation Methodology
 ---
 
-# 4. City-Wide Air Quality Aggregation Methodology
+# 5. City-Wide Air Quality Aggregation Methodology
 
 ### The Challenge of City-Level Averages
 

--- a/src/docs-website/docs/data-access/researchers-guide/data-access-channels.md
+++ b/src/docs-website/docs/data-access/researchers-guide/data-access-channels.md
@@ -1,9 +1,9 @@
 ---
-sidebar_position: 8
-sidebar_label: 7. Data Access Channels
+sidebar_position: 9
+sidebar_label: 8. Data Access Channels
 ---
 
-# 7. Data Access Channels
+# 8. Data Access Channels
 
 ### Overview of Access Methods
 

--- a/src/docs-website/docs/data-access/researchers-guide/data-quality-and-accuracy.md
+++ b/src/docs-website/docs/data-access/researchers-guide/data-quality-and-accuracy.md
@@ -1,9 +1,9 @@
 ---
-sidebar_position: 9
-sidebar_label: 8. Data Quality & Accuracy
+sidebar_position: 10
+sidebar_label: 9. Data Quality & Accuracy
 ---
 
-# 8. Data Quality and Accuracy
+# 9. Data Quality and Accuracy
 
 ### Accuracy of AirQo Monitors
 

--- a/src/docs-website/docs/data-access/researchers-guide/field-deployment-and-calibration-guidance.md
+++ b/src/docs-website/docs/data-access/researchers-guide/field-deployment-and-calibration-guidance.md
@@ -1,13 +1,13 @@
 ---
-sidebar_position: 11
-sidebar_label: 10. Field Deployment & Calibration
+sidebar_position: 12
+sidebar_label: 11. Field Deployment & Calibration
 ---
 
-# 10. Field Deployment and Calibration Guidance
+# 11. Field Deployment and Calibration Guidance
 
 This section addresses practical calibration and deployment questions commonly raised by research teams integrating AirQo low-cost sensors with reference-grade instruments in field-based monitoring projects.
 
-### 10.1 Calibration Frequency
+### 11.1 Calibration Frequency
 
 In challenging field environments characterised by high humidity, heavy dust loading, or significant biomass burning influence, AirQo recommends the following calibration intervals:
 
@@ -15,7 +15,7 @@ In challenging field environments characterised by high humidity, heavy dust loa
 - **Recalibration interval** — A 2–3 month recalibration interval is generally sufficient for most African urban environments. However, in areas with extreme seasonal shifts (e.g., pronounced dry-season dust or heavy wet-season humidity), quarterly recalibration (every 3 months) is strongly recommended to account for sensor drift and changing pollution composition.
 - **Continuous quality monitoring** — AirQo applies machine learning-based calibration corrections continuously to account for environmental drift between formal recalibration events. Researchers should document the calibration model version applied to their dataset.
 
-### 10.2 Calibration Approach: Co-location vs. Remote Methods
+### 11.2 Calibration Approach: Co-location vs. Remote Methods
 
 Physical co-location with a reference-grade monitor remains the gold standard for calibrating low-cost sensors. It is necessary, particularly at the start of a project and at each formal recalibration event.
 
@@ -23,15 +23,15 @@ Physical co-location with a reference-grade monitor remains the gold standard fo
 - **Frequency over a 12-month period** — We recommend at least 2–3 formal co-location events over a 12-month monitoring period: one at project start, one mid-year, and one toward the end of the study period. This captures seasonal variation in calibration relationships.
 - **Remote and model-based correction** — Between formal co-location events, AirQo applies machine learning-based remote calibration corrections using environmental variables (temperature, humidity) and cross-sensor network consistency checks. These methods reduce but do not eliminate the need for periodic physical co-location, which remains essential for model validation.
 
-### 10.3 Sensor Movement During Calibration and Maintenance
+### 11.3 Sensor Movement During Calibration and Maintenance
 
 Temporary relocation of sensors to a co-location site is standard and acceptable practice. Key operational considerations:
 
 - Document all sensor relocations with timestamps in your metadata. Data collected during transit or at the calibration site should be clearly flagged and excluded from your primary analysis dataset.
-- Where backup sensors are available (see [Section 10.4](#104-use-of-backup-sensors)), rotate a spare into the network while the primary sensor undergoes calibration. This preserves spatial data coverage and minimises gaps in your time series.
+- Where backup sensors are available (see [Section 11.4](#114-use-of-backup-sensors)), rotate a spare into the network while the primary sensor undergoes calibration. This preserves spatial data coverage and minimises gaps in your time series.
 - Where physical relocation is not feasible, model-based correction using network-wide consistency checks can serve as an interim measure; however, this should not be the primary long-term strategy.
 
-### 10.4 Use of Backup Sensors
+### 11.4 Use of Backup Sensors
 
 Including at least one spare sensor per network is strongly recommended, particularly for research-grade monitoring projects where data continuity is essential. AirQo's experience across African city deployments confirms that spare sensors are critical for:
 
@@ -41,7 +41,7 @@ Including at least one spare sensor per network is strongly recommended, particu
 
 For a network of 10 sensors, we recommend budgeting for 1–2 spare units (10–20% of network size). This is considered best practice in AirQo's operational networks and is strongly recommended for policy-grade data generation projects.
 
-### 10.5 Reference-Grade Monitor Requirements
+### 11.5 Reference-Grade Monitor Requirements
 
 For a network of approximately 10 low-cost sensors, AirQo recommends the following approach to reference-grade instrumentation:
 
@@ -55,9 +55,9 @@ AirQo does not supply reference-grade air quality monitoring equipment. For proj
 For research projects seeking to integrate AirQo sensors within a larger hybrid monitoring system, contact [support@airqo.net](mailto:support@airqo.net) to discuss partnership arrangements, including technical training support, API integration, and data hosting on the AirQo platform.
 :::
 
-### 10.6 Physical Deployment Geometry for Co-location
+### 11.6 Physical Deployment Geometry for Co-location
 
-When co-locating an AirQo sensor with a reference-grade monitor (see [Section 10.5](#105-reference-grade-monitor-requirements)), the physical setup materially affects calibration model reliability, sometimes as much as sensor-intrinsic uncertainty. The specifications below are field-tested across AirQo co-location campaigns in Kampala and Nairobi and help ensure the low-cost sensor (LCS) and reference monitor sample a comparable air parcel.
+When co-locating an AirQo sensor with a reference-grade monitor (see [Section 11.5](#115-reference-grade-monitor-requirements)), the physical setup materially affects calibration model reliability, sometimes as much as sensor-intrinsic uncertainty. The specifications below are field-tested across AirQo co-location campaigns in Kampala and Nairobi and help ensure the low-cost sensor (LCS) and reference monitor sample a comparable air parcel.
 
 - **Mounting height** — Match the LCS inlet height to the reference monitor's inlet height within ±0.5 m (ideally ±0.3 m). Typical urban neighbourhood-scale sites use 2.0–4.0 m above ground level. Vertical PM gradients near traffic and dust resuspension mean height mismatches can bias results as much as sensor drift.
 - **Horizontal separation** — Position units 1–5 m apart, inlet-to-inlet. Never go below 1 m: closer spacing risks the LCS fan/pump exhaust affecting the reference monitor's inlet (or vice versa). Avoid separations beyond roughly 10–20 m so both instruments still sample the same air mass.
@@ -72,9 +72,9 @@ When co-locating an AirQo sensor with a reference-grade monitor (see [Section 10
 | Inlet orientation | Identical, facing prevailing wind | Reduces differential rain/dust impaction across inlets |
 | Clearance radius | ≥ 2 m (≥ 3 m upwind preferred) | Avoids turbulence, shading, and localised sources |
 
-**Documentation** — Record inlet heights, separation distance, orientation, and GPS coordinates at setup, and again after any reconfiguration. Photograph each setup: a wide establishing shot, an inlet close-up with a tape measure visible, and any obstacles within roughly 10 m. This geometry metadata should accompany your dataset alongside the calibration model version (see [Section 10.1](#101-calibration-frequency)) so results remain auditable and reproducible across sites and seasons.
+**Documentation** — Record inlet heights, separation distance, orientation, and GPS coordinates at setup, and again after any reconfiguration. Photograph each setup: a wide establishing shot, an inlet close-up with a tape measure visible, and any obstacles within roughly 10 m. This geometry metadata should accompany your dataset alongside the calibration model version (see [Section 11.1](#111-calibration-frequency)) so results remain auditable and reproducible across sites and seasons.
 
-**Seasonal adaptation** — In high-dust (e.g., Harmattan/dry season) or high-humidity (wet season) conditions, increase inlet inspection frequency and keep enclosures ventilated but rain-tight; see [Section 10.1](#101-calibration-frequency) for corresponding calibration interval adjustments.
+**Seasonal adaptation** — In high-dust (e.g., Harmattan/dry season) or high-humidity (wet season) conditions, increase inlet inspection frequency and keep enclosures ventilated but rain-tight; see [Section 11.1](#111-calibration-frequency) for corresponding calibration interval adjustments.
 
 :::info Further reading
 For the full physical co-location framework, see the U.S. EPA Enhanced Air Sensor Guidebook and Collocation Instruction Guide: https://www.epa.gov/air-sensor-toolbox

--- a/src/docs-website/docs/data-access/researchers-guide/frequently-asked-questions.md
+++ b/src/docs-website/docs/data-access/researchers-guide/frequently-asked-questions.md
@@ -33,6 +33,20 @@ Investigate extreme values before removal. Check for sensor malfunction periods,
 **Is AirQo data suitable for health impact assessment?**
 Yes, for epidemiological studies and exposure assessment. Use appropriate exposure assignment methods and account for measurement error.
 
+**Why doesn't my monitor appear in its exact location on the map?**
+Coordinates are intentionally offset by up to ~0.5km to protect the privacy of the institutions hosting monitors. See [Location Approximation](./spatial-disaggregation-and-geographic-filtering.md#31-location-approximation-for-monitor-coordinates) for the full policy and how to adjust proximity analysis for it.
+
+### Device Ownership Questions
+
+**How do I claim a device that was shipped to me?**
+See the [Main Claiming Flow](../device-claiming-guide/main-claiming-flow.md) — scan the QR code or enter the Device Name and Claim Token from the printed label.
+
+**What uptime and data availability should I expect from my device?**
+See [Device Uptime Targets](../device-performance-guide/device-uptime-targets.md) and [Data Availability Targets](../device-performance-guide/data-availability-targets.md) — both depend on power source and firmware version.
+
+**Who is responsible for maintaining my device, and what does it cost?**
+AirQo covers the device and its software; you're responsible for your AirQloud's reliability. See [Maintenance Cost Options](../device-performance-guide/maintenance-and-support.md#maintenance-cost-options) for the knowledge-transfer vs. on-site maintenance choices.
+
 ### Data Access Questions
 
 **I need data urgently for a deadline.**

--- a/src/docs-website/docs/data-access/researchers-guide/frequently-asked-questions.md
+++ b/src/docs-website/docs/data-access/researchers-guide/frequently-asked-questions.md
@@ -1,9 +1,9 @@
 ---
-sidebar_position: 14
-sidebar_label: 13. Frequently Asked Questions
+sidebar_position: 15
+sidebar_label: 14. Frequently Asked Questions
 ---
 
-# 13. Frequently Asked Questions
+# 14. Frequently Asked Questions
 
 ### General Questions
 
@@ -34,7 +34,7 @@ Investigate extreme values before removal. Check for sensor malfunction periods,
 Yes, for epidemiological studies and exposure assessment. Use appropriate exposure assignment methods and account for measurement error.
 
 **Why doesn't my monitor appear in its exact location on the map?**
-Coordinates are intentionally offset by up to ~0.5km to protect the privacy of the institutions hosting monitors. See [Location Approximation](./spatial-disaggregation-and-geographic-filtering.md#31-location-approximation-for-monitor-coordinates) for the full policy and how to adjust proximity analysis for it.
+Coordinates are intentionally offset by up to ~0.5km to protect the privacy of the institutions hosting monitors. See [Location Approximation](./location-approximation.md) for the full policy and how to adjust proximity analysis for it.
 
 ### Device Ownership Questions
 

--- a/src/docs-website/docs/data-access/researchers-guide/location-approximation.md
+++ b/src/docs-website/docs/data-access/researchers-guide/location-approximation.md
@@ -1,0 +1,39 @@
+---
+sidebar_position: 5
+sidebar_label: 4. Location Approximation
+---
+
+# 4. Location Approximation for Monitor Coordinates
+
+:::caution Privacy and security disclosure
+For privacy and security reasons, all monitoring station coordinates provided through AirQo's data platforms are intentionally approximated. This policy protects the privacy of institutions, businesses, and property owners hosting AirQo monitoring equipment.
+:::
+
+| | |
+|---|---|
+| **Offset Range** | Approximately 0.5 kilometres from actual physical locations |
+| **Consistency** | Approximated coordinates remain consistent across all queries |
+| **Affected Platforms** | All data access methods: Analytics Platform, API, mobile app |
+
+## Implications for Research
+
+The coordinate approximation is still valid for: area-based and neighbourhood-level analysis, regional air quality modelling, trend identification and temporal patterns, zone-level exposure assessment, and city-wide spatial analysis.
+
+It requires adjustment for: highly localised point-source correlation studies, proximity analysis requiring exact locations, and fine-scale spatial modelling below 1 km resolution.
+
+## Best Practices for Research Using Approximated Coordinates
+
+1. **Adjust your analysis radius** — for any proximity analysis, use a radius at least 0.5 km larger than your target area to account for the potential offset.
+2. **Take an area-based approach** — focus on neighbourhood or zone-level analysis rather than highly localised point-source correlations.
+3. **Use statistical methods that account for spatial uncertainty** in your modelling.
+4. **Triangulate with other data sources** where possible, to validate spatial relationships found in the approximated data.
+
+This approximation policy balances the need for open data access with privacy considerations, providing researchers with valuable location context while respecting the privacy of site hosts.
+
+:::info Accessing exact coordinates
+For research requiring precise monitor locations, contact [support@airqo.net](mailto:support@airqo.net) to discuss exact coordinate access, data sharing agreements, and collaboration opportunities.
+:::
+
+:::tip Querying approximated coordinates via the API
+The `approximate_latitude` and `approximate_longitude` fields are returned by the public [Grid summary endpoint](../../api/reference/metadata.md#grid-summary-with-site-details) — no authentication required. That reference page also covers proximity-analysis code examples in JavaScript and Python.
+:::

--- a/src/docs-website/docs/data-access/researchers-guide/monitor-coverage-and-representativeness.md
+++ b/src/docs-website/docs/data-access/researchers-guide/monitor-coverage-and-representativeness.md
@@ -1,9 +1,9 @@
 ---
-sidebar_position: 6
-sidebar_label: 5. Monitor Coverage & Representativeness
+sidebar_position: 7
+sidebar_label: 6. Monitor Coverage & Representativeness
 ---
 
-# 5. Monitor Coverage Area and Representativeness
+# 6. Monitor Coverage Area and Representativeness
 
 ### Spatial Representativeness
 

--- a/src/docs-website/docs/data-access/researchers-guide/monitoring-network-information.md
+++ b/src/docs-website/docs/data-access/researchers-guide/monitoring-network-information.md
@@ -1,9 +1,9 @@
 ---
-sidebar_position: 7
-sidebar_label: 6. Monitoring Network Information
+sidebar_position: 8
+sidebar_label: 7. Monitoring Network Information
 ---
 
-# 6. Monitoring Network Information
+# 7. Monitoring Network Information
 
 ### Network Size and Coverage
 

--- a/src/docs-website/docs/data-access/researchers-guide/network-technical-specifications.md
+++ b/src/docs-website/docs/data-access/researchers-guide/network-technical-specifications.md
@@ -1,9 +1,9 @@
 ---
-sidebar_position: 10
-sidebar_label: 9. Network Technical Specifications
+sidebar_position: 11
+sidebar_label: 10. Network Technical Specifications
 ---
 
-# 9. Network Technical Specifications
+# 10. Network Technical Specifications
 
 ### AirQo Binos Monitor Specifications
 

--- a/src/docs-website/docs/data-access/researchers-guide/research-collaboration-opportunities.md
+++ b/src/docs-website/docs/data-access/researchers-guide/research-collaboration-opportunities.md
@@ -1,9 +1,9 @@
 ---
-sidebar_position: 15
-sidebar_label: 14. Research Collaboration
+sidebar_position: 16
+sidebar_label: 15. Research Collaboration
 ---
 
-# 14. Research Collaboration Opportunities
+# 15. Research Collaboration Opportunities
 
 AirQo welcomes research collaborations that advance air quality science and public health in Africa. We are particularly interested in: epidemiological studies linking air quality to health outcomes, exposure assessment, source apportionment, policy evaluation, air quality forecasting, sensor validation, machine learning applications, and environmental justice research.
 

--- a/src/docs-website/docs/data-access/researchers-guide/spatial-disaggregation-and-geographic-filtering.md
+++ b/src/docs-website/docs/data-access/researchers-guide/spatial-disaggregation-and-geographic-filtering.md
@@ -23,8 +23,21 @@ The coordinate approximation is still valid for: area-based and neighbourhood-le
 
 It requires adjustment for: highly localised point-source correlation studies, proximity analysis requiring exact locations, and fine-scale spatial modelling below 1 km resolution.
 
+**Best practices for research using approximated coordinates:**
+
+1. **Adjust your analysis radius** — for any proximity analysis, use a radius at least 0.5 km larger than your target area to account for the potential offset.
+2. **Take an area-based approach** — focus on neighbourhood or zone-level analysis rather than highly localised point-source correlations.
+3. **Use statistical methods that account for spatial uncertainty** in your modelling.
+4. **Triangulate with other data sources** where possible, to validate spatial relationships found in the approximated data.
+
+This approximation policy balances the need for open data access with privacy considerations, providing researchers with valuable location context while respecting the privacy of site hosts.
+
 :::info Accessing exact coordinates
 For research requiring precise monitor locations, contact [support@airqo.net](mailto:support@airqo.net) to discuss exact coordinate access, data sharing agreements, and collaboration opportunities.
+:::
+
+:::tip Querying approximated coordinates via the API
+The `approximate_latitude` and `approximate_longitude` fields are returned by the public [Grid summary endpoint](../../api/reference/metadata.md#grid-summary-with-site-details) — no authentication required. That reference page also covers proximity-analysis code examples in JavaScript and Python.
 :::
 
 ### 3.2 Selecting Monitors by Geographic Area

--- a/src/docs-website/docs/data-access/researchers-guide/spatial-disaggregation-and-geographic-filtering.md
+++ b/src/docs-website/docs/data-access/researchers-guide/spatial-disaggregation-and-geographic-filtering.md
@@ -5,42 +5,11 @@ sidebar_label: 3. Spatial Disaggregation & Filtering
 
 # 3. Spatial Disaggregation and Geographic Filtering
 
-### 3.1 Location Approximation for Monitor Coordinates
-
-:::caution Privacy and security disclosure
-For privacy and security reasons, all monitoring station coordinates provided through AirQo's data platforms are intentionally approximated. This policy protects the privacy of institutions, businesses, and property owners hosting AirQo monitoring equipment.
+:::info Looking for location approximation?
+Coordinate approximation now has its own page: [4. Location Approximation](./location-approximation.md).
 :::
 
-| | |
-|---|---|
-| **Offset Range** | Approximately 0.5 kilometres from actual physical locations |
-| **Consistency** | Approximated coordinates remain consistent across all queries |
-| **Affected Platforms** | All data access methods: Analytics Platform, API, mobile app |
-
-**Implications for research:**
-
-The coordinate approximation is still valid for: area-based and neighbourhood-level analysis, regional air quality modelling, trend identification and temporal patterns, zone-level exposure assessment, and city-wide spatial analysis.
-
-It requires adjustment for: highly localised point-source correlation studies, proximity analysis requiring exact locations, and fine-scale spatial modelling below 1 km resolution.
-
-**Best practices for research using approximated coordinates:**
-
-1. **Adjust your analysis radius** — for any proximity analysis, use a radius at least 0.5 km larger than your target area to account for the potential offset.
-2. **Take an area-based approach** — focus on neighbourhood or zone-level analysis rather than highly localised point-source correlations.
-3. **Use statistical methods that account for spatial uncertainty** in your modelling.
-4. **Triangulate with other data sources** where possible, to validate spatial relationships found in the approximated data.
-
-This approximation policy balances the need for open data access with privacy considerations, providing researchers with valuable location context while respecting the privacy of site hosts.
-
-:::info Accessing exact coordinates
-For research requiring precise monitor locations, contact [support@airqo.net](mailto:support@airqo.net) to discuss exact coordinate access, data sharing agreements, and collaboration opportunities.
-:::
-
-:::tip Querying approximated coordinates via the API
-The `approximate_latitude` and `approximate_longitude` fields are returned by the public [Grid summary endpoint](../../api/reference/metadata.md#grid-summary-with-site-details) — no authentication required. That reference page also covers proximity-analysis code examples in JavaScript and Python.
-:::
-
-### 3.2 Selecting Monitors by Geographic Area
+### 3.1 Selecting Monitors by Geographic Area
 
 AirQo provides three methods for spatial data selection:
 
@@ -48,6 +17,6 @@ AirQo provides three methods for spatial data selection:
 - **Method 2 – Grid API**: Query data by geographic coordinates or administrative boundaries (districts, divisions, parishes). See the [AirQo API documentation](../../api/intro.md).
 - **Method 3 – Manual Monitor Selection**: Use the Analytics Platform interactive map to identify and select individual monitors within your study region.
 
-### 3.3 Geographic Coverage
+### 3.2 Geographic Coverage
 
 Visit our [network coverage page](https://airqo.net/solutions/network-coverage) for monitor locations, or contact [support@airqo.net](mailto:support@airqo.net) for specific coverage in your study area.

--- a/src/docs-website/docs/data-access/researchers-guide/support-and-contact-information.md
+++ b/src/docs-website/docs/data-access/researchers-guide/support-and-contact-information.md
@@ -1,9 +1,9 @@
 ---
-sidebar_position: 16
-sidebar_label: 15. Support & Contact Information
+sidebar_position: 17
+sidebar_label: 16. Support & Contact Information
 ---
 
-# 15. Support and Contact Information
+# 16. Support and Contact Information
 
 | | |
 |---|---|

--- a/src/docs-website/docs/data-access/researchers-guide/terms-of-use.md
+++ b/src/docs-website/docs/data-access/researchers-guide/terms-of-use.md
@@ -1,9 +1,9 @@
 ---
-sidebar_position: 18
-sidebar_label: 17. Terms of Use
+sidebar_position: 19
+sidebar_label: 18. Terms of Use
 ---
 
-# 17. Terms of Use
+# 18. Terms of Use
 
 ### Data Use Agreement
 

--- a/src/docs-website/docs/data-access/researchers-guide/who-air-quality-guidelines-reference.md
+++ b/src/docs-website/docs/data-access/researchers-guide/who-air-quality-guidelines-reference.md
@@ -1,9 +1,9 @@
 ---
-sidebar_position: 13
-sidebar_label: 12. WHO Air Quality Guidelines
+sidebar_position: 14
+sidebar_label: 13. WHO Air Quality Guidelines
 ---
 
-# 12. WHO Air Quality Guidelines Reference
+# 13. WHO Air Quality Guidelines Reference
 
 | Pollutant | Averaging Period | WHO 2021 Guideline Level |
 |-----------|-----------------|--------------------------|


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?

Adds three new pieces of partner/researcher-facing documentation to the Data Access Guide on the docs website:

- **Device Claiming Guide** — a new guide (`data-access/device-claiming-guide/`) walking partners through claiming an AirQo device onto their account: the main QR/claim-token flow, alternative scenarios (no token, bulk claiming, recalled devices, orphaned devices), and a completion/troubleshooting reference.
- **Device Performance & SLA Guide** — a new guide (`data-access/device-performance-guide/`) covering what the monitors measure, data reporting frequency by power source/firmware, uptime and data-availability targets, maintenance responsibilities and cost options, and environmental factors affecting performance.
- **Location approximation guidance** — expanded the existing coordinate-approximation policy section in the researchers guide with concrete best practices, and corrected/extended the `grids/summary` endpoint reference in the API docs (fixed field names to match the real API, clarified it needs no auth token, added JS/Python code samples). Added deep-linked FAQ entries so common questions can be answered with a direct link straight into the relevant section instead of a whole guide.

### Why is this change needed?

Partners repeatedly ask the same questions — how to claim a device, what uptime/data availability to expect, why their device doesn't appear in the exact spot on the map — that previously had no canonical, linkable answer in the docs. This consolidates that guidance so the team can share a direct link instead of re-explaining it each time.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [x] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:** `docs-website` only — no application/backend service code was changed. The API reference edits describe an existing `device-registry` endpoint but do not modify it.

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:** Ran `docusaurus build` after each round of edits — clean build, no broken links. Verified generated anchor IDs (e.g. `#31-location-approximation-for-monitor-coordinates`, `#grid-summary-with-site-details`) directly in the build output to confirm the new deep-linked FAQ entries resolve correctly. Confirmed the corrected API field names (`approximate_latitude`/`approximate_longitude`) and no-auth behavior of `GET /devices/grids/summary` against the `device-registry` route/model source.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

- The Device Uptime Targets table only publishes the one configuration confirmed by source notes (Solar + New Firmware V42.74 → 90%); the other three combinations were dropped rather than guessed, since the source table was incomplete. Follow-up needed to fill these in.
- Other open follow-ups from the SLA source notes: no linked "detailed maintenance guide" document yet, no concrete pricing for either maintenance option (training vs. on-site), and the reporting-frequency table only covers Binos devices.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review
