### PR TITLE
chore(vertex): harden local dev setup for API proxying and auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ secret
 .prod-env.yaml
 .idea/*
 .claude/
+src/beacon/ISSUES.md

--- a/src/vertex/app/api/auth/[...nextauth]/options.ts
+++ b/src/vertex/app/api/auth/[...nextauth]/options.ts
@@ -83,6 +83,12 @@ const getCookieDomain = () => {
 
   try {
     const host = new URL(referenceUrl).hostname.toLowerCase();
+    
+    // Ignore custom cookie domains on localhost to prevent NextAuth warnings in development
+    if (host === 'localhost' || host === '127.0.0.1') {
+      return undefined;
+    }
+
     const normalizedDomain = configuredCookieDomain.replace(/^\./, '').toLowerCase();
     const hostMatches =
       host === normalizedDomain || host.endsWith(`.${normalizedDomain}`);

--- a/src/vertex/app/api/auth/[...nextauth]/options.ts
+++ b/src/vertex/app/api/auth/[...nextauth]/options.ts
@@ -8,6 +8,7 @@ import type {
   DecodedToken,
 } from '@/app/types/users';
 import { getApiErrorMessage } from '@/core/utils/getApiErrorMessage';
+import { resolveCookieDomain } from '@/core/utils/authCookieDomain';
 import logger from '@/lib/logger';
 import { isHCaptchaEnabled } from '@/lib/envConstants';
 import { buildServerApiUrl } from '@/lib/api-routing';
@@ -71,52 +72,47 @@ if (!process.env.NEXTAUTH_URL && azureContainerAppsUrl) {
 const authSecret = process.env.NEXTAUTH_SECRET || process.env.AUTH_SECRET;
 const configuredCookieDomain =
   process.env.NEXTAUTH_COOKIE_DOMAIN?.trim() || undefined;
+/**
+ * Resolved lazily, per request. NEXTAUTH_URL is frequently unset at module
+ * load and only filled in by setRuntimeAuthUrls once the first request
+ * arrives, so evaluating this once up front would either miss the localhost
+ * guard entirely or pin a production domain onto local logins. Memoised on
+ * the reference URL so the warnings are logged once per distinct value.
+ */
+let cachedCookieDomainFor: string | undefined;
+let cachedCookieDomain: string | undefined;
 const getCookieDomain = () => {
-  if (!configuredCookieDomain) {
-    return undefined;
-  }
-
   const referenceUrl = process.env.NEXTAUTH_URL || process.env.NEXTAUTH_URL_INTERNAL;
-  if (!referenceUrl) {
-    return configuredCookieDomain;
+  const cacheKey = referenceUrl ?? '';
+  if (cachedCookieDomainFor === cacheKey) {
+    return cachedCookieDomain;
   }
-
-  try {
-    const host = new URL(referenceUrl).hostname.toLowerCase();
-    
-    // Ignore custom cookie domains on localhost to prevent NextAuth warnings in development
-    if (host === 'localhost' || host === '127.0.0.1') {
-      return undefined;
+  cachedCookieDomainFor = cacheKey;
+  cachedCookieDomain = resolveCookieDomain(configuredCookieDomain, referenceUrl, (warning) => {
+    if (warning.kind === 'host-mismatch') {
+      logger.warn(
+        '[NextAuth] NEXTAUTH_COOKIE_DOMAIN does not match NEXTAUTH_URL host; disabling cookie domain override.',
+        { configuredCookieDomain: warning.configuredCookieDomain, host: warning.host }
+      );
+    } else {
+      logger.warn(
+        '[NextAuth] Invalid NEXTAUTH_URL while validating cookie domain; disabling cookie domain override.',
+        { configuredCookieDomain: warning.configuredCookieDomain, referenceUrl: warning.referenceUrl }
+      );
     }
-
-    const normalizedDomain = configuredCookieDomain.replace(/^\./, '').toLowerCase();
-    const hostMatches =
-      host === normalizedDomain || host.endsWith(`.${normalizedDomain}`);
-
-    if (hostMatches) {
-      return configuredCookieDomain;
-    }
-
-    logger.warn(
-      '[NextAuth] NEXTAUTH_COOKIE_DOMAIN does not match NEXTAUTH_URL host; disabling cookie domain override.',
-      { configuredCookieDomain, host }
-    );
-    return undefined;
-  } catch {
-    logger.warn(
-      '[NextAuth] Invalid NEXTAUTH_URL while validating cookie domain; disabling cookie domain override.',
-      { configuredCookieDomain, referenceUrl }
-    );
-    return undefined;
-  }
+  });
+  return cachedCookieDomain;
 };
-const cookieDomain = getCookieDomain();
 const cookieOptions = {
   httpOnly: true,
   sameSite: 'lax' as const,
   path: '/',
   secure: isProduction,
-  domain: cookieDomain,
+  // Getter rather than a captured value: NextAuth reads cookie options while
+  // handling a request, which is after setRuntimeAuthUrls has run.
+  get domain() {
+    return getCookieDomain();
+  },
 };
 
 if (isProduction && !authSecret) {

--- a/src/vertex/core/utils/authCookieDomain.test.ts
+++ b/src/vertex/core/utils/authCookieDomain.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from "vitest";
+import { resolveCookieDomain } from "./authCookieDomain";
+
+describe("resolveCookieDomain", () => {
+  it("returns undefined when no cookie domain is configured", () => {
+    expect(resolveCookieDomain(undefined, "https://vertex.airqo.net")).toBeUndefined();
+  });
+
+  it("keeps the configured domain when there is no reference URL to validate against", () => {
+    expect(resolveCookieDomain(".airqo.net", undefined)).toBe(".airqo.net");
+  });
+
+  it.each(["http://localhost:3000", "http://127.0.0.1:3000", "http://[::1]:3000"])(
+    "drops the configured domain for local host %s",
+    (url) => {
+      const warn = vi.fn();
+      expect(resolveCookieDomain(".airqo.net", url, warn)).toBeUndefined();
+      expect(warn).not.toHaveBeenCalled();
+    }
+  );
+
+  it("keeps the configured domain for hosts inside it", () => {
+    expect(resolveCookieDomain(".airqo.net", "https://vertex.airqo.net")).toBe(".airqo.net");
+    expect(resolveCookieDomain("airqo.net", "https://airqo.net")).toBe("airqo.net");
+  });
+
+  it("drops the domain and warns when the host is outside it", () => {
+    const warn = vi.fn();
+    expect(resolveCookieDomain(".airqo.net", "https://vertex.example.org", warn)).toBeUndefined();
+    expect(warn).toHaveBeenCalledWith({
+      kind: "host-mismatch",
+      configuredCookieDomain: ".airqo.net",
+      host: "vertex.example.org",
+    });
+  });
+
+  it("drops the domain and warns when the reference URL is unparsable", () => {
+    const warn = vi.fn();
+    expect(resolveCookieDomain(".airqo.net", "not a url", warn)).toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(expect.objectContaining({ kind: "invalid-reference-url" }));
+  });
+});

--- a/src/vertex/core/utils/authCookieDomain.ts
+++ b/src/vertex/core/utils/authCookieDomain.ts
@@ -1,0 +1,52 @@
+export type CookieDomainWarning =
+  | { kind: 'host-mismatch'; configuredCookieDomain: string; host: string }
+  | { kind: 'invalid-reference-url'; configuredCookieDomain: string; referenceUrl: string };
+
+const LOCAL_HOSTS = new Set(['localhost', '127.0.0.1', '[::1]']);
+
+/**
+ * Decides which `domain` the NextAuth session cookie should carry.
+ *
+ * Pure so it can be evaluated per request: the reference URL is often only
+ * known once the first request arrives (see setRuntimeAuthUrls in the auth
+ * route), so the result must not be cached at module load.
+ *
+ * - no configured domain → undefined (host-only cookie)
+ * - no reference URL yet → the configured domain (nothing to validate against)
+ * - localhost / loopback → undefined, so local dev never inherits a
+ *   production domain that the browser would reject
+ * - host outside the configured domain → undefined, with a warning
+ */
+export function resolveCookieDomain(
+  configuredCookieDomain: string | undefined,
+  referenceUrl: string | undefined,
+  warn?: (warning: CookieDomainWarning) => void
+): string | undefined {
+  if (!configuredCookieDomain) {
+    return undefined;
+  }
+  if (!referenceUrl) {
+    return configuredCookieDomain;
+  }
+
+  let host: string;
+  try {
+    host = new URL(referenceUrl).hostname.toLowerCase();
+  } catch {
+    warn?.({ kind: 'invalid-reference-url', configuredCookieDomain, referenceUrl });
+    return undefined;
+  }
+
+  if (LOCAL_HOSTS.has(host)) {
+    return undefined;
+  }
+
+  const normalizedDomain = configuredCookieDomain.replace(/^\./, '').toLowerCase();
+  const hostMatches = host === normalizedDomain || host.endsWith(`.${normalizedDomain}`);
+  if (hostMatches) {
+    return configuredCookieDomain;
+  }
+
+  warn?.({ kind: 'host-mismatch', configuredCookieDomain, host });
+  return undefined;
+}

--- a/src/vertex/core/utils/proxyClient.test.ts
+++ b/src/vertex/core/utils/proxyClient.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { createProxyHandler } from "./proxyClient";
 import axios from "axios";
+import { buildServerApiUrl } from "@/lib/api-routing";
 import { NextRequest } from "next/server";
 import { mockGetServerSession, createMockSession, resetNextAuthMocks } from "@/test/mocks/nextAuth";
 import { mockAxiosSuccess, mockAxiosError } from "@/test/factories/apiResponseFactory";
@@ -53,6 +54,31 @@ describe("proxyClient", () => {
     const res = await handler(req, { params: { path: ["users"] } });
     
     expect(res.status).toBe(405);
+  });
+
+  it("returns 508 when the API URL resolves to the proxy's own origin", async () => {
+    vi.mocked(buildServerApiUrl).mockReturnValueOnce("http://localhost:3000/api/users");
+    const handler = createProxyHandler();
+    const req = createRequest("GET", "http://localhost:3000/api/users");
+
+    const res = await handler(req, { params: { path: ["users"] } });
+
+    expect(res.status).toBe(508);
+    expect(axios).not.toHaveBeenCalled();
+  });
+
+  it("does not treat an API origin that merely shares a prefix as a loop", async () => {
+    vi.mocked(buildServerApiUrl).mockReturnValueOnce("http://localhost:30001/api/users");
+    const handler = createProxyHandler();
+    const req = createRequest("GET", "http://localhost:3000/api/users");
+    vi.mocked(axios).mockResolvedValueOnce(mockAxiosSuccess({ users: [] }));
+
+    const res = await handler(req, { params: { path: ["users"] } });
+
+    expect(res.status).toBe(200);
+    expect(axios).toHaveBeenCalledWith(expect.objectContaining({
+      url: "http://localhost:30001/api/users",
+    }));
   });
 
   it("forwards GET request successfully", async () => {

--- a/src/vertex/core/utils/proxyClient.ts
+++ b/src/vertex/core/utils/proxyClient.ts
@@ -108,6 +108,19 @@ export const createProxyHandler = (options: ProxyOptions = {}) => {
       let API_URL: string;
       try {
         API_URL = buildServerApiUrl(targetPath);
+
+        // Prevent infinite proxy loops if the API URL resolves back to the proxy itself
+        const requestOrigin = new URL(req.url).origin;
+        if (API_URL.startsWith(requestOrigin)) {
+          logger.error('Infinite proxy loop detected. Check NEXT_PUBLIC_API_URL configuration.', { 
+            API_URL, 
+            requestOrigin 
+          });
+          return NextResponse.json(
+            { error: 'Configuration Error: Proxy loop detected. Ensure API base URL does not point to the frontend application itself.' },
+            { status: 508 }
+          );
+        }
       } catch (envError) {
         logger.error('Failed to get API base URL from environment:', { error: envError instanceof Error ? envError.message : String(envError) });
         return NextResponse.json(

--- a/src/vertex/core/utils/proxyClient.ts
+++ b/src/vertex/core/utils/proxyClient.ts
@@ -55,6 +55,15 @@ const getSession = async (): Promise<ExtendedSession | null> => {
   }
 };
 
+const isSameOrigin = (url: string, origin: string): boolean => {
+  try {
+    return new URL(url).origin === origin;
+  } catch {
+    // Not an absolute URL, so it cannot point back at this server.
+    return false;
+  }
+};
+
 export const createProxyHandler = (options: ProxyOptions = {}) => {
   const { requiresAuth = false, requiresApiToken = false } = options;
 
@@ -109,9 +118,11 @@ export const createProxyHandler = (options: ProxyOptions = {}) => {
       try {
         API_URL = buildServerApiUrl(targetPath);
 
-        // Prevent infinite proxy loops if the API URL resolves back to the proxy itself
+        // Prevent infinite proxy loops if the API URL resolves back to the proxy
+        // itself. Compare parsed origins, not string prefixes: a prefix check
+        // would flag e.g. http://localhost:30001 from http://localhost:3000.
         const requestOrigin = new URL(req.url).origin;
-        if (API_URL.startsWith(requestOrigin)) {
+        if (isSameOrigin(API_URL, requestOrigin)) {
           logger.error('Infinite proxy loop detected. Check NEXT_PUBLIC_API_URL configuration.', { 
             API_URL, 
             requestOrigin 

--- a/src/vertex/next.config.js
+++ b/src/vertex/next.config.js
@@ -5,7 +5,7 @@ const nextConfig = {
       return [
         {
           source: '/api/v2/:path*',
-          destination: 'https://staging-vertex.airqo.net/api/v2/:path*',
+          destination: 'https://staging-analytics.airqo.net/api/v2/:path*',
         },
       ];
     }

--- a/src/vertex/next.config.mjs
+++ b/src/vertex/next.config.mjs
@@ -11,7 +11,7 @@ const nextConfig = {
       return [
         {
           source: '/api/v2/:path*',
-          destination: 'https://staging-vertex.airqo.net/api/v2/:path*',
+          destination: 'https://staging-analytics.airqo.net/api/v2/:path*',
         },
       ];
     }

--- a/src/vertex/test-server.js
+++ b/src/vertex/test-server.js
@@ -1,0 +1,11 @@
+const { createServer } = require('http');
+const axios = require('axios');
+const nextEnv = require('@next/env');
+nextEnv.loadEnvConfig(process.cwd());
+
+const server = createServer((req, res) => {
+  res.end('ok');
+});
+server.listen(3001, () => {
+  console.log('Test server ready');
+});


### PR DESCRIPTION
- point the dev-only /api/v2 rewrite at staging-analytics instead of staging-vertex so local runs hit the API host rather than the frontend
- skip the configured cookie domain on localhost/127.0.0.1 to silence NextAuth cookie-domain warnings in development
- detect and short-circuit proxy loops in createProxyHandler when the resolved API URL points back at the frontend origin (returns 508 with a configuration hint instead of recursing)
- add a minimal test-server.js for exercising env loading locally
- ignore src/beacon/ISSUES.md scratch notes

#### Summary of Changes (What does this PR do?)

- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

#### Status of maturity (all need to be checked before merging):

- [ ] I've tested this locally
- [ ] I consider this code done
- [ ] This change ready to hit production in its current state
- [ ] The title of the PR states what changed and the related issues number (used for the release note).
- [ ] I've included issue number in the "Closes #ISSUE-NUMBER" part of the "[What are the relevant tickets?](#what-are-the-relevant-tickets)" section to [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [ ] I've updated corresponding documentation for the changes in this PR.
- [ ] I have written unit and/or e2e tests for my change(s).

#### How should this be manually tested?

- Please include the steps to be done inorder to setup and test this PR.

#### What are the relevant tickets?

- Closes #<enter issue number here>
- [Jira_card_number]() (If exists)

#### Screenshots (optional)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Authentication cookies now work correctly when the application runs on `localhost` or `127.0.0.1`.
  - Added protection against misconfigured API proxy requests that could cause infinite loops; affected requests now return a clear configuration error.
  - Development API requests are routed to the Analytics staging service instead of the Vertex staging service.

- **Chores**
  - Added a lightweight local server to support development and testing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->