### PR TITLE
Rename Analytics Platform to AirQo Nexus in docs

### DIFF
--- a/src/docs-website/docs/data-access/device-claiming-guide/main-claiming-flow.md
+++ b/src/docs-website/docs/data-access/device-claiming-guide/main-claiming-flow.md
@@ -20,4 +20,4 @@ This is the happy path: your device shipped with a printed claim label attached.
 QR codes remove the risk of mistyping a claim token (letters vs. digits, e.g. `0` vs `O`). Scan the label whenever your device has a camera-readable code available.
 :::
 
-Once your device is claimed, its readings become available through the same channels covered in the [Data Access Guide for Researchers](../researchers-guide/data-access-channels.md) — mobile app, Analytics Platform, and API.
+Once your device is claimed, its readings become available through the same channels covered in the [Data Access Guide for Researchers](../researchers-guide/data-access-channels.md) — mobile app, AirQo Nexus, and API.

--- a/src/docs-website/docs/data-access/fair-usage-policy/contact-and-support.md
+++ b/src/docs-website/docs/data-access/fair-usage-policy/contact-and-support.md
@@ -12,7 +12,7 @@ AirQo is committed to supporting researchers and will gladly provide guidance on
 | **General Enquiries & Support** | [support@airqo.net](mailto:support@airqo.net) |
 | **Website** | https://airqo.africa |
 | **API Documentation** | [AirQo API →](../../api/intro.md) |
-| **Analytics Platform** | https://airqo.africa/products/analytics |
+| **AirQo Nexus** | https://airqo.africa/products/nexus |
 | **Network Coverage** | https://airqo.net/solutions/network-coverage |
 | **Response Time** | 3–5 business days (mark urgent requests in the subject line) |
 

--- a/src/docs-website/docs/data-access/fair-usage-policy/fair-usage-principles.md
+++ b/src/docs-website/docs/data-access/fair-usage-policy/fair-usage-principles.md
@@ -10,7 +10,7 @@ All users — regardless of seniority, institutional affiliation, or urgency of 
 | Principle | What It Means in Practice |
 |-----------|--------------------------|
 | **Batch Your Downloads** | Break multi-year data requests into quarterly or monthly chunks. Do not attempt to circumvent batch limits through workarounds. |
-| **Use the Right Tool** | Use the Analytics Platform for exploratory and moderate-sized downloads. Use the API for automated, large-scale, or programmatic access. |
+| **Use the Right Tool** | Use the AirQo Nexus for exploratory and moderate-sized downloads. Use the API for automated, large-scale, or programmatic access. |
 | **Use Calibrated Data** | Always download calibrated (not raw) data for research. This reduces the need for repeated re-downloads to apply corrections. |
 | **Download Once, Store Locally** | Save your downloaded files. Do not re-download the same data multiple times. Maintain a local archive for your study period. |
 | **Apply Quality Control Locally** | AirQo recommends a ≥50% data completeness threshold. Apply QC filters after downloading, not by requesting new downloads. |

--- a/src/docs-website/docs/data-access/fair-usage-policy/how-to-download-large-datasets.md
+++ b/src/docs-website/docs/data-access/fair-usage-policy/how-to-download-large-datasets.md
@@ -7,11 +7,11 @@ sidebar_label: 3. How to Download Large Datasets
 
 Obtaining multi-year datasets is entirely possible. It simply requires breaking up your requests into manageable batches, which is standard practice in data-intensive research and reflects good data management hygiene.
 
-### 3.1 Recommended Approach: Batch Downloads via the Analytics Platform
+### 3.1 Recommended Approach: Batch Downloads via the AirQo Nexus
 
-For most academic and public health researchers, the Analytics Platform is the simplest and most accessible option. Follow this workflow:
+For most academic and public health researchers, the AirQo Nexus is the simplest and most accessible option. Follow this workflow:
 
-1. Navigate to the AirQo Analytics Platform: https://airqo.africa/products/analytics
+1. Navigate to the AirQo Nexus: https://airqo.africa/products/nexus
 2. Select your study area (e.g., Kampala) and the monitors of interest.
 3. Choose a data frequency (hourly is recommended for seasonal analysis).
 4. Set your date range to a three-month window (e.g., January – March 2019).

--- a/src/docs-website/docs/data-access/fair-usage-policy/quick-reference-summary.md
+++ b/src/docs-website/docs/data-access/fair-usage-policy/quick-reference-summary.md
@@ -7,11 +7,11 @@ sidebar_label: 7. Quick Reference Summary
 
 | Topic | Summary |
 |-------|---------|
-| **Download Limit** | ~3 months per single query on Analytics Platform |
+| **Download Limit** | ~3 months per single query on AirQo Nexus |
 | **Reason** | Shared infrastructure; intentional and permanent design decision |
-| **6-Year Dataset** | ~24 quarterly downloads via Analytics Platform, or scripted API access |
+| **6-Year Dataset** | ~24 quarterly downloads via AirQo Nexus, or scripted API access |
 | **API Documentation** | [AirQo API →](../../api/intro.md) |
-| **Analytics Platform** | https://airqo.africa/products/analytics |
+| **AirQo Nexus** | https://airqo.africa/products/nexus |
 | **Recommended Data Type** | Calibrated data (not raw) |
 | **Recommended Frequency** | Hourly data for seasonal/temporal analysis |
 | **Completeness Threshold** | ≥50% of expected readings per monitor per period |

--- a/src/docs-website/docs/data-access/fair-usage-policy/what-not-to-do.md
+++ b/src/docs-website/docs/data-access/fair-usage-policy/what-not-to-do.md
@@ -6,7 +6,7 @@ sidebar_label: 5. What Not To Do
 # 5. What Not To Do
 
 :::danger
-- Do not request bulk exports of more than three months in a single query on the Analytics Platform.
+- Do not request bulk exports of more than three months in a single query on the AirQo Nexus.
 - Do not send repeated automated API requests without rate-limiting your own scripts.
 - Do not request that AirQo staff manually extract and send multi-year bulk datasets on your behalf as a workaround to platform limits.
 - Do not share API credentials or export scripts with unlimited loop behaviour in public code repositories.

--- a/src/docs-website/docs/data-access/researchers-guide/appendix-quick-reference-checklist.md
+++ b/src/docs-website/docs/data-access/researchers-guide/appendix-quick-reference-checklist.md
@@ -8,10 +8,10 @@ sidebar_label: "Appendix: Quick Reference Checklist"
 ### Before Starting Your Research
 
 - [ ] Review AirQo calibration methodology paper.
-- [ ] Identify monitors in your study area using the Analytics Platform map.
+- [ ] Identify monitors in your study area using the AirQo Nexus map.
 - [ ] Check data availability for your study period.
 - [ ] Plan your download batches (quarterly recommended for multi-year studies).
-- [ ] Determine appropriate data access method (Analytics Platform vs. API).
+- [ ] Determine appropriate data access method (AirQo Nexus vs. API).
 - [ ] Register for API access if needed.
 - [ ] Review WHO guidelines for your pollutants of interest.
 

--- a/src/docs-website/docs/data-access/researchers-guide/best-practices-for-researchers.md
+++ b/src/docs-website/docs/data-access/researchers-guide/best-practices-for-researchers.md
@@ -9,7 +9,7 @@ sidebar_label: 12. Best Practices for Researchers
 
 1. **Define your study period and geographic region.** Identify monitor boundaries and consider seasonal data availability.
 2. **Use calibrated (not raw) data.** Always download calibrated data for research analysis and document the calibration version.
-3. **Download data in quarterly batches** via the Analytics Platform or use the API for automated access. Save raw downloaded files as backup.
+3. **Download data in quarterly batches** via the AirQo Nexus or use the API for automated access. Save raw downloaded files as backup.
 4. **Assess data quality.** Calculate completeness for each monitor and time period. Flag monitors with consistent low uptime.
 5. **Apply quality control filters.** Implement the 50% completeness threshold (or justify an alternative). Remove obvious outliers with documentation.
 6. **Document everything.** Record all data processing steps, inclusion/exclusion criteria, and maintain metadata on monitor locations and characteristics.

--- a/src/docs-website/docs/data-access/researchers-guide/data-access-channels.md
+++ b/src/docs-website/docs/data-access/researchers-guide/data-access-channels.md
@@ -10,7 +10,7 @@ sidebar_label: 8. Data Access Channels
 | Channel | Best For | Link |
 |---------|----------|------|
 | Mobile App (iOS/Android) | Field work, real-time monitoring | https://airqo.africa/products/mobile-app |
-| Analytics Platform | Researchers, visualisation, historical analysis, CSV export | https://airqo.africa/products/analytics |
+| AirQo Nexus | Researchers, visualisation, historical analysis, CSV export | https://airqo.africa/products/nexus |
 | API (RESTful) | Programmatic, large-scale, automated pipelines | https://airqo.africa/products/api |
 | Network Coverage Explorer | Metadata on Africa's air quality monitoring landscape (stations, instrumentation, institutional ownership) | https://airqo.net/solutions/network-coverage |
 
@@ -27,7 +27,7 @@ This is useful for researchers who need to understand *where* monitoring exists 
 ### Downloading Large Historical Datasets
 
 :::warning Batch download limit
-The Analytics Platform limits single exports to approximately three months of data. This is an intentional, permanent design decision to ensure equitable system performance for all users. For multi-year datasets, download data in quarterly batches and combine the files in your analysis software.
+The AirQo Nexus limits single exports to approximately three months of data. This is an intentional, permanent design decision to ensure equitable system performance for all users. For multi-year datasets, download data in quarterly batches and combine the files in your analysis software.
 :::
 
 For automated or large-scale data access, use the [AirQo API](../../api/intro.md) with appropriate rate-limiting in your scripts. Full guidance on batch workflows and API access is provided in the [companion fair usage document](../fair-usage-policy/index.md).
@@ -44,4 +44,4 @@ Academic researchers requiring higher API access than the free tier provides are
 
 ### Data Access Costs
 
-Data access is free of charge across the mobile app and Analytics Platform, consistent with our open-access philosophy. API subscription packages help subsidise computing infrastructure costs while maintaining free access for standard research use.
+Data access is free of charge across the mobile app and AirQo Nexus, consistent with our open-access philosophy. API subscription packages help subsidise computing infrastructure costs while maintaining free access for standard research use.

--- a/src/docs-website/docs/data-access/researchers-guide/frequently-asked-questions.md
+++ b/src/docs-website/docs/data-access/researchers-guide/frequently-asked-questions.md
@@ -25,7 +25,7 @@ Ensure consistent QC criteria across cities, account for differences in monitor 
 Monitor coordinates are provided in WGS84 (latitude/longitude). Verify in the metadata when downloading.
 
 **Can I access raw 10-minute data?**
-Yes. The Analytics Platform provides pre-aggregated hourly/daily data. The API can provide 10-minute resolution.
+Yes. The AirQo Nexus provides pre-aggregated hourly/daily data. The API can provide 10-minute resolution.
 
 **How do I handle outliers?**
 Investigate extreme values before removal. Check for sensor malfunction periods, genuine extreme pollution events, and data transmission errors. Document your approach transparently.
@@ -50,7 +50,7 @@ AirQo covers the device and its software; you're responsible for your AirQloud's
 ### Data Access Questions
 
 **I need data urgently for a deadline.**
-Data is immediately available through the Analytics Platform and API. For large custom requests, plan ahead and allow additional time.
+Data is immediately available through the AirQo Nexus and API. For large custom requests, plan ahead and allow additional time.
 
 **My download failed or seems incomplete.**
 Contact [support@airqo.net](mailto:support@airqo.net) with the time and date of your download attempt, monitors and date range requested, platform used, and any error messages.

--- a/src/docs-website/docs/data-access/researchers-guide/index.md
+++ b/src/docs-website/docs/data-access/researchers-guide/index.md
@@ -33,7 +33,7 @@ Equitable access means every user — from a PhD student in Kampala to a governm
 
 ## How Equitable Access Works in Practice
 
-The most visible manifestation of our fair usage policy is the download batch limit on the Analytics Platform: single data exports are capped at approximately three months of data per query. This is not a bug, a temporary limitation, or something that will be removed upon request. It is an intentional engineering decision.
+The most visible manifestation of our fair usage policy is the download batch limit on the AirQo Nexus: single data exports are capped at approximately three months of data per query. This is not a bug, a temporary limitation, or something that will be removed upon request. It is an intentional engineering decision.
 
 The rationale is straightforward: a single query for six years of hourly data across 50+ monitors could request tens of millions of database rows, consuming significant server memory, CPU time, and bandwidth. If this were permitted without restriction, it would degrade service for every other concurrent user.
 

--- a/src/docs-website/docs/data-access/researchers-guide/location-approximation.md
+++ b/src/docs-website/docs/data-access/researchers-guide/location-approximation.md
@@ -13,7 +13,7 @@ For privacy and security reasons, all monitoring station coordinates provided th
 |---|---|
 | **Offset Range** | Approximately 0.5 kilometres from actual physical locations |
 | **Consistency** | Approximated coordinates remain consistent across all queries |
-| **Affected Platforms** | All data access methods: Analytics Platform, API, mobile app |
+| **Affected Platforms** | All data access methods: AirQo Nexus, API, mobile app |
 
 ## Implications for Research
 

--- a/src/docs-website/docs/data-access/researchers-guide/spatial-disaggregation-and-geographic-filtering.md
+++ b/src/docs-website/docs/data-access/researchers-guide/spatial-disaggregation-and-geographic-filtering.md
@@ -13,9 +13,9 @@ Coordinate approximation now has its own page: [4. Location Approximation](./loc
 
 AirQo provides three methods for spatial data selection:
 
-- **Method 1 – Analytics Platform (Bulk Export)**: Select specific cities or regions, choose individual monitoring sites, define custom date ranges, and export in CSV format.
+- **Method 1 – AirQo Nexus (Bulk Export)**: Select specific cities or regions, choose individual monitoring sites, define custom date ranges, and export in CSV format.
 - **Method 2 – Grid API**: Query data by geographic coordinates or administrative boundaries (districts, divisions, parishes). See the [AirQo API documentation](../../api/intro.md).
-- **Method 3 – Manual Monitor Selection**: Use the Analytics Platform interactive map to identify and select individual monitors within your study region.
+- **Method 3 – Manual Monitor Selection**: Use the AirQo Nexus interactive map to identify and select individual monitors within your study region.
 
 ### 3.2 Geographic Coverage
 

--- a/src/docs-website/docs/data-access/researchers-guide/support-and-contact-information.md
+++ b/src/docs-website/docs/data-access/researchers-guide/support-and-contact-information.md
@@ -9,7 +9,7 @@ sidebar_label: 16. Support & Contact Information
 |---|---|
 | **Primary Contact** | [support@airqo.net](mailto:support@airqo.net) |
 | **Website** | https://airqo.africa |
-| **Analytics Platform** | https://airqo.africa/products/analytics |
+| **AirQo Nexus** | https://airqo.africa/products/nexus |
 | **API Documentation** | [AirQo API →](../../api/intro.md) |
 | **Network Coverage** | https://airqo.net/solutions/network-coverage |
 | **Response Time** | 3–5 business days (mark urgent requests in subject line) |


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
<!-- Brief summary of the changes -->
Renames the "Analytics Platform" product references to "AirQo Nexus" across the data access documentation, and fixes the dead product link from `airqo.africa/products/analytics` to `airqo.africa/products/nexus`.

### Why is this change needed?
<!-- Explain the motivation/problem this solves -->
The AirQo Analytics product was recently renamed to AirQo Nexus, and its website page moved to a new URL. The data access docs still referenced the old name and linked to a page that no longer exists, which would confuse readers and produce broken links.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [x] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `docs-website`

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:**
Manually verified via `grep` that no remaining references to `products/analytics` or "Analytics Platform" exist anywhere under `docs/data-access/`, and confirmed the new `AirQo Nexus` naming and `products/nexus` link read correctly in context across all 14 updated files.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

<!-- If breaking changes, explain what breaks and migration steps -->

---

## :memo: Additional Notes
<!-- Any additional context, dependencies, or concerns -->
Only the `docs/data-access/` documentation was updated, since that was the reported scope. Other docs mentioning "Analytics" (e.g. `docs/api/analytics-api/`) refer to the API product name and were intentionally left unchanged.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated data access, fair usage, research, and support guidance to reference AirQo Nexus instead of the Analytics Platform.
  * Updated product links and navigation URLs to point to AirQo Nexus.
  * Clarified AirQo Nexus availability across device readings, downloads, FAQs, access methods, and research workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->