### PR TITLE
Add device-to-map visibility timeline FAQ

### DIFF
--- a/src/docs-website/docs/data-access/device-claiming-guide/completion-and-troubleshooting.md
+++ b/src/docs-website/docs/data-access/device-claiming-guide/completion-and-troubleshooting.md
@@ -11,7 +11,7 @@ Claiming has succeeded once:
 
 - ✅ Device shows up under "My Devices" with status "claimed."
 - ✅ Device is attached to a cohort/group (either the one you chose, your personal default, or completed later via "Complete Device Setup").
-- ✅ You can see incoming readings once the device starts transmitting.
+- ✅ You can see incoming readings once the device starts transmitting — see [How long does it take for a newly deployed device to appear on the map?](../researchers-guide/frequently-asked-questions.md#device-visibility-questions) for typical timing.
 
 ## Troubleshooting
 

--- a/src/docs-website/docs/data-access/device-claiming-guide/completion-and-troubleshooting.md
+++ b/src/docs-website/docs/data-access/device-claiming-guide/completion-and-troubleshooting.md
@@ -11,7 +11,7 @@ Claiming has succeeded once:
 
 - ✅ Device shows up under "My Devices" with status "claimed."
 - ✅ Device is attached to a cohort/group (either the one you chose, your personal default, or completed later via "Complete Device Setup").
-- ✅ You can see incoming readings once the device starts transmitting — see [How long does it take for a newly deployed device to appear on the map?](../researchers-guide/frequently-asked-questions.md#device-visibility-questions) for typical timing.
+- ✅ You can see incoming readings once the device starts transmitting. It may take a further **1–6 hours** to appear on the AirQo Nexus map — see [How long does it take for a newly deployed device to appear on the map?](../researchers-guide/frequently-asked-questions.md#device-visibility-questions) for typical timing.
 
 ## Troubleshooting
 

--- a/src/docs-website/docs/data-access/researchers-guide/frequently-asked-questions.md
+++ b/src/docs-website/docs/data-access/researchers-guide/frequently-asked-questions.md
@@ -50,12 +50,12 @@ AirQo covers the device and its software; you're responsible for your AirQloud's
 ### Device Visibility Questions
 
 **How long does it take for a newly deployed device to appear on the map?**
-Once a device is actively transmitting data, it typically appears on the AirQo Nexus map within **1–6 hours**. There's no manual step on our end — the pipeline is fully automated — but it runs on scheduled cycles rather than instantly, so some wait is normal. Here's where that time goes:
+Once a device is deployed, it typically appears on the AirQo Nexus map within **1–6 hours of starting to transmit data**. There's no manual step on our end — the pipeline is fully automated — but it runs on scheduled cycles rather than instantly, so some wait is normal. Here's where that time goes:
 
 | Stage | Typical time added |
 |---|---|
 | Device recorded as deployed | Immediate |
-| Device starts transmitting (hardware/network-dependent) | Varies — outside the pipeline's control |
+| Device starts transmitting (hardware/network-dependent) | Varies — happens before the 1–6 hour window begins |
 | Pipeline recognises the new device | Up to ~3 hours |
 | Readings collected, calibrated, and processed | Up to ~1–2 hours |
 | Processed readings made queryable | Up to ~1 hour |

--- a/src/docs-website/docs/data-access/researchers-guide/frequently-asked-questions.md
+++ b/src/docs-website/docs/data-access/researchers-guide/frequently-asked-questions.md
@@ -47,6 +47,31 @@ See [Device Uptime Targets](../device-performance-guide/device-uptime-targets.md
 **Who is responsible for maintaining my device, and what does it cost?**
 AirQo covers the device and its software; you're responsible for your AirQloud's reliability. See [Maintenance Cost Options](../device-performance-guide/maintenance-and-support.md#maintenance-cost-options) for the knowledge-transfer vs. on-site maintenance choices.
 
+### Device Visibility Questions
+
+**How long does it take for a newly deployed device to appear on the map?**
+Once a device is actively transmitting data, it typically appears on the AirQo Nexus map within **1–6 hours**. There's no manual step on our end — the pipeline is fully automated — but it runs on scheduled cycles rather than instantly, so some wait is normal. Here's where that time goes:
+
+| Stage | Typical time added |
+|---|---|
+| Device recorded as deployed | Immediate |
+| Device starts transmitting (hardware/network-dependent) | Varies — outside the pipeline's control |
+| Pipeline recognises the new device | Up to ~3 hours |
+| Readings collected, calibrated, and processed | Up to ~1–2 hours |
+| Processed readings made queryable | Up to ~1 hour |
+| Map displays the device | Near-instant; refresh the map if a view was already open |
+
+**Why isn't my new device showing up yet?**
+The most common causes, roughly in order of likelihood:
+- **Cycle timing** — the pipeline runs on periodic (hourly/multi-hourly) cycles, not continuously. A device deployed just after a cycle has run waits almost a full cycle for the next one. This is the most common cause, and isn't a fault.
+- **Not transmitting yet** — power, SIM/connectivity, or wiring issues at the deployment site mean there's no data yet to process. This is a field/hardware issue, not a pipeline delay — see [Factors Affecting Performance](../device-performance-guide/factors-affecting-performance.md).
+- **Missing or incorrect site coordinates** — the map only shows devices whose site has valid location data. Data can be flowing correctly and still never appear on the map until the site's coordinates are corrected.
+- **Browser/map caching** — if the map was already open, it may be showing a snapshot from a few minutes earlier. Refresh before assuming a backend delay.
+- **Recalled or deactivated devices** — stop appearing on the map within the same processing cycles above; this is expected behaviour, not a fault.
+
+**When should I escalate a device that hasn't appeared on the map?**
+If the device has been confirmed to be actively transmitting for more than **6 hours** and its site's location data is verified correct, it's reasonable to contact [support@airqo.net](mailto:support@airqo.net) rather than continue waiting.
+
 ### Data Access Questions
 
 **I need data urgently for a deadline.**


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Adds a new "Device Visibility Questions" subsection to the Data Access researchers guide FAQ explaining how long a newly deployed device typically takes to appear on the AirQo Nexus map (1–6 hours), the stage-by-stage breakdown of that time, common causes of delay, and when to escalate to support. Also cross-links this new FAQ entry from the device-claiming guide's completion checklist.

### Why is this change needed?
External stakeholders and partners frequently ask how long it takes for a newly deployed device to show up on the map, and there was no documented answer. This content was extracted from an internal reference document and adapted into the existing FAQ format so partners can self-serve the answer instead of asking support each time.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [x] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:** docs-website

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [ ] All existing tests pass

**Test summary:** Verified the new FAQ subsection and its internal anchor link render correctly by reviewing the rendered Markdown; confirmed the cross-link from the device-claiming completion checklist points to the correct section anchor.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

Source content was adapted from an internal temporary reference doc (`DEVICE_MAP_VISIBILITY_TIMELINE.md` in the device-registry service); its internal-only notes (document status, audience, future infra roadmap) were intentionally left out of the public-facing FAQ.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added FAQ guidance on when newly deployed devices appear on the AirQo Nexus map.
  * Included expected timing by deployment stage, common reasons for delays, and escalation guidance after six hours.
  * Linked the device-claiming completion criteria to the new timing information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->