### PR TITLE
fix(vertex): remove dead user.networks permission paths

### DIFF
--- a/src/vertex/app/api/network/route.ts
+++ b/src/vertex/app/api/network/route.ts
@@ -5,6 +5,7 @@ import logger from "@/lib/logger";
 import { CreateNetworkPayload, CreateNetworkResponse } from "@/core/apis/networks";
 import axios from "axios";
 import { networkFormSchema } from "@/components/features/networks/schema";
+import { buildServerApiUrl } from "@/lib/api-routing";
 
 /**
  * Retrieves the access token from the server-side session.
@@ -63,7 +64,7 @@ export async function POST(req: NextRequest) {
 
     const payload: CreateNetworkPayload = { ...networkData, admin_secret: adminSecret };
 
-    const backendApiUrl = `${process.env.NEXT_PUBLIC_API_URL}/devices/networks`;
+    const backendApiUrl = buildServerApiUrl('/devices/networks');
 
     const apiResponse = await axios.post<CreateNetworkResponse>(backendApiUrl, payload, {
       headers: {

--- a/src/vertex/app/api/network/route.ts
+++ b/src/vertex/app/api/network/route.ts
@@ -63,7 +63,7 @@ export async function POST(req: NextRequest) {
 
     const payload: CreateNetworkPayload = { ...networkData, admin_secret: adminSecret };
 
-    const backendApiUrl = `${process.env.NEXT_PUBLIC_API_URL}/users/networks`;
+    const backendApiUrl = `${process.env.NEXT_PUBLIC_API_URL}/devices/networks`;
 
     const apiResponse = await axios.post<CreateNetworkResponse>(backendApiUrl, payload, {
       headers: {

--- a/src/vertex/core/apis/networks.ts
+++ b/src/vertex/core/apis/networks.ts
@@ -101,7 +101,7 @@ export const networks = {
   getNetworksApi: async (): Promise<Network[]> => {
     try {
       const response = await createSecureApiClient().get<NetworksSummaryResponse>(
-        `/users/networks`,
+        `/devices/networks`,
         { headers: { "X-Auth-Type": "JWT" } }
       );
       return response.data.networks || [];

--- a/src/vertex/core/hooks/usePermissions.test.tsx
+++ b/src/vertex/core/hooks/usePermissions.test.tsx
@@ -43,7 +43,6 @@ describe("usePermissions", () => {
           user: { 
             userDetails: mockUser,
             activeGroup: { _id: "org-1" },
-            activeNetwork: { _id: "net-1" },
           } 
         },
       });
@@ -54,7 +53,6 @@ describe("usePermissions", () => {
         PERMISSIONS.DEVICE.VIEW, 
         expect.objectContaining({
           activeOrganization: { _id: "org-1" },
-          activeNetwork: { _id: "net-1" }
         })
       );
     });

--- a/src/vertex/core/hooks/usePermissions.ts
+++ b/src/vertex/core/hooks/usePermissions.ts
@@ -42,14 +42,13 @@ export const MOCK_PERMISSIONS: Partial<Record<Permission, boolean>> = {
  * the fallback handles the null case internally.
  *
  * Both this hook and useHasAnyPermission use the same spread-last merge pattern:
- * defaults (activeGroup/activeNetwork) are set first, then `...context` is spread
+ * defaults (activeGroup) are set first, then `...context` is spread
  * on top. This means an explicit `activeOrganization: undefined` in context IS
  * honoured and produces a global (all-orgs) check, which is the intended escape hatch.
  */
 export const usePermission = (permission: Permission, context?: Partial<AccessContext>) => {
   const user = useAppSelector((state) => state.user.userDetails);
   const activeGroup = useAppSelector((state) => state.user.activeGroup);
-  const activeNetwork = useAppSelector((state) => state.user.activeNetwork);
   const userContext = useAppSelector((state) => state.user.userContext);
 
   const result = useMemo(() => {
@@ -61,10 +60,9 @@ export const usePermission = (permission: Permission, context?: Partial<AccessCo
 
     return permissionService.hasPermission(user, permission, {
       activeOrganization: activeGroup ?? undefined,
-      activeNetwork: activeNetwork ?? undefined,
       ...context,
     });
-  }, [user, permission, activeGroup, activeNetwork, userContext, context]);
+  }, [user, permission, activeGroup, userContext, context]);
 
   return result;
 };
@@ -75,7 +73,6 @@ export const usePermission = (permission: Permission, context?: Partial<AccessCo
 export const usePermissionCheck = (permission: Permission, context?: Partial<AccessContext>) => {
   const user = useAppSelector((state) => state.user.userDetails);
   const activeGroup = useAppSelector((state) => state.user.activeGroup);
-  const activeNetwork = useAppSelector((state) => state.user.activeNetwork);
 
   return useMemo(() => {
     if (!user) {
@@ -87,10 +84,9 @@ export const usePermissionCheck = (permission: Permission, context?: Partial<Acc
 
     return permissionService.checkPermission(user, permission, {
       activeOrganization: activeGroup ?? undefined,
-      activeNetwork: activeNetwork ?? undefined,
       ...context,
     });
-  }, [user, permission, activeGroup, activeNetwork, context]);
+  }, [user, permission, activeGroup, context]);
 };
 
 /**
@@ -193,7 +189,6 @@ export const usePermissionDescription = (permission: Permission) => {
 export const usePermissions = (permissions: Permission[], context?: Partial<AccessContext>) => {
   const user = useAppSelector((state) => state.user.userDetails);
   const activeGroup = useAppSelector((state) => state.user.activeGroup);
-  const activeNetwork = useAppSelector((state) => state.user.activeNetwork);
 
   const result = useMemo(() => {
     if (MOCK_PERMISSIONS_ENABLED) {
@@ -213,12 +208,11 @@ export const usePermissions = (permissions: Permission[], context?: Partial<Acce
     return permissions.reduce((acc, permission) => {
       acc[permission] = permissionService.hasPermission(user, permission, {
         activeOrganization: activeGroup ?? undefined,
-        activeNetwork: activeNetwork ?? undefined,
         ...context,
       });
       return acc;
     }, {} as Record<Permission, boolean>);
-  }, [user, permissions, activeGroup, activeNetwork, context]);
+  }, [user, permissions, activeGroup, context]);
 
   return result;
 };
@@ -232,7 +226,6 @@ export const usePermissions = (permissions: Permission[], context?: Partial<Acce
 export const useHasAnyPermission = (permissions: Permission[], context?: Partial<AccessContext>) => {
   const user = useAppSelector((state) => state.user.userDetails);
   const activeGroup = useAppSelector((state) => state.user.activeGroup);
-  const activeNetwork = useAppSelector((state) => state.user.activeNetwork);
 
   return useMemo(() => {
     if (MOCK_PERMISSIONS_ENABLED) {
@@ -244,11 +237,10 @@ export const useHasAnyPermission = (permissions: Permission[], context?: Partial
     return permissions.some((permission) =>
       permissionService.hasPermission(user, permission, {
         activeOrganization: activeGroup ?? undefined,
-        activeNetwork: activeNetwork ?? undefined,
         ...context,
       })
     );
-  }, [user, permissions, activeGroup, activeNetwork, context]);
+  }, [user, permissions, activeGroup, context]);
 };
 
 /**
@@ -257,7 +249,6 @@ export const useHasAnyPermission = (permissions: Permission[], context?: Partial
 export const useHasAllPermissions = (permissions: Permission[], context?: Partial<AccessContext>) => {
   const user = useAppSelector((state) => state.user.userDetails);
   const activeGroup = useAppSelector((state) => state.user.activeGroup);
-  const activeNetwork = useAppSelector((state) => state.user.activeNetwork);
 
   return useMemo(() => {
     if (MOCK_PERMISSIONS_ENABLED) {
@@ -269,9 +260,8 @@ export const useHasAllPermissions = (permissions: Permission[], context?: Partia
     return permissions.every((permission) =>
       permissionService.hasPermission(user, permission, {
         activeOrganization: activeGroup ?? undefined,
-        activeNetwork: activeNetwork ?? undefined,
         ...context,
       })
     );
-  }, [user, permissions, activeGroup, activeNetwork, context]);
+  }, [user, permissions, activeGroup, context]);
 };

--- a/src/vertex/core/permissions/permissionService.ts
+++ b/src/vertex/core/permissions/permissionService.ts
@@ -1,11 +1,10 @@
-import { UserDetails, Network, Group } from "@/app/types/users";
+import { UserDetails, Group } from "@/app/types/users";
 import { PERMISSIONS, Permission, mapLegacyPermission } from "./constants";
 
 // Access context for permission checking
 export interface AccessContext {
   user: UserDetails;
   activeOrganization?: Group;
-  activeNetwork?: Network;
   userRoles?: string[];
   requestedPermission: Permission;
   resourceContext?: {
@@ -124,13 +123,6 @@ class PermissionService {
       mapped.forEach((p) => permissions.add(p));
     };
 
-    // From user's networks
-    if (user.networks) {
-      user.networks.forEach((network) => {
-        network.role?.role_permissions?.forEach((rp) => addPerm(rp.permission));
-      });
-    }
-
     // From user's groups
     if (user.groups) {
       user.groups.forEach((group) => {
@@ -181,15 +173,7 @@ class PermissionService {
    * Get user's role in specific organization
    */
   getUserRole(user: UserDetails, organizationId?: string): string | undefined {
-    if (!user.networks && !user.groups) return undefined;
-
-    // Check networks first
-    if (user.networks) {
-      const networkRole = user.networks.find((network) => network._id === organizationId);
-      if (networkRole?.role?.role_name) {
-        return networkRole.role.role_name;
-      }
-    }
+    if (!user.groups) return undefined;
 
     // Check groups
     if (user.groups) {
@@ -206,19 +190,14 @@ class PermissionService {
    * Check if user is super admin
    */
   isSuperAdmin(user: UserDetails): boolean {
-    if (!user.networks && !user.groups) return false;
-
-    // Check if user has SUPER_ADMIN permission in any network
-    const hasSuperAdminNetwork = !!user.networks?.some((network) =>
-      network.role?.role_permissions?.some((p) => p.permission === PERMISSIONS.SYSTEM.SUPER_ADMIN)
-    );
+    if (!user.groups) return false;
 
     // Check if user has SUPER_ADMIN permission in any group
     const hasSuperAdminGroup = !!user.groups?.some((group) =>
       group.role?.role_permissions?.some((p) => p.permission === PERMISSIONS.SYSTEM.SUPER_ADMIN)
     );
 
-    return hasSuperAdminNetwork || hasSuperAdminGroup;
+    return hasSuperAdminGroup;
   }
 
   /**
@@ -261,18 +240,6 @@ class PermissionService {
   getOrganizationPermissions(user: UserDetails, organizationId: string): Permission[] {
     const permissions = new Set<Permission>();
 
-    // Check networks
-    if (user.networks) {
-      const network = user.networks.find((n) => n._id === organizationId);
-      if (network?.role?.role_permissions) {
-        network.role.role_permissions.forEach((permission) => {
-          if (permission.permission) {
-            permissions.add(permission.permission as Permission);
-          }
-        });
-      }
-    }
-
     // Check groups
     if (user.groups) {
       const group = user.groups.find((g) => g._id === organizationId);
@@ -301,19 +268,6 @@ class PermissionService {
    */
   getUserRoles(user: UserDetails): Array<{ role: string; organizationId: string; organizationName: string }> {
     const roles: Array<{ role: string; organizationId: string; organizationName: string }> = [];
-
-    // Add network roles
-    if (user.networks) {
-      user.networks.forEach((network) => {
-        if (network.role?.role_name) {
-          roles.push({
-            role: network.role.role_name,
-            organizationId: network._id,
-            organizationName: network.net_name,
-          });
-        }
-      });
-    }
 
     // Add group roles
     if (user.groups) {


### PR DESCRIPTION
…seNetworks to device-registry (#3954)

#### Summary of Changes (What does this PR do?)

- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

#### Status of maturity (all need to be checked before merging):

- [ ] I've tested this locally
- [ ] I consider this code done
- [ ] This change ready to hit production in its current state
- [ ] The title of the PR states what changed and the related issues number (used for the release note).
- [ ] I've included issue number in the "Closes #ISSUE-NUMBER" part of the "[What are the relevant tickets?](#what-are-the-relevant-tickets)" section to [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [ ] I've updated corresponding documentation for the changes in this PR.
- [ ] I have written unit and/or e2e tests for my change(s).

#### How should this be manually tested?

- Please include the steps to be done inorder to setup and test this PR.

#### What are the relevant tickets?

- Closes #<enter issue number here>
- [Jira_card_number]() (If exists)

#### Screenshots (optional)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Network creation and network listings now use the correct device-network service, improving reliability when managing networks.
  * Permission checks now consistently use organization and group context, preventing outdated network-level roles from affecting access decisions.
* **Access Control**
  * Network-specific permission context and role evaluation have been removed; access is now determined through organization and group permissions.
  * Permission results are more consistent across supported access checks by using the same organization and group-based scope.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->