### PR TITLE
Document Mobile App Near You for proxy-site lookup

### DIFF
--- a/src/docs-website/docs/api/reference/finding-ids.md
+++ b/src/docs-website/docs/api/reference/finding-ids.md
@@ -52,6 +52,10 @@ A Site ID identifies a specific physical monitoring location.
 
 A Site ID looks like: `64f7b3e8c9d25a0013f2d456`
 
+:::note Don't know which site to use for a specific place?
+Not every neighbourhood or landmark has a monitoring site named after it. To find the closest active site to a location, the quickest option today is the **Near You** feature in the [AirQo Mobile App](https://airqo.net/explore/mobile-app) — it uses GPS to list the nearest active sites within 10 km. A coordinate-based lookup in the public API is planned but not yet available; contact [support@airqo.net](mailto:support@airqo.net) in the meantime.
+:::
+
 ---
 
 ## Device ID and Device Name

--- a/src/docs-website/docs/data-access/researchers-guide/frequently-asked-questions.md
+++ b/src/docs-website/docs/data-access/researchers-guide/frequently-asked-questions.md
@@ -85,3 +85,6 @@ Yes, data is open access. However, we encourage collaborators to access data dir
 
 **Why is my download limited to three months?**
 This is an intentional, permanent system design to ensure equitable access for all users. Please download data in quarterly batches. See the [Fair Usage Policy](../fair-usage-policy/index.md) for full guidance.
+
+#### The specific place I'm studying isn't listed as a monitoring site — what should I use instead?
+AirQo Nexus lists monitoring sites, not every neighbourhood or landmark, so a specific place of interest won't always have a site named after it. Use the closest active site as a proxy: the quickest way to find one is the **Near You** feature in the [AirQo Mobile App](https://airqo.net/explore/mobile-app) (Dashboard tab, or "Nearby" on the Map tab), which uses your phone's GPS to list the nearest active sites within 10 km. See [3.3 Finding the Nearest Monitor to a Specific Location](./spatial-disaggregation-and-geographic-filtering.md#33-finding-the-nearest-monitor-to-a-specific-location) for other options, including asking [support@airqo.net](mailto:support@airqo.net) to confirm the most appropriate proxy site for you.

--- a/src/docs-website/docs/data-access/researchers-guide/spatial-disaggregation-and-geographic-filtering.md
+++ b/src/docs-website/docs/data-access/researchers-guide/spatial-disaggregation-and-geographic-filtering.md
@@ -20,3 +20,15 @@ AirQo provides three methods for spatial data selection:
 ### 3.2 Geographic Coverage
 
 Visit our [network coverage page](https://airqo.net/solutions/network-coverage) for monitor locations, or contact [support@airqo.net](mailto:support@airqo.net) for specific coverage in your study area.
+
+### 3.3 Finding the Nearest Monitor to a Specific Location
+
+Not every neighbourhood, village, or landmark has a monitor named after it — AirQo Nexus lists monitoring **sites**, not every administrative area. If the specific place you're interested in doesn't appear in the site list, the fastest way to find a usable proxy site is by proximity rather than by name:
+
+- **AirQo Mobile App — "Near You"**: Install the [AirQo Mobile App](https://airqo.net/explore/mobile-app), enable location access, and open the **Near You** tab on the Dashboard (also available as a "Nearby" filter on the Map tab). It uses your phone's GPS to list the closest active monitoring sites within 10 km, nearest first. This is currently the quickest way for anyone — researchers included — to identify a proxy site for a location that isn't directly listed.
+- **Manually via the Nexus map**: On the [AirQo Nexus](https://airqo.net) interactive map, zoom in on your area of interest and visually identify the closest available site(s), keeping in mind the [~0.5 km coordinate approximation](./location-approximation.md) applied to all displayed locations.
+- **Ask AirQo support**: If you'd like AirQo to confirm the most appropriate proxy site for a specific location (e.g. for a paper or report), contact [support@airqo.net](mailto:support@airqo.net) with the location name or coordinates.
+
+:::note Programmatic coordinate-based lookup
+A coordinate-based "nearest sites" API is on our roadmap for researchers who need this programmatically rather than through the app. It isn't part of the public API yet — see the [Finding IDs](../../api/reference/finding-ids.md) page for currently available ways to look up Site IDs, or contact [support@airqo.net](mailto:support@airqo.net) in the meantime.
+:::


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?
Updates the Researchers' Guide and API reference docs to explain how to find a proxy monitoring site when the exact place a researcher is interested in (e.g. a neighbourhood or landmark) isn't listed as a named site in AirQo Nexus.

Specifically:
- Adds a new **"3.3 Finding the Nearest Monitor to a Specific Location"** section to the Spatial Disaggregation & Filtering page, pointing to the Mobile App's GPS-based **"Near You"** feature, the Nexus map as a manual fallback, and support escalation.
- Adds a matching FAQ entry: *"The specific place I'm studying isn't listed as a monitoring site — what should I use instead?"*
- Adds a callout on the **Finding IDs** API reference page under Site ID, so API users hit the same guidance.

### Why is this change needed?
A researcher using Nexus for data export emailed asking which site to use as a proxy for Busega, since it isn't one of the listed sites. This is a recurring gap in the docs — the guide explained how to select monitors by area, but never told researchers what to do when their specific place of interest has no matching site. The Mobile App's "Near You" feature already solves this (GPS-based, lists nearest active sites within 10 km, sorted nearest-first), it just wasn't documented anywhere for researchers.

Note: a coordinate-based "nearest sites" *API* endpoint exists in device-registry but is currently unused dead code with known bugs (unsorted results, ignored `online_status` filter, a client/server field-name mismatch), so it was deliberately **not** documented as a public API in this PR — only the working Mobile App feature is referenced. Flagged separately to the backend/mobile teams as follow-up cleanup.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [x] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**
- `docs-website` only (no application or API code changed)

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:** Ran `npx docusaurus build` locally — build completed successfully with no broken-link or broken-anchor warnings, confirming the new cross-references (Spatial Disaggregation ↔ FAQ ↔ Finding IDs ↔ Location Approximation) all resolve correctly. Docs-website has no automated content tests beyond the build's link checker.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

While researching the right recommendation, I traced the mobile app and device-registry backend to confirm the guidance would be accurate:
- The Mobile App's "Near You" (Dashboard tab) and "Nearby" (Map tab) features are live, GPS-based, and compute+sort distance client-side — confirmed working end-to-end.
- The backend `GET /api/v2/devices/sites/nearest` endpoint and its matching `NearestPlacesRepository` in the mobile codebase are **not called from any screen** — dead code — and have real bugs (no distance sorting, `online_status` param silently ignored, `distanceKm` vs. `distance` field-name mismatch that would render as 0.0 km). Intentionally left undocumented until that's cleaned up; happy to open a follow-up PR for the backend fixes if wanted.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for finding the nearest active monitoring site when a location is not directly listed.
  * Documented the mobile app’s **Near You** feature, which uses GPS to show nearby sites within 10 km.
  * Added alternative guidance using the interactive map and support contact.
  * Clarified that a coordinate-based nearest-site API is not currently available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->