### PR TITLE
Document the Network Coverage API for cross-manufacturer embedding

### DIFF
--- a/src/docs-website/docs/api/intro.md
+++ b/src/docs-website/docs/api/intro.md
@@ -17,6 +17,7 @@ The AirQo API gives you programmatic access to air quality measurements from our
 | **City or municipality** monitoring a defined geographical area | [Grid ID Access →](./for-cities/intro.md) |
 | **Developer** who needs historical or raw sensor data at scale | [Analytics API →](./analytics-api/raw-data.md) |
 | **Researcher or planner** who needs predictive air quality data | [Forecast API →](./forecasts/overview.md) |
+| **Website or app** embedding a live view of Africa's air quality monitoring landscape, across every manufacturer and operator | [Network Coverage API →](./network-coverage/intro.md) |
 
 ---
 

--- a/src/docs-website/docs/api/intro.md
+++ b/src/docs-website/docs/api/intro.md
@@ -17,7 +17,7 @@ The AirQo API gives you programmatic access to air quality measurements from our
 | **City or municipality** monitoring a defined geographical area | [Grid ID Access →](./for-cities/intro.md) |
 | **Developer** who needs historical or raw sensor data at scale | [Analytics API →](./analytics-api/raw-data.md) |
 | **Researcher or planner** who needs predictive air quality data | [Forecast API →](./forecasts/overview.md) |
-| **Website or app** embedding a live view of Africa's air quality monitoring landscape, across every manufacturer and operator | [Network Coverage API →](./network-coverage/intro.md) |
+| **Website or app** that wants monitor *locations and metadata* — not readings — across every manufacturer and operator in Africa | [Network Coverage API →](./network-coverage/intro.md) |
 
 ---
 

--- a/src/docs-website/docs/api/network-coverage/_category_.json
+++ b/src/docs-website/docs/api/network-coverage/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "Network Coverage",
-  "position": 4.5,
+  "position": 6.5,
   "collapsible": true,
   "collapsed": true
 }

--- a/src/docs-website/docs/api/network-coverage/_category_.json
+++ b/src/docs-website/docs/api/network-coverage/_category_.json
@@ -1,0 +1,6 @@
+{
+  "label": "Network Coverage",
+  "position": 4.5,
+  "collapsible": true,
+  "collapsed": true
+}

--- a/src/docs-website/docs/api/network-coverage/city-population-data.md
+++ b/src/docs-website/docs/api/network-coverage/city-population-data.md
@@ -73,8 +73,8 @@ POST /api/v2/devices/network-coverage/cities?token={SECRET_TOKEN}
 
 ```json
 {
-  "city": "Kampala",
-  "country": "Uganda",
+  "city": "kampala",
+  "country": "uganda",
   "iso2": "UG",
   "population": 1680000,
   "year": 2024,

--- a/src/docs-website/docs/api/network-coverage/city-population-data.md
+++ b/src/docs-website/docs/api/network-coverage/city-population-data.md
@@ -1,0 +1,123 @@
+---
+sidebar_position: 5
+sidebar_label: City Population Data
+---
+
+# City Population Data
+
+A small reference dataset pairing cities with population figures, used to calculate the "population reached" numbers in [Impact Statistics](./impact-statistics.md). Most integrations only need the `GET` — the `POST` is for contributing a missing or updated figure.
+
+---
+
+## List city population records
+
+```http
+GET /api/v2/devices/network-coverage/cities?token={SECRET_TOKEN}
+```
+
+**Query parameters**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `token` | string | Required |
+| `country` | string | Optional. Filter to one country. |
+
+**Example**
+
+```bash
+curl "https://api.airqo.net/api/v2/devices/network-coverage/cities?country=Uganda&token={SECRET_TOKEN}"
+```
+
+**Example response**
+
+```json
+{
+  "success": true,
+  "cities": [
+    {
+      "_id": "66f1a2b3c4d5e6f7a8b9c0d1",
+      "city": "kampala",
+      "displayCity": "Kampala",
+      "country": "uganda",
+      "displayCountry": "Uganda",
+      "iso2": "UG",
+      "population": 1680000,
+      "year": 2024,
+      "source": "UBOS 2024 projection",
+      "notes": ""
+    }
+  ]
+}
+```
+
+**Response fields**
+
+| Field | Description |
+|-------|-------------|
+| `city`, `country` | Lower-cased matching keys |
+| `displayCity`, `displayCountry` | Human-readable names for display |
+| `population` | Population figure |
+| `year` | The year the figure applies to |
+| `source` | Citation for the figure, e.g. a national statistics bureau |
+| `notes` | Optional free-text context |
+
+---
+
+## Add a city population record
+
+```http
+POST /api/v2/devices/network-coverage/cities?token={SECRET_TOKEN}
+```
+
+**Request body**
+
+```json
+{
+  "city": "Kampala",
+  "country": "Uganda",
+  "iso2": "UG",
+  "population": 1680000,
+  "year": 2024,
+  "source": "UBOS 2024 projection",
+  "notes": "Optional context"
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `city` | string | Yes | |
+| `country` | string | Yes | |
+| `iso2` | string | Yes | Two-letter country code |
+| `population` | number | Yes | |
+| `year` | number | Yes | |
+| `source` | string | Yes | Citation for the figure |
+| `notes` | string | No | |
+
+**Example response**
+
+```json
+{
+  "success": true,
+  "message": "City population saved",
+  "cities": [
+    {
+      "_id": "66f1a2b3c4d5e6f7a8b9c0d1",
+      "city": "kampala",
+      "displayCity": "Kampala",
+      "country": "uganda",
+      "displayCountry": "Uganda",
+      "iso2": "UG",
+      "population": 1680000,
+      "year": 2024,
+      "source": "UBOS 2024 projection"
+    }
+  ]
+}
+```
+
+---
+
+## Next steps
+
+- [Back to impact statistics →](./impact-statistics.md)
+- [Submit a monitor to the community registry →](./community-registry.md)

--- a/src/docs-website/docs/api/network-coverage/community-registry.md
+++ b/src/docs-website/docs/api/network-coverage/community-registry.md
@@ -1,0 +1,95 @@
+---
+sidebar_position: 7
+sidebar_label: Community Registry
+---
+
+# Community Registry
+
+This is how the shared dataset grows: anyone, from any site built on this API, can add a monitor that isn't already on record — this is the "Add monitor to network" dialog on the reference page. It's for cataloguing **any** air quality monitor, run by any organisation, using any manufacturer's equipment. It is not for registering an AirQo-owned device specifically.
+
+:::note Registering an AirQo device is different
+If you're deploying an AirQo-owned device, use [Deploy to a Site](../../vertex/device-deployment/deploy-to-site.md) in Vertex instead. This registry endpoint is a lightweight, public catalogue entry — it doesn't create a device record or wire up data ingestion.
+:::
+
+---
+
+## Submit a monitor
+
+```http
+POST /api/v2/devices/network-coverage/registry?token={SECRET_TOKEN}
+```
+
+**Request body**
+
+```json
+{
+  "name": "US Embassy Kampala",
+  "city": "Kampala",
+  "country": "Uganda",
+  "iso2": "UG",
+  "latitude": 0.3123,
+  "longitude": 32.5811,
+  "type": "Reference",
+  "status": "active",
+  "network": "us-embassy",
+  "operator": "US Department of State",
+  "equipment": "BAM 1022",
+  "manufacturer": "Met One Instruments",
+  "pollutants": ["PM2.5"],
+  "site": "US Embassy compound",
+  "deployed": "2019-03-01",
+  "publicData": "Yes",
+  "viewDataUrl": "https://airnow.gov",
+  "captchaToken": "10000000-aaaa-bbbb-cccc-000000000001"
+}
+```
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `name` | string | Yes | |
+| `country` | string | Yes | |
+| `latitude`, `longitude` | number | Yes | -90–90 / -180–180 |
+| `network` | string | Yes | |
+| `operator` | string | Yes | |
+| `manufacturer` | string | Yes | |
+| `pollutants` | string[] | Yes | |
+| `captchaToken` | string | Yes | An hCaptcha response token — see below |
+| `type` | `Reference` \| `LCS` \| `Inactive` | No | Defaults to `LCS` |
+| `status` | `active` \| `inactive` | No | Defaults to `active` |
+| `city`, `iso2`, `site`, `equipment`, `deployed` | string | No | |
+| `calibrationLastDate`, `calibrationMethod`, `uptime30d` | string | No | |
+| `organisation`, `coLocation`, `coLocationNote` | string | No | |
+| `resolution`, `transmission` | string | No | |
+| `publicData` | `Yes` \| `No` | No | Defaults to `No` |
+| `viewDataUrl` | string | No | Link to the monitor's own data portal, if public |
+| `countryId` | string | No | Only send this if you already have the country's slug from the [summary endpoint](./monitors-and-countries.md) — otherwise omit it and let the backend derive one from `country` |
+
+**Example response**
+
+```json
+{
+  "success": true,
+  "message": "Monitor added to registry",
+  "registry": {
+    "_id": "66f4a2b3c4d5e6f7a8b9c0d2",
+    "name": "US Embassy Kampala",
+    "country": "Uganda",
+    "countryId": "uganda"
+  }
+}
+```
+
+Once submitted, the new entry is picked up by the [summary](./monitors-and-countries.md), [country-monitors](./monitors-and-countries.md#get-monitors-for-a-single-country), and [monitor-detail](./monitor-details.md) endpoints like any other monitor.
+
+---
+
+## The hCaptcha requirement
+
+`captchaToken` is a response token from [hCaptcha](https://www.hcaptcha.com/), solved client-side and passed through on submission — the same anti-spam gate the reference page's dialog uses. To reuse this endpoint on your own site, register your own hCaptcha site key and solve it in your form before calling this endpoint; a missing or invalid token is rejected.
+
+---
+
+## Next steps
+
+- [Back to the API overview →](./intro.md)
+- [Deploy an AirQo device instead →](../../vertex/device-deployment/deploy-to-site.md)

--- a/src/docs-website/docs/api/network-coverage/community-registry.md
+++ b/src/docs-website/docs/api/network-coverage/community-registry.md
@@ -19,6 +19,10 @@ If you're deploying an AirQo-owned device, use [Deploy to a Site](../../vertex/d
 POST /api/v2/devices/network-coverage/registry?token={SECRET_TOKEN}
 ```
 
+:::warning Never call this with `token` from a public-facing form
+This is the endpoint your own "Add monitor" form would submit to — but if that form is a public webpage, don't have the browser call this URL with `?token=` directly; the token would be readable in your page's requests. Submit the form to your own backend first, and have your backend attach the token when it calls this endpoint server-side. See [the note on query-string tokens →](./intro.md#endpoints-at-a-glance).
+:::
+
 **Request body**
 
 ```json

--- a/src/docs-website/docs/api/network-coverage/csv-export.md
+++ b/src/docs-website/docs/api/network-coverage/csv-export.md
@@ -11,6 +11,10 @@ Returns the currently-matched monitors as a flat CSV — one row per monitor —
 GET /api/v2/devices/network-coverage/export.csv?token={SECRET_TOKEN}
 ```
 
+:::warning Don't put `token` in a public "Download" link
+If you're wiring this up to a download button a visitor clicks, don't use a link with `?token=` in it — anyone can read the token out of that URL. Route the download through your own backend instead, the same way as any other endpoint on this page. See [the note on query-string tokens →](./intro.md#endpoints-at-a-glance).
+:::
+
 **Query parameters**
 
 | Parameter | Type | Description |

--- a/src/docs-website/docs/api/network-coverage/csv-export.md
+++ b/src/docs-website/docs/api/network-coverage/csv-export.md
@@ -1,0 +1,45 @@
+---
+sidebar_position: 6
+sidebar_label: CSV Export
+---
+
+# CSV Export
+
+Returns the currently-matched monitors as a flat CSV — one row per monitor — using the same filters as the [summary endpoint](./monitors-and-countries.md). Useful if you want a downloadable data table without re-shaping the JSON response yourself.
+
+```http
+GET /api/v2/devices/network-coverage/export.csv?token={SECRET_TOKEN}
+```
+
+**Query parameters**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `token` | string | Required |
+| `tenant` | string | Optional. Defaults to `airqo`. |
+| `search` | string | Optional. Filters monitors by name, city, or country. |
+| `activeOnly` | boolean | Optional. |
+| `types` | string | Optional. Comma-separated: `Reference`, `LCS`. |
+| `network` | string | Optional. Comma-separated network names. |
+| `countryId` | string | Optional. Scope the export to one country. |
+
+**Example**
+
+```bash
+curl "https://api.airqo.net/api/v2/devices/network-coverage/export.csv?countryId=uganda&token={SECRET_TOKEN}" \
+  -H "Accept: text/csv" \
+  -o network-coverage-uganda.csv
+```
+
+The response is `Content-Type: text/csv`, with a header row followed by one row per matched monitor covering the same fields documented in [Monitor Details](./monitor-details.md) (`name`, `city`, `country`, `type`, `status`, `operator`, `manufacturer`, `pollutants`, and so on).
+
+:::note The reference page builds its own CSV/PDF client-side
+The **Download** button on [airqo.net/solutions/network-coverage](https://airqo.net/solutions/network-coverage) currently formats a summary report (totals, filters applied, per-country breakdown) from data it already has in memory, rather than calling this endpoint. If you just need a raw, one-row-per-monitor table, call `export.csv` directly — it's simpler than reconstructing the report format.
+:::
+
+---
+
+## Next steps
+
+- [Back to the summary endpoint →](./monitors-and-countries.md)
+- [Submit a monitor to the community registry →](./community-registry.md)

--- a/src/docs-website/docs/api/network-coverage/impact-statistics.md
+++ b/src/docs-website/docs/api/network-coverage/impact-statistics.md
@@ -1,0 +1,112 @@
+---
+sidebar_position: 4
+sidebar_label: Impact Statistics
+---
+
+# Impact Statistics
+
+Returns the aggregate numbers behind the map — total monitors, breakdowns by type/status/manufacturer, and estimated population reached. This is what powers the reference page's headline stats.
+
+---
+
+## Get impact summary
+
+```http
+GET /api/v2/devices/network-coverage/impact?token={SECRET_TOKEN}
+```
+
+**Query parameters**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `token` | string | Required |
+| `tenant` | string | Optional. Defaults to `airqo`. |
+| `activeOnly` | boolean | Optional. Restrict all counts to active monitors. |
+| `types` | string | Optional. Comma-separated: `Reference`, `LCS`. |
+| `network` | string | Optional. Comma-separated network names. |
+
+**Example**
+
+```bash
+curl "https://api.airqo.net/api/v2/devices/network-coverage/impact?token={SECRET_TOKEN}"
+```
+
+**Example response**
+
+```json
+{
+  "success": true,
+  "message": "Impact summary retrieved successfully",
+  "impact": {
+    "totalMonitors": 1840,
+    "byType": { "Reference": 62, "LCS": 1712, "Inactive": 66 },
+    "byStatus": { "active": 1774, "inactive": 66 },
+    "totalCities": 128,
+    "totalCountries": 30,
+    "totalPopulationReached": 84500000,
+    "citiesWithPopulationData": 46,
+    "byCountry": [
+      {
+        "country": "Uganda",
+        "iso2": "UG",
+        "population": 45700000,
+        "total": 142,
+        "Reference": 4,
+        "LCS": 138,
+        "active": 136,
+        "inactive": 6
+      }
+    ],
+    "byCity": [
+      {
+        "city": "Kampala",
+        "country": "Uganda",
+        "iso2": "UG",
+        "population": 1680000,
+        "total": 58,
+        "Reference": 2,
+        "LCS": 56,
+        "active": 55,
+        "inactive": 3
+      }
+    ],
+    "bySensorManufacturer": [
+      {
+        "sensorManufacturer": "AirQo",
+        "totalMonitors": 1600,
+        "byType": { "Reference": 0, "LCS": 1600, "Inactive": 40 },
+        "byStatus": { "active": 1560, "inactive": 40 },
+        "totalCities": 90,
+        "totalCountries": 22,
+        "totalPopulationReached": 60000000,
+        "citiesWithPopulationData": 38,
+        "byCountry": [],
+        "byCity": []
+      }
+    ],
+    "generatedAt": "2025-09-28T09:00:00.000Z"
+  }
+}
+```
+
+**Response fields**
+
+| Field | Description |
+|-------|-------------|
+| `totalMonitors`, `byType`, `byStatus` | Global counts across all matched monitors |
+| `totalCities`, `totalCountries` | Distinct cities/countries with at least one monitor |
+| `totalPopulationReached` | Sum of population figures (from [City Population Data](./city-population-data.md)) for every city with a monitor — `null` where population data isn't available for enough cities to compute a meaningful figure |
+| `citiesWithPopulationData` | How many of `totalCities` have a known population — use this alongside `totalPopulationReached` to gauge coverage of the population estimate itself |
+| `byCountry[]`, `byCity[]` | Per-country / per-city breakdowns with the same shape as the top-level counts, plus `population` |
+| `bySensorManufacturer[]` | The same full breakdown, scoped to each manufacturer — lets you answer "how much of the network does manufacturer X cover?" |
+
+:::note Population figures are estimates
+`totalPopulationReached` reflects a monitor being present *somewhere* in a city, not real coverage radius or air-quality representativeness across that city's full population. Treat it as a headline number, not a scientific exposure estimate.
+:::
+
+---
+
+## Next steps
+
+- [See where population figures come from →](./city-population-data.md)
+- [Export the underlying data →](./csv-export.md)

--- a/src/docs-website/docs/api/network-coverage/impact-statistics.md
+++ b/src/docs-website/docs/api/network-coverage/impact-statistics.md
@@ -74,7 +74,7 @@ curl "https://api.airqo.net/api/v2/devices/network-coverage/impact?token={SECRET
       {
         "sensorManufacturer": "AirQo",
         "totalMonitors": 1600,
-        "byType": { "Reference": 0, "LCS": 1600, "Inactive": 40 },
+        "byType": { "Reference": 0, "LCS": 1560, "Inactive": 40 },
         "byStatus": { "active": 1560, "inactive": 40 },
         "totalCities": 90,
         "totalCountries": 22,

--- a/src/docs-website/docs/api/network-coverage/intro.md
+++ b/src/docs-website/docs/api/network-coverage/intro.md
@@ -13,6 +13,10 @@ The point of documenting it here is to let it be reused: any organisation with a
 This page assumes you already know how authentication and requests work. If you haven't yet, start with [AirQo API →](../intro.md) for the fundamentals, then come back here.
 :::
 
+:::info This is location and monitor metadata, not air-quality readings
+Every endpoint here answers "what monitors exist, where, and run by whom" — not "what is the air quality right now." If you already have a monitor's identifiers and want its actual readings, that's the [Analytics API](../analytics-api/raw-data.md) or [Forecast API](../forecasts/overview.md) instead. In that sense this API is a sibling of the [Metadata API →](../reference/metadata.md): Metadata covers AirQo's own registered grids, cohorts, sites, and devices; Network Coverage covers the same *kind* of information — monitor identity and location — extended to every manufacturer and operator across Africa, not just AirQo's fleet.
+:::
+
 ---
 
 ## What the reference map does with this data

--- a/src/docs-website/docs/api/network-coverage/intro.md
+++ b/src/docs-website/docs/api/network-coverage/intro.md
@@ -1,0 +1,72 @@
+---
+sidebar_position: 1
+sidebar_label: Overview
+---
+
+# Network Coverage API
+
+This is a shared record of the **air quality monitoring landscape across Africa** — not a list of AirQo devices. Reference-grade instruments, low-cost sensors, and equipment from any manufacturer or operator (national ministries, embassies, universities, city authorities, other sensor networks) all live in the same backend, tagged with who runs them and who made them. [airqo.net/solutions/network-coverage](https://airqo.net/solutions/network-coverage) is simply the first interactive map built on top of it.
+
+The point of documenting it here is to let it be reused: any organisation with a stake in the continent's air quality picture — a UN agency, the Clean Air Fund, the Clean Air Network, EPIC, a national environment agency, a research institution — can pull this same data into their own site, and can contribute monitors their partners run that AirQo doesn't know about. One shared backend, fed and read by many client-facing apps, gives everyone a more complete picture than any single site maintaining its own list.
+
+:::tip New to the AirQo API?
+This page assumes you already know how authentication and requests work. If you haven't yet, start with [AirQo API →](../intro.md) for the fundamentals, then come back here.
+:::
+
+---
+
+## What the reference map does with this data
+
+[airqo.net/solutions/network-coverage](https://airqo.net/solutions/network-coverage) is one interface built on the endpoints below — a full-screen map with a country-first drill-down. Any of the same features can be rebuilt on another site using the same data:
+
+1. **Overview** — every African country is shaded or pinned based on how many monitors it has, regardless of who operates them. Two view modes are available:
+   - **Monitors** — one pin per monitor, coloured by type (Low-Cost Sensor, Reference, or Inactive).
+   - **Coverage** — countries are shaded by monitor-count bucket (0, 1–9, 10–49, 50–199, 200–999, 1000+).
+2. **Country drill-down** — clicking a country lists its monitors in a sidebar. From there you can search, and filter by monitor type, network/operator, and an "active only" toggle.
+3. **Monitor detail** — clicking a monitor shows its full profile: operator, equipment, manufacturer, pollutants measured, sampling resolution, transmission method, deployment date, calibration history, 30-day uptime, co-location status, and whether its data is publicly viewable (with a link to view live data, where available).
+4. **Impact statistics** — aggregate numbers behind the map: total monitors, breakdown by type and status, countries and cities covered, estimated population reached, and a breakdown **by sensor manufacturer** — this is a cross-manufacturer dataset by design, not an AirQo fleet count.
+5. **Export** — the current filtered view can be downloaded as a PDF (map snapshot + data table) or CSV.
+6. **Community submissions** — anyone, on any site built on this API, can add a monitor to the shared registry directly (name, location, operator, equipment, pollutants), protected by hCaptcha. This is how the dataset stays complete — it doesn't rely on AirQo alone to know about every monitor on the continent. Contributing your own AirQo-owned device is a separate, more involved flow — see [Deploy to a Site](../../vertex/device-deployment/deploy-to-site.md) for that.
+
+Everything below maps one of those features to the endpoint behind it.
+
+---
+
+## Endpoints at a glance
+
+All endpoints live under `/api/v2/devices/network-coverage` and follow the same [authentication](../getting-started/authentication.md) rules as the rest of the API — pass your `token` as a query parameter.
+
+| Feature | Endpoint | Docs |
+|---------|----------|------|
+| Country-by-country monitor counts (map overview) | `GET /api/v2/devices/network-coverage` | [Monitors & Countries →](./monitors-and-countries.md) |
+| Monitors within one country (drill-down) | `GET /api/v2/devices/network-coverage/countries/{countryId}/monitors` | [Monitors & Countries →](./monitors-and-countries.md) |
+| Single monitor profile (detail panel) | `GET /api/v2/devices/network-coverage/monitors/{monitorId}` | [Monitor Details →](./monitor-details.md) |
+| Aggregate stats (impact numbers) | `GET /api/v2/devices/network-coverage/impact` | [Impact Statistics →](./impact-statistics.md) |
+| City population reference data | `GET`/`POST /api/v2/devices/network-coverage/cities` | [City Population Data →](./city-population-data.md) |
+| Filtered data export | `GET /api/v2/devices/network-coverage/export.csv` | [CSV Export →](./csv-export.md) |
+| Community monitor submission | `POST /api/v2/devices/network-coverage/registry` | [Community Registry →](./community-registry.md) |
+
+---
+
+## Monitor type and status
+
+Every monitor returned by these endpoints carries a `type` and a `status`. They're independent of each other:
+
+| Field | Values | Meaning |
+|-------|--------|---------|
+| `type` | `Reference`, `LCS`, `Inactive` | `Reference` = reference-grade instrument, `LCS` = low-cost sensor. A monitor can also be typed `Inactive` directly in the registry when it's been decommissioned. |
+| `status` | `active`, `inactive` | Whether the monitor is currently operational, independent of its hardware type. |
+
+:::note Filtering by "Inactive"
+The `types` query parameter only accepts `Reference` and `LCS` — the backend treats "Inactive" as a status, not a hardware type. To show inactive monitors, fetch the data and filter client-side on `status === 'inactive'`, the way the reference page does.
+:::
+
+---
+
+## Next steps
+
+- [List countries and their monitors →](./monitors-and-countries.md)
+- [Fetch a single monitor's profile →](./monitor-details.md)
+- [Pull aggregate impact statistics →](./impact-statistics.md)
+- [Export filtered data →](./csv-export.md)
+- [Submit a monitor to the community registry →](./community-registry.md)

--- a/src/docs-website/docs/api/network-coverage/intro.md
+++ b/src/docs-website/docs/api/network-coverage/intro.md
@@ -40,6 +40,10 @@ Everything below maps one of those features to the endpoint behind it.
 
 All endpoints live under `/api/v2/devices/network-coverage` and follow the same [authentication](../getting-started/authentication.md) rules as the rest of the API — pass your `token` as a query parameter.
 
+:::warning Keep `token` out of anything a browser or public link can see
+Because `token` travels in the URL, calling these endpoints directly from client-side JavaScript, an HTML form, or a public download link can leak it into server access logs, browser history, analytics tools, or a `Referer` header sent to whatever the response links to. HTTPS protects the URL in transit, but does nothing to stop any of that once the request lands. Make these calls from your own backend and hand the result to the browser — the way [airqo.net/solutions/network-coverage](https://airqo.net/solutions/network-coverage) itself does: its frontend never sees the token, a server-side route attaches it before forwarding the request.
+:::
+
 | Feature | Endpoint | Docs |
 |---------|----------|------|
 | Country-by-country monitor counts (map overview) | `GET /api/v2/devices/network-coverage` | [Monitors & Countries →](./monitors-and-countries.md) |

--- a/src/docs-website/docs/api/network-coverage/monitor-details.md
+++ b/src/docs-website/docs/api/network-coverage/monitor-details.md
@@ -1,0 +1,113 @@
+---
+sidebar_position: 3
+sidebar_label: Monitor Details
+---
+
+# Monitor Details
+
+Fetches the full profile for one monitor — this is what fills the detail panel when a user clicks a pin on the map.
+
+---
+
+## Get a single monitor
+
+```http
+GET /api/v2/devices/network-coverage/monitors/{monitorId}?token={SECRET_TOKEN}
+```
+
+**Path parameters**
+
+| Parameter | Description |
+|-----------|-------------|
+| `monitorId` | The `id` of a monitor, from the summary or country-monitors response |
+
+**Query parameters**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `token` | string | Required |
+| `tenant` | string | Optional. Defaults to `airqo`. |
+
+**Example**
+
+```bash
+curl "https://api.airqo.net/api/v2/devices/network-coverage/monitors/66f4a2b3c4d5e6f7a8b9c0d2?token={SECRET_TOKEN}"
+```
+
+**Example response**
+
+```json
+{
+  "success": true,
+  "message": "Successfully retrieved monitor",
+  "monitor": {
+    "id": "66f4a2b3c4d5e6f7a8b9c0d2",
+    "name": "US Embassy Kampala",
+    "city": "Kampala",
+    "country": "Uganda",
+    "countryId": "uganda",
+    "iso2": "UG",
+    "latitude": 0.3123,
+    "longitude": 32.5811,
+    "type": "Reference",
+    "status": "active",
+    "lastActive": "2025-09-28T07:30:00.000Z",
+    "network": "us-embassy",
+    "operator": "US Department of State",
+    "equipment": "BAM 1022",
+    "manufacturer": "Met One Instruments",
+    "pollutants": ["PM2.5"],
+    "resolution": "Hourly",
+    "transmission": "Fiber",
+    "site": "US Embassy compound",
+    "landUse": "Institutional",
+    "deployed": "2019-03-01",
+    "calibrationLastDate": "",
+    "calibrationMethod": "",
+    "uptime30d": "",
+    "publicData": "Yes",
+    "organisation": "US Department of State",
+    "coLocation": "Not available",
+    "coLocationNote": "",
+    "viewDataUrl": "https://airnow.gov"
+  }
+}
+```
+
+This particular monitor happens to be a reference instrument contributed by another operator, not an AirQo device — the shape of the response is identical either way, which is the point: your client code doesn't need to special-case who runs a monitor.
+
+**Monitor fields**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Monitor identifier |
+| `name` | string | Monitor / site name |
+| `city`, `country`, `countryId`, `iso2` | string | Location context — `countryId` matches the `id` used in [Monitors & Countries](./monitors-and-countries.md) |
+| `latitude`, `longitude` | number | Coordinates used to place the pin |
+| `type` | `Reference` \| `LCS` \| `Inactive` | Hardware category |
+| `status` | `active` \| `inactive` | Current operational status |
+| `lastActive` | string (ISO date) | Last time the monitor reported data |
+| `network` | string | The operating network — matches a value in `meta.availableNetworks` from the summary endpoint |
+| `operator`, `organisation` | string | Who runs the monitor |
+| `equipment`, `manufacturer` | string | Hardware details |
+| `pollutants` | string[] | Pollutants measured, e.g. `["PM2.5", "PM10"]` |
+| `resolution` | string | Sampling/reporting frequency, e.g. `"Hourly"` |
+| `transmission` | string | How data reaches the server, e.g. `"GSM"` |
+| `site`, `landUse` | string | Physical site description |
+| `deployed` | string | Deployment date |
+| `calibrationLastDate`, `calibrationMethod` | string | Calibration history |
+| `uptime30d` | string | Rolling 30-day uptime, e.g. `"96%"` |
+| `publicData` | `Yes` \| `No` | Whether this monitor's readings are publicly viewable |
+| `coLocation`, `coLocationNote` | string | Co-location details, if any |
+| `viewDataUrl` | string | Link to view this monitor's live data, when `publicData` is `Yes` |
+
+:::note Coordinate approximation
+Like the rest of the API, coordinates for AirQo-owned sites are subject to the [~0.5 km privacy approximation](../../data-access/researchers-guide/location-approximation.md). Monitors contributed by other operators via the [community registry](./community-registry.md) are not adjusted.
+:::
+
+---
+
+## Next steps
+
+- [Back to country monitor lists →](./monitors-and-countries.md)
+- [Pull aggregate impact statistics →](./impact-statistics.md)

--- a/src/docs-website/docs/api/network-coverage/monitors-and-countries.md
+++ b/src/docs-website/docs/api/network-coverage/monitors-and-countries.md
@@ -1,0 +1,199 @@
+---
+sidebar_position: 2
+sidebar_label: Monitors & Countries
+---
+
+# Monitors & Countries
+
+These two endpoints power the map's country overview and the per-country drill-down list. Fetch the summary first to render the map, then fetch a single country's monitors when the user clicks into it.
+
+---
+
+## Get the full network summary
+
+```http
+GET /api/v2/devices/network-coverage?token={SECRET_TOKEN}
+```
+
+Returns every country with monitors, each with its list of monitors nested inside. This is what draws the initial map — both the **Monitors** pins and the **Coverage** choropleth are derived from this one response.
+
+**Query parameters**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `token` | string | Required |
+| `tenant` | string | Optional. The organisation instance to query. Defaults to `airqo`. |
+| `search` | string | Optional. Filters monitors by name, city, or country. |
+| `activeOnly` | boolean | Optional. When `true`, excludes monitors with `status: "inactive"`. |
+| `types` | string | Optional. Comma-separated: `Reference`, `LCS`. Omit to include both. |
+| `network` | string | Optional. Comma-separated network/operator names to filter by. |
+
+:::tip Fetching the full dataset
+If you want to filter or search client-side (so a user can toggle filters without a fresh request each time, and the map never shows a partial dataset while typing), omit `search`, `types`, and `network` and fetch everything once.
+:::
+
+**Example — all Reference and LCS monitors, active only**
+
+```bash
+curl "https://api.airqo.net/api/v2/devices/network-coverage?activeOnly=true&token={SECRET_TOKEN}"
+```
+
+**Example response**
+
+```json
+{
+  "success": true,
+  "message": "Network coverage data retrieved successfully",
+  "countries": [
+    {
+      "id": "uganda",
+      "country": "Uganda",
+      "iso2": "UG",
+      "stats": {
+        "total": 142,
+        "Reference": 4,
+        "LCS": 138,
+        "Inactive": 6,
+        "active": 136,
+        "inactive": 6
+      },
+      "monitors": [
+        {
+          "id": "64f7b3e8c9d25a0013f2d456",
+          "name": "Kampala Road",
+          "city": "Kampala",
+          "country": "Uganda",
+          "countryId": "uganda",
+          "iso2": "UG",
+          "latitude": 0.3476,
+          "longitude": 32.5825,
+          "type": "LCS",
+          "status": "active",
+          "lastActive": "2025-09-28T08:45:00.000Z",
+          "network": "airqo",
+          "operator": "AirQo",
+          "equipment": "AirQo BAM Node",
+          "manufacturer": "AirQo",
+          "pollutants": ["PM2.5", "PM10"],
+          "resolution": "Hourly",
+          "transmission": "GSM",
+          "site": "Kampala Road, Kampala",
+          "landUse": "Roadside",
+          "deployed": "2020-12-01",
+          "calibrationLastDate": "2025-06-01",
+          "calibrationMethod": "Field co-location",
+          "uptime30d": "96%",
+          "publicData": "Yes",
+          "organisation": "AirQo",
+          "coLocation": "Not available",
+          "coLocationNote": "",
+          "viewDataUrl": "https://airqo.net/explore-data"
+        },
+        {
+          "id": "66f4a2b3c4d5e6f7a8b9c0d2",
+          "name": "US Embassy Kampala",
+          "city": "Kampala",
+          "country": "Uganda",
+          "countryId": "uganda",
+          "iso2": "UG",
+          "latitude": 0.3123,
+          "longitude": 32.5811,
+          "type": "Reference",
+          "status": "active",
+          "lastActive": "2025-09-28T07:30:00.000Z",
+          "network": "us-embassy",
+          "operator": "US Department of State",
+          "equipment": "BAM 1022",
+          "manufacturer": "Met One Instruments",
+          "pollutants": ["PM2.5"],
+          "resolution": "Hourly",
+          "transmission": "Fiber",
+          "site": "US Embassy compound",
+          "landUse": "Institutional",
+          "deployed": "2019-03-01",
+          "publicData": "Yes",
+          "organisation": "US Department of State",
+          "coLocation": "Not available",
+          "coLocationNote": "",
+          "viewDataUrl": "https://airnow.gov"
+        }
+      ]
+    }
+  ],
+  "meta": {
+    "totalCountries": 30,
+    "monitoredCountries": 12,
+    "totalMonitors": 1840,
+    "totalPopulationReached": 84500000,
+    "citiesWithPopulationData": 46,
+    "availableNetworks": ["airqo", "kcca", "us-embassy"],
+    "generatedAt": "2025-09-28T09:00:00.000Z"
+  }
+}
+```
+
+Notice that a single country's `monitors[]` mixes an AirQo low-cost sensor with a US Embassy reference monitor from a different manufacturer entirely — that's the point of a shared backend: one query returns the whole monitoring landscape for that country, not just one organisation's fleet.
+
+**Response fields**
+
+| Field | Description |
+|-------|-------------|
+| `countries[].id` | A slug derived from the country name — use this as `{countryId}` below |
+| `countries[].stats` | Per-country monitor counts, broken down by `type` and by `status` |
+| `countries[].monitors[]` | Full monitor objects — see [Monitor Details](./monitor-details.md) for the complete field list |
+| `meta.totalCountries` | Total African countries tracked (monitored or not) |
+| `meta.monitoredCountries` | Countries that have at least one monitor |
+| `meta.availableNetworks` | Every distinct `network` value present in the dataset — use this to populate a network filter dropdown |
+
+---
+
+## Get monitors for a single country
+
+```http
+GET /api/v2/devices/network-coverage/countries/{countryId}/monitors?token={SECRET_TOKEN}
+```
+
+Returns one country's monitors. Use this when a user selects a country instead of re-filtering the full summary client-side — it's the same shape, scoped server-side.
+
+**Path parameters**
+
+| Parameter | Description |
+|-----------|-------------|
+| `countryId` | The `id` value from a country in the summary response (e.g. `uganda`) |
+
+**Query parameters**
+
+Same as the summary endpoint, minus `search`: `token`, `tenant`, `activeOnly`, `types`, `network`.
+
+**Example**
+
+```bash
+curl "https://api.airqo.net/api/v2/devices/network-coverage/countries/uganda/monitors?token={SECRET_TOKEN}"
+```
+
+**Example response**
+
+```json
+{
+  "success": true,
+  "message": "Successfully retrieved monitors for Uganda",
+  "countryId": "uganda",
+  "country": "Uganda",
+  "iso2": "UG",
+  "monitors": [
+    {
+      "id": "64f7b3e8c9d25a0013f2d456",
+      "name": "Kampala Road",
+      "type": "LCS",
+      "status": "active"
+    }
+  ]
+}
+```
+
+---
+
+## Next steps
+
+- [View a single monitor's full profile →](./monitor-details.md)
+- [Pull aggregate impact statistics →](./impact-statistics.md)

--- a/src/docs-website/docs/api/network-coverage/monitors-and-countries.md
+++ b/src/docs-website/docs/api/network-coverage/monitors-and-countries.md
@@ -50,12 +50,12 @@ curl "https://api.airqo.net/api/v2/devices/network-coverage?activeOnly=true&toke
       "country": "Uganda",
       "iso2": "UG",
       "stats": {
-        "total": 142,
+        "total": 136,
         "Reference": 4,
-        "LCS": 138,
-        "Inactive": 6,
+        "LCS": 132,
+        "Inactive": 0,
         "active": 136,
-        "inactive": 6
+        "inactive": 0
       },
       "monitors": [
         {
@@ -173,6 +173,8 @@ curl "https://api.airqo.net/api/v2/devices/network-coverage/countries/uganda/mon
 
 **Example response**
 
+Each entry in `monitors[]` is a full monitor object — the same shape returned by [Monitor Details](./monitor-details.md), and the same shape used in the summary endpoint above:
+
 ```json
 {
   "success": true,
@@ -184,8 +186,33 @@ curl "https://api.airqo.net/api/v2/devices/network-coverage/countries/uganda/mon
     {
       "id": "64f7b3e8c9d25a0013f2d456",
       "name": "Kampala Road",
+      "city": "Kampala",
+      "country": "Uganda",
+      "countryId": "uganda",
+      "iso2": "UG",
+      "latitude": 0.3476,
+      "longitude": 32.5825,
       "type": "LCS",
-      "status": "active"
+      "status": "active",
+      "lastActive": "2025-09-28T08:45:00.000Z",
+      "network": "airqo",
+      "operator": "AirQo",
+      "equipment": "AirQo BAM Node",
+      "manufacturer": "AirQo",
+      "pollutants": ["PM2.5", "PM10"],
+      "resolution": "Hourly",
+      "transmission": "GSM",
+      "site": "Kampala Road, Kampala",
+      "landUse": "Roadside",
+      "deployed": "2020-12-01",
+      "calibrationLastDate": "2025-06-01",
+      "calibrationMethod": "Field co-location",
+      "uptime30d": "96%",
+      "publicData": "Yes",
+      "organisation": "AirQo",
+      "coLocation": "Not available",
+      "coLocationNote": "",
+      "viewDataUrl": "https://airqo.net/explore-data"
     }
   ]
 }

--- a/src/docs-website/docs/api/reference/metadata.md
+++ b/src/docs-website/docs/api/reference/metadata.md
@@ -5,9 +5,13 @@ sidebar_label: Metadata API
 
 # Metadata API
 
-The Metadata API lets you browse the AirQo monitoring infrastructure — grids, cohorts, sites, devices, and geographic boundaries — so you can discover the right identifiers before querying measurement or forecast data.
+The Metadata API lets you browse **AirQo's own** monitoring infrastructure — grids, cohorts, sites, devices, and geographic boundaries — so you can discover the right identifiers before querying measurement or forecast data.
 
 All endpoints require your `token` query parameter, with one exception noted below. See [Authentication →](../getting-started/authentication.md).
+
+:::info Looking for monitors beyond AirQo's own fleet?
+This page is scoped to infrastructure AirQo directly manages. For a broader, cross-manufacturer registry of monitors across Africa — including reference-grade instruments and equipment run by other operators (ministries, embassies, universities, other sensor networks) — see the [Network Coverage API →](../network-coverage/intro.md). AirQo's own public sites appear in both; the Network Coverage API additionally includes monitors that were never registered as AirQo sites/devices at all.
+:::
 
 ---
 


### PR DESCRIPTION
# :rocket: Pull Request

## :clipboard: Description

### What does this PR do?

Adds a new **Network Coverage API** section to the AirQo API docs, documenting the endpoints behind `airqo.net/solutions/network-coverage`:

- `GET /api/v2/devices/network-coverage` — country-by-country monitor summary
- `GET /api/v2/devices/network-coverage/countries/{countryId}/monitors` — monitors in one country
- `GET /api/v2/devices/network-coverage/monitors/{monitorId}` — single monitor profile
- `GET /api/v2/devices/network-coverage/impact` — aggregate impact statistics
- `GET`/`POST /api/v2/devices/network-coverage/cities` — city population reference data
- `GET /api/v2/devices/network-coverage/export.csv` — filtered CSV export
- `POST /api/v2/devices/network-coverage/registry` — community monitor submission

The docs are framed around the underlying data model rather than the reference page: it's a shared, cross-manufacturer record of the air quality monitoring landscape across Africa (reference-grade instruments, low-cost sensors, and equipment from any operator — ministries, embassies, universities, other sensor networks), not an AirQo-only device list. This is meant to let any organisation with a stake in Africa's air quality picture (UN agencies, Clean Air Fund, Clean Air Network, EPIC, national agencies, researchers) embed the same coverage view on their own site, and contribute monitors back into the same shared backend.

Also added a row to the main `api/intro.md` "Who is this for?" table pointing website/app integrators at the new section.

### Why is this change needed?

The endpoints already existed and were live, but undocumented outside the frontend source. Publishing them lets any website embed the same view of Africa's air quality monitoring landscape, or build their own on the same shared data, instead of each integration reverse-engineering the API from the website's network requests.

---

## :link: Related Issues

- [ ] Closes #
- [ ] Fixes #
- [ ] Related to #

---

## :arrows_counterclockwise: Type of Change

- [ ] :bug: Bug fix
- [ ] :sparkles: New feature
- [ ] :wrench: Enhancement/improvement
- [x] :books: Documentation update
- [ ] :recycle: Refactor
- [ ] :wastebasket: Removal/deprecation

---

## :building_construction: Affected Services

**Microservices changed:**

- `docs-website` only — new docs under `docs/api/network-coverage/` plus one edited line in `docs/api/intro.md`. No application code, API, or backend service was touched.

---

## :test_tube: Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

**Test summary:** Ran `npx docusaurus build` locally (the site is configured with `onBrokenLinks: 'throw'`), which completed with no errors — confirms every internal link between the new pages, and to existing pages like `vertex/device-deployment/deploy-to-site.md` and `data-access/researchers-guide/location-approximation.md`, resolves correctly. Endpoint paths, query parameters, and response shapes were cross-checked against the live frontend source (`src/website/src/services/website/network-coverage.service.ts` and `networkCoverageTypes.ts`) rather than written from assumption.

---

## :boom: Breaking Changes

- [x] **No breaking changes**
- [ ] **Has breaking changes** (describe below)

---

## :memo: Additional Notes

- New category `docs/api/network-coverage/` is positioned at `6.5` in the sidebar, immediately before "Reference" (`7`) — it's a monitor-location/metadata registry, not an air-quality data-access pattern, so it's grouped next to the existing Metadata API rather than among For Cities/For Partners/Analytics API. No existing `_category_.json` positions needed to change.
- Added explicit cross-links between `reference/metadata.md` and `network-coverage/intro.md` so a reader browsing either discovers the other and understands the split: Metadata covers AirQo's own registered grids/cohorts/sites/devices; Network Coverage covers the same kind of information (monitor identity and location) extended to every manufacturer and operator across Africa.
- Noted one accuracy nuance in `csv-export.md`: the reference page's own "Download CSV" button currently builds a summary report client-side from already-fetched JSON rather than calling the `export.csv` endpoint directly — flagged so integrators aren't misled about how the reference implementation works.

---

## :white_check_mark: Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Ready for review
